### PR TITLE
feat: GS1 DataBar の可変長AI に isVariableLength フラグを追加（FNC1 対応の明示）

### DIFF
--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -3,8 +3,30 @@ import {
   calcGtin14CheckDigit,
   validateGtin14Input,
   buildBwipText,
+  AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
+
+// ────────────────────────────────────────────
+// AI_DEFS: isVariableLength
+// ────────────────────────────────────────────
+describe('AI_DEFS isVariableLength', () => {
+  it('固定長AI (17, 11, 15) は isVariableLength=false', () => {
+    const fixedAis = ['17', '11', '15'];
+    for (const ai of fixedAis) {
+      const def = AI_DEFS.find((d) => d.ai === ai);
+      expect(def?.isVariableLength, `AI ${ai} should be fixed-length`).toBe(false);
+    }
+  });
+
+  it('可変長AI (10, 21) は isVariableLength=true', () => {
+    const variableAis = ['10', '21'];
+    for (const ai of variableAis) {
+      const def = AI_DEFS.find((d) => d.ai === ai);
+      expect(def?.isVariableLength, `AI ${ai} should be variable-length`).toBe(true);
+    }
+  });
+});
 
 // ────────────────────────────────────────────
 // calcGtin14CheckDigit

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -54,6 +54,13 @@ export interface AiEntry {
   ai: AiCode;
   label: string;
   placeholder: string;
+  /**
+   * 可変長AIかどうか。
+   * true の場合、後続AIが存在するときバーコード内でFNC1区切りが必要。
+   * FNC1の挿入は bwip-js の gs1process() が自動で処理するため、
+   * buildBwipText() での明示的な挿入は不要。
+   */
+  isVariableLength: boolean;
   /** 入力値のバリデーション。エラーメッセージを返す（正常時は空文字） */
   validate: (value: string) => string;
 }
@@ -63,6 +70,7 @@ export const AI_DEFS: AiEntry[] = [
     ai: '17',
     label: '賞味/消費期限 (17)',
     placeholder: 'YYMMDD (例: 231231)',
+    isVariableLength: false,
     validate: (v) => {
       if (!v) return '';
       if (!/^\d{6}$/.test(v)) return 'YYMMDD形式の6桁を入力してください';
@@ -77,6 +85,7 @@ export const AI_DEFS: AiEntry[] = [
     ai: '10',
     label: 'ロット番号 (10)',
     placeholder: '英数字 (例: ABC123)',
+    isVariableLength: true,
     validate: (v) => {
       if (!v) return '';
       if (!/^[\x20-\x7E]{1,20}$/.test(v))
@@ -88,6 +97,7 @@ export const AI_DEFS: AiEntry[] = [
     ai: '11',
     label: '製造日 (11)',
     placeholder: 'YYMMDD (例: 230101)',
+    isVariableLength: false,
     validate: (v) => {
       if (!v) return '';
       if (!/^\d{6}$/.test(v)) return 'YYMMDD形式の6桁を入力してください';
@@ -102,6 +112,7 @@ export const AI_DEFS: AiEntry[] = [
     ai: '15',
     label: '最良品質保持期限 (15)',
     placeholder: 'YYMMDD (例: 231231)',
+    isVariableLength: false,
     validate: (v) => {
       if (!v) return '';
       if (!/^\d{6}$/.test(v)) return 'YYMMDD形式の6桁を入力してください';
@@ -116,6 +127,7 @@ export const AI_DEFS: AiEntry[] = [
     ai: '21',
     label: 'シリアル番号 (21)',
     placeholder: '英数字 (例: SN001)',
+    isVariableLength: true,
     validate: (v) => {
       if (!v) return '';
       if (!/^[\x20-\x7E]{1,20}$/.test(v))
@@ -128,6 +140,10 @@ export const AI_DEFS: AiEntry[] = [
 /**
  * bwip-js の databarlimitedcomposite 用テキスト文字列を組み立てる
  * フォーマット: (01)GTIN14|(AI1)value1(AI2)value2...
+ *
+ * FNC1（可変長AIの終端区切り文字）の挿入は bwip-js の gs1process() が
+ * 自動で処理する。isVariableLength=true のAIが後続AIを持つ場合、
+ * ライブラリ内部でFNC1が自動挿入されるため、この関数での明示的な挿入は不要。
  *
  * @param fullGtin - 14桁のGTIN
  * @param compositeFields - AI→値のペア配列（値が空のものは除外）


### PR DESCRIPTION
## 概要

GS1 DataBar の可変長 AI（ロット番号・シリアル番号）は、後続 AI が存在する場合にバーコード内で FNC1（Function1）区切り文字が必要です。

調査の結果、bwip-js の `gs1process()` が `(AI)value` 形式を解析して FNC1 を自動挿入するため、コード側での明示的な処理は不要であることが判明しました。ただし、その設計意図がコードから読み取れないため、今回のPRで明示的に記録します。

## 変更内容

- `AiEntry` インターフェースに `isVariableLength: boolean` フラグを追加
  - `false`：AI `17`（賞味期限）、`11`（製造日）、`15`（品質保持期限）— 固定長 6 桁
  - `true`：AI `10`（ロット番号）、`21`（シリアル番号）— 可変長 最大 20 文字
- `buildBwipText()` のコメントに「FNC1 は bwip-js が自動挿入する」旨を追記
- `AI_DEFS isVariableLength` テストスイートを追加

## テスト

- ユニットテスト 18件 全パス
- 型エラー 0件（`astro check`）

## 参考

GS1 仕様：可変長データの終端には FNC1 を置く必要があるが、bwip-js の `bwipp_gs1process()` 内部で固定長 AI リスト（`aifixed`）と照合して自動挿入されるため、`(AI)value` 形式で渡す限り追加実装は不要。