### PR TITLE
refactor: エラーメッセージ取得を getErrorMessage ヘルパーに集約

### DIFF
--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -4,6 +4,7 @@ import { InputField } from '@/components/ui/InputField';
 import { OutputField } from '@/components/ui/OutputField';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { caption, colors } from '@/utils/styles';
+import { getErrorMessage } from '@/utils/errors';
 import { downloadBytes } from '@/utils/download';
 import {
   detectEncoding,
@@ -99,7 +100,7 @@ export function EncodingConverterTool() {
     } catch (e) {
       setDetection(null);
       setDecodedPreview('');
-      setError(e instanceof Error ? e.message : '判定に失敗しました');
+      setError(getErrorMessage(e, '判定に失敗しました'));
     }
   }
 
@@ -135,7 +136,7 @@ export function EncodingConverterTool() {
     } catch (e) {
       setOutputBytes(null);
       setOutputPreview('');
-      setError(e instanceof Error ? e.message : '変換に失敗しました');
+      setError(getErrorMessage(e, '変換に失敗しました'));
     }
   }
 

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { getErrorMessage } from '@/utils/errors';
 import bwipjs from 'bwip-js';
 import JSZip from 'jszip';
 import { CopyButton } from '@/components/ui/CopyButton';
@@ -118,7 +119,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
       onSvgChangeRef.current(finalSvg, gtinResult.fullGtin);
     } catch (e) {
       setSvgContent('');
-      setBwipError(e instanceof Error ? e.message : 'バーコード生成に失敗しました');
+      setBwipError(getErrorMessage(e, 'バーコード生成に失敗しました'));
       onSvgChangeRef.current('', '');
     }
   }, [gtinInput, gtinError, aiFields, gtinResult, allAiValid, hasAnyAiValue]);

--- a/src/hooks/useCodec.ts
+++ b/src/hooks/useCodec.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { DependencyList } from 'react';
+import { getErrorMessage } from '@/utils/errors';
 
 interface UseCodecOptions {
   /** デバウンス（ms）。既定 300。 */
@@ -40,7 +41,7 @@ export function useCodec(
         setError('');
       } catch (e) {
         setOutput('');
-        setError(e instanceof Error ? e.message : fallbackError);
+        setError(getErrorMessage(e, fallbackError));
       }
     }, debounceMs);
     return () => clearTimeout(timer);

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { getErrorMessage } from '@/utils/errors';
+
+const FALLBACK = 'フォールバックメッセージ';
+
+// ────────────────────────────────────────────
+// Error インスタンス
+// ────────────────────────────────────────────
+describe('getErrorMessage — Error インスタンス', () => {
+  it('Error インスタンスは message を返す', () => {
+    expect(getErrorMessage(new Error('エラーが発生しました'), FALLBACK)).toBe('エラーが発生しました');
+  });
+
+  it('TypeError などの Error サブクラスも message を返す', () => {
+    expect(getErrorMessage(new TypeError('型エラー'), FALLBACK)).toBe('型エラー');
+    expect(getErrorMessage(new RangeError('範囲エラー'), FALLBACK)).toBe('範囲エラー');
+  });
+
+  it('message が空文字の Error は空文字を返す（fallback ではない）', () => {
+    expect(getErrorMessage(new Error(''), FALLBACK)).toBe('');
+  });
+});
+
+// ────────────────────────────────────────────
+// 非 Error 値
+// ────────────────────────────────────────────
+describe('getErrorMessage — 非 Error 値', () => {
+  it('文字列は fallback を返す', () => {
+    expect(getErrorMessage('string error', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('null は fallback を返す', () => {
+    expect(getErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('undefined は fallback を返す', () => {
+    expect(getErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('数値は fallback を返す', () => {
+    expect(getErrorMessage(42, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('message プロパティを持つプレーンオブジェクトは fallback を返す', () => {
+    expect(getErrorMessage({ message: 'オブジェクトエラー' }, FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,7 @@
+/**
+ * unknown 型の例外値から表示用メッセージを取り出す。
+ * Error インスタンスなら `message` を、それ以外は fallback を返す。
+ */
+export function getErrorMessage(e: unknown, fallback: string): string {
+  return e instanceof Error ? e.message : fallback;
+}


### PR DESCRIPTION
## 概要

`unknown` 型の例外から表示用文字列を取り出す `getErrorMessage(e, fallback)` を `src/utils/errors.ts` に追加し、コードベース内で重複していた `instanceof Error` イディオム 4 箇所を置換。

## 変更内容

- **新規** `src/utils/errors.ts` — `getErrorMessage(e: unknown, fallback: string): string` を 1 関数追加
- **修正** `src/hooks/useCodec.ts` — 1 箇所置換
- **修正** `src/components/tools/EncodingConverter.tsx` — 2 箇所置換（判定・変換エラー）
- **修正** `src/components/tools/Gs1Databar.tsx` — 1 箇所置換

## やらなかったこと（YAGNI）

- `useAsyncAction` / `useTryCatch` フック追加なし（各ツールの state 構造が異なるため）
- エラーメッセージ定数化なし（各ツール固有のフォールバック文言を維持）
- Result 型導入なし（`src/utils/*.ts` 全書き換えが必要で投資量に見合わない）
- QrTicket の `} catch { ... }` 系は非対象（`instanceof Error` チェックがなく today 動作変更なし）

## テスト計画

- [ ] `node_modules/.bin/astro check` — 型エラー 0 件（実施済み）
- [ ] Base64 ツールで不正な base64 入力 → エラーメッセージ表示を確認
- [ ] EncodingConverter で判定・変換エラーの表示を確認
- [ ] GS1 Databar で不正な GTIN 入力時のエラー表示を確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)