### PR TITLE
refactor: ツールコンポーネントの重複コードを共通化（高・中優先度6パターン）

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -336,3 +336,39 @@ TypeScript の警告がコミット前に検出されず、複数ファイル・
 - ✅ `.astro`・`.tsx`・`.ts` すべてをコミット前に型チェックできる
 - ✅ エラーのみブロック、hint/warning は通過させる（開発速度を損なわない）
 - ⚠️ `astro check` は初回起動がやや遅い（数秒）
+
+---
+
+## [013] 共通 UI コンポーネントを `src/components/ui/` に集約
+
+**2026-04-13 | ステータス: 採用**
+
+### 背景
+ツール数が7件に増えた段階で、各ツールコンポーネントに同じパターンが重複していた。
+
+- `label + input/textarea + error表示 + hint表示 + サンプルボタン` の組み合わせ（5ツールで重複）
+- `SVGダウンロード + PNGダウンロード` のボタンペア（JanCode・Gs1Databar で重複）
+- フォーカスリングハンドラ（`onFocusRing`/`onBlurRing`）の直書き（全ツールで重複）
+- `role="alert"` エラー表示の `<p>` タグ（複数ツールで重複）
+
+### 決断
+以下の共通コンポーネントを `src/components/ui/` に追加する。
+
+| コンポーネント | 責務 |
+|---|---|
+| `InputField` | label・input または textarea・error/hint・サンプルボタンを統合したフォームフィールド |
+| `ErrorMessage` | `role="alert"` 付きエラー表示。`id` を指定すると `aria-describedby` と連動できる |
+| `DownloadButtonGroup` | SVG/PNGダウンロードのボタンペア。`onDownloadPng` は省略可 |
+
+**新規ツールを作るときは、生の `<input>` / `<textarea>` ではなく `InputField` を使うこと。**
+
+### 却下した選択肢
+- **共通化せずに継続**: ツール数が増えるほど修正箇所が増える。フォーカスリングのスタイル変更1件でも全ツールを触ることになる。
+- **Astro コンポーネントで実装**: インタラクション（エラー状態・サンプル入力ボタン）を含むため、React コンポーネントとして実装するほうが自然。
+- **shadcn/ui 等の UI ライブラリ導入**: `.npmrc` の `min-release-age=7` 制約があり追加パッケージのリスクがある。DADSカラーシステムとの統合も複雑になる。
+
+### 結果・トレードオフ
+- ✅ フォームフィールド周りの変更が `InputField.tsx` 1ファイルの修正で全ツールに反映される
+- ✅ アクセシビリティ属性（`aria-describedby`・`aria-invalid`・`role="alert"`）の抜け漏れがなくなる
+- ✅ 各ツールコンポーネントのコード量が約 30〜40 行削減された
+- ⚠️ `InputField` のラベルスタイルは `bodyEmphasis`（17px Bold）に固定されるため、それと異なるスタイルが必要な場合は生の要素を使うこと

--- a/src/components/tools/DummyText.tsx
+++ b/src/components/tools/DummyText.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { CopyButton } from '../ui/CopyButton';
-import { bodyEmphasis, caption, micro, colors } from '../../utils/styles';
+import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
 
 type CharType = 'hiragana' | 'katakana' | 'japanese' | 'alphanumeric' | 'lorem';
 
@@ -159,8 +159,8 @@ export function DummyTextTool() {
             background: colors.bg,
             color: colors.text,
           }}
-          onFocus={(e) => { e.target.style.outline = `2px solid ${colors.link}`; e.target.style.outlineOffset = '2px'; }}
-          onBlurCapture={(e) => { e.target.style.outline = 'none'; }}
+          onFocus={onFocusRing}
+          onBlurCapture={onBlurRing}
         />
         <p style={{ ...micro, color: colors.muted, marginTop: '0.25rem' }}>1〜5000文字</p>
       </div>

--- a/src/components/tools/DummyText.tsx
+++ b/src/components/tools/DummyText.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useClampedInput } from '../../hooks/useClampedInput';
 import { CopyButton } from '../ui/CopyButton';
 import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
 
@@ -56,16 +57,13 @@ function generateText(type: CharType, length: number): string {
 
 export function DummyTextTool() {
   const [charType, setCharType] = useState<CharType>('japanese');
-  const [length, setLength] = useState(10);
-  const [lengthInput, setLengthInput] = useState('10');
+  const { value: length, inputStr: lengthInput, handleChange: handleLengthChange, handleBlur: handleLengthBlur } = useClampedInput(10, 1, 5000);
   const [lineBreak, setLineBreak] = useState(false);
-  const [chunkSize, setChunkSize] = useState(40);
-  const [chunkInput, setChunkInput] = useState('40');
+  const { value: chunkSize, inputStr: chunkInput, handleChange: handleChunkChange, handleBlur: handleChunkBlur } = useClampedInput(40, 1, 1000);
   const [result, setResult] = useState('');
 
   const generate = useCallback(() => {
-    const n = Math.min(5000, Math.max(1, length));
-    const raw = generateText(charType, n);
+    const raw = generateText(charType, length);
     if (lineBreak) {
       const lines: string[] = [];
       for (let i = 0; i < raw.length; i += chunkSize) {
@@ -78,32 +76,6 @@ export function DummyTextTool() {
   }, [charType, length, lineBreak, chunkSize]);
 
   useEffect(() => { generate(); }, [generate]);
-
-  const handleChunkChange = (value: string) => {
-    setChunkInput(value);
-    const n = parseInt(value, 10);
-    if (!isNaN(n) && n >= 1 && n <= 1000) setChunkSize(n);
-  };
-
-  const handleChunkBlur = () => {
-    const n = parseInt(chunkInput, 10);
-    if (isNaN(n) || n < 1) { setChunkSize(1); setChunkInput('1'); }
-    else if (n > 1000) { setChunkSize(1000); setChunkInput('1000'); }
-    else { setChunkSize(n); setChunkInput(String(n)); }
-  };
-
-  const handleLengthChange = (value: string) => {
-    setLengthInput(value);
-    const n = parseInt(value, 10);
-    if (!isNaN(n) && n >= 1 && n <= 5000) setLength(n);
-  };
-
-  const handleLengthBlur = () => {
-    const n = parseInt(lengthInput, 10);
-    if (isNaN(n) || n < 1) { setLength(1); setLengthInput('1'); }
-    else if (n > 5000) { setLength(5000); setLengthInput('5000'); }
-    else { setLength(n); setLengthInput(String(n)); }
-  };
 
   return (
     <div className="space-y-6">

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -9,7 +9,8 @@ import {
   AI_DEFS,
   type AiCode,
 } from '../../utils/gs1-databar';
-import { bodyEmphasis, caption, colors } from '../../utils/styles';
+import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { downloadSvg as downloadSvgFile, downloadPngFromSvgContent, svgContentToPngBlob } from '../../utils/download';
 
 interface AiFieldState {
   ai: AiCode;
@@ -90,36 +91,6 @@ function injectCompositeText(svg: string, text: string): string {
   const barcodeTranslate = `translate(${barcodeOffsetX.toFixed(1)},${textRowH})`;
 
   return `${openTag}${textEl}<g transform="${barcodeTranslate}">${inner}</g></svg>`;
-}
-
-function svgToPngBlob(svgContent: string): Promise<Blob> {
-  return new Promise((resolve, reject) => {
-    const m = svgContent.match(/width="(\d+)" height="(\d+)"/);
-    if (!m) { reject(new Error('SVG に width/height がありません')); return; }
-    const svgW = parseInt(m[1], 10);
-    const svgH = parseInt(m[2], 10);
-
-    const scale = 2;
-    const canvas = document.createElement('canvas');
-    canvas.width = svgW * scale;
-    canvas.height = svgH * scale;
-    const ctx = canvas.getContext('2d')!;
-    ctx.scale(scale, scale);
-
-    const img = new Image();
-    const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      URL.revokeObjectURL(url);
-      canvas.toBlob((b) => {
-        if (b) resolve(b);
-        else reject(new Error('PNG 変換に失敗しました'));
-      }, 'image/png');
-    };
-    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('SVG 読み込み失敗')); };
-    img.src = url;
-  });
 }
 
 // ─────────────────────────────────────────────
@@ -225,25 +196,12 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
 
   const downloadSvg = () => {
     if (!svgContent || !gtinResult) return;
-    const blob = new Blob([svgContent], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `gs1-databar-${gtinResult.fullGtin}.svg`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadSvgFile(svgContent, `gs1-databar-${gtinResult.fullGtin}.svg`);
   };
 
   const downloadPng = () => {
     if (!svgContent || !gtinResult) return;
-    svgToPngBlob(svgContent).then((blob) => {
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `gs1-databar-${gtinResult!.fullGtin}.png`;
-      a.click();
-      URL.revokeObjectURL(url);
-    });
+    downloadPngFromSvgContent(svgContent, `gs1-databar-${gtinResult.fullGtin}.png`);
   };
 
   const usedAis = new Set(aiFields.map((f) => f.ai));
@@ -252,14 +210,6 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
   const gs1String = gtinResult
     ? buildBwipText(gtinResult.fullGtin, aiFields.map((f) => ({ ai: f.ai, value: f.value })))
     : '';
-
-  const focusRingOn = (e: React.FocusEvent<HTMLElement>) => {
-    e.target.style.outline = `2px solid ${colors.link}`;
-    e.target.style.outlineOffset = '2px';
-  };
-  const focusRingOff = (e: React.FocusEvent<HTMLElement>) => {
-    e.target.style.outline = 'none';
-  };
 
   return (
     <div
@@ -323,8 +273,8 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
               background: colors.bg,
               color: colors.text,
             }}
-            onFocus={focusRingOn}
-            onBlur={focusRingOff}
+            onFocus={onFocusRing}
+            onBlur={onBlurRing}
             aria-describedby={gtinError ? `${inputId}-error` : `${inputId}-hint`}
           />
           {gtinError ? (
@@ -409,8 +359,8 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                         background: colors.bg,
                         color: colors.text,
                       }}
-                      onFocus={focusRingOn}
-                      onBlur={focusRingOff}
+                      onFocus={onFocusRing}
+                      onBlur={onBlurRing}
                     />
                     {field.error && (
                       <p role="alert" style={{ ...caption, color: colors.error, marginTop: '0.25rem' }}>
@@ -546,7 +496,7 @@ export function Gs1DatabarTool() {
       await Promise.all(
         validEntries.map(async ([, { svg, gtin }]) => {
           folder.file(`gs1-databar-${gtin}.svg`, svg);
-          const pngBlob = await svgToPngBlob(svg);
+          const pngBlob = await svgContentToPngBlob(svg);
           folder.file(`gs1-databar-${gtin}.png`, pngBlob);
         }),
       );

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -10,6 +10,8 @@ import {
   type AiCode,
 } from '../../utils/gs1-databar';
 import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { InputField } from '../ui/InputField';
+import { DownloadButtonGroup } from '../ui/DownloadButtonGroup';
 import { downloadSvg as downloadSvgFile, downloadPngFromSvgContent, svgContentToPngBlob } from '../../utils/download';
 
 interface AiFieldState {
@@ -244,49 +246,19 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
       {/* カード本体 */}
       <div className="p-4 space-y-5">
         {/* GTIN入力 */}
-        <div>
-          <div className="mb-2 flex items-center justify-between">
-            <label htmlFor={inputId} style={{ ...caption, color: colors.text, fontWeight: 600 }}>
-              GTIN-14（先頭13桁）
-            </label>
-            <button
-              onClick={() => handleGtinInput(sampleGtin)}
-              style={{ ...caption, color: colors.link }}
-              className="hover:underline"
-            >
-              サンプル入力
-            </button>
-          </div>
-          <input
-            id={inputId}
-            type="text"
-            inputMode="numeric"
-            maxLength={13}
-            value={gtinInput}
-            onChange={(e) => handleGtinInput(e.target.value)}
-            placeholder="0498700000001（13桁、先頭は0か1）"
-            className="w-full rounded px-3 py-2 font-mono"
-            style={{
-              ...caption,
-              border: `1px solid ${gtinError ? colors.error : colors.borderInput}`,
-              outline: 'none',
-              background: colors.bg,
-              color: colors.text,
-            }}
-            onFocus={onFocusRing}
-            onBlur={onBlurRing}
-            aria-describedby={gtinError ? `${inputId}-error` : `${inputId}-hint`}
-          />
-          {gtinError ? (
-            <p id={`${inputId}-error`} role="alert" style={{ ...caption, color: colors.error, marginTop: '0.25rem' }}>
-              {gtinError}
-            </p>
-          ) : (
-            <p id={`${inputId}-hint`} style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}>
-              {gtinInput.length} / 13 桁
-            </p>
-          )}
-        </div>
+        <InputField
+          id={inputId}
+          label="GTIN-14（先頭13桁）"
+          value={gtinInput}
+          onChange={handleGtinInput}
+          placeholder="0498700000001（13桁、先頭は0か1）"
+          inputMode="numeric"
+          maxLength={13}
+          error={gtinError || undefined}
+          hint={`${gtinInput.length} / 13 桁`}
+          onSampleClick={() => handleGtinInput(sampleGtin)}
+          mono
+        />
 
         {/* GTIN計算結果 */}
         {gtinResult && (
@@ -392,22 +364,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
               aria-label={`GS1 DataBar ${gtinResult?.fullGtin} のバーコード`}
               dangerouslySetInnerHTML={{ __html: svgContent }}
             />
-            <div className="flex gap-2">
-              <button
-                onClick={downloadSvg}
-                className="rounded px-4 py-2 font-bold transition-colors hover:bg-blue-50"
-                style={{ ...caption, fontWeight: 700, border: `1px solid ${colors.primary}`, color: colors.primary }}
-              >
-                SVGダウンロード
-              </button>
-              <button
-                onClick={downloadPng}
-                className="rounded px-4 py-2 font-bold text-white transition-colors hover:opacity-90"
-                style={{ ...caption, fontWeight: 700, background: colors.primary }}
-              >
-                PNGダウンロード
-              </button>
-            </div>
+            <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />
           </div>
         )}
 

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react';
 import JsBarcode from 'jsbarcode';
 import { CopyButton } from '../ui/CopyButton';
 import { calcJan, validateJanInput, type JanMode } from '../../utils/jan-code';
-import { bodyEmphasis, caption, shadows, colors } from '../../utils/styles';
+import { bodyEmphasis, caption, shadows, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { downloadSvg as downloadSvgFile, downloadPngFromSvgElement } from '../../utils/download';
 
 export function JanCodeTool() {
   const [mode, setMode] = useState<JanMode>('jan13');
@@ -48,38 +49,12 @@ export function JanCodeTool() {
 
   const downloadSvg = () => {
     if (!svgRef.current) return;
-    const svg = svgRef.current.outerHTML;
-    const blob = new Blob([svg], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `jan-${result!.fullCode}.svg`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadSvgFile(svgRef.current.outerHTML, `jan-${result!.fullCode}.svg`);
   };
 
   const downloadPng = () => {
     if (!svgRef.current) return;
-    const svg = svgRef.current;
-    const { width, height } = svg.getBoundingClientRect();
-    const canvas = document.createElement('canvas');
-    const scale = 2; // Retina
-    canvas.width = width * scale;
-    canvas.height = height * scale;
-    const ctx = canvas.getContext('2d')!;
-    ctx.scale(scale, scale);
-    const img = new Image();
-    const blob = new Blob([svg.outerHTML], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      URL.revokeObjectURL(url);
-      const a = document.createElement('a');
-      a.href = canvas.toDataURL('image/png');
-      a.download = `jan-${result!.fullCode}.png`;
-      a.click();
-    };
-    img.src = url;
+    downloadPngFromSvgElement(svgRef.current, `jan-${result!.fullCode}.png`);
   };
 
   const SAMPLE: Record<JanMode, string> = {
@@ -146,8 +121,8 @@ export function JanCodeTool() {
             background: colors.bg,
             color: colors.text,
           }}
-          onFocus={(e) => { e.target.style.outline = `2px solid ${colors.link}`; e.target.style.outlineOffset = '2px'; }}
-          onBlur={(e) => { e.target.style.outline = 'none'; }}
+          onFocus={onFocusRing}
+          onBlur={onBlurRing}
           aria-describedby={error ? 'jan-error' : 'jan-hint'}
         />
         {error ? (

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 import JsBarcode from 'jsbarcode';
 import { CopyButton } from '../ui/CopyButton';
+import { ToggleGroup } from '../ui/ToggleGroup';
 import { calcJan, validateJanInput, type JanMode } from '../../utils/jan-code';
-import { bodyEmphasis, caption, shadows, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '../../utils/styles';
 import { downloadSvg as downloadSvgFile, downloadPngFromSvgElement } from '../../utils/download';
 
 export function JanCodeTool() {
@@ -65,31 +66,15 @@ export function JanCodeTool() {
   return (
     <div className="space-y-6">
       {/* モード切替 */}
-      <div
-        className="flex gap-1 rounded p-1"
-        role="tablist"
-        aria-label="JANコードモード"
-        style={{ background: colors.bgSubtle }}
-      >
-        {(['jan13', 'jan8'] as JanMode[]).map((m) => (
-          <button
-            key={m}
-            role="tab"
-            aria-selected={mode === m}
-            onClick={() => handleModeChange(m)}
-            className="flex-1 rounded py-1.5 transition-colors"
-            style={{
-              ...caption,
-              fontWeight: 700,
-              background: mode === m ? colors.bg : 'transparent',
-              color: mode === m ? colors.text : colors.muted,
-              boxShadow: mode === m ? shadows.tab : 'none',
-            }}
-          >
-            {m === 'jan13' ? 'JAN-13' : 'JAN-8'}
-          </button>
-        ))}
-      </div>
+      <ToggleGroup
+        options={[
+          { value: 'jan13', label: 'JAN-13' },
+          { value: 'jan8', label: 'JAN-8' },
+        ]}
+        value={mode}
+        onChange={handleModeChange}
+        ariaLabel="JANコードモード"
+      />
 
       {/* 入力 */}
       <div>

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect, useRef } from 'react';
 import JsBarcode from 'jsbarcode';
 import { CopyButton } from '../ui/CopyButton';
 import { ToggleGroup } from '../ui/ToggleGroup';
+import { InputField } from '../ui/InputField';
+import { DownloadButtonGroup } from '../ui/DownloadButtonGroup';
 import { calcJan, validateJanInput, type JanMode } from '../../utils/jan-code';
-import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { bodyEmphasis, caption, colors } from '../../utils/styles';
 import { downloadSvg as downloadSvgFile, downloadPngFromSvgElement } from '../../utils/download';
 
 export function JanCodeTool() {
@@ -77,49 +79,19 @@ export function JanCodeTool() {
       />
 
       {/* 入力 */}
-      <div>
-        <div className="mb-2 flex items-center justify-between">
-          <label htmlFor="jan-input" style={{ ...bodyEmphasis, color: colors.text }}>
-            {mode === 'jan13' ? '12桁を入力' : '7桁を入力'}
-          </label>
-          <button
-            onClick={() => handleInput(SAMPLE[mode])}
-            style={{ ...caption, color: colors.link }}
-            className="hover:underline"
-          >
-            サンプル入力
-          </button>
-        </div>
-        <input
-          id="jan-input"
-          type="text"
-          inputMode="numeric"
-          maxLength={mode === 'jan13' ? 12 : 7}
-          value={input}
-          onChange={(e) => handleInput(e.target.value)}
-          placeholder={mode === 'jan13' ? '490123456789（12桁）' : '4901234（7桁）'}
-          className="w-full rounded px-3 py-2 font-mono"
-          style={{
-            ...caption,
-            border: `1px solid ${error ? colors.error : colors.borderInput}`,
-            outline: 'none',
-            background: colors.bg,
-            color: colors.text,
-          }}
-          onFocus={onFocusRing}
-          onBlur={onBlurRing}
-          aria-describedby={error ? 'jan-error' : 'jan-hint'}
-        />
-        {error ? (
-          <p id="jan-error" role="alert" style={{ ...caption, color: colors.error, marginTop: '0.25rem' }}>
-            {error}
-          </p>
-        ) : (
-          <p id="jan-hint" style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}>
-            {input.length} / {mode === 'jan13' ? 12 : 7} 桁
-          </p>
-        )}
-      </div>
+      <InputField
+        id="jan-input"
+        label={mode === 'jan13' ? '12桁を入力' : '7桁を入力'}
+        value={input}
+        onChange={handleInput}
+        placeholder={mode === 'jan13' ? '490123456789（12桁）' : '4901234（7桁）'}
+        inputMode="numeric"
+        maxLength={mode === 'jan13' ? 12 : 7}
+        error={error || undefined}
+        hint={`${input.length} / ${mode === 'jan13' ? 12 : 7} 桁`}
+        onSampleClick={() => handleInput(SAMPLE[mode])}
+        mono
+      />
 
       {/* 結果 */}
       {result && (
@@ -181,22 +153,7 @@ export function JanCodeTool() {
             style={{ border: `1px solid ${colors.border}`, background: colors.bg }}
           >
             <svg ref={svgRef} aria-label={`JANコード ${result.fullCode} のバーコード`} />
-            <div className="flex gap-2">
-              <button
-                onClick={downloadSvg}
-                className="rounded px-4 py-2 font-bold transition-colors hover:bg-blue-50"
-                style={{ ...caption, fontWeight: 700, border: `1px solid ${colors.primary}`, color: colors.primary }}
-              >
-                SVGダウンロード
-              </button>
-              <button
-                onClick={downloadPng}
-                className="rounded px-4 py-2 font-bold text-white transition-colors hover:opacity-90"
-                style={{ ...caption, fontWeight: 700, background: colors.primary }}
-              >
-                PNGダウンロード
-              </button>
-            </div>
+            <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />
           </div>
         </div>
       )}

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { CopyButton } from '../ui/CopyButton';
-import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { bodyEmphasis, caption, micro, colors } from '../../utils/styles';
+import { InputField } from '../ui/InputField';
 import {
   parseJwt, formatTimestamp, formatRemaining, base64UrlToBytes,
   type ExpStatus,
@@ -191,68 +192,32 @@ export function JwtDecoderTool() {
   return (
     <div className="space-y-4">
       {/* トークン入力 */}
-      <div>
-        <div className="mb-1 flex items-center justify-between">
-          <label htmlFor="jwt-input" style={{ ...bodyEmphasis, color: colors.text }}>JWTトークンを貼り付け</label>
-          <button
-            onClick={async () => { setSecretKey(SAMPLE_SECRET); setToken(await generateSampleJwt(SAMPLE_SECRET)); }}
-            style={{ ...caption, color: colors.link }}
-            className="hover:underline"
-          >
-            サンプル入力
-          </button>
-        </div>
-        <textarea
-          id="jwt-input"
-          value={token}
-          onInput={(e) => setToken((e.target as HTMLTextAreaElement).value)}
-          placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-          rows={4}
-          className="w-full rounded-lg px-3 py-2 font-mono"
-          style={{
-            ...caption,
-            border: `1px solid ${isInvalid ? colors.error : colors.borderInput}`,
-            outline: 'none',
-            background: colors.bg,
-            color: colors.text,
-          }}
-          onFocus={onFocusRing}
-          onBlur={onBlurRing}
-          aria-describedby={isInvalid ? 'jwt-error' : undefined}
-        />
-        {isInvalid && (
-          <p id="jwt-error" role="alert" style={{ ...caption, color: colors.error, marginTop: '0.25rem' }}>
-            有効なJWTトークンではありません
-          </p>
-        )}
-      </div>
+      <InputField
+        id="jwt-input"
+        label="JWTトークンを貼り付け"
+        value={token}
+        onChange={setToken}
+        placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        multiline
+        rows={4}
+        error={isInvalid ? '有効なJWTトークンではありません' : undefined}
+        onSampleClick={async () => { setSecretKey(SAMPLE_SECRET); setToken(await generateSampleJwt(SAMPLE_SECRET)); }}
+        mono
+      />
 
       {/* 署名検証キー入力 */}
       {parsed && (
-        <div>
-          <label htmlFor="jwt-secret" style={{ ...bodyEmphasis, color: colors.text, display: 'block', marginBottom: '0.25rem' }}>
-            {keyLabel}
-            <span style={{ ...micro, color: colors.muted, fontWeight: 400, marginLeft: '0.5rem' }}>（任意）</span>
-          </label>
-          <textarea
-            id="jwt-secret"
-            value={secretKey}
-            onInput={(e) => setSecretKey((e.target as HTMLTextAreaElement).value)}
-            placeholder={keyPlaceholder}
-            rows={isHmac ? 2 : 4}
-            className="w-full rounded-lg px-3 py-2 font-mono"
-            style={{
-              ...caption,
-              border: `1px solid ${colors.borderInput}`,
-              outline: 'none',
-              background: colors.bg,
-              color: colors.text,
-              resize: 'vertical',
-            }}
-            onFocus={onFocusRing}
-            onBlur={onBlurRing}
-          />
-        </div>
+        <InputField
+          id="jwt-secret"
+          label={<>{keyLabel}<span style={{ ...micro, color: colors.muted, fontWeight: 400, marginLeft: '0.5rem' }}>（任意）</span></>}
+          value={secretKey}
+          onChange={setSecretKey}
+          placeholder={keyPlaceholder}
+          multiline
+          rows={isHmac ? 2 : 4}
+          mono
+          resize
+        />
       )}
 
       {/* 有効期限チェックトグル */}

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { CopyButton } from '../ui/CopyButton';
-import { bodyEmphasis, caption, micro, colors } from '../../utils/styles';
+import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
 import {
   parseJwt, formatTimestamp, formatRemaining, base64UrlToBytes,
   type ExpStatus,
@@ -216,8 +216,8 @@ export function JwtDecoderTool() {
             background: colors.bg,
             color: colors.text,
           }}
-          onFocus={(e) => { e.target.style.outline = `2px solid ${colors.link}`; e.target.style.outlineOffset = '2px'; }}
-          onBlur={(e) => { e.target.style.outline = 'none'; }}
+          onFocus={onFocusRing}
+          onBlur={onBlurRing}
           aria-describedby={isInvalid ? 'jwt-error' : undefined}
         />
         {isInvalid && (
@@ -249,8 +249,8 @@ export function JwtDecoderTool() {
               color: colors.text,
               resize: 'vertical',
             }}
-            onFocus={(e) => { e.target.style.outline = `2px solid ${colors.link}`; e.target.style.outlineOffset = '2px'; }}
-            onBlur={(e) => { e.target.style.outline = 'none'; }}
+            onFocus={onFocusRing}
+            onBlur={onBlurRing}
           />
         </div>
       )}

--- a/src/components/tools/QrCode.tsx
+++ b/src/components/tools/QrCode.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import qrcode from 'qrcode-generator';
-import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { bodyEmphasis, caption, micro, colors } from '../../utils/styles';
+import { InputField } from '../ui/InputField';
+import { ErrorMessage } from '../ui/ErrorMessage';
 import { downloadSvgElement } from '../../utils/download';
 
 type ErrorLevel = 'L' | 'M' | 'Q' | 'H';
@@ -57,33 +59,16 @@ export function QrCodeGenerator() {
   return (
     <div className="space-y-6">
       {/* テキスト入力 */}
-      <div>
-        <label
-          htmlFor="qr-text"
-          style={{ ...bodyEmphasis, color: colors.text, display: 'block', marginBottom: '0.25rem' }}
-        >
-          テキスト / URL
-        </label>
-        <textarea
-          id="qr-text"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder="https://example.com"
-          rows={3}
-          className="w-full rounded-lg px-3 py-2"
-          style={{
-            ...caption,
-            border: `1px solid ${colors.borderInput}`,
-            outline: 'none',
-            background: colors.bg,
-            color: colors.text,
-            resize: 'vertical',
-            fontFamily: 'inherit',
-          }}
-          onFocus={onFocusRing}
-          onBlur={onBlurRing}
-        />
-      </div>
+      <InputField
+        id="qr-text"
+        label="テキスト / URL"
+        value={text}
+        onChange={setText}
+        placeholder="https://example.com"
+        multiline
+        rows={3}
+        resize
+      />
 
       {/* 誤り訂正レベル */}
       <div>
@@ -122,9 +107,7 @@ export function QrCodeGenerator() {
       </div>
 
       {/* エラー */}
-      {error && (
-        <p style={{ ...caption, color: colors.error }}>{error}</p>
-      )}
+      {error && <ErrorMessage message={error} />}
 
       {/* QRコード表示 */}
       {svgHtml && (

--- a/src/components/tools/QrCode.tsx
+++ b/src/components/tools/QrCode.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import qrcode from 'qrcode-generator';
-import { bodyEmphasis, caption, micro, colors } from '../../utils/styles';
+import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { downloadSvgElement } from '../../utils/download';
 
 type ErrorLevel = 'L' | 'M' | 'Q' | 'H';
 
@@ -50,15 +51,7 @@ export function QrCodeGenerator() {
     if (!containerRef.current) return;
     const svgEl = containerRef.current.querySelector('svg');
     if (!svgEl) return;
-    const serializer = new XMLSerializer();
-    const svgStr = serializer.serializeToString(svgEl);
-    const blob = new Blob([svgStr], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'qrcode.svg';
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadSvgElement(svgEl, 'qrcode.svg');
   };
 
   return (
@@ -87,8 +80,8 @@ export function QrCodeGenerator() {
             resize: 'vertical',
             fontFamily: 'inherit',
           }}
-          onFocus={(e) => { e.target.style.outline = `2px solid ${colors.link}`; e.target.style.outlineOffset = '2px'; }}
-          onBlur={(e) => { e.target.style.outline = 'none'; }}
+          onFocus={onFocusRing}
+          onBlur={onBlurRing}
         />
       </div>
 

--- a/src/components/tools/UlidGenerator.tsx
+++ b/src/components/tools/UlidGenerator.tsx
@@ -1,31 +1,7 @@
 import { useState, useCallback } from 'react';
 import { ulid } from 'ulidx';
 import { CopyButton } from '../ui/CopyButton';
-import { copyToClipboard } from '../../utils/clipboard';
-import { bodyEmphasis, caption, micro, colors } from '../../utils/styles';
-
-function RowCopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  const handleClick = async () => {
-    const ok = await copyToClipboard(text);
-    if (ok) { setCopied(true); setTimeout(() => setCopied(false), 2000); }
-  };
-  return (
-    <button
-      onClick={handleClick}
-      aria-label={copied ? 'コピーしました' : 'コピー'}
-      className="rounded-md transition-colors"
-      style={{
-        fontSize: '0.75rem', padding: '0.25rem 0.5rem',
-        background: copied ? colors.successBg : colors.bgSubtle,
-        color: copied ? colors.success : colors.muted,
-        border: 'none', cursor: 'pointer', whiteSpace: 'nowrap',
-      }}
-    >
-      {copied ? '✓' : '📋'}
-    </button>
-  );
-}
+import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
 
 
 interface UlidRow {
@@ -114,13 +90,8 @@ export function UlidGeneratorTool() {
               background: colors.bg,
               color: colors.text,
             }}
-            onFocus={(e) => {
-              e.target.style.outline = `2px solid ${colors.link}`;
-              e.target.style.outlineOffset = '2px';
-            }}
-            onBlurCapture={(e) => {
-              e.target.style.outline = 'none';
-            }}
+            onFocus={onFocusRing}
+            onBlurCapture={onBlurRing}
             aria-describedby="ulid-count-hint"
           />
           <button
@@ -133,13 +104,8 @@ export function UlidGeneratorTool() {
               color: '#ffffff',
               border: 'none',
             }}
-            onFocus={(e) => {
-              (e.target as HTMLButtonElement).style.outline = `2px solid ${colors.link}`;
-              (e.target as HTMLButtonElement).style.outlineOffset = '2px';
-            }}
-            onBlur={(e) => {
-              (e.target as HTMLButtonElement).style.outline = 'none';
-            }}
+            onFocus={onFocusRing}
+            onBlur={onBlurRing}
           >
             生成
           </button>
@@ -308,11 +274,14 @@ export function UlidGeneratorTool() {
                       {row.timestamp}
                     </td>
                     <td style={{ padding: '0.25rem 0.5rem', textAlign: 'center', whiteSpace: 'nowrap' }}>
-                      <RowCopyButton text={
-                        quoteStyle === 'double' ? `"${row.id}"` :
-                        quoteStyle === 'single' ? `'${row.id}'` :
-                        row.id
-                      } />
+                      <CopyButton
+                        text={
+                          quoteStyle === 'double' ? `"${row.id}"` :
+                          quoteStyle === 'single' ? `'${row.id}'` :
+                          row.id
+                        }
+                        compact
+                      />
                     </td>
                   </tr>
                 ))}

--- a/src/components/tools/UlidGenerator.tsx
+++ b/src/components/tools/UlidGenerator.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { ulid } from 'ulidx';
 import { CopyButton } from '../ui/CopyButton';
 import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { useClampedInput } from '../../hooks/useClampedInput';
 
 
 interface UlidRow {
@@ -22,37 +23,13 @@ function generateRows(count: number): UlidRow[] {
 type QuoteStyle = 'none' | 'single' | 'double';
 
 export function UlidGeneratorTool() {
-  const [count, setCount] = useState(10);
-  const [countInput, setCountInput] = useState('10');
+  const { value: count, inputStr: countInput, handleChange: handleCountChange, handleBlur: handleCountBlur } = useClampedInput(10, 1, 100);
   const [rows, setRows] = useState<UlidRow[]>([]);
   const [quoteStyle, setQuoteStyle] = useState<QuoteStyle>('none');
 
   const generate = useCallback(() => {
-    const n = Math.min(100, Math.max(1, count));
-    setRows(generateRows(n));
+    setRows(generateRows(count));
   }, [count]);
-
-  const handleCountChange = (value: string) => {
-    setCountInput(value);
-    const n = parseInt(value, 10);
-    if (!isNaN(n) && n >= 1 && n <= 100) {
-      setCount(n);
-    }
-  };
-
-  const handleCountBlur = () => {
-    const n = parseInt(countInput, 10);
-    if (isNaN(n) || n < 1) {
-      setCount(1);
-      setCountInput('1');
-    } else if (n > 100) {
-      setCount(100);
-      setCountInput('100');
-    } else {
-      setCount(n);
-      setCountInput(String(n));
-    }
-  };
 
   const allUlids = rows.map((r, i) => {
     const isLast = i === rows.length - 1;

--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { CopyButton } from '../ui/CopyButton';
-import { bodyEmphasis, caption, colors, shadows } from '../../utils/styles';
+import { bodyEmphasis, caption, colors, shadows, onFocusRing, onBlurRing } from '../../utils/styles';
 import { encodeUrl, decodeUrl, validateDecodeInput } from '../../utils/url-encode';
 
 type Mode = 'encode' | 'decode';
@@ -90,8 +90,8 @@ export function UrlEncoderTool() {
             background: colors.bg,
             color: colors.text,
           }}
-          onFocus={(e) => { e.target.style.outline = `2px solid ${colors.link}`; e.target.style.outlineOffset = '2px'; }}
-          onBlur={(e) => { e.target.style.outline = 'none'; }}
+          onFocus={onFocusRing}
+          onBlur={onBlurRing}
           aria-describedby={error ? 'url-error' : undefined}
         />
         {error && (

--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { CopyButton } from '../ui/CopyButton';
 import { ToggleGroup } from '../ui/ToggleGroup';
-import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { InputField } from '../ui/InputField';
+import { bodyEmphasis, caption, colors } from '../../utils/styles';
 import { encodeUrl, decodeUrl, validateDecodeInput } from '../../utils/url-encode';
 
 type Mode = 'encode' | 'decode';
@@ -54,43 +55,18 @@ export function UrlEncoderTool() {
       />
 
       {/* 入力 */}
-      <div>
-        <div className="mb-1 flex items-center justify-between">
-          <label htmlFor="url-input" style={{ ...bodyEmphasis, color: colors.text }}>
-            入力
-          </label>
-          <button
-            onClick={() => handleInput(SAMPLE[mode])}
-            style={{ ...caption, color: colors.link }}
-            className="hover:underline"
-          >
-            サンプル入力
-          </button>
-        </div>
-        <textarea
-          id="url-input"
-          value={input}
-          onInput={(e) => handleInput((e.target as HTMLTextAreaElement).value)}
-          placeholder={mode === 'encode' ? 'https://example.com/検索?q=テスト' : 'https%3A%2F%2Fexample.com%2F...'}
-          rows={4}
-          className="w-full rounded-lg px-3 py-2 font-mono"
-          style={{
-            ...caption,
-            border: `1px solid ${error ? colors.error : colors.borderInput}`,
-            outline: 'none',
-            background: colors.bg,
-            color: colors.text,
-          }}
-          onFocus={onFocusRing}
-          onBlur={onBlurRing}
-          aria-describedby={error ? 'url-error' : undefined}
-        />
-        {error && (
-          <p id="url-error" role="alert" style={{ ...caption, color: colors.error, marginTop: '0.25rem' }}>
-            {error}
-          </p>
-        )}
-      </div>
+      <InputField
+        id="url-input"
+        label="入力"
+        value={input}
+        onChange={handleInput}
+        placeholder={mode === 'encode' ? 'https://example.com/検索?q=テスト' : 'https%3A%2F%2Fexample.com%2F...'}
+        multiline
+        rows={4}
+        error={error || undefined}
+        onSampleClick={() => handleInput(SAMPLE[mode])}
+        mono
+      />
 
       {/* 出力 */}
       <div>

--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { CopyButton } from '../ui/CopyButton';
-import { bodyEmphasis, caption, colors, shadows, onFocusRing, onBlurRing } from '../../utils/styles';
+import { ToggleGroup } from '../ui/ToggleGroup';
+import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '../../utils/styles';
 import { encodeUrl, decodeUrl, validateDecodeInput } from '../../utils/url-encode';
 
 type Mode = 'encode' | 'decode';
@@ -41,26 +42,16 @@ export function UrlEncoderTool() {
 
   return (
     <div className="space-y-4">
-      {/* モード切替: Filter/Search Button style */}
-      <div className="flex gap-1 rounded-lg p-1" style={{ background: colors.bgSubtle }}>
-        {(['encode', 'decode'] as Mode[]).map((m) => (
-          <button
-            key={m}
-            onClick={() => handleModeChange(m)}
-            aria-pressed={mode === m}
-            className="flex-1 rounded-lg py-1.5 transition-colors"
-            style={{
-              ...caption,
-              fontWeight: 500,
-              background: mode === m ? colors.bg : 'transparent',
-              color: mode === m ? colors.text : colors.muted,
-              boxShadow: mode === m ? shadows.tab : 'none',
-            }}
-          >
-            {m === 'encode' ? 'エンコード' : 'デコード'}
-          </button>
-        ))}
-      </div>
+      {/* モード切替 */}
+      <ToggleGroup
+        options={[
+          { value: 'encode', label: 'エンコード' },
+          { value: 'decode', label: 'デコード' },
+        ]}
+        value={mode}
+        onChange={handleModeChange}
+        ariaLabel="変換モード"
+      />
 
       {/* 入力 */}
       <div>

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -6,9 +6,11 @@ interface Props {
   text: string;
   label?: string;
   className?: string;
+  /** テーブル行など狭い場所向けのコンパクト表示 */
+  compact?: boolean;
 }
 
-export function CopyButton({ text, label = 'コピー', className = '' }: Props) {
+export function CopyButton({ text, label = 'コピー', className = '', compact = false }: Props) {
   const [copied, setCopied] = useState(false);
 
   const handleClick = async () => {
@@ -18,6 +20,27 @@ export function CopyButton({ text, label = 'コピー', className = '' }: Props)
       setTimeout(() => setCopied(false), 2000);
     }
   };
+
+  if (compact) {
+    return (
+      <button
+        onClick={handleClick}
+        aria-label={copied ? 'コピーしました' : label}
+        className="rounded-md transition-colors"
+        style={{
+          fontSize: '0.75rem',
+          padding: '0.25rem 0.5rem',
+          background: copied ? colors.successBg : colors.bgSubtle,
+          color: copied ? colors.success : colors.muted,
+          border: 'none',
+          cursor: 'pointer',
+          whiteSpace: 'nowrap' as const,
+        }}
+      >
+        {copied ? '✓' : '📋'}
+      </button>
+    );
+  }
 
   return (
     <button

--- a/src/components/ui/DownloadButtonGroup.tsx
+++ b/src/components/ui/DownloadButtonGroup.tsx
@@ -1,0 +1,38 @@
+import { caption, colors } from '../../utils/styles';
+
+interface Props {
+  onDownloadSvg: () => void;
+  onDownloadPng?: () => void;
+}
+
+export function DownloadButtonGroup({ onDownloadSvg, onDownloadPng }: Props) {
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={onDownloadSvg}
+        className="rounded px-4 py-2 transition-colors hover:bg-blue-50"
+        style={{
+          ...caption,
+          fontWeight: 700,
+          border: `1px solid ${colors.primary}`,
+          color: colors.primary,
+        }}
+      >
+        SVGダウンロード
+      </button>
+      {onDownloadPng && (
+        <button
+          onClick={onDownloadPng}
+          className="rounded px-4 py-2 text-white transition-colors hover:opacity-90"
+          style={{
+            ...caption,
+            fontWeight: 700,
+            background: colors.primary,
+          }}
+        >
+          PNGダウンロード
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/ErrorMessage.tsx
+++ b/src/components/ui/ErrorMessage.tsx
@@ -1,0 +1,18 @@
+import { caption, colors } from '../../utils/styles';
+
+interface Props {
+  id?: string;
+  message: string;
+}
+
+export function ErrorMessage({ id, message }: Props) {
+  return (
+    <p
+      id={id}
+      role="alert"
+      style={{ ...caption, color: colors.error, marginTop: '0.25rem' }}
+    >
+      {message}
+    </p>
+  );
+}

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -1,0 +1,116 @@
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '../../utils/styles';
+import { ErrorMessage } from './ErrorMessage';
+
+interface Props {
+  id: string;
+  label: ReactNode;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  multiline?: boolean;
+  rows?: number;
+  error?: string;
+  hint?: string;
+  onSampleClick?: () => void;
+  inputMode?: InputHTMLAttributes<HTMLInputElement>['inputMode'];
+  maxLength?: number;
+  readOnly?: boolean;
+  mono?: boolean;
+  resize?: boolean;
+}
+
+export function InputField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  multiline = false,
+  rows = 4,
+  error,
+  hint,
+  onSampleClick,
+  inputMode,
+  maxLength,
+  readOnly = false,
+  mono = false,
+  resize = false,
+}: Props) {
+  const hintId = hint ? `${id}-hint` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [errorId, hintId].filter(Boolean).join(' ') || undefined;
+
+  const baseInputStyle = {
+    ...caption,
+    width: '100%',
+    border: `1px solid ${error ? colors.error : colors.borderInput}`,
+    borderRadius: '0.5rem',
+    padding: '0.5rem 0.75rem',
+    outline: 'none',
+    background: readOnly ? colors.bgSurface : colors.bg,
+    color: colors.text,
+    ...(mono ? { fontFamily: 'monospace', letterSpacing: '0.02em' } : {}),
+    ...(multiline && !resize ? { resize: 'none' as const } : {}),
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between" style={{ marginBottom: '0.25rem' }}>
+        <label htmlFor={id} style={{ ...bodyEmphasis, color: colors.text }}>
+          {label}
+        </label>
+        {onSampleClick && (
+          <button
+            type="button"
+            onClick={onSampleClick}
+            style={{ ...micro, color: colors.link, background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+          >
+            サンプルを入力
+          </button>
+        )}
+      </div>
+
+      {multiline ? (
+        <textarea
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          rows={rows}
+          readOnly={readOnly}
+          maxLength={maxLength}
+          aria-describedby={describedBy}
+          aria-invalid={!!error}
+          style={baseInputStyle}
+          onFocus={onFocusRing}
+          onBlur={onBlurRing}
+        />
+      ) : (
+        <input
+          id={id}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          maxLength={maxLength}
+          inputMode={inputMode}
+          aria-describedby={describedBy}
+          aria-invalid={!!error}
+          style={baseInputStyle}
+          onFocus={onFocusRing}
+          onBlur={onBlurRing}
+        />
+      )}
+
+      {error ? (
+        <ErrorMessage id={errorId} message={error} />
+      ) : hint ? (
+        <p id={hintId} style={{ ...micro, color: colors.muted, marginTop: '0.25rem' }}>
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ui/ToggleGroup.tsx
+++ b/src/components/ui/ToggleGroup.tsx
@@ -1,0 +1,42 @@
+import { caption, colors, shadows } from '../../utils/styles';
+
+interface Option<T> {
+  value: T;
+  label: string;
+}
+
+interface Props<T extends string> {
+  options: Option<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel?: string;
+}
+
+export function ToggleGroup<T extends string>({ options, value, onChange, ariaLabel }: Props<T>) {
+  return (
+    <div
+      className="flex gap-1 rounded-lg p-1"
+      role="group"
+      aria-label={ariaLabel}
+      style={{ background: colors.bgSubtle }}
+    >
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          aria-pressed={value === opt.value}
+          className="flex-1 rounded-lg py-1.5 transition-colors"
+          style={{
+            ...caption,
+            fontWeight: 600,
+            background: value === opt.value ? colors.bg : 'transparent',
+            color: value === opt.value ? colors.text : colors.muted,
+            boxShadow: value === opt.value ? shadows.tab : 'none',
+          }}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useClampedInput.ts
+++ b/src/hooks/useClampedInput.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+/**
+ * 数値入力フィールド用フック。
+ * 入力中は文字列のまま保持し、blur 時に min/max でクランプして確定する。
+ */
+export function useClampedInput(initial: number, min: number, max: number) {
+  const [value, setValue] = useState(initial);
+  const [inputStr, setInputStr] = useState(String(initial));
+
+  const handleChange = (raw: string) => {
+    setInputStr(raw);
+    const n = parseInt(raw, 10);
+    if (!isNaN(n) && n >= min && n <= max) setValue(n);
+  };
+
+  const handleBlur = () => {
+    const n = parseInt(inputStr, 10);
+    if (isNaN(n) || n < min) {
+      setValue(min);
+      setInputStr(String(min));
+    } else if (n > max) {
+      setValue(max);
+      setInputStr(String(max));
+    } else {
+      setValue(n);
+      setInputStr(String(n));
+    }
+  };
+
+  return { value, inputStr, handleChange, handleBlur };
+}

--- a/src/pages/tools/dummy-text.astro
+++ b/src/pages/tools/dummy-text.astro
@@ -10,12 +10,12 @@ const tool = tools.find((t) => t.slug === 'dummy-text')!;
   <DummyTextTool client:load />
 
   <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">このツールについて</h2>
-    <p style="font-size: 1.06rem; font-weight: 400; line-height: 1.47; letter-spacing: -0.374px; color: rgba(0,0,0,0.8);">
+    <h2 class="mb-3 text-apple-dark dark:text-white tool-info-heading">このツールについて</h2>
+    <p class="tool-info-body">
       UI・デザインのモックアップや動作確認用に、任意の文字数のダミーテキストを生成します。
     </p>
-    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">文字種について</h3>
-    <ul class="list-inside list-disc space-y-1" style="font-size: 0.875rem; line-height: 1.29; letter-spacing: -0.224px; color: rgba(0,0,0,0.8);">
+    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white tool-info-heading">文字種について</h3>
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
       <li>ひらがな・カタカナ：ランダムな仮名文字を生成</li>
       <li>漢字混じり日本語：漢字・ひらがな・助詞をミックス</li>
       <li>英数字：a-z・A-Z・0-9 をランダムに生成</li>

--- a/src/pages/tools/jwt-decoder.astro
+++ b/src/pages/tools/jwt-decoder.astro
@@ -10,8 +10,8 @@ const tool = tools.find((t) => t.slug === 'jwt-decoder')!;
   <JwtDecoderTool client:load />
 
   <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">このツールについて</h2>
-    <p style="font-size: 1.06rem; font-weight: 400; line-height: 1.47; letter-spacing: -0.374px; color: rgba(0,0,0,0.8);">
+    <h2 class="mb-3 text-apple-dark dark:text-white tool-info-heading">このツールについて</h2>
+    <p class="tool-info-body">
       JWTトークンを <code class="rounded px-1 font-mono" style="background: #f5f5f7; font-size: 0.875rem;">.</code> で分割し、
       Base64URL デコードして Header・Payload・署名を表示します。
       <code class="rounded px-1 font-mono" style="background: #f5f5f7; font-size: 0.875rem;">exp</code>・
@@ -19,8 +19,8 @@ const tool = tools.find((t) => t.slug === 'jwt-decoder')!;
       <code class="rounded px-1 font-mono" style="background: #f5f5f7; font-size: 0.875rem;">nbf</code> は人間が読める日時に変換します。
       署名の検証は行いません。
     </p>
-    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">ユースケース</h3>
-    <ul class="list-inside list-disc space-y-1" style="font-size: 0.875rem; line-height: 1.29; letter-spacing: -0.224px; color: rgba(0,0,0,0.8);">
+    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white tool-info-heading">ユースケース</h3>
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
       <li>APIレスポンスのJWTトークンの中身を素早く確認したい</li>
       <li>有効期限（exp）が切れていないか確認したい</li>
       <li>Payloadに含まれるクレームを確認したい</li>

--- a/src/pages/tools/qr-code.astro
+++ b/src/pages/tools/qr-code.astro
@@ -10,12 +10,12 @@ const tool = tools.find((t) => t.slug === 'qr-code')!;
   <QrCodeGenerator client:load />
 
   <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">このツールについて</h2>
-    <p style="font-size: 1.06rem; font-weight: 400; line-height: 1.47; letter-spacing: -0.374px; color: rgba(0,0,0,0.8);">
+    <h2 class="mb-3 text-apple-dark dark:text-white tool-info-heading">このツールについて</h2>
+    <p class="tool-info-body">
       テキストやURLを入力するとQRコードをリアルタイムに生成します。SVG形式でダウンロードできます。
     </p>
-    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">誤り訂正レベルについて</h3>
-    <ul class="list-inside list-disc space-y-1" style="font-size: 0.875rem; line-height: 1.29; letter-spacing: -0.224px; color: rgba(0,0,0,0.8);">
+    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white tool-info-heading">誤り訂正レベルについて</h3>
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
       <li>L（7%）: データ量を優先。読み取り環境が良い場合に向く</li>
       <li>M（15%）: 標準的な用途に最適</li>
       <li>Q（25%）: 汚れや破損が想定される印刷物向け</li>

--- a/src/pages/tools/ulid-generator.astro
+++ b/src/pages/tools/ulid-generator.astro
@@ -10,12 +10,12 @@ const tool = tools.find((t) => t.slug === 'ulid-generator')!;
   <UlidGeneratorTool client:load />
 
   <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">このツールについて</h2>
-    <p style="font-size: 1.06rem; font-weight: 400; line-height: 1.47; letter-spacing: -0.374px; color: rgba(0,0,0,0.8);">
+    <h2 class="mb-3 text-apple-dark dark:text-white tool-info-heading">このツールについて</h2>
+    <p class="tool-info-body">
       ULIDはUUID v4の代替となるソート可能な一意識別子です。タイムスタンプ部分（最初の10文字）と乱数部分（残り16文字）で構成されます。
     </p>
-    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">ユースケース</h3>
-    <ul class="list-inside list-disc space-y-1" style="font-size: 0.875rem; line-height: 1.29; letter-spacing: -0.224px; color: rgba(0,0,0,0.8);">
+    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white tool-info-heading">ユースケース</h3>
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
       <li>データベースのプライマリキーとして使いたい</li>
       <li>時系列ソート可能なIDが必要</li>
       <li>UUIDより読みやすいIDが欲しい</li>

--- a/src/pages/tools/url-encode.astro
+++ b/src/pages/tools/url-encode.astro
@@ -12,16 +12,16 @@ const tool = tools.find((t) => t.slug === 'url-encode')!;
   <!-- Body Emphasis: 17px weight 600, line-height 1.24, tracking -0.374px -->
   <!-- Body: 17px weight 400, line-height 1.47, tracking -0.374px -->
   <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">このツールについて</h2>
-    <p style="font-size: 1.06rem; font-weight: 400; line-height: 1.47; letter-spacing: -0.374px; color: rgba(0,0,0,0.8);">
+    <h2 class="mb-3 text-apple-dark dark:text-white tool-info-heading">このツールについて</h2>
+    <p class="tool-info-body">
       URLエンコードとは、URLに使えない文字（日本語・スペース・記号など）を
       <code class="rounded px-1 font-mono" style="background: #f5f5f7; font-size: 0.875rem;">%XX</code>
       形式に変換する処理です。<br />
       フォームのGETパラメータや API のクエリ文字列を組み立てるときに活用できます。
     </p>
-    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white" style="font-size: 1.06rem; font-weight: 600; line-height: 1.24; letter-spacing: -0.374px;">ユースケース</h3>
+    <h3 class="mb-2 mt-4 text-apple-dark dark:text-white tool-info-heading">ユースケース</h3>
     <!-- Caption: 14px, line-height 1.29, tracking -0.224px -->
-    <ul class="list-inside list-disc space-y-1" style="font-size: 0.875rem; line-height: 1.29; letter-spacing: -0.224px; color: rgba(0,0,0,0.8);">
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
       <li>APIのクエリパラメータに日本語を渡したい</li>
       <li>URLに含めるデータを安全にエンコードしたい</li>
       <li>エンコードされた文字列を元のテキストに戻したい</li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -81,3 +81,26 @@
   --color-border-input: #D1D5DB; /* neutral-300 */
   --color-error-text:   #B91C1C; /* red-700 */
 }
+
+/* ツール説明セクションのテキストスタイル */
+.tool-info-heading {
+  font-size: 1.06rem;
+  font-weight: 600;
+  line-height: 1.24;
+  letter-spacing: -0.374px;
+}
+
+.tool-info-body {
+  font-size: 1.06rem;
+  font-weight: 400;
+  line-height: 1.47;
+  letter-spacing: -0.374px;
+  color: rgba(0, 0, 0, 0.8);
+}
+
+.tool-info-list {
+  font-size: 0.875rem;
+  line-height: 1.29;
+  letter-spacing: -0.224px;
+  color: rgba(0, 0, 0, 0.8);
+}

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,80 @@
+/**
+ * ファイルダウンロードユーティリティ
+ */
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/** SVG文字列をファイルとしてダウンロードする */
+export function downloadSvg(svgContent: string, filename: string): void {
+  triggerDownload(new Blob([svgContent], { type: 'image/svg+xml' }), filename);
+}
+
+/** SVG要素をファイルとしてダウンロードする */
+export function downloadSvgElement(svgEl: Element, filename: string): void {
+  downloadSvg(new XMLSerializer().serializeToString(svgEl), filename);
+}
+
+/** SVG文字列からPNG Blobを生成する（Retina x2倍）。SVGにwidth/height属性が必要 */
+export function svgContentToPngBlob(svgContent: string): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const m = svgContent.match(/width="(\d+)" height="(\d+)"/);
+    if (!m) { reject(new Error('SVG に width/height がありません')); return; }
+    const scale = 2;
+    const canvas = document.createElement('canvas');
+    canvas.width = parseInt(m[1], 10) * scale;
+    canvas.height = parseInt(m[2], 10) * scale;
+    const ctx = canvas.getContext('2d')!;
+    ctx.scale(scale, scale);
+    const img = new Image();
+    const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      canvas.toBlob((b) => {
+        if (b) resolve(b);
+        else reject(new Error('PNG 変換に失敗しました'));
+      }, 'image/png');
+    };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('SVG 読み込み失敗')); };
+    img.src = url;
+  });
+}
+
+/** SVG文字列からPNGをダウンロードする（Retina x2倍）。SVGにwidth/height属性が必要 */
+export function downloadPngFromSvgContent(svgContent: string, filename: string): Promise<void> {
+  return svgContentToPngBlob(svgContent).then((blob) => triggerDownload(blob, filename));
+}
+
+/**
+ * SVG要素からPNGをダウンロードする（getBoundingClientRectで寸法取得、Retina x2倍）
+ * 要素がDOMに描画されている必要がある
+ */
+export function downloadPngFromSvgElement(svgEl: SVGSVGElement, filename: string): void {
+  const { width, height } = svgEl.getBoundingClientRect();
+  const scale = 2;
+  const canvas = document.createElement('canvas');
+  canvas.width = width * scale;
+  canvas.height = height * scale;
+  const ctx = canvas.getContext('2d')!;
+  ctx.scale(scale, scale);
+  const img = new Image();
+  const blob = new Blob([svgEl.outerHTML], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  img.onload = () => {
+    ctx.drawImage(img, 0, 0);
+    URL.revokeObjectURL(url);
+    const a = document.createElement('a');
+    a.href = canvas.toDataURL('image/png');
+    a.download = filename;
+    a.click();
+  };
+  img.src = url;
+}

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, FocusEvent } from 'react';
 
 /**
  * DADSカラーシステム
@@ -48,3 +48,14 @@ export const caption: CSSProperties = {
 
 /** ヒント・補足テキスト（caption と同値。DADS最小サイズ12px禁止のため14pxに統一） */
 export const micro = caption;
+
+/** フォーカスリング表示（onFocus に渡す） */
+export function onFocusRing(e: FocusEvent<HTMLElement>): void {
+  e.currentTarget.style.outline = `2px solid ${colors.link}`;
+  e.currentTarget.style.outlineOffset = '2px';
+}
+
+/** フォーカスリング非表示（onBlur / onBlurCapture に渡す） */
+export function onBlurRing(e: FocusEvent<HTMLElement>): void {
+  e.currentTarget.style.outline = 'none';
+}


### PR DESCRIPTION
## 概要

各ツールコンポーネントに散在していた重複コードを、優先度の高いものから順に共通化しました。

## 変更内容

### 高優先度（3パターン）

- **フォーカスリング処理** — `utils/styles.ts` に `onFocusRing` / `onBlurRing` を追加し、全6ツールの重複インラインハンドラ（計11箇所）を削除
- **SVG/PNG ダウンロード処理** — `utils/download.ts` を新規作成（5関数）。`JanCode`・`Gs1Databar` の重複ロジックと `svgToPngBlob` を削除、`QrCode` も統一
- **CopyButton の重複実装** — `CopyButton` に `compact` プロパティを追加し、`UlidGenerator` の `RowCopyButton`（28行）を削除

### 中優先度（3パターン）

- **数値入力クランプ処理** — `src/hooks/useClampedInput.ts` を新規作成。`UlidGenerator`・`DummyText` の重複 change/blur ロジックを統合
- **モード切替タブ UI** — `src/components/ui/ToggleGroup.tsx` を新規作成。`JanCode`・`UrlEncoder` の重複タブ UI を統合
- **Astro ページのインラインスタイル** — `global.css` に `tool-info-heading` / `tool-info-body` / `tool-info-list` クラスを追加し、5ページ×複数箇所の重複インラインスタイル文字列を削除

### 共通 UI コンポーネント追加（今後の開発向け）

- **`InputField`** — label・input/textarea・error/hint・サンプルボタンを統合した汎用フォームフィールド。既存5ツールに適用済み。新規ツールでは生の `<input>` / `<textarea>` ではなくこちらを使うこと
- **`ErrorMessage`** — `role="alert"` 付きエラー表示コンポーネント
- **`DownloadButtonGroup`** — SVG/PNGダウンロードのボタンペア（`onDownloadPng` は省略可）

## 型チェック

`astro check` — エラー 0件

## 対象外（意図的に放置）

- バリデーション冒頭ガード節（2ファイル×2行、抽象化コスト > ベネフィット）
- チェックディジット計算（GS1/JAN でウェイト割り当て・戻り値型が異なり、共通化で複雑化するリスクあり）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)