### PR TITLE
feat: Phase 3 ツール一貫性適用（space-y 統一・QRコードサンプルボタン）

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -931,6 +931,15 @@ Phase 2 でアクセシビリティ要件（コントラスト比 4.5:1）を満
 - [ ] お気に入り（localStorage）
 - [ ] OGP画像自動生成
 
+### フロントエンドデザインリファクタリング
+
+- [x] **Phase 1**: 基盤整備（カラートークン統一・focus ring CSS化・skip-link・dead class除去）
+- [x] **Phase 2a**: ToggleGroup 統一（QrCode/DummyText/Ulid/UuidV7 の自前セグメント置換）
+- [x] **Phase 2b**: Astro パーシャル化（PageContainer / CategoryBadge / ToolInfoSection）
+- [x] **Phase 2c**: 共通 React UI（ClearButton / CountInput / ResultTable / ErrorMessage block variant）
+- [x] **Phase 3**: ツール一貫性適用（全ツール space-y-6 統一・QrCode サンプルボタン追加）
+- [ ] **Phase 4**: モバイル UX（ハンバーガーメニュー・タップ領域・focus トラップ）
+
 ### Phase 3: 成熟
 
 - [ ] 30+ツール

--- a/src/components/tools/Base64Codec.tsx
+++ b/src/components/tools/Base64Codec.tsx
@@ -39,7 +39,7 @@ export function Base64CodecTool() {
         : SAMPLE_DECODE_STANDARD;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* モード切替 */}
       <ToggleGroup
         options={[

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -187,7 +187,7 @@ export function EncodingConverterTool() {
   const bomActive = BOM_ENCODINGS.has(targetEnc);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* モード切替 */}
       <ToggleGroup
         options={[

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -460,7 +460,7 @@ export function Gs1DatabarTool() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* カードリスト */}
       {cards.map((card, index) => (
         <BarcodeCard

--- a/src/components/tools/JsonCsv.tsx
+++ b/src/components/tools/JsonCsv.tsx
@@ -60,7 +60,7 @@ export function JsonCsvTool() {
     ) : null;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* モード切替 */}
       <ToggleGroup
         options={[

--- a/src/components/tools/JsonXml.tsx
+++ b/src/components/tools/JsonXml.tsx
@@ -48,7 +48,7 @@ export function JsonXmlTool() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* モード切替 */}
       <ToggleGroup
         options={[

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -258,7 +258,7 @@ export function JwtDecoderTool() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* トークン入力 */}
       <InputField
         id="jwt-input"

--- a/src/components/tools/QrCode.tsx
+++ b/src/components/tools/QrCode.tsx
@@ -69,6 +69,7 @@ export function QrCodeGenerator() {
         multiline
         rows={3}
         resize
+        onSampleClick={() => setText('https://example.com')}
       />
 
       {/* 誤り訂正レベル */}

--- a/src/components/tools/QrTicket.tsx
+++ b/src/components/tools/QrTicket.tsx
@@ -288,7 +288,7 @@ export function QrTicketTool() {
   // ─── レンダリング ─────────────────────────────────────────
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <ToggleGroup options={MODE_OPTIONS} value={mode} onChange={setMode} ariaLabel="動作モード" />
 
       {mode === 'generate' ? (

--- a/src/components/tools/UlidGenerator.tsx
+++ b/src/components/tools/UlidGenerator.tsx
@@ -83,7 +83,7 @@ export function UlidGeneratorTool() {
   ];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <CountInput
         id="ulid-count"
         defaultValue={10}

--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -43,7 +43,7 @@ export function UrlEncoderTool() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* モード切替 */}
       <ToggleGroup
         options={[

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -152,7 +152,7 @@ export function UuidV7GeneratorTool() {
   ];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <CountInput
         id="uuid-count"
         defaultValue={1}

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -67,7 +67,7 @@ export function GenerateTab({
   onDownloadZip,
 }: GenerateTabProps) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* 鍵ペアセクション */}
       <div style={sectionStyle}>
         <h3 style={sectionHeaderStyle}>鍵ペア</h3>

--- a/src/components/tools/qr-ticket/VerifyTab.tsx
+++ b/src/components/tools/qr-ticket/VerifyTab.tsx
@@ -40,7 +40,7 @@ export function VerifyTab({
   onRescan,
 }: VerifyTabProps) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* 公開鍵セクション */}
       <div style={sectionStyle}>
         <h3 style={sectionHeaderStyle}>公開鍵</h3>


### PR DESCRIPTION
## 概要

Phase 3「ツール一貫性適用」の実装です。機能変更はなく、構造と余白の統一のみを行います。

## 変更内容

### space-y-6 統一

ツール本体のルート `div` を `space-y-6` に統一しました（従来 `space-y-4` だった9ツールを修正）。

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `Base64Codec.tsx` | `space-y-4` | `space-y-6` |
| `EncodingConverter.tsx` | `space-y-4` | `space-y-6` |
| `Gs1Databar.tsx` | `space-y-4` | `space-y-6` |
| `JsonCsv.tsx` | `space-y-4` | `space-y-6` |
| `JsonXml.tsx` | `space-y-4` | `space-y-6` |
| `JwtDecoder.tsx` | `space-y-4` | `space-y-6` |
| `UlidGenerator.tsx` | `space-y-4` | `space-y-6` |
| `UrlEncoder.tsx` | `space-y-4` | `space-y-6` |
| `UuidV7Generator.tsx` | `space-y-4` | `space-y-6` |

元々 `space-y-6` だったツール（DummyText, JanCode, QrCode）は変更なし。

### QRコードサンプルボタン追加

`InputField` の `onSampleClick` を使用して `https://example.com` をサンプル入力するボタンを追加。

### SPEC.md 更新

9章にフロントエンドデザインリファクタリングのフェーズ一覧を追記（Phase 1〜3 完了・Phase 4 未着手）。

## 検証

- `astro check`: 0 エラー・0 warnings
- Playwright でPC（1280×800）・スマホ（390×844）スクリーンショット確認済み
- URLエンコード・QRコード・JWTデコーダーページで余白・サンプルボタン動作を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)