### PR TITLE
perf: normalizeNewlines を上限アロケート方式に最適化（issue #54）

### DIFF
--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -137,19 +137,25 @@ export const NEWLINE_OPTIONS: Array<{ value: NewlineMode; label: string }> = [
 export function normalizeNewlines(bytes: Uint8Array, mode: NewlineMode): Uint8Array {
   if (mode === 'keep' || bytes.length === 0) return bytes;
 
-  const out: number[] = [];
   if (mode === 'lf') {
+    // 出力は最大でも入力長（CRLF→LF は 1 バイト減のみ）
+    const out = new Uint8Array(bytes.length);
+    let w = 0;
     for (let i = 0; i < bytes.length; i++) {
       if (bytes[i] === 0x0d && bytes[i + 1] === 0x0a) continue; // CR を捨てて次で LF を出力
-      out.push(bytes[i]);
+      out[w++] = bytes[i];
     }
-  } else {
-    for (let i = 0; i < bytes.length; i++) {
-      if (bytes[i] === 0x0a && bytes[i - 1] !== 0x0d) out.push(0x0d);
-      out.push(bytes[i]);
-    }
+    return out.subarray(0, w);
   }
-  return Uint8Array.from(out);
+
+  // crlf: 出力は最大で入力長 * 2（全 LF が CRLF に変わるワースト）
+  const out = new Uint8Array(bytes.length * 2);
+  let w = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0x0a && bytes[i - 1] !== 0x0d) out[w++] = 0x0d;
+    out[w++] = bytes[i];
+  }
+  return out.subarray(0, w);
 }
 
 // トグルボタン用の短縮ラベル (4文字以内 or ASCII)。検出結果カードの表示には ENCODING_LABELS を使う

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -142,7 +142,7 @@ export function normalizeNewlines(bytes: Uint8Array, mode: NewlineMode): Uint8Ar
     const out = new Uint8Array(bytes.length);
     let w = 0;
     for (let i = 0; i < bytes.length; i++) {
-      if (bytes[i] === 0x0d && bytes[i + 1] === 0x0a) continue; // CR を捨てて次で LF を出力
+      if (bytes[i] === 0x0d && i + 1 < bytes.length && bytes[i + 1] === 0x0a) continue; // CR を捨てて次で LF を出力
       out[w++] = bytes[i];
     }
     return out.subarray(0, w);
@@ -152,7 +152,7 @@ export function normalizeNewlines(bytes: Uint8Array, mode: NewlineMode): Uint8Ar
   const out = new Uint8Array(bytes.length * 2);
   let w = 0;
   for (let i = 0; i < bytes.length; i++) {
-    if (bytes[i] === 0x0a && bytes[i - 1] !== 0x0d) out[w++] = 0x0d;
+    if (bytes[i] === 0x0a && (i === 0 || bytes[i - 1] !== 0x0d)) out[w++] = 0x0d;
     out[w++] = bytes[i];
   }
   return out.subarray(0, w);


### PR DESCRIPTION
## 概要

issue #54 で提案された `normalizeNewlines` の最適化を実施。

`number[]` への `push` + `Uint8Array.from()` 変換を廃止し、事前アロケートした `Uint8Array` に直接インデックス書き込みする方式に変更。

## 変更内容

- `lf` モード: `new Uint8Array(bytes.length)` を確保 → 直接書き込み → `subarray(0, w)` で返す
- `crlf` モード: `new Uint8Array(bytes.length * 2)` を確保（ワーストケース上限）→ 直接書き込み → `subarray(0, w)` で返す
- `keep` モード・空入力: 従来通り入力参照をそのまま返す（変更なし）

## テスト結果

- ユニットテスト（`encoding.test.ts`）: **21 ケース全て緑**
- E2E テスト ケース K/L/M/N（`encoding-converter.spec.ts`）: **4 ケース全て緑**
- 型チェック（`astro check`）: **エラーゼロ**

## Closes

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)