### PR TITLE
fix: テキストエリアの縦位置ズレを修正

### DIFF
--- a/src/components/tools/JsonCsv.tsx
+++ b/src/components/tools/JsonCsv.tsx
@@ -103,7 +103,7 @@ export function JsonCsvTool() {
 
         {/* 出力 */}
         <div className="w-full md:flex-1 min-w-0">
-          <div className="flex items-center justify-between" style={{ marginBottom: '0.75rem' }}>
+          <div className="flex items-center justify-between" style={{ marginBottom: '0.75rem', minHeight: '2rem' }}>
             <label htmlFor="json-csv-output" style={{ ...bodyEmphasis, color: colors.text }}>出力</label>
             <div
               className="flex gap-2"
@@ -116,6 +116,7 @@ export function JsonCsvTool() {
                   className="rounded-lg px-3 py-1.5 transition-colors"
                   style={{
                     ...caption,
+                    lineHeight: 1,
                     color: colors.primary,
                     border: `1px solid ${colors.primary}`,
                     background: colors.bg,

--- a/src/components/tools/JsonXml.tsx
+++ b/src/components/tools/JsonXml.tsx
@@ -105,7 +105,7 @@ export function JsonXmlTool() {
 
         {/* 出力 */}
         <div className="w-full md:flex-1 min-w-0">
-          <div className="flex items-center justify-between" style={{ marginBottom: '0.75rem' }}>
+          <div className="flex items-center justify-between" style={{ marginBottom: '0.75rem', minHeight: '2rem' }}>
             <label htmlFor="json-xml-output" style={{ ...bodyEmphasis, color: colors.text }}>出力</label>
             <span style={{ visibility: output ? 'visible' : 'hidden' }}>
               <CopyButton text={output} label="コピー" />

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -56,7 +56,7 @@ export function InputField({
 
   return (
     <div>
-      <div className="flex items-center justify-between" style={{ marginBottom: '0.75rem' }}>
+      <div className="flex items-center justify-between" style={{ marginBottom: '0.75rem', minHeight: '2rem' }}>
         <label htmlFor={id} style={{ ...bodyEmphasis, color: colors.text }}>
           {label}
         </label>


### PR DESCRIPTION
## 概要

- ダウンロードボタンが `caption` スタイルの `lineHeight: 1.7` を継承し高さ38pxになっていたため、CopyButton（32px）との差でラベル行が高くなりテキストエリアの開始位置がずれていた
- `lineHeight: 1` を追加してボタン高さを揃え、入力・出力テキストエリアの縦位置を修正
- `InputField` のラベル行に `minHeight: 2rem` を追加し、サンプルボタン有無による高さ差をなくす防御的修正も適用

## 変更ファイル

- `src/components/tools/JsonCsv.tsx` — ダウンロードボタンに `lineHeight: 1` を追加
- `src/components/tools/JsonXml.tsx` — 出力ラベル行に `minHeight: 2rem` を追加
- `src/components/ui/InputField.tsx` — ラベル行に `minHeight: 2rem` を追加

## テスト

- `astro check`: エラー0件
- `vitest run`: 78件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)