### PR TITLE
feat: Phase 2b Astro パーシャル化（PageContainer・CategoryBadge・ToolInfoSection）

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,9 +1,9 @@
 ---
-
+import PageContainer from '@/components/ui/PageContainer.astro';
 ---
 
 <header class="sticky top-0 z-50 bg-white border-b border-neutral-200" style="height: 64px;">
-  <div class="mx-auto flex h-full max-w-280 items-center px-4 sm:px-6">
+  <PageContainer class="flex h-full items-center">
     <a
       href="/"
       class="text-xl font-bold text-primary transition-opacity hover:opacity-80"
@@ -11,5 +11,5 @@
     >
       DevTools
     </a>
-  </div>
+  </PageContainer>
 </header>

--- a/src/components/ui/CategoryBadge.astro
+++ b/src/components/ui/CategoryBadge.astro
@@ -1,0 +1,13 @@
+---
+interface Props {
+  label: string;
+  class?: string;
+}
+const { label, class: extraClass = '' } = Astro.props;
+---
+<span
+  class:list={['rounded-full px-3 font-bold text-blue-800 bg-blue-100', extraClass]}
+  style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em;"
+>
+  {label}
+</span>

--- a/src/components/ui/PageContainer.astro
+++ b/src/components/ui/PageContainer.astro
@@ -1,0 +1,9 @@
+---
+interface Props {
+  class?: string;
+}
+const { class: extraClass = '' } = Astro.props;
+---
+<div class:list={['mx-auto max-w-280 px-4 sm:px-6', extraClass]}>
+  <slot />
+</div>

--- a/src/components/ui/ToolInfoSection.astro
+++ b/src/components/ui/ToolInfoSection.astro
@@ -1,0 +1,9 @@
+---
+---
+<section
+  class="mt-10 rounded-lg p-6"
+  style="background: var(--color-bg); border: 1px solid var(--color-border);"
+>
+  <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <slot />
+</section>

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -2,6 +2,8 @@
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import Sidebar from '@/components/layout/Sidebar.astro';
 import ToolIcon from '@/components/ui/ToolIcon.astro';
+import PageContainer from '@/components/ui/PageContainer.astro';
+import CategoryBadge from '@/components/ui/CategoryBadge.astro';
 import { categoryLabel } from '@/data/tools';
 import type { Tool } from '@/data/tools';
 
@@ -29,7 +31,7 @@ const jsonLd = {
 ---
 
 <BaseLayout title={tool.name} description={tool.description} jsonLd={jsonLd}>
-  <div class="mx-auto flex max-w-280 gap-6 px-4 sm:px-6 py-8">
+  <PageContainer class="flex gap-6 py-8">
     <!-- サイドバー (デスクトップ) -->
     <div class="hidden lg:block">
       <Sidebar currentSlug={tool.slug} />
@@ -67,16 +69,11 @@ const jsonLd = {
             {tool.description}
           </p>
         </div>
-        <span
-          class="hidden sm:inline-block shrink-0 rounded-full px-3 py-1 font-bold text-blue-800 bg-blue-100"
-          style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em;"
-        >
-          {categoryLabel[tool.category]}
-        </span>
+        <CategoryBadge label={categoryLabel[tool.category]} class="hidden sm:inline-block shrink-0 py-1" />
       </div>
 
       <!-- ツール本体 -->
       <slot />
     </main>
-  </div>
+  </PageContainer>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import ToolIcon from '@/components/ui/ToolIcon.astro';
+import PageContainer from '@/components/ui/PageContainer.astro';
+import CategoryBadge from '@/components/ui/CategoryBadge.astro';
 import { tools, categoryLabel, type ToolCategory } from '@/data/tools';
 
 const categories: ToolCategory[] = ['generate', 'convert'];
@@ -35,7 +37,8 @@ const jsonLd = {
   </section>
 
   <!-- ツール一覧 -->
-  <main id="main-content" class="mx-auto max-w-280 px-4 sm:px-6 py-8">
+  <main id="main-content">
+  <PageContainer class="py-8">
     <!-- タブ -->
     <div
       id="tab-bar"
@@ -96,12 +99,7 @@ const jsonLd = {
                   >
                     <div class="mb-4 flex items-start justify-between">
                       <ToolIcon slug={tool.slug} size={28} class="text-primary" />
-                      <span
-                        class="rounded-full px-3 py-0.5 font-bold text-blue-800 bg-blue-100"
-                        style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em;"
-                      >
-                        {categoryLabel[tool.category]}
-                      </span>
+                      <CategoryBadge label={categoryLabel[tool.category]} class="py-0.5" />
                     </div>
                     <h2
                       class="mb-2 font-bold text-neutral-900 group-hover:text-primary transition-colors"
@@ -128,6 +126,7 @@ const jsonLd = {
         ))
       }
     </div>
+  </PageContainer>
   </main>
 </BaseLayout>
 

--- a/src/pages/tools/base64.astro
+++ b/src/pages/tools/base64.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { Base64CodecTool } from '@/components/tools/Base64Codec';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'base64')!;
 <ToolLayout tool={tool}>
   <Base64CodecTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       テキストを Base64 形式にエンコード、またはデコードします。
       外部サーバーへの送信は一切なく、すべての処理はブラウザ内で完結します。
@@ -26,5 +26,5 @@ const tool = tools.find((t) => t.slug === 'base64')!;
       <li>JWT のペイロード部分（URL-safe Base64）をデコードして確認したい</li>
       <li>API レスポンスの Base64 エンコードされたデータをデコードしたい</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/dummy-text.astro
+++ b/src/pages/tools/dummy-text.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { DummyTextTool } from '@/components/tools/DummyText';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'dummy-text')!;
 <ToolLayout tool={tool}>
   <DummyTextTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       UI・デザインのモックアップや動作確認用に、任意の文字数のダミーテキストを生成します。
     </p>
@@ -21,5 +21,5 @@ const tool = tools.find((t) => t.slug === 'dummy-text')!;
       <li>英数字：a-z・A-Z・0-9 をランダムに生成</li>
       <li>Lorem Ipsum：古典的な欧文ダミーテキスト</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/encoding-converter.astro
+++ b/src/pages/tools/encoding-converter.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { EncodingConverterTool } from '@/components/tools/EncodingConverter';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'encoding-converter')!;
 <ToolLayout tool={tool}>
   <EncodingConverterTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       テキストやファイルの文字コードを自動判定し、他のエンコーディングへ変換します。
       すべての処理はブラウザ内で完結し、サーバーへの送信は一切ありません。
@@ -30,5 +30,5 @@ const tool = tools.find((t) => t.slug === 'encoding-converter')!;
       <li>受け取ったテキストファイルがどの文字コードか不明なので判定したい</li>
       <li>EUC-JP のログファイルを UTF-8 に変換して確認したい</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/gs1-databar.astro
+++ b/src/pages/tools/gs1-databar.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { Gs1DatabarTool } from '@/components/tools/Gs1Databar';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'gs1-databar')!;
 <ToolLayout tool={tool}>
   <Gs1DatabarTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       GS1 DataBar Limited 合成シンボルは、GTIN-14（商品識別コード）を格納するリニアバーコードと、
       賞味期限・ロット番号などの追加情報を格納する CC-A（2次元合成コンポーネント）を組み合わせたバーコードです。
@@ -34,5 +34,5 @@ const tool = tools.find((t) => t.slug === 'gs1-databar')!;
       <li>物流ラベルへの GTIN + シリアル番号の組み合わせ印字</li>
       <li>GS1 準拠バーコードの検証・テスト用サンプル生成</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/jan-code.astro
+++ b/src/pages/tools/jan-code.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { JanCodeTool } from '@/components/tools/JanCode';
 import { tools } from '@/data/tools';
 
@@ -8,4 +9,18 @@ const tool = tools.find((t) => t.slug === 'jan-code')!;
 
 <ToolLayout tool={tool}>
   <JanCodeTool client:load />
+
+  <ToolInfoSection>
+    <p class="tool-info-body">
+      JANコード（JAN: Japanese Article Number）は EAN-13 / EAN-8 と同規格の商品識別用バーコードです。
+      GS1 が管理し、国際的な流通システムで広く使われています。
+      最終桁のチェックデジットはモジュラス10 / ウェイト3で計算されます。
+    </p>
+    <h3 class="mb-2 mt-4 tool-info-heading">ユースケース</h3>
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
+      <li>商品バーコードのチェックデジットを素早く確認したい</li>
+      <li>JAN-13 / JAN-8 のサンプルを生成してバーコードリーダーでテストしたい</li>
+      <li>GS1 アプリケーション向けの商品コードを準備したい</li>
+    </ul>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/json-csv.astro
+++ b/src/pages/tools/json-csv.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { JsonCsvTool } from '@/components/tools/JsonCsv';
 import { tools } from '@/data/tools';
 
@@ -8,4 +9,18 @@ const tool = tools.find((t) => t.slug === 'json-csv')!;
 
 <ToolLayout tool={tool}>
   <JsonCsvTool client:load />
+
+  <ToolInfoSection>
+    <p class="tool-info-body">
+      JSONとCSVを相互変換します。JSON → CSV では配列をヘッダー付きCSVに変換し、
+      ネストしたオブジェクトはドット記法（例: <code class="rounded px-1 font-mono" style="background: var(--color-bg-subtle); font-size: 0.875rem;">address.city</code>）でフラット化します。
+      CSV → JSON ではヘッダー行をキーとしてオブジェクト配列に変換します。
+    </p>
+    <h3 class="mb-2 mt-4 tool-info-heading">ユースケース</h3>
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
+      <li>APIレスポンスのJSONをExcelで開くためにCSVに変換したい</li>
+      <li>CSVデータをAPIに渡すためにJSON化したい</li>
+      <li>ネストしたJSONのどのキーがCSV列に展開されるか確認したい</li>
+    </ul>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/json-xml.astro
+++ b/src/pages/tools/json-xml.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { JsonXmlTool } from '@/components/tools/JsonXml';
 import { tools } from '@/data/tools';
 
@@ -8,4 +9,17 @@ const tool = tools.find((t) => t.slug === 'json-xml')!;
 
 <ToolLayout tool={tool}>
   <JsonXmlTool client:load />
+
+  <ToolInfoSection>
+    <p class="tool-info-body">
+      JSONとXMLを相互変換します。JSON → XML ではルートタグを <code class="rounded px-1 font-mono" style="background: var(--color-bg-subtle); font-size: 0.875rem;">root</code> として変換し、
+      XML → JSON では要素を再帰的にオブジェクトに展開します。
+    </p>
+    <h3 class="mb-2 mt-4 tool-info-heading">ユースケース</h3>
+    <ul class="list-inside list-disc space-y-1 tool-info-list">
+      <li>JSONデータをXMLベースのAPIへ渡す形式に変換したい</li>
+      <li>XMLデータをJSONとして扱いたい</li>
+      <li>レガシーシステムとのデータ連携フォーマットを確認したい</li>
+    </ul>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/jwt-decoder.astro
+++ b/src/pages/tools/jwt-decoder.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { JwtDecoderTool } from '@/components/tools/JwtDecoder';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'jwt-decoder')!;
 <ToolLayout tool={tool}>
   <JwtDecoderTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       JWTトークンを <code
         class="rounded px-1 font-mono"
@@ -32,5 +32,5 @@ const tool = tools.find((t) => t.slug === 'jwt-decoder')!;
       <li>有効期限（exp）が切れていないか確認したい</li>
       <li>Payloadに含まれるクレームを確認したい</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/qr-code.astro
+++ b/src/pages/tools/qr-code.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { QrCodeGenerator } from '@/components/tools/QrCode';
 import { tools } from '@/data/tools';
 
@@ -9,19 +10,16 @@ const tool = tools.find((t) => t.slug === 'qr-code')!;
 <ToolLayout tool={tool}>
   <QrCodeGenerator client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       テキストやURLを入力するとQRコードをリアルタイムに生成します。SVG形式でダウンロードできます。
     </p>
-    <h3 class="mb-2 mt-4 tool-info-heading">
-      誤り訂正レベルについて
-    </h3>
+    <h3 class="mb-2 mt-4 tool-info-heading">誤り訂正レベルについて</h3>
     <ul class="list-inside list-disc space-y-1 tool-info-list">
       <li>L（7%）: データ量を優先。読み取り環境が良い場合に向く</li>
       <li>M（15%）: 標準的な用途に最適</li>
       <li>Q（25%）: 汚れや破損が想定される印刷物向け</li>
       <li>H（30%）: ロゴ埋め込みなど一部が隠れる場合に向く</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/qr-ticket.astro
+++ b/src/pages/tools/qr-ticket.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { QrTicketTool } from '@/components/tools/QrTicket';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'qr-ticket')!;
 <ToolLayout tool={tool}>
   <QrTicketTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       ECDSA（楕円曲線デジタル署名）でチケットデータに署名し、QRコードとして出力します。
       公開鍵のみで署名を検証できるため、主催者が秘密鍵を手放さずに複数スタッフへ検証権限を配布できます。
@@ -38,5 +38,5 @@ const tool = tools.find((t) => t.slug === 'qr-ticket')!;
       <li>秘密鍵はブラウザを閉じると失われます。必ずコピーして安全な場所に保管してください</li>
       <li>カメラ読み取りはHTTPS環境またはlocalhostでのみ動作します</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/ulid-generator.astro
+++ b/src/pages/tools/ulid-generator.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { UlidGeneratorTool } from '@/components/tools/UlidGenerator';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'ulid-generator')!;
 <ToolLayout tool={tool}>
   <UlidGeneratorTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       ULIDはUUID
       v4の代替となるソート可能な一意識別子です。タイムスタンプ部分（最初の10文字）と乱数部分（残り16文字）で構成されます。
@@ -21,5 +21,5 @@ const tool = tools.find((t) => t.slug === 'ulid-generator')!;
       <li>時系列ソート可能なIDが必要</li>
       <li>UUIDより読みやすいIDが欲しい</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/url-encode.astro
+++ b/src/pages/tools/url-encode.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { UrlEncoderTool } from '@/components/tools/UrlEncoder';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'url-encode')!;
 <ToolLayout tool={tool}>
   <UrlEncoderTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       URLエンコードとは、URLに使えない文字（日本語・スペース・記号など）を
       <code class="rounded px-1 font-mono" style="background: var(--color-bg-subtle); font-size: 0.875rem;"
@@ -25,5 +25,5 @@ const tool = tools.find((t) => t.slug === 'url-encode')!;
       <li>URLに含めるデータを安全にエンコードしたい</li>
       <li>エンコードされた文字列を元のテキストに戻したい</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>

--- a/src/pages/tools/uuid-v7.astro
+++ b/src/pages/tools/uuid-v7.astro
@@ -1,5 +1,6 @@
 ---
 import ToolLayout from '@/layouts/ToolLayout.astro';
+import ToolInfoSection from '@/components/ui/ToolInfoSection.astro';
 import { UuidV7GeneratorTool } from '@/components/tools/UuidV7Generator';
 import { tools } from '@/data/tools';
 
@@ -9,8 +10,7 @@ const tool = tools.find((t) => t.slug === 'uuid-v7')!;
 <ToolLayout tool={tool}>
   <UuidV7GeneratorTool client:load />
 
-  <section class="mt-10 rounded-lg bg-white p-6" style="border: 1px solid rgba(0,0,0,0.1);">
-    <h2 class="mb-3 tool-info-heading">このツールについて</h2>
+  <ToolInfoSection>
     <p class="tool-info-body">
       UUID v7 は RFC 9562 で標準化された、時刻順ソートが可能なバージョンの UUID です。
       先頭 48 ビットにミリ秒精度の UNIX タイムスタンプを埋め込むため、データベースのインデックス効率が高く、
@@ -30,5 +30,5 @@ const tool = tools.find((t) => t.slug === 'uuid-v7')!;
       <li>UUID v4 より挿入パフォーマンスを改善したい（B-Tree インデックス断片化を抑制）</li>
       <li>ID からタイムスタンプを取り出したい</li>
     </ul>
-  </section>
+  </ToolInfoSection>
 </ToolLayout>


### PR DESCRIPTION
## 概要

- `PageContainer.astro` / `CategoryBadge.astro` / `ToolInfoSection.astro` の3コンポーネントを新規追加
- レイアウト系の重複マークアップを抽出・統一

## 変更内容

### 新規コンポーネント

| コンポーネント | 役割 | 利用箇所 |
|---|---|---|
| `PageContainer.astro` | `mx-auto max-w-280 px-4 sm:px-6` ラッパー | Header・ToolLayout・index |
| `CategoryBadge.astro` | カテゴリバッジ（生成 / 変換・解析） | index・ToolLayout |
| `ToolInfoSection.astro` | 「このツールについて」セクションシェル | 全13ツールページ |

### ツールページ更新

- 既存10ページの `<section class="mt-10 rounded-lg bg-white p-6">` + `<h2>このツールについて</h2>` を `ToolInfoSection` に置換
- **jan-code・json-csv・json-xml** に「このツールについて」セクションを新規追加（計3ページ欠落していた）
- セクション背景を `bg-white` から `var(--color-bg)` へ、ボーダーを `rgba(0,0,0,0.1)` から `var(--color-border)` へ移行

## 確認済み

- `astro check`: 0 エラー
- vitest: 168/168 通過
- E2E: 81/81 通過
- Playwright 目視確認: PC（1280×800）・モバイル（390×844）で index・jan-code・json-xml を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)