### PR TITLE
fix: PWA強制ダークモード対策とJSON/XML説明文の誤記修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | URLエンコード/デコード | テキストとURLエンコード形式を相互変換                 |
 | Base64 エンコード/デコード | テキストと Base64 を相互変換。標準・URL-safe 両形式に対応 |
 | JWTデコーダー          | Header・Payload・署名を分解表示。HS/RS/ES署名検証対応 |
-| JSON / XML 変換        | JSONとXMLを相互変換。ルートタグ名指定対応             |
+| JSON / XML 変換        | JSONとXMLを相互変換。ルートタグは root 固定           |
 | JSON / CSV 変換        | JSONとCSVを相互変換。ネストオブジェクトはドット記法でフラット化 |
 
 ## 技術スタック

--- a/SPEC.md
+++ b/SPEC.md
@@ -219,7 +219,7 @@ devtools/
 | 7   | JWTデコーダー          | `jwt-decoder` | JWTトークン貼り付け → Header/Payload/署名を分解表示。HS/RS/ES署名検証対応 |
 | 8   | URLエンコード/デコード | `url-encode`  | テキスト⇔URLエンコード相互変換                                            |
 | 9   | Base64エンコード/デコード | `base64`   | テキスト⇔Base64 相互変換。通常の Base64 と URL-safe Base64 に対応          |
-| 10  | JSON / XML 変換        | `json-xml`    | JSON⇔XML 相互変換。ルートタグ名指定対応、XML属性は `@_` プレフィックス形式 |
+| 10  | JSON / XML 変換        | `json-xml`    | JSON⇔XML 相互変換。ルートタグは `root` 固定、XML属性は `@_` プレフィックス形式 |
 | 11  | JSON / CSV 変換        | `json-csv`    | JSON⇔CSV 相互変換。ネストオブジェクトはドット記法でフラット化              |
 
 ---

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -65,7 +65,7 @@ export const tools: Tool[] = [
   {
     slug: 'json-xml',
     name: 'JSON / XML 変換',
-    description: 'JSONとXMLを相互変換します。ルートタグ名指定対応',
+    description: 'JSONとXMLを相互変換します。ルートタグは root 固定',
     category: 'convert',
   },
   {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,12 +96,12 @@
   font-weight: 400;
   line-height: 1.47;
   letter-spacing: -0.374px;
-  color: rgba(0, 0, 0, 0.8);
+  color: var(--color-text);
 }
 
 .tool-info-list {
   font-size: 0.875rem;
   line-height: 1.29;
   letter-spacing: -0.224px;
-  color: rgba(0, 0, 0, 0.8);
+  color: var(--color-text);
 }


### PR DESCRIPTION
## 変更内容

### PWA Android ダークモード対策
- `src/styles/global.css` の `.tool-info-body` / `.tool-info-list` のテキストカラーを `rgba(0, 0, 0, 0.8)` から `var(--color-text)` に変更
- Android PWA インストール時に強制ダークモードが適用されると背景が暗転し、ハードコードされた黒色テキストが見えなくなる問題を修正
- ダークモード対応時は `--color-text` を上書きするだけで対応できる構成に統一

### JSON/XML 変換の説明文誤記修正
- 「ルートタグ名指定対応」→「ルートタグは root 固定」に修正（実装と一致）
- 修正対象: `src/data/tools.ts`、`README.md`、`SPEC.md`

## テスト計画
- [ ] ブラウザで各ツールページの「このツールについて」セクションのテキストが正常に表示されることを確認
- [ ] JSON/XML 変換ページの説明文が正しく表示されることを確認