### PR TITLE
develop → main: AndroidのPWAダークモード対応修正

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,9 @@
 @import '@fontsource/noto-sans-jp/700.css';
 @import '@fontsource/jetbrains-mono/400.css';
 
+/* ダークモード未サポート: dark: クラスはメディアクエリではなく .dark クラス指定時のみ適用 */
+@variant dark (&:where(.dark, .dark *));
+
 @theme {
   --font-sans:
     'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
## 概要

`develop` ブランチの変更を `main` にマージする。

## 含まれる変更

- #30 fix: AndroidのPWAダークモードで「このツールについて」テキストが白くなる問題を修正

## 変更内容

Tailwind v4 の `dark:` をメディアクエリからクラスベースに変更し、AndroidのPWAダークモード環境で全ツールの「このツールについて」見出しが白背景上に白文字で不可視になる問題を解消した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)