### PR TITLE
fix: AndroidのPWAダークモードで「このツールについて」テキストが白くなる問題を修正

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,9 @@
 @import '@fontsource/noto-sans-jp/700.css';
 @import '@fontsource/jetbrains-mono/400.css';
 
+/* ダークモード未サポート: dark: クラスはメディアクエリではなく .dark クラス指定時のみ適用 */
+@variant dark (&:where(.dark, .dark *));
+
 @theme {
   --font-sans:
     'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
## 概要

AndroidのPWAダークモード環境で、全ツールの「このツールについて」セクションの見出しテキストが白背景上に白文字で表示されて読めなくなる問題を修正した。

## 原因

- Tailwind v4 のデフォルトでは `dark:` がOSの `prefers-color-scheme: dark` メディアクエリに紐づく
- AndroidのPWAがダークモードのとき `dark:text-white` が発火し、見出しが白文字になる
- 一方 `bg-white` の背景は変化しないため、白地に白テキストで不可視になっていた

## 修正内容

`src/styles/global.css` に1行追加：

```css
@variant dark (&:where(.dark, .dark *));
```

`dark:` の適用条件をメディアクエリから `.dark` クラス指定に変更。本プロジェクトはダークモード未サポートで `.dark` を付与しないため、`dark:` 系クラスが一切発火しなくなる。全ツールページに一括適用される。

## 影響範囲

- `src/styles/global.css` のみ（全ページに反映）
- ダークモード対応を将来追加するときは `html` 要素に `.dark` クラスを付与する設計を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)