### PR TITLE
fix: スマホ幅でのコピーボタンはみ出しとヘッダー表示を改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,11 @@ UIコンポーネントやレイアウトを変更した場合、コミット前
 ### Playwright ツール呼び出し例
 
 ```
-browser_navigate → URL
+# 0. キャッシュクリア（必須）
+browser_evaluate: caches.keys() → caches.delete() / localStorage.clear() / sessionStorage.clear()
+browser_navigate → URL（キャッシュなし再取得）
+
+# 1. PC・スマホ両サイズで撮影
 browser_resize → width: 1280, height: 800 → browser_take_screenshot
 browser_resize → width: 390, height: 844 → browser_take_screenshot
 ```

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -3,7 +3,7 @@
 ---
 
 <footer class="bg-neutral-900 text-neutral-300">
-  <div class="mx-auto max-w-280 px-6 py-12">
+  <div class="mx-auto max-w-280 px-4 sm:px-6 py-12">
     <div class="flex flex-col gap-3 sm:flex-row sm:justify-between">
       <p class="text-sm text-neutral-500" style="letter-spacing: 0.02em;">
         © 2026 DevTools — すべての処理はブラウザ内で完結します

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -3,7 +3,7 @@
 ---
 
 <header class="sticky top-0 z-50 bg-white border-b border-neutral-200" style="height: 64px;">
-  <div class="mx-auto flex h-full max-w-280 items-center px-6">
+  <div class="mx-auto flex h-full max-w-280 items-center px-4 sm:px-6">
     <a
       href="/"
       class="text-xl font-bold text-primary transition-opacity hover:opacity-80"

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -245,7 +245,12 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
               >
                 {gtinResult.fullGtin}
               </span>
-              <CopyButton text={gtinResult.fullGtin} label="コピー" />
+              <span className="hidden sm:inline-flex">
+                <CopyButton text={gtinResult.fullGtin} label="コピー" />
+              </span>
+              <span className="sm:hidden inline-flex">
+                <CopyButton text={gtinResult.fullGtin} compact />
+              </span>
             </div>
           </div>
         )}

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -29,7 +29,7 @@ const jsonLd = {
 ---
 
 <BaseLayout title={tool.name} description={tool.description} jsonLd={jsonLd}>
-  <div class="mx-auto flex max-w-280 gap-6 px-6 py-8">
+  <div class="mx-auto flex max-w-280 gap-6 px-4 sm:px-6 py-8">
     <!-- サイドバー (デスクトップ) -->
     <div class="hidden lg:block">
       <Sidebar currentSlug={tool.slug} />
@@ -68,7 +68,7 @@ const jsonLd = {
           </p>
         </div>
         <span
-          class="shrink-0 rounded-full px-3 py-1 font-bold text-blue-800 bg-blue-100"
+          class="hidden sm:inline-block shrink-0 rounded-full px-3 py-1 font-bold text-blue-800 bg-blue-100"
           style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em;"
         >
           {categoryLabel[tool.category]}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const jsonLd = {
   </section>
 
   <!-- ツール一覧 -->
-  <main class="mx-auto max-w-280 px-6 py-8">
+  <main class="mx-auto max-w-280 px-4 sm:px-6 py-8">
     <!-- タブ -->
     <div
       id="tab-bar"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,6 +4,35 @@
 
 ---
 
+## [2026-04-25] Playwright 確認前にブラウザキャッシュをクリアする
+
+### 現象
+
+Playwright でスクリーンショットを撮影したとき、Service Worker キャッシュや localStorage に古いデータが残っており、実際の変更が映り込まなかった。ユーザーが毎回ブラウザの「デバイス上のサイトデータ」を手動削除する必要があった。
+
+### 教訓
+
+**Playwright でスクリーンショット確認をする前に、必ずキャッシュをクリアしてからリロードする。**
+
+### 手順
+
+```js
+// 1. browser_evaluate でキャッシュ削除
+const keys = await caches.keys();
+await Promise.all(keys.map(k => caches.delete(k)));
+localStorage.clear();
+sessionStorage.clear();
+
+// 2. browser_navigate でリロード（キャッシュなし再取得）
+// 3. その後スクリーンショット撮影
+```
+
+### 予防策
+
+UIコンポーネント・レイアウト変更後の Playwright 確認手順に「キャッシュクリア → リロード → 撮影」を必ず含める。
+
+---
+
 ## [2026-04-25] SVG 手動組立時の XSS 対策（GS1データバー）
 
 ### 現象


### PR DESCRIPTION
## 概要

スマホサイズ（390px幅）で発生していた2つのレイアウト問題を修正します。

- **GS1 DataBar コピーボタンのはみ出し**: GTIN-14結果行で14桁の数字＋コピーボタンがカード幅（約326px）を超えていた
- **ツールページヘッダーの表示が狭い**: カテゴリバッジが固定幅で場所を取り、タイトル列が約110pxしか確保できなかった

## 変更内容

### `src/components/tools/Gs1Databar.tsx`
- GTIN-14結果行のコピーボタンをレスポンシブ切替に変更
  - `sm`（640px）以上：ラベル付き「コピー」ボタン（従来通り）
  - `sm` 未満：アイコンのみのコンパクトボタン（`compact` prop、`UlidGenerator` 等で実績あり）

### `src/layouts/ToolLayout.astro`（全ツールページ共通）
- 外側余白を `px-6` → `px-4 sm:px-6` に変更（スマホで左右16px広がる）
- カテゴリバッジに `hidden sm:inline-block` を追加（パンくずリストに既にカテゴリ名が表示されるため情報の欠落なし）

## 確認方法

```
npm run dev
# http://localhost:4321/tools/gs1-databar でサンプルを入力
# 390x844 でスクリーンショット確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)