### PR TITLE
fix: コピーボタンのラベルを「コピー」に統一

### DIFF
--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -80,7 +80,6 @@ export function UrlEncoderTool() {
         value={output}
         rows={4}
         ariaLabel="変換結果"
-        copyLabel="出力をコピー"
         resize={false}
       />
 

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -110,7 +110,7 @@ export function GenerateTab({
               <div>
                 <div className="flex items-center justify-between" style={{ marginBottom: '0.5rem' }}>
                   <span style={{ ...caption, fontWeight: 600, color: colors.text }}>秘密鍵（主催者が保管）</span>
-                  <CopyButton text={privateKeyJwkStr} label="秘密鍵をコピー" />
+                  <CopyButton text={privateKeyJwkStr} label="コピー" />
                 </div>
                 <textarea
                   readOnly
@@ -132,7 +132,7 @@ export function GenerateTab({
               <div>
                 <div className="flex items-center justify-between" style={{ marginBottom: '0.5rem' }}>
                   <span style={{ ...caption, fontWeight: 600, color: colors.text }}>公開鍵（検証スタッフへ共有）</span>
-                  <CopyButton text={publicKeyJwkStr} label="公開鍵をコピー" />
+                  <CopyButton text={publicKeyJwkStr} label="コピー" />
                 </div>
                 <textarea
                   readOnly


### PR DESCRIPTION
## 概要

各ツールコンポーネントで `CopyButton` のラベルが統一されていなかった問題を修正する。

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `src/components/tools/UrlEncoder.tsx` | `"出力をコピー"` | デフォルト `"コピー"` |
| `src/components/tools/qr-ticket/GenerateTab.tsx` | `"秘密鍵をコピー"` | `"コピー"` |
| `src/components/tools/qr-ticket/GenerateTab.tsx` | `"公開鍵をコピー"` | `"コピー"` |

## 変更しなかった箇所

- `"コピー"` — DummyText, JanCode, Gs1Databar, JwtDecoder（標準ラベル、変更不要）
- `"すべてコピー"` — UuidV7Generator, UlidGenerator（一括操作であり意味が異なるため維持）
- ラベルなし compact モード — 狭いスペース向けで意図的な省略

## テスト計画

- [ ] `/tools/url-encoder` でコピーボタンが「コピー」と表示されること
- [ ] QR チケット生成タブで秘密鍵・公開鍵の両ボタンが「コピー」と表示されること
- [ ] `astro check` で型エラーがゼロであること

https://claude.ai/code/session_011F2w2SH8c7pg1M1D6ekyct

---
_Generated by [Claude Code](https://claude.ai/code/session_011F2w2SH8c7pg1M1D6ekyct)_