### PR TITLE
feat: Phase 2a ToggleGroup 統一（自前セグメントコントロール置換）

### DIFF
--- a/src/components/tools/DummyText.tsx
+++ b/src/components/tools/DummyText.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useClampedInput } from '@/hooks/useClampedInput';
 import { CopyButton } from '@/components/ui/CopyButton';
-import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
+import { ToggleGroup } from '@/components/ui/ToggleGroup';
 
 type CharType = 'hiragana' | 'katakana' | 'japanese' | 'alphanumeric' | 'lorem';
 
@@ -96,30 +97,13 @@ export function DummyTextTool() {
       {/* 文字種 */}
       <div>
         <p style={{ ...bodyEmphasis, color: colors.text, marginBottom: '0.75rem' }}>文字種</p>
-        <div className="flex flex-wrap gap-2">
-          {CHAR_TYPES.map(({ value, label }) => (
-            <button
-              key={value}
-              onClick={() => setCharType(value)}
-              style={{
-                ...caption,
-                padding: '0.5rem 1rem',
-                borderRadius: '999px',
-                border:
-                  charType === value
-                    ? `1.5px solid ${colors.primary}`
-                    : `1.5px solid ${colors.borderInput}`,
-                background: charType === value ? colors.primaryBg : colors.bg,
-                color: charType === value ? colors.primary : colors.muted,
-                cursor: 'pointer',
-                fontWeight: charType === value ? 600 : 400,
-              }}
-              aria-pressed={charType === value}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        <ToggleGroup
+          options={CHAR_TYPES}
+          value={charType}
+          onChange={setCharType}
+          ariaLabel="文字種"
+          layout="wrap"
+        />
       </div>
 
       {/* 文字数 */}
@@ -152,42 +136,23 @@ export function DummyTextTool() {
             background: colors.bg,
             color: colors.text,
           }}
-          onFocus={onFocusRing}
-          onBlurCapture={onBlurRing}
         />
-        <p style={{ ...micro, color: colors.muted, marginTop: '0.25rem' }}>1〜5000文字</p>
+        <p style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}>1〜5000文字</p>
       </div>
 
       {/* 改行 */}
       <div>
         <p style={{ ...bodyEmphasis, color: colors.text, marginBottom: '0.25rem' }}>改行</p>
         <div className="flex items-center gap-3 flex-wrap">
-          <div
-            className="flex rounded-lg overflow-hidden"
-            style={{ border: `1px solid ${colors.borderInput}`, display: 'inline-flex' }}
-            role="group"
-            aria-label="改行設定"
-          >
-            {([false, true] as const).map((val) => (
-              <button
-                key={String(val)}
-                onClick={() => setLineBreak(val)}
-                style={{
-                  ...caption,
-                  padding: '0.5rem 1.25rem',
-                  background: lineBreak === val ? colors.primary : colors.bg,
-                  color: lineBreak === val ? colors.textOnPrimary : colors.muted,
-                  border: 'none',
-                  borderRight: !val ? `1px solid ${colors.borderInput}` : 'none',
-                  cursor: 'pointer',
-                  fontWeight: lineBreak === val ? 600 : 400,
-                }}
-                aria-pressed={lineBreak === val}
-              >
-                {val ? 'あり' : 'なし'}
-              </button>
-            ))}
-          </div>
+          <ToggleGroup<'false' | 'true'>
+            options={[
+              { value: 'false', label: 'なし' },
+              { value: 'true', label: 'あり' },
+            ]}
+            value={String(lineBreak) as 'false' | 'true'}
+            onChange={(v) => setLineBreak(v === 'true')}
+            ariaLabel="改行設定"
+          />
           {lineBreak && (
             <div className="flex items-center gap-2">
               <label htmlFor="chunk-size" style={{ ...caption, color: colors.muted }}>
@@ -210,15 +175,8 @@ export function DummyTextTool() {
                   background: colors.bg,
                   color: colors.text,
                 }}
-                onFocus={(e) => {
-                  e.target.style.outline = `2px solid ${colors.link}`;
-                  e.target.style.outlineOffset = '2px';
-                }}
-                onBlurCapture={(e) => {
-                  e.target.style.outline = 'none';
-                }}
               />
-              <span style={{ ...micro, color: colors.muted }}>文字ごと（1〜1000）</span>
+              <span style={{ ...caption, color: colors.muted }}>文字ごと（1〜1000）</span>
             </div>
           )}
         </div>

--- a/src/components/tools/QrCode.tsx
+++ b/src/components/tools/QrCode.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import qrcode from '@/utils/qrcode';
-import { bodyEmphasis, caption, micro, colors } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { InputField } from '@/components/ui/InputField';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { downloadSvgElement } from '@/utils/download';
+import { ToggleGroup } from '@/components/ui/ToggleGroup';
 
 type ErrorLevel = 'L' | 'M' | 'Q' | 'H';
 
@@ -76,34 +77,13 @@ export function QrCodeGenerator() {
           誤り訂正レベル
         </p>
         <div className="flex items-center gap-2 flex-wrap">
-          <div
-            className="flex rounded-lg overflow-hidden"
-            style={{ border: `1px solid ${colors.borderInput}`, display: 'inline-flex' }}
-            role="group"
-            aria-label="誤り訂正レベル"
-          >
-            {ERROR_LEVELS.map(({ value, label }, i) => (
-              <button
-                key={value}
-                onClick={() => setErrorLevel(value)}
-                style={{
-                  ...caption,
-                  padding: '0.5rem 1rem',
-                  background: errorLevel === value ? colors.primary : colors.bg,
-                  color: errorLevel === value ? colors.textOnPrimary : colors.muted,
-                  border: 'none',
-                  borderRight:
-                    i < ERROR_LEVELS.length - 1 ? `1px solid ${colors.borderInput}` : 'none',
-                  cursor: 'pointer',
-                  fontWeight: errorLevel === value ? 600 : 400,
-                }}
-                aria-pressed={errorLevel === value}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-          <span style={{ ...micro, color: colors.muted }}>
+          <ToggleGroup
+            options={ERROR_LEVELS.map(({ value, label }) => ({ value, label }))}
+            value={errorLevel}
+            onChange={setErrorLevel}
+            ariaLabel="誤り訂正レベル"
+          />
+          <span style={{ ...caption, color: colors.muted }}>
             復元率: {ERROR_LEVELS.find((e) => e.value === errorLevel)?.desc}
           </span>
         </div>

--- a/src/components/tools/UlidGenerator.tsx
+++ b/src/components/tools/UlidGenerator.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback } from 'react';
 import { ulid } from 'ulidx';
 import { CopyButton } from '@/components/ui/CopyButton';
-import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { useClampedInput } from '@/hooks/useClampedInput';
+import { ToggleGroup } from '@/components/ui/ToggleGroup';
 
 interface UlidRow {
   id: string;
@@ -78,8 +79,6 @@ export function UlidGeneratorTool() {
               background: colors.bg,
               color: colors.text,
             }}
-            onFocus={onFocusRing}
-            onBlurCapture={onBlurRing}
             aria-describedby="ulid-count-hint"
           />
           <button
@@ -96,7 +95,7 @@ export function UlidGeneratorTool() {
             生成
           </button>
         </div>
-        <p id="ulid-count-hint" style={{ ...micro, color: colors.muted, marginTop: '0.25rem' }}>
+        <p id="ulid-count-hint" style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}>
           1〜100
         </p>
       </div>
@@ -115,38 +114,18 @@ export function UlidGeneratorTool() {
             <span style={{ ...bodyEmphasis, color: colors.text }}>{rows.length} 件生成</span>
             <div className="flex flex-wrap items-center gap-2">
               {/* クォートスタイル選択 */}
-              <div
-                className="flex items-center rounded-lg overflow-hidden shrink-0"
-                style={{ border: `1px solid ${colors.borderInput}` }}
-                role="group"
-                aria-label="クォートスタイル"
-              >
-                {(
-                  [
-                    ['none', 'なし'],
-                    ['double', '"..."'],
-                    ['single', "'...'"],
-                  ] as [QuoteStyle, string][]
-                ).map(([value, label]) => (
-                  <button
-                    key={value}
-                    onClick={() => setQuoteStyle(value)}
-                    style={{
-                      ...micro,
-                      padding: '0.25rem 0.625rem',
-                      background: quoteStyle === value ? colors.primary : colors.bg,
-                      color: quoteStyle === value ? colors.textOnPrimary : colors.muted,
-                      border: 'none',
-                      cursor: 'pointer',
-                      whiteSpace: 'nowrap',
-                      fontFamily: value !== 'none' ? 'monospace' : 'inherit',
-                      borderRight: value !== 'single' ? `1px solid ${colors.borderInput}` : 'none',
-                    }}
-                    aria-pressed={quoteStyle === value}
-                  >
-                    {label}
-                  </button>
-                ))}
+              <div className="shrink-0">
+                <ToggleGroup<QuoteStyle>
+                  options={[
+                    { value: 'none', label: 'なし' },
+                    { value: 'double', label: '"..."' },
+                    { value: 'single', label: "'...'" },
+                  ]}
+                  value={quoteStyle}
+                  onChange={setQuoteStyle}
+                  ariaLabel="クォートスタイル"
+                  size="sm"
+                />
               </div>
               <div className="shrink-0">
                 <CopyButton text={allUlids} label="すべてコピー" />
@@ -174,7 +153,7 @@ export function UlidGeneratorTool() {
                   <th
                     scope="col"
                     style={{
-                      ...micro,
+                      ...caption,
                       color: colors.muted,
                       textAlign: 'right',
                       padding: '0.5rem 0.75rem',
@@ -188,7 +167,7 @@ export function UlidGeneratorTool() {
                   <th
                     scope="col"
                     style={{
-                      ...micro,
+                      ...caption,
                       color: colors.muted,
                       textAlign: 'left',
                       padding: '0.5rem 0.75rem',
@@ -201,7 +180,7 @@ export function UlidGeneratorTool() {
                   <th
                     scope="col"
                     style={{
-                      ...micro,
+                      ...caption,
                       color: colors.muted,
                       textAlign: 'left',
                       padding: '0.5rem 0.75rem',
@@ -214,7 +193,7 @@ export function UlidGeneratorTool() {
                   <th
                     scope="col"
                     style={{
-                      ...micro,
+                      ...caption,
                       color: colors.muted,
                       textAlign: 'center',
                       padding: '0.5rem 0.75rem',
@@ -238,7 +217,7 @@ export function UlidGeneratorTool() {
                   >
                     <td
                       style={{
-                        ...micro,
+                        ...caption,
                         color: colors.muted,
                         textAlign: 'right',
                         padding: '0.5rem 0.75rem',
@@ -250,7 +229,7 @@ export function UlidGeneratorTool() {
                     <td
                       className="font-mono"
                       style={{
-                        ...micro,
+                        ...caption,
                         color: colors.text,
                         padding: '0.5rem 0.75rem',
                         whiteSpace: 'nowrap',
@@ -263,7 +242,7 @@ export function UlidGeneratorTool() {
                     <td
                       className="font-mono"
                       style={{
-                        ...micro,
+                        ...caption,
                         color: colors.muted,
                         padding: '0.5rem 0.75rem',
                         whiteSpace: 'nowrap',

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback } from 'react';
 import { v7 as uuidv7 } from 'uuid';
 import { CopyButton } from '@/components/ui/CopyButton';
-import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { useClampedInput } from '@/hooks/useClampedInput';
+import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { parseUuidV7Fields, extractUuidV7Timestamp } from '@/utils/uuid-v7';
 
 interface UuidRow {
@@ -33,7 +34,7 @@ function ColoredUuid({ uuid }: { uuid: string }) {
   // tttttttt-tttt-7rrr-Vrrr-rrrrrrrrrrrr
   const parts = uuid.split('-');
   return (
-    <span className="font-mono" style={{ ...micro, letterSpacing: '0.02em', whiteSpace: 'nowrap' }}>
+    <span className="font-mono" style={{ ...caption, letterSpacing: '0.02em', whiteSpace: 'nowrap' }}>
       <span style={{ color: FIELD_COLORS.unixTsMs }}>{parts[0]}</span>
       <span style={{ color: colors.muted }}>-</span>
       <span style={{ color: FIELD_COLORS.unixTsMs }}>{parts[1]}</span>
@@ -66,18 +67,18 @@ function FieldBreakdownPanel({ uuid }: { uuid: string }) {
       className="rounded-lg p-3"
       style={{ background: colors.bgSubtle, border: `1px solid ${colors.border}` }}
     >
-      <p style={{ ...micro, color: colors.muted, marginBottom: '0.5rem' }}>フィールド分解</p>
+      <p style={{ ...caption, color: colors.muted, marginBottom: '0.5rem' }}>フィールド分解</p>
       <div className="flex flex-wrap gap-x-4 gap-y-2">
         {fieldDefs.map((f) => (
           <div key={f.key} className="flex flex-col gap-0.5">
-            <span style={{ ...micro, color: colors.muted, fontSize: '0.75rem' }}>
+            <span style={{ ...caption, color: colors.muted, fontSize: '0.75rem' }}>
               {f.key}{' '}
               <span style={{ fontSize: '0.7rem', opacity: 0.7 }}>({f.bits})</span>
             </span>
             <code
               className="rounded px-1.5 py-0.5"
               style={{
-                ...micro,
+                ...caption,
                 fontFamily: 'monospace',
                 color: f.color,
                 background: colors.bg,
@@ -160,8 +161,6 @@ export function UuidV7GeneratorTool() {
               background: colors.bg,
               color: colors.text,
             }}
-            onFocus={onFocusRing}
-            onBlurCapture={onBlurRing}
             aria-describedby="uuid-count-hint"
           />
           <button
@@ -178,7 +177,7 @@ export function UuidV7GeneratorTool() {
             生成
           </button>
         </div>
-        <p id="uuid-count-hint" style={{ ...micro, color: colors.muted, marginTop: '0.25rem' }}>
+        <p id="uuid-count-hint" style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}>
           1〜100
         </p>
       </div>
@@ -198,38 +197,18 @@ export function UuidV7GeneratorTool() {
               <span style={{ ...bodyEmphasis, color: colors.text }}>{rows.length} 件生成</span>
               <div className="flex flex-wrap items-center gap-2">
                 {/* クォートスタイル選択 */}
-                <div
-                  className="flex items-center rounded-lg overflow-hidden shrink-0"
-                  style={{ border: `1px solid ${colors.borderInput}` }}
-                  role="group"
-                  aria-label="クォートスタイル"
-                >
-                  {(
-                    [
-                      ['none', 'なし'],
-                      ['double', '"..."'],
-                      ['single', "'...'"],
-                    ] as [QuoteStyle, string][]
-                  ).map(([value, label]) => (
-                    <button
-                      key={value}
-                      onClick={() => setQuoteStyle(value)}
-                      style={{
-                        ...micro,
-                        padding: '0.25rem 0.625rem',
-                        background: quoteStyle === value ? colors.primary : colors.bg,
-                        color: quoteStyle === value ? colors.textOnPrimary : colors.muted,
-                        border: 'none',
-                        cursor: 'pointer',
-                        whiteSpace: 'nowrap',
-                        fontFamily: value !== 'none' ? 'monospace' : 'inherit',
-                        borderRight: value !== 'single' ? `1px solid ${colors.borderInput}` : 'none',
-                      }}
-                      aria-pressed={quoteStyle === value}
-                    >
-                      {label}
-                    </button>
-                  ))}
+                <div className="shrink-0">
+                  <ToggleGroup<QuoteStyle>
+                    options={[
+                      { value: 'none', label: 'なし' },
+                      { value: 'double', label: '"..."' },
+                      { value: 'single', label: "'...'" },
+                    ]}
+                    value={quoteStyle}
+                    onChange={setQuoteStyle}
+                    ariaLabel="クォートスタイル"
+                    size="sm"
+                  />
                 </div>
                 <div className="shrink-0">
                   <CopyButton text={allUuids} label="すべてコピー" />
@@ -257,7 +236,7 @@ export function UuidV7GeneratorTool() {
                     <th
                       scope="col"
                       style={{
-                        ...micro,
+                        ...caption,
                         color: colors.muted,
                         textAlign: 'right',
                         padding: '0.5rem 0.75rem',
@@ -271,7 +250,7 @@ export function UuidV7GeneratorTool() {
                     <th
                       scope="col"
                       style={{
-                        ...micro,
+                        ...caption,
                         color: colors.muted,
                         textAlign: 'left',
                         padding: '0.5rem 0.75rem',
@@ -284,7 +263,7 @@ export function UuidV7GeneratorTool() {
                     <th
                       scope="col"
                       style={{
-                        ...micro,
+                        ...caption,
                         color: colors.muted,
                         textAlign: 'left',
                         padding: '0.5rem 0.75rem',
@@ -297,7 +276,7 @@ export function UuidV7GeneratorTool() {
                     <th
                       scope="col"
                       style={{
-                        ...micro,
+                        ...caption,
                         color: colors.muted,
                         textAlign: 'center',
                         padding: '0.5rem 0.75rem',
@@ -332,7 +311,7 @@ export function UuidV7GeneratorTool() {
                       >
                         <td
                           style={{
-                            ...micro,
+                            ...caption,
                             color: colors.muted,
                             textAlign: 'right',
                             padding: '0.5rem 0.75rem',
@@ -347,7 +326,7 @@ export function UuidV7GeneratorTool() {
                         <td
                           className="font-mono"
                           style={{
-                            ...micro,
+                            ...caption,
                             color: colors.muted,
                             padding: '0.5rem 0.75rem',
                             whiteSpace: 'nowrap',

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -297,14 +297,12 @@ export function UuidV7GeneratorTool() {
                         key={row.id}
                         onClick={() => setSelectedIndex(i)}
                         style={{
-                          borderBottom: i < rows.length - 1 ? `1px solid ${colors.border}` : 'none',
                           background: isSelected
                             ? 'color-mix(in srgb, var(--color-primary) 8%, var(--color-bg))'
                             : i % 2 === 0
                               ? colors.bg
                               : colors.bgSurface,
                           cursor: 'pointer',
-                          boxShadow: isSelected ? `inset 0 0 0 2px ${colors.primary}` : 'none',
                         }}
                         aria-selected={isSelected}
                       >
@@ -315,11 +313,27 @@ export function UuidV7GeneratorTool() {
                             textAlign: 'right',
                             padding: '0.5rem 0.75rem',
                             fontVariantNumeric: 'tabular-nums',
+                            borderTop: isSelected ? `2px solid ${colors.primary}` : 'none',
+                            borderBottom: isSelected
+                              ? `2px solid ${colors.primary}`
+                              : i < rows.length - 1
+                                ? `1px solid ${colors.border}`
+                                : 'none',
                           }}
                         >
                           {i + 1}
                         </td>
-                        <td style={{ padding: '0.5rem 0.75rem' }}>
+                        <td
+                          style={{
+                            padding: '0.5rem 0.75rem',
+                            borderTop: isSelected ? `2px solid ${colors.primary}` : 'none',
+                            borderBottom: isSelected
+                              ? `2px solid ${colors.primary}`
+                              : i < rows.length - 1
+                                ? `1px solid ${colors.border}`
+                                : 'none',
+                          }}
+                        >
                           <ColoredUuid uuid={row.id} />
                         </td>
                         <td
@@ -329,6 +343,12 @@ export function UuidV7GeneratorTool() {
                             color: colors.muted,
                             padding: '0.5rem 0.75rem',
                             whiteSpace: 'nowrap',
+                            borderTop: isSelected ? `2px solid ${colors.primary}` : 'none',
+                            borderBottom: isSelected
+                              ? `2px solid ${colors.primary}`
+                              : i < rows.length - 1
+                                ? `1px solid ${colors.border}`
+                                : 'none',
                           }}
                         >
                           {row.timestamp}
@@ -338,6 +358,12 @@ export function UuidV7GeneratorTool() {
                             padding: '0.25rem 0.5rem',
                             textAlign: 'center',
                             whiteSpace: 'nowrap',
+                            borderTop: isSelected ? `2px solid ${colors.primary}` : 'none',
+                            borderBottom: isSelected
+                              ? `2px solid ${colors.primary}`
+                              : i < rows.length - 1
+                                ? `1px solid ${colors.border}`
+                                : 'none',
                           }}
                         >
                           <CopyButton text={formatId(row.id)} compact />

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -304,8 +304,7 @@ export function UuidV7GeneratorTool() {
                               ? colors.bg
                               : colors.bgSurface,
                           cursor: 'pointer',
-                          outline: isSelected ? `2px solid ${colors.primary}` : 'none',
-                          outlineOffset: '-2px',
+                          boxShadow: isSelected ? `inset 0 0 0 2px ${colors.primary}` : 'none',
                         }}
                         aria-selected={isSelected}
                       >

--- a/src/components/ui/ToggleGroup.tsx
+++ b/src/components/ui/ToggleGroup.tsx
@@ -24,16 +24,19 @@ export function ToggleGroup<T extends string>({
   size = 'md',
   layout = 'grid',
 }: Props<T>) {
+  const isWrap = layout === 'wrap';
+
   return (
     <div
-      className={`rounded-lg p-1 ${layout === 'grid' ? 'grid gap-1' : 'flex flex-wrap gap-1'}`}
+      className={`rounded-lg p-1 ${isWrap ? 'flex flex-wrap gap-1' : 'grid gap-1'}`}
       role="group"
       aria-label={ariaLabel}
       style={{
         background: colors.bgSubtle,
-        ...(layout === 'grid'
-          ? { gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }
-          : {}),
+        border: `1px solid ${colors.borderInput}`,
+        ...(isWrap
+          ? { width: 'max-content', maxWidth: '100%' }
+          : { gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }),
       }}
     >
       {options.map((opt) => (

--- a/src/components/ui/ToggleGroup.tsx
+++ b/src/components/ui/ToggleGroup.tsx
@@ -1,4 +1,4 @@
-import { caption, colors, shadows } from '@/utils/styles';
+import { caption, elevation, colors } from '@/utils/styles';
 
 interface Option<T> {
   value: T;
@@ -10,28 +10,44 @@ interface Props<T extends string> {
   value: T | undefined;
   onChange: (value: T) => void;
   ariaLabel?: string;
+  /** ボタンサイズ。デフォルトは `md` */
+  size?: 'sm' | 'md';
+  /** `grid`: 等幅グリッド（デフォルト）。`wrap`: flex-wrap で自然幅 */
+  layout?: 'grid' | 'wrap';
 }
 
-export function ToggleGroup<T extends string>({ options, value, onChange, ariaLabel }: Props<T>) {
+export function ToggleGroup<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  size = 'md',
+  layout = 'grid',
+}: Props<T>) {
   return (
     <div
-      className="grid gap-1 rounded-lg p-1"
+      className={`rounded-lg p-1 ${layout === 'grid' ? 'grid gap-1' : 'flex flex-wrap gap-1'}`}
       role="group"
       aria-label={ariaLabel}
-      style={{ gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))`, background: colors.bgSubtle }}
+      style={{
+        background: colors.bgSubtle,
+        ...(layout === 'grid'
+          ? { gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }
+          : {}),
+      }}
     >
       {options.map((opt) => (
         <button
           key={opt.value}
           onClick={() => onChange(opt.value)}
           aria-pressed={value === opt.value}
-          className="rounded-lg px-3 py-1.5 whitespace-nowrap transition-colors"
+          className={`rounded-lg whitespace-nowrap transition-colors ${size === 'sm' ? 'px-2.5 py-0.5' : 'px-3 py-1.5'}`}
           style={{
             ...caption,
             fontWeight: 600,
             background: value === opt.value ? colors.bg : 'transparent',
             color: value === opt.value ? colors.text : colors.muted,
-            boxShadow: value === opt.value ? shadows.tab : 'none',
+            boxShadow: value === opt.value ? elevation.level2 : 'none',
           }}
         >
           {opt.label}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -87,6 +87,11 @@
   --color-text-on-primary: #ffffff; /* プライマリ色背景上の文字（白抜き）。ダークモード時も白を維持 */
 }
 
+/* ボタン・リンク類のカーソルを pointer に統一 */
+:where(button, a, [role="button"]) {
+  cursor: pointer;
+}
+
 /* focus-visible を CSS で一括適用（JS の onFocusRing/onBlurRing ハンドラは不要） */
 :where(button, a, [role="button"], input, textarea, select):focus-visible {
   outline: var(--focus-ring);


### PR DESCRIPTION
## 概要

- `ToggleGroup` コンポーネントに `size`（sm/md）・`layout`（grid/wrap）プロップを追加し、4つのツールの自前セグメントコントロールを置換

## 変更内容

### ToggleGroup 拡張
- `size?: 'sm' | 'md'`（デフォルト `md`）: アクションバー内の小型トグルに `sm` を使用
- `layout?: 'grid' | 'wrap'`（デフォルト `grid`）: 多項目の文字種選択に `wrap` を使用
- `shadows` → `elevation.level2` に移行（Phase 1 で deprecated 化したトークンを除去）
- コンテナに `border: 1px solid borderInput` を追加（選択中以外のボタンも認識しやすく）

### ツール置換一覧

| ツール | 置換箇所 | size | layout |
|--------|---------|------|--------|
| QrCode | 誤り訂正レベル（L/M/Q/H） | md | grid |
| DummyText | 文字種（5項目） | md | wrap |
| DummyText | 改行あり/なし | md | grid |
| UlidGenerator | クォートスタイル | sm | grid |
| UuidV7Generator | クォートスタイル | sm | grid |

### あわせて修正
- 各ツールの `onFocusRing`/`onBlurRing` ハンドラを除去（CSS focus-visible に統一）
- `micro` → `caption` に置換（`micro` は deprecated のため）
- UUIDv7 の選択行枠が `border-radius` の角で途切れる問題を修正（`box-shadow` → 各 `td` の `borderTop`/`borderBottom` に変更）

## 確認済み

- `astro check`: 0 エラー
- vitest: 168/168 通過
- Playwright 目視確認: PC（1280×800）・モバイル（390×844）の 4 ツールすべて正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)