### PR TITLE
refactor: 文字コード選択UIをToggleGroupからSelectに置き換え

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -116,6 +116,7 @@ devtools/
     │   │   ├── ErrorMessage.tsx
     │   │   ├── InputField.tsx
     │   │   ├── OutputField.tsx          # 出力カード共通UI（ラベル＋CopyButton＋readOnly textarea）
+    │   │   ├── Select.tsx               # ジェネリックセレクトボックス
     │   │   ├── ToggleGroup.tsx
     │   │   └── ToolIcon.astro           # slug → SVG アイコンマッピング
     │   └── tools/
@@ -794,6 +795,7 @@ devtools/
 | `ErrorMessage` | `role="alert"` 付きエラーテキスト |
 | `DownloadButtonGroup` | SVG／PNG ダウンロードボタンのペア |
 | `ToggleGroup<T>` | モード切替などの排他選択トグル |
+| `Select<T>` | 選択肢が多い場合（目安7択以上）のジェネリックセレクトボックス |
 
 #### 共通フック（`src/hooks/`）
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1100,3 +1100,35 @@ CLAUDE.md（プロジェクト規約）で「Tailwind のカラークラス（`t
 - ✅ ダークモード追加（[003] 参照）時には CSS 変数値の差し替えだけで全箇所が追従
 - ⚠️ ホバー切替を毎回 `onMouseEnter`/`onMouseLeave` 2 行で書く必要がある。頻出するなら将来的に `useHoverStyle` フックに括り出す余地あり
 - ⚠️ ページ／レイアウト系（`src/pages/*.astro`、`src/components/layout/*`、`src/components/ui/DownloadButtonGroup.tsx`）には Tailwind 色クラスが残存している。今回はツール本体の規約違反のみをスコープとし、ページ／レイアウトは別タスクで扱う
+
+---
+
+## [034] 文字コード選択UIを ToggleGroup から Select に変更
+
+### 背景
+
+`EncodingConverter.tsx` の文字コード選択は「元の文字コード（7択）」「変換後の文字コード（6択）」と選択肢が多い。`ToggleGroup` は `gridTemplateColumns: repeat(N, 1fr)` の単一行前提で、7択を1行に並べると横潰れ・スマホ崩れが発生するため、ROW1/ROW2 に分割して `some()` で「他行が選択中なら自分は非選択」とみなすワークアラウンドで実装していた。
+
+### 決断
+
+ネイティブ `<select>` を使った `Select<T>` 共通コンポーネント（`src/components/ui/Select.tsx`）を新規作成し、文字コード選択に採用する。`ToggleGroup` と同じジェネリック API 形状（`options / value / onChange / ariaLabel`）にして将来の置き換えも容易にした。
+
+理由:
+- **a11y**: ネイティブ要素のため矢印キー操作・スクリーンリーダー読み上げが OS 標準で完璧
+- **スマホ対応**: OS ネイティブピッカーが開くため幅不足の心配がない
+- **コード簡潔化**: `some()` ワークアラウンドと2行分の `ToggleGroup` が1行の `Select` に集約
+- **縦スペース節約**: ラベル＋2行が1行に収まる
+
+「自動判定」は Select の先頭オプションとして他の選択肢と同列に並べた。
+
+### 却下した選択肢
+
+- **ToggleGroup を flex-wrap 対応に改修**: 見た目は保てるが、`ToggleGroup` のアーキテクチャ（単一行 `grid`）から大きく外れ、`some()` ワークアラウンドは残ったまま。a11y 改善効果もない。
+- **ハイブリッド（「自動判定」のみ独立トグル + Select）**: 操作のアフォーダンスが混在して一貫性が下がる。ユーザーが「Select に統一」を選択したため採用しない。
+
+### 結果・トレードオフ
+
+- ✅ `some()` ワークアラウンドが解消し、`encoding.ts` の選択肢配列が統合（`SOURCE_ENCODINGS` / `TARGET_ENCODINGS`）
+- ✅ スマホ・タブレットでネイティブピッカーが使える
+- ✅ a11y 向上（矢印キー選択・スクリーンリーダー対応）
+- ⚠️ ToggleGroup に比べて「選択肢をひと目で見比べる」体験が失われる（クリックで開く必要がある）。ただし7択の文字コードは短縮名（UTF-8/SJIS 等）で差異が大きく、ひと目で比較するメリットは薄い

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
+import { Select } from '@/components/ui/Select';
 import { InputField } from '@/components/ui/InputField';
 import { OutputField } from '@/components/ui/OutputField';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
@@ -15,10 +16,8 @@ import {
   ENCODING_LABELS,
   BOM_ENCODINGS,
   UTF16_ENCODINGS,
-  SOURCE_ENCODINGS_ROW1,
-  SOURCE_ENCODINGS_ROW2,
-  TARGET_ENCODINGS_ROW1,
-  TARGET_ENCODINGS_ROW2,
+  SOURCE_ENCODINGS,
+  TARGET_ENCODINGS,
   NEWLINE_OPTIONS,
   type EncodingName,
   type SourceEncoding,
@@ -337,40 +336,24 @@ export function EncodingConverterTool() {
             <div style={{ ...caption, color: colors.muted, marginBottom: '0.5rem' }}>
               元の文字コード:
             </div>
-            <div className="space-y-2">
-              <ToggleGroup
-                options={SOURCE_ENCODINGS_ROW1}
-                value={SOURCE_ENCODINGS_ROW1.some((o) => o.value === sourceEnc) ? sourceEnc : undefined}
-                onChange={(v) => setSourceEnc(v as SourceEncoding)}
-                ariaLabel="元の文字コード (AUTO・UTF-8・SJIS・EUC-JP)"
-              />
-              <ToggleGroup
-                options={SOURCE_ENCODINGS_ROW2}
-                value={SOURCE_ENCODINGS_ROW2.some((o) => o.value === sourceEnc) ? sourceEnc : undefined}
-                onChange={(v) => setSourceEnc(v as SourceEncoding)}
-                ariaLabel="元の文字コード (JIS・UTF-16)"
-              />
-            </div>
+            <Select
+              options={SOURCE_ENCODINGS}
+              value={sourceEnc}
+              onChange={(v) => setSourceEnc(v as SourceEncoding)}
+              ariaLabel="元の文字コード"
+            />
           </div>
 
           <div>
             <div style={{ ...caption, color: colors.muted, marginBottom: '0.5rem' }}>
               変換後の文字コード:
             </div>
-            <div className="space-y-2">
-              <ToggleGroup
-                options={TARGET_ENCODINGS_ROW1}
-                value={TARGET_ENCODINGS_ROW1.some((o) => o.value === targetEnc) ? targetEnc : undefined}
-                onChange={(v) => setTargetEnc(v as EncodingName)}
-                ariaLabel="変換後の文字コード (UTF-8・SJIS・EUC-JP)"
-              />
-              <ToggleGroup
-                options={TARGET_ENCODINGS_ROW2}
-                value={TARGET_ENCODINGS_ROW2.some((o) => o.value === targetEnc) ? targetEnc : undefined}
-                onChange={(v) => setTargetEnc(v as EncodingName)}
-                ariaLabel="変換後の文字コード (JIS・UTF-16)"
-              />
-            </div>
+            <Select
+              options={TARGET_ENCODINGS}
+              value={targetEnc}
+              onChange={(v) => setTargetEnc(v as EncodingName)}
+              ariaLabel="変換後の文字コード"
+            />
           </div>
 
           {UTF16_ENCODINGS.has(targetEnc) ? (

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -333,10 +333,14 @@ export function EncodingConverterTool() {
       {mode === 'convert' && (
         <div className="space-y-3">
           <div>
-            <div style={{ ...caption, color: colors.muted, marginBottom: '0.5rem' }}>
+            <label
+              htmlFor="enc-source"
+              style={{ ...caption, color: colors.muted, marginBottom: '0.5rem', display: 'block' }}
+            >
               元の文字コード:
-            </div>
+            </label>
             <Select
+              id="enc-source"
               options={SOURCE_ENCODINGS}
               value={sourceEnc}
               onChange={(v) => setSourceEnc(v as SourceEncoding)}
@@ -345,10 +349,14 @@ export function EncodingConverterTool() {
           </div>
 
           <div>
-            <div style={{ ...caption, color: colors.muted, marginBottom: '0.5rem' }}>
+            <label
+              htmlFor="enc-target"
+              style={{ ...caption, color: colors.muted, marginBottom: '0.5rem', display: 'block' }}
+            >
               変換後の文字コード:
-            </div>
+            </label>
             <Select
+              id="enc-target"
               options={TARGET_ENCODINGS}
               value={targetEnc}
               onChange={(v) => setTargetEnc(v as EncodingName)}

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -344,7 +344,6 @@ export function EncodingConverterTool() {
               options={SOURCE_ENCODINGS}
               value={sourceEnc}
               onChange={(v) => setSourceEnc(v as SourceEncoding)}
-              ariaLabel="元の文字コード"
             />
           </div>
 
@@ -360,7 +359,6 @@ export function EncodingConverterTool() {
               options={TARGET_ENCODINGS}
               value={targetEnc}
               onChange={(v) => setTargetEnc(v as EncodingName)}
-              ariaLabel="変換後の文字コード"
             />
           </div>
 

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/utils/gs1-databar';
 import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '@/utils/styles';
 import { InputField } from '@/components/ui/InputField';
+import { Select } from '@/components/ui/Select';
 import { DownloadButtonGroup } from '@/components/ui/DownloadButtonGroup';
 import {
   downloadSvg as downloadSvgFile,
@@ -279,35 +280,25 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
               const def = AI_DEFS.find((d) => d.ai === field.ai)!;
               return (
                 <div key={i} className="flex gap-2 items-start">
-                  <select
-                    value={field.ai}
-                    onChange={(e) => handleAiSelect(i, e.target.value as AiCode)}
-                    className="rounded px-2 py-2 shrink-0"
-                    style={{
-                      ...caption,
-                      border: `1px solid ${colors.borderInput}`,
-                      background: colors.bg,
-                      color: colors.text,
-                      width: '200px',
-                    }}
-                  >
-                    {AI_DEFS.map((d) => (
-                      <option
-                        key={d.ai}
-                        value={d.ai}
-                        disabled={usedAis.has(d.ai) && d.ai !== field.ai}
-                      >
-                        {d.label}
-                      </option>
-                    ))}
-                  </select>
+                  <div style={{ width: '200px', flexShrink: 0 }}>
+                    <Select<AiCode>
+                      value={field.ai}
+                      onChange={(v) => handleAiSelect(i, v)}
+                      ariaLabel={`AI コード ${i + 1}`}
+                      options={AI_DEFS.map((d) => ({
+                        value: d.ai,
+                        label: d.label,
+                        disabled: usedAis.has(d.ai) && d.ai !== field.ai,
+                      }))}
+                    />
+                  </div>
                   <div className="flex-1">
                     <input
                       type="text"
                       value={field.value}
                       onChange={(e) => handleAiChange(i, e.target.value)}
                       placeholder={def.placeholder}
-                      className="w-full rounded px-3 py-2 font-mono"
+                      className="w-full rounded-lg px-3 py-2 font-mono"
                       style={{
                         ...caption,
                         border: `1px solid ${field.error ? colors.error : colors.borderInput}`,
@@ -329,7 +320,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                   </div>
                   <button
                     onClick={() => removeAiField(i)}
-                    className="rounded p-2 transition-colors shrink-0"
+                    className="rounded-lg p-2 transition-colors shrink-0"
                     style={{
                       ...caption,
                       color: colors.muted,

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,41 @@
+import { caption, colors, onFocusRing, onBlurRing } from '@/utils/styles';
+
+interface Option<T> {
+  value: T;
+  label: string;
+}
+
+interface Props<T extends string> {
+  options: Option<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel?: string;
+  id?: string;
+}
+
+export function Select<T extends string>({ options, value, onChange, ariaLabel, id }: Props<T>) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value as T)}
+      aria-label={ariaLabel}
+      onFocus={onFocusRing}
+      onBlur={onBlurRing}
+      className="rounded-lg px-3 py-2 w-full"
+      style={{
+        ...caption,
+        border: `1px solid ${colors.borderInput}`,
+        background: colors.bg,
+        color: colors.text,
+        appearance: 'auto',
+      }}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -15,27 +15,48 @@ interface Props<T extends string> {
 
 export function Select<T extends string>({ options, value, onChange, ariaLabel, id }: Props<T>) {
   return (
-    <select
-      id={id}
-      value={value}
-      onChange={(e) => onChange(e.target.value as T)}
-      aria-label={ariaLabel}
-      onFocus={onFocusRing}
-      onBlur={onBlurRing}
-      className="rounded-lg px-3 py-2 w-full"
-      style={{
-        ...caption,
-        border: `1px solid ${colors.borderInput}`,
-        background: colors.bg,
-        color: colors.text,
-        appearance: 'auto',
-      }}
-    >
-      {options.map((opt) => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
-        </option>
-      ))}
-    </select>
+    <div style={{ position: 'relative' }}>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value as T)}
+        aria-label={ariaLabel}
+        onFocus={onFocusRing}
+        onBlur={onBlurRing}
+        className="rounded-lg px-3 py-2 w-full"
+        style={{
+          ...caption,
+          border: `1px solid ${colors.borderInput}`,
+          background: colors.bg,
+          color: colors.text,
+          appearance: 'none',
+          paddingRight: '2.5rem',
+        }}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 12 12"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          right: '0.75rem',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          pointerEvents: 'none',
+          color: colors.muted,
+        }}
+      >
+        <path d="M2 4L6 8L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </div>
   );
 }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -3,6 +3,7 @@ import { caption, colors, onFocusRing, onBlurRing } from '@/utils/styles';
 interface Option<T> {
   value: T;
   label: string;
+  disabled?: boolean;
 }
 
 interface Props<T extends string> {
@@ -34,7 +35,7 @@ export function Select<T extends string>({ options, value, onChange, ariaLabel, 
         }}
       >
         {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
+          <option key={opt.value} value={opt.value} disabled={opt.disabled}>
             {opt.label}
           </option>
         ))}

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -158,25 +158,20 @@ export function normalizeNewlines(bytes: Uint8Array, mode: NewlineMode): Uint8Ar
   return out.subarray(0, w);
 }
 
-// トグルボタン用の短縮ラベル (4文字以内 or ASCII)。検出結果カードの表示には ENCODING_LABELS を使う
-export const SOURCE_ENCODINGS_ROW1: Array<{ value: SourceEncoding; label: string }> = [
+export const SOURCE_ENCODINGS: Array<{ value: SourceEncoding; label: string }> = [
   { value: 'AUTO', label: '自動判定' },
   { value: 'UTF8', label: 'UTF-8' },
   { value: 'SJIS', label: 'SJIS' },
   { value: 'EUCJP', label: 'EUC-JP' },
-];
-export const SOURCE_ENCODINGS_ROW2: Array<{ value: SourceEncoding; label: string }> = [
   { value: 'JIS', label: 'JIS' },
   { value: 'UTF16LE', label: 'UTF-16LE' },
   { value: 'UTF16BE', label: 'UTF-16BE' },
 ];
 
-export const TARGET_ENCODINGS_ROW1: Array<{ value: EncodingName; label: string }> = [
+export const TARGET_ENCODINGS: Array<{ value: EncodingName; label: string }> = [
   { value: 'UTF8', label: 'UTF-8' },
   { value: 'SJIS', label: 'SJIS' },
   { value: 'EUCJP', label: 'EUC-JP' },
-];
-export const TARGET_ENCODINGS_ROW2: Array<{ value: EncodingName; label: string }> = [
   { value: 'JIS', label: 'JIS' },
   { value: 'UTF16LE', label: 'UTF-16LE' },
   { value: 'UTF16BE', label: 'UTF-16BE' },

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -228,6 +228,60 @@ UIレイアウト変更後は Playwright でPC（1280×800）とスマホ（390�
 
 ---
 
+## [2026-04-25] `<label htmlFor>` がある場合は Select に aria-label を併用しない
+
+### 状況
+
+`EncodingConverter.tsx` で `<label htmlFor="enc-source">` が存在するにもかかわらず、Select コンポーネントに `ariaLabel="元の文字コード"` も渡していた。
+
+### 教訓
+
+**`<label htmlFor>` で紐付け済みの場合、`aria-label` は不要（かつ冗長）。**
+
+- `aria-label` が存在すると `<label>` より優先されるため、意図した読み上げテキストと差異が出る可能性がある。
+- `<label>` を持たない要素（Gs1Databar の AI コード Select 等）には引き続き `ariaLabel` を使う。
+
+```tsx
+// ❌ 冗長
+<label htmlFor="enc-source">元の文字コード:</label>
+<Select id="enc-source" ariaLabel="元の文字コード" ... />
+
+// ✅ 正しい
+<label htmlFor="enc-source">元の文字コード:</label>
+<Select id="enc-source" ... />
+```
+
+---
+
+## [2026-04-25] Playwright では DOM 直接操作より expect オートリトライを優先
+
+### 状況
+
+`gs1-databar.spec.ts` で `page.evaluate` / `page.waitForFunction` で DOM を直接操作・監視していた。
+
+### 教訓
+
+**ロール/ラベルロケーター + `expect` のオートリトライで React の再レンダー後の状態変化を待つ。**
+
+```ts
+// ❌ 旧パターン
+await page.waitForFunction(() => {
+  const opt = document.querySelector('select[aria-label="..."] option[value="11"]');
+  return opt?.disabled === true;
+});
+const disabled = await page.locator('...').evaluate((el) => el.disabled);
+expect(disabled).toBe(false);
+
+// ✅ 新パターン
+await expect(page.getByLabel('AI コード 2').getByRole('option', { name: '製造日 (11)' })).toBeDisabled();
+await expect(page.getByLabel('AI コード 2').getByRole('option', { name: '賞味/消費期限 (17)' })).toBeEnabled();
+```
+
+- `page.evaluate` によるクリックより `getByRole('button', ...).first().click()` の方がシンプルで堅牢。
+- DOM 直接操作は `waitForReactHydration` が通った後でも flaky になりやすい。
+
+---
+
 ## 2026-04-25: `Uint8Array<ArrayBuffer>` の戻り型は `crypto.subtle.verify` で必須
 
 ### 状況

--- a/tests/e2e/encoding-converter.spec.ts
+++ b/tests/e2e/encoding-converter.spec.ts
@@ -108,44 +108,41 @@ test.describe('文字コード判定・変換', () => {
     await expect(page.getByTestId('detection-result')).not.toBeVisible();
   });
 
-  test('ケースH: 変換モードで Row1 選択中は Row2 がハイライトされない', async ({ page }) => {
+  test('ケースH: 変換モードの文字コード Select に全選択肢がありデフォルト値が正しい', async ({ page }) => {
     await page.getByRole('button', { name: '変換' }).click();
 
-    // 「元の文字コード」グループに絞って検証（source/target 両方に JIS があるため）
-    const srcRow1 = page.getByRole('group', { name: '元の文字コード (AUTO・UTF-8・SJIS・EUC-JP)' });
-    const srcRow2 = page.getByRole('group', { name: '元の文字コード (JIS・UTF-16)' });
+    const srcSelect = page.getByLabel('元の文字コード');
+    const tgtSelect = page.getByLabel('変換後の文字コード');
 
-    // 初期状態: 自動判定(Row1) が選択中
-    await expect(srcRow1.getByRole('button', { name: '自動判定' })).toHaveAttribute('aria-pressed', 'true');
+    // デフォルト値
+    await expect(srcSelect).toHaveValue('AUTO');
+    await expect(tgtSelect).toHaveValue('UTF8');
 
-    // Row2 のボタンは全て非選択（ここが以前バグっていた箇所）
-    for (const name of ['JIS', 'UTF-16LE', 'UTF-16BE']) {
-      await expect(srcRow2.getByRole('button', { name })).toHaveAttribute('aria-pressed', 'false');
-    }
+    // 元の文字コードを JIS に変更できる
+    await srcSelect.selectOption('JIS');
+    await expect(srcSelect).toHaveValue('JIS');
 
-    // JIS (Row2) をクリックすると Row2 がアクティブになり Row1 は全て非選択
-    await srcRow2.getByRole('button', { name: 'JIS' }).click();
-    await expect(srcRow2.getByRole('button', { name: 'JIS' })).toHaveAttribute('aria-pressed', 'true');
-    for (const name of ['自動判定', 'UTF-8', 'SJIS', 'EUC-JP']) {
-      await expect(srcRow1.getByRole('button', { name })).toHaveAttribute('aria-pressed', 'false');
-    }
+    // 変換後の文字コードを SJIS に変更できる
+    await tgtSelect.selectOption('SJIS');
+    await expect(tgtSelect).toHaveValue('SJIS');
   });
 
   test('ケースI: UTF-8 以外ターゲット選択時はコピーボタンが非表示になる', async ({ page }) => {
     await page.getByRole('button', { name: '変換' }).click();
     await page.getByLabel('入力テキスト').fill('あいうえお');
 
+    const tgtSelect = page.getByLabel('変換後の文字コード');
+
     // UTF-8 ターゲット（デフォルト）→ コピーボタンが表示される
-    const targetRow1 = page.getByRole('group', { name: '変換後の文字コード (UTF-8・SJIS・EUC-JP)' });
-    await targetRow1.getByRole('button', { name: 'UTF-8' }).click();
+    await tgtSelect.selectOption('UTF8');
     await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible({ timeout: 2000 });
 
     // SJIS ターゲット → コピーボタンが非表示になる
-    await targetRow1.getByRole('button', { name: 'SJIS' }).click();
+    await tgtSelect.selectOption('SJIS');
     await expect(page.getByRole('button', { name: 'コピー' })).not.toBeVisible();
 
     // UTF-8 に戻すとコピーボタンが再表示される
-    await targetRow1.getByRole('button', { name: 'UTF-8' }).click();
+    await tgtSelect.selectOption('UTF8');
     await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible();
   });
 
@@ -246,19 +243,19 @@ test.describe('文字コード判定・変換', () => {
   test('ケースN: UTF-16LE ターゲット選択時は改行コードトグルが非表示になる', async ({ page }) => {
     await page.getByRole('button', { name: '変換' }).click();
 
+    const tgtSelect = page.getByLabel('変換後の文字コード');
+
     // UTF-8 ターゲットでは改行コードトグルが表示される
     await expect(page.getByRole('group', { name: '改行コード' })).toBeVisible({ timeout: 2000 });
 
     // UTF-16LE ターゲットに切り替えると非表示になる
-    const targetRow2 = page.getByRole('group', { name: '変換後の文字コード (JIS・UTF-16)' });
-    await targetRow2.getByRole('button', { name: 'UTF-16LE' }).click();
+    await tgtSelect.selectOption('UTF16LE');
     await expect(page.getByRole('group', { name: '改行コード' })).not.toBeVisible();
     // UTF-16 向けの注記が表示される
     await expect(page.getByText('UTF-16 では改行コード正規化は適用されません')).toBeVisible();
 
     // UTF-8 に戻すと再表示される
-    const targetRow1 = page.getByRole('group', { name: '変換後の文字コード (UTF-8・SJIS・EUC-JP)' });
-    await targetRow1.getByRole('button', { name: 'UTF-8' }).click();
+    await tgtSelect.selectOption('UTF8');
     await expect(page.getByRole('group', { name: '改行コード' })).toBeVisible();
   });
 });

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -1,14 +1,10 @@
 import { test, expect } from '@playwright/test';
+import { waitForReactHydration } from './helpers';
 
 test.describe('GS1 DataBar 生成', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/tools/gs1-databar');
-    // React のイベントハンドラが select 要素に紐付くまで待つ
-    await page.waitForFunction(() => {
-      const el = document.querySelector('select[aria-label="AI コード 1"]');
-      if (!el) return false;
-      return Object.keys(el).some((k) => k.startsWith('__react'));
-    });
+    await waitForReactHydration(page);
   });
 
   test('ページが正しく表示される', async ({ page }) => {

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -32,40 +32,29 @@ test.describe('GS1 DataBar 生成', () => {
 
   test('1 行目の AI を変更すると 2 行目の disabled が連動する', async ({ page }) => {
     // 初期状態: Select1='17', Select2='10'。未使用の '11'（製造日）を 1 行目に選択
-    await page.locator('select[aria-label="AI コード 1"]').selectOption('11');
-    await expect(page.locator('select[aria-label="AI コード 1"]')).toHaveValue('11');
+    await page.getByLabel('AI コード 1').selectOption('11');
+    await expect(page.getByLabel('AI コード 1')).toHaveValue('11');
 
-    // React 再レンダリング後に '11' が Select 2 で disabled になるのを待つ
-    await page.waitForFunction(() => {
-      const opt = document.querySelector('select[aria-label="AI コード 2"] option[value="11"]') as HTMLOptionElement | null;
-      return opt?.disabled === true;
-    });
+    // React 再レンダリング後に '11' が Select 2 で disabled になるのを expect のオートリトライで待つ
+    await expect(
+      page.getByLabel('AI コード 2').getByRole('option', { name: '製造日 (11)' })
+    ).toBeDisabled();
 
-    // '17' は 2 行目で enabled になる（current の '10' は現在の field.ai なので enabled）
-    const opt17Disabled = await page
-      .locator('select[aria-label="AI コード 2"] option[value="17"]')
-      .evaluate((el) => (el as HTMLOptionElement).disabled);
-    expect(opt17Disabled).toBe(false);
+    // '17' は 2 行目で enabled になる
+    await expect(
+      page.getByLabel('AI コード 2').getByRole('option', { name: '賞味/消費期限 (17)' })
+    ).toBeEnabled();
   });
 
   test('削除ボタンでフィールドが減る', async ({ page }) => {
     // 初期状態: 2 フィールド
-    await expect(page.locator('select[aria-label="AI コード 1"]')).toBeVisible();
-    await expect(page.locator('select[aria-label="AI コード 2"]')).toBeVisible();
+    await expect(page.getByLabel('AI コード 1')).toBeVisible();
+    await expect(page.getByLabel('AI コード 2')).toBeVisible();
 
-    // 1 行目の削除（evaluate 経由で確実にクリック）
-    await page.evaluate(() => {
-      (document.querySelector('button[aria-label="フィールドを削除"]') as HTMLElement)?.click();
-    });
+    await page.getByRole('button', { name: 'フィールドを削除' }).first().click();
 
-    // React 再レンダリング後に Select 2 が消えるのを待つ
-    await page.waitForFunction(
-      () => !document.querySelector('select[aria-label="AI コード 2"]'),
-      undefined,
-      { timeout: 5000 }
-    );
-
-    await expect(page.locator('select[aria-label="AI コード 1"]')).toBeVisible();
+    await expect(page.getByLabel('AI コード 2')).toBeHidden();
+    await expect(page.getByLabel('AI コード 1')).toBeVisible();
   });
 
   test('+ フィールド追加でフィールドが増える', async ({ page }) => {

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('GS1 DataBar 生成', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tools/gs1-databar');
+    // React のイベントハンドラが select 要素に紐付くまで待つ
+    await page.waitForFunction(() => {
+      const el = document.querySelector('select[aria-label="AI コード 1"]');
+      if (!el) return false;
+      return Object.keys(el).some((k) => k.startsWith('__react'));
+    });
+  });
+
+  test('ページが正しく表示される', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'GS1 DataBar 生成' })).toBeVisible();
+    await expect(page.getByLabel('AI コード 1')).toBeVisible();
+    await expect(page.getByRole('button', { name: '+ フィールド追加' })).toBeVisible();
+  });
+
+  test('AI コード Select のデフォルト値が正しい', async ({ page }) => {
+    // 初期フィールドは賞味/消費期限(17) と ロット番号(10)
+    await expect(page.getByLabel('AI コード 1')).toHaveValue('17');
+    await expect(page.getByLabel('AI コード 2')).toHaveValue('10');
+  });
+
+  test('別フィールドで選択済みの AI は disabled になる', async ({ page }) => {
+    // 1 行目は '17'（賞味/消費期限）、2 行目は '10'（ロット番号）
+    // 2 行目 Select で '17' の option は disabled のはず
+    const opt17InSelect2 = page.getByLabel('AI コード 2').getByRole('option', { name: '賞味/消費期限 (17)' });
+    await expect(opt17InSelect2).toBeDisabled();
+
+    // 2 行目 Select で '10' の option は disabled でない
+    const opt10InSelect2 = page.getByLabel('AI コード 2').getByRole('option', { name: 'ロット番号 (10)' });
+    await expect(opt10InSelect2).toBeEnabled();
+  });
+
+  test('1 行目の AI を変更すると 2 行目の disabled が連動する', async ({ page }) => {
+    // 初期状態: Select1='17', Select2='10'。未使用の '11'（製造日）を 1 行目に選択
+    await page.locator('select[aria-label="AI コード 1"]').selectOption('11');
+    await expect(page.locator('select[aria-label="AI コード 1"]')).toHaveValue('11');
+
+    // React 再レンダリング後に '11' が Select 2 で disabled になるのを待つ
+    await page.waitForFunction(() => {
+      const opt = document.querySelector('select[aria-label="AI コード 2"] option[value="11"]') as HTMLOptionElement | null;
+      return opt?.disabled === true;
+    });
+
+    // '17' は 2 行目で enabled になる（current の '10' は現在の field.ai なので enabled）
+    const opt17Disabled = await page
+      .locator('select[aria-label="AI コード 2"] option[value="17"]')
+      .evaluate((el) => (el as HTMLOptionElement).disabled);
+    expect(opt17Disabled).toBe(false);
+  });
+
+  test('削除ボタンでフィールドが減る', async ({ page }) => {
+    // 初期状態: 2 フィールド
+    await expect(page.locator('select[aria-label="AI コード 1"]')).toBeVisible();
+    await expect(page.locator('select[aria-label="AI コード 2"]')).toBeVisible();
+
+    // 1 行目の削除（evaluate 経由で確実にクリック）
+    await page.evaluate(() => {
+      (document.querySelector('button[aria-label="フィールドを削除"]') as HTMLElement)?.click();
+    });
+
+    // React 再レンダリング後に Select 2 が消えるのを待つ
+    await page.waitForFunction(
+      () => !document.querySelector('select[aria-label="AI コード 2"]'),
+      undefined,
+      { timeout: 5000 }
+    );
+
+    await expect(page.locator('select[aria-label="AI コード 1"]')).toBeVisible();
+  });
+
+  test('+ フィールド追加でフィールドが増える', async ({ page }) => {
+    // 初期状態: 2 フィールド。1 行削除してから追加
+    await page.getByRole('button', { name: 'フィールドを削除' }).first().click();
+    await expect(page.getByLabel('AI コード 1')).toBeVisible();
+
+    await page.getByRole('button', { name: '+ フィールド追加' }).click();
+    await expect(page.getByLabel('AI コード 2')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要

- 文字コード判定・変換の「元の文字コード」「変換後の文字コード」選択UIをToggleGroup（ラジオボタン群）から `Select<T>` コンポーネントに置き換え
- 共通 `Select<T>` コンポーネントを新規作成（`src/components/ui/Select.tsx`）
- DADS準拠: `appearance: none` + カスタムSVG矢印を `right: 0.75rem` に配置
- Gs1Databar の独自 `<select>` も同コンポーネントに統合（`disabled` per-option 対応を追加）
- E2E テストを更新・追加（encoding-converter: 16件、gs1-databar: 6件 全パス）

## 変更内容

- `src/components/ui/Select.tsx` — 新規作成。`Option<T>` に `disabled?` を追加
- `src/utils/encoding.ts` — SOURCE_ENCODINGS / TARGET_ENCODINGS を一本化
- `src/components/tools/EncodingConverter.tsx` — ToggleGroup → Select に置き換え
- `src/components/tools/Gs1Databar.tsx` — 独自select → 共通Select に統合、aria-label付与、rounded-lg統一
- `tests/e2e/encoding-converter.spec.ts` — ケースH/I/Nをselect操作に書き換え
- `tests/e2e/gs1-databar.spec.ts` — 新規追加（6件）
- `SPEC.md`, `docs/decisions.md` — Select追加・[034][035]記録

## テスト結果

```
npx playwright test tests/e2e/encoding-converter.spec.ts  → 16 passed
npx playwright test tests/e2e/gs1-databar.spec.ts         → 6 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)