### PR TITLE
feat: Phase 4 モバイル UX（ハンバーガーメニュー・タップ領域・focus トラップ）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 test-results/
 playwright-report/
 coverage/
+.claude/scheduled_tasks.lock

--- a/SPEC.md
+++ b/SPEC.md
@@ -938,7 +938,7 @@ Phase 2 でアクセシビリティ要件（コントラスト比 4.5:1）を満
 - [x] **Phase 2b**: Astro パーシャル化（PageContainer / CategoryBadge / ToolInfoSection）
 - [x] **Phase 2c**: 共通 React UI（ClearButton / CountInput / ResultTable / ErrorMessage block variant）
 - [x] **Phase 3**: ツール一貫性適用（全ツール space-y-6 統一・QrCode サンプルボタン追加）
-- [ ] **Phase 4**: モバイル UX（ハンバーガーメニュー・タップ領域・focus トラップ）
+- [x] **Phase 4**: モバイル UX（ハンバーガーメニュー・タップ領域・focus トラップ）
 
 ### Phase 3: 成熟
 

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -15,13 +15,11 @@ import PageContainer from '@/components/ui/PageContainer.astro';
     <button
       id="mobile-menu-toggle"
       type="button"
-      class="lg:hidden flex items-center justify-center rounded-md transition-colors"
+      class="lg:hidden flex items-center justify-center rounded-md transition-colors hover:bg-neutral-100"
       style="width: 44px; height: 44px; color: #374151;"
       aria-label="メニューを開く"
       aria-expanded="false"
       aria-controls="mobile-drawer"
-      onmouseenter="this.style.background='#f3f4f6'"
-      onmouseleave="this.style.background='transparent'"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -3,7 +3,7 @@ import PageContainer from '@/components/ui/PageContainer.astro';
 ---
 
 <header class="sticky top-0 z-50 bg-white border-b border-neutral-200" style="height: 64px;">
-  <PageContainer class="flex h-full items-center">
+  <PageContainer class="flex h-full items-center justify-between">
     <a
       href="/"
       class="text-xl font-bold text-primary transition-opacity hover:opacity-80"
@@ -11,5 +11,34 @@ import PageContainer from '@/components/ui/PageContainer.astro';
     >
       DevTools
     </a>
+    <!-- ハンバーガーボタン (lg未満のみ表示) -->
+    <button
+      id="mobile-menu-toggle"
+      type="button"
+      class="lg:hidden flex items-center justify-center rounded-md transition-colors"
+      style="width: 44px; height: 44px; color: #374151;"
+      aria-label="メニューを開く"
+      aria-expanded="false"
+      aria-controls="mobile-drawer"
+      onmouseenter="this.style.background='#f3f4f6'"
+      onmouseleave="this.style.background='transparent'"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="3" y1="6" x2="21" y2="6"></line>
+        <line x1="3" y1="12" x2="21" y2="12"></line>
+        <line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
   </PageContainer>
 </header>

--- a/src/components/layout/MobileDrawer.astro
+++ b/src/components/layout/MobileDrawer.astro
@@ -1,5 +1,5 @@
 ---
-import { tools, categoryLabel, type ToolCategory } from '@/data/tools';
+import { tools, categoryLabel, categories } from '@/data/tools';
 import ToolIcon from '@/components/ui/ToolIcon.astro';
 
 interface Props {
@@ -7,8 +7,6 @@ interface Props {
 }
 
 const { currentSlug } = Astro.props;
-
-const categories: ToolCategory[] = ['generate', 'convert'];
 ---
 
 <!-- モバイルドロワー (lg未満のみ表示) -->
@@ -34,11 +32,9 @@ const categories: ToolCategory[] = ['generate', 'convert'];
       <button
         id="mobile-drawer-close"
         type="button"
-        class="flex items-center justify-center rounded-md transition-colors"
+        class="flex items-center justify-center rounded-md transition-colors hover:bg-neutral-100"
         style="width: 44px; height: 44px; color: #374151;"
         aria-label="メニューを閉じる"
-        onmouseenter="this.style.background='#f3f4f6'"
-        onmouseleave="this.style.background='transparent'"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -72,21 +68,22 @@ const categories: ToolCategory[] = ['generate', 'convert'];
             <ul>
               {tools
                 .filter((t) => t.category === cat)
-                .map((tool) => (
-                  <li>
-                    <a
-                      href={`/tools/${tool.slug}`}
-                      aria-current={currentSlug === tool.slug ? 'page' : undefined}
-                      class="flex items-center gap-2 rounded px-3 transition-colors"
-                      style={`min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: ${currentSlug === tool.slug ? '#1a56db' : '#374151'}; font-weight: ${currentSlug === tool.slug ? '700' : '400'}; background: ${currentSlug === tool.slug ? '#eff6ff' : 'transparent'};`}
-                      onmouseenter={`if(${currentSlug === tool.slug ? 'false' : 'true'}) this.style.background='#f3f4f6'`}
-                      onmouseleave={`if(${currentSlug === tool.slug ? 'false' : 'true'}) this.style.background='transparent'`}
-                    >
-                      <ToolIcon slug={tool.slug} size={16} class="shrink-0" />
-                      <span>{tool.name}</span>
-                    </a>
-                  </li>
-                ))}
+                .map((tool) => {
+                  const isActive = currentSlug === tool.slug;
+                  return (
+                    <li>
+                      <a
+                        href={`/tools/${tool.slug}`}
+                        aria-current={isActive ? 'page' : undefined}
+                        class={`flex items-center gap-2 rounded px-3 transition-colors ${isActive ? 'font-bold text-primary bg-blue-50' : 'text-neutral-700 hover:bg-neutral-100'}`}
+                        style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+                      >
+                        <ToolIcon slug={tool.slug} size={16} class="shrink-0" />
+                        <span>{tool.name}</span>
+                      </a>
+                    </li>
+                  );
+                })}
             </ul>
           </div>
         ))

--- a/src/components/layout/MobileDrawer.astro
+++ b/src/components/layout/MobileDrawer.astro
@@ -26,11 +26,11 @@ const categories: ToolCategory[] = ['generate', 'convert'];
     role="dialog"
     aria-label="ナビゲーション"
     aria-modal="true"
-    class="absolute left-0 top-0 h-full w-64 bg-white overflow-y-auto shadow-xl"
+    class="absolute right-0 top-0 h-full w-64 bg-white overflow-y-auto shadow-xl"
     style="padding: 1rem;"
   >
     <!-- 閉じるボタン -->
-    <div class="flex justify-end mb-2">
+    <div class="flex justify-start mb-2">
       <button
         id="mobile-drawer-close"
         type="button"

--- a/src/components/layout/MobileDrawer.astro
+++ b/src/components/layout/MobileDrawer.astro
@@ -1,0 +1,167 @@
+---
+import { tools, categoryLabel, type ToolCategory } from '@/data/tools';
+import ToolIcon from '@/components/ui/ToolIcon.astro';
+
+interface Props {
+  currentSlug?: string;
+}
+
+const { currentSlug } = Astro.props;
+
+const categories: ToolCategory[] = ['generate', 'convert'];
+---
+
+<!-- モバイルドロワー (lg未満のみ表示) -->
+<div id="mobile-drawer-overlay" class="lg:hidden fixed inset-0" style="z-index: 60;" aria-hidden="true" hidden>
+  <!-- 背景 -->
+  <div
+    id="mobile-drawer-backdrop"
+    class="absolute inset-0"
+    style="background: rgba(17,24,39,0.5);"
+  ></div>
+
+  <!-- ドロワーパネル -->
+  <div
+    id="mobile-drawer"
+    role="dialog"
+    aria-label="ナビゲーション"
+    aria-modal="true"
+    class="absolute left-0 top-0 h-full w-64 bg-white overflow-y-auto shadow-xl"
+    style="padding: 1rem;"
+  >
+    <!-- 閉じるボタン -->
+    <div class="flex justify-end mb-2">
+      <button
+        id="mobile-drawer-close"
+        type="button"
+        class="flex items-center justify-center rounded-md transition-colors"
+        style="width: 44px; height: 44px; color: #374151;"
+        aria-label="メニューを閉じる"
+        onmouseenter="this.style.background='#f3f4f6'"
+        onmouseleave="this.style.background='transparent'"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+
+    <!-- ツール一覧 -->
+    <nav aria-label="ツール一覧">
+      {
+        categories.map((cat) => (
+          <div class="mb-6">
+            <h2
+              class="mb-2 px-3 font-bold uppercase"
+              style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: #6b7280;"
+            >
+              {categoryLabel[cat]}
+            </h2>
+            <ul>
+              {tools
+                .filter((t) => t.category === cat)
+                .map((tool) => (
+                  <li>
+                    <a
+                      href={`/tools/${tool.slug}`}
+                      aria-current={currentSlug === tool.slug ? 'page' : undefined}
+                      class="flex items-center gap-2 rounded px-3 transition-colors"
+                      style={`min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: ${currentSlug === tool.slug ? '#1a56db' : '#374151'}; font-weight: ${currentSlug === tool.slug ? '700' : '400'}; background: ${currentSlug === tool.slug ? '#eff6ff' : 'transparent'};`}
+                      onmouseenter={`if(${currentSlug === tool.slug ? 'false' : 'true'}) this.style.background='#f3f4f6'`}
+                      onmouseleave={`if(${currentSlug === tool.slug ? 'false' : 'true'}) this.style.background='transparent'`}
+                    >
+                      <ToolIcon slug={tool.slug} size={16} class="shrink-0" />
+                      <span>{tool.name}</span>
+                    </a>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        ))
+      }
+    </nav>
+  </div>
+</div>
+
+<script>
+  const toggle = document.getElementById('mobile-menu-toggle') as HTMLButtonElement | null;
+  const overlay = document.getElementById('mobile-drawer-overlay') as HTMLElement | null;
+  const backdrop = document.getElementById('mobile-drawer-backdrop') as HTMLElement | null;
+  const drawer = document.getElementById('mobile-drawer') as HTMLElement | null;
+  const closeBtn = document.getElementById('mobile-drawer-close') as HTMLButtonElement | null;
+
+  if (!overlay || !toggle) {
+    // ドロワーが存在しないページではボタンを非表示にする
+    if (toggle) toggle.style.display = 'none';
+  } else {
+    function openDrawer(): void {
+      overlay!.hidden = false;
+      overlay!.removeAttribute('aria-hidden');
+      toggle!.setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
+      // 閉じるボタンにフォーカス移動
+      closeBtn?.focus();
+      document.addEventListener('keydown', handleKeyDown);
+    }
+
+    function closeDrawer(): void {
+      overlay!.hidden = true;
+      overlay!.setAttribute('aria-hidden', 'true');
+      toggle!.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
+      toggle!.focus();
+    }
+
+    function getFocusable(): HTMLElement[] {
+      if (!drawer) return [];
+      return Array.from(
+        drawer.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+    }
+
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (e.key === 'Escape') {
+        closeDrawer();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const focusable = getFocusable();
+      if (!focusable.length) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    toggle.addEventListener('click', openDrawer);
+    backdrop?.addEventListener('click', closeDrawer);
+    closeBtn?.addEventListener('click', closeDrawer);
+  }
+</script>

--- a/src/components/layout/Sidebar.astro
+++ b/src/components/layout/Sidebar.astro
@@ -30,13 +30,13 @@ const categories: ToolCategory[] = ['generate', 'convert'];
                   <a
                     href={`/tools/${tool.slug}`}
                     aria-current={currentSlug === tool.slug ? 'page' : undefined}
-                    class={`flex items-center gap-2 rounded px-3 py-2 transition-colors
+                    class={`flex items-center gap-2 rounded px-3 transition-colors
                   ${
                     currentSlug === tool.slug
                       ? 'font-bold text-primary bg-blue-50'
                       : 'text-neutral-700 hover:bg-neutral-100'
                   }`}
-                    style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+                    style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
                   >
                     <ToolIcon slug={tool.slug} size={16} class="shrink-0" />
                     <span>{tool.name}</span>

--- a/src/components/layout/Sidebar.astro
+++ b/src/components/layout/Sidebar.astro
@@ -1,5 +1,5 @@
 ---
-import { tools, categoryLabel, type ToolCategory } from '@/data/tools';
+import { tools, categoryLabel, categories } from '@/data/tools';
 import ToolIcon from '@/components/ui/ToolIcon.astro';
 
 interface Props {
@@ -7,8 +7,6 @@ interface Props {
 }
 
 const { currentSlug } = Astro.props;
-
-const categories: ToolCategory[] = ['generate', 'convert'];
 ---
 
 <aside class="w-56 shrink-0">

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -92,3 +92,5 @@ export const categoryLabel: Record<ToolCategory, string> = {
   generate: '生成',
   convert: '変換・解析',
 };
+
+export const categories: ToolCategory[] = ['generate', 'convert'];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,15 +1,17 @@
 ---
 import Header from '@/components/layout/Header.astro';
 import Footer from '@/components/layout/Footer.astro';
+import MobileDrawer from '@/components/layout/MobileDrawer.astro';
 import '../styles/global.css';
 
 interface Props {
   title: string;
   description?: string;
   jsonLd?: object;
+  currentSlug?: string;
 }
 
-const { title, description = 'ブラウザで完結する無料の開発者ツール集', jsonLd } = Astro.props;
+const { title, description = 'ブラウザで完結する無料の開発者ツール集', jsonLd, currentSlug } = Astro.props;
 const pageTitle = `${title} | DevTools`;
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
 ---
@@ -38,6 +40,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).href;
   <body class="bg-neutral-50 text-neutral-900 min-h-screen">
     <a href="#main-content" class="skip-link">本文へスキップ</a>
     <Header />
+    <MobileDrawer currentSlug={currentSlug} />
     <slot />
     <Footer />
     <script is:inline>

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -30,7 +30,7 @@ const jsonLd = {
 };
 ---
 
-<BaseLayout title={tool.name} description={tool.description} jsonLd={jsonLd}>
+<BaseLayout title={tool.name} description={tool.description} jsonLd={jsonLd} currentSlug={tool.slug}>
   <PageContainer class="flex gap-6 py-8">
     <!-- サイドバー (デスクトップ) -->
     <div class="hidden lg:block">

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -8,8 +8,8 @@ import type { Page } from '@playwright/test';
  */
 export async function waitForReactHydration(page: Page): Promise<void> {
   await page.waitForFunction(() => {
-    const el = document.querySelector('input, textarea, button');
-    if (!el) return false;
-    return Object.keys(el).some(k => k.startsWith('__react'));
+    const els = document.querySelectorAll('input, textarea, button');
+    if (!els.length) return false;
+    return Array.from(els).some(el => Object.keys(el).some(k => k.startsWith('__react')));
   });
 }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -10,6 +10,6 @@ export async function waitForReactHydration(page: Page): Promise<void> {
   await page.waitForFunction(() => {
     const els = document.querySelectorAll('input, textarea, button');
     if (!els.length) return false;
-    return Array.from(els).some(el => Object.keys(el).some(k => k.startsWith('__react')));
+    return [...els].some(el => Object.keys(el).some(k => k.startsWith('__react')));
   });
 }

--- a/tests/e2e/mobile-drawer.spec.ts
+++ b/tests/e2e/mobile-drawer.spec.ts
@@ -78,8 +78,8 @@ test.describe('モバイルドロワー', () => {
     await page.getByRole('button', { name: 'メニューを開く' }).click();
     await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
 
-    // ドロワーパネル幅 (256px) より右側の背景部分をクリック
-    await page.mouse.click(350, 400);
+    // ドロワーパネル (右 256px) より左側の背景部分をクリック
+    await page.mouse.click(40, 400);
 
     await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
   });

--- a/tests/e2e/mobile-drawer.spec.ts
+++ b/tests/e2e/mobile-drawer.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
+
+test.describe('モバイルドロワー', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto('/tools/url-encode');
+  });
+
+  test('モバイルでハンバーガーボタンが表示される', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'メニューを開く' })).toBeVisible();
+  });
+
+  test('デスクトップではハンバーガーボタンが非表示', async ({ page }) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+    await expect(page.getByRole('button', { name: 'メニューを開く' })).not.toBeVisible();
+  });
+
+  test('ハンバーガーボタンでドロワーが開く', async ({ page }) => {
+    const dialog = page.getByRole('dialog', { name: 'ナビゲーション' });
+    await expect(dialog).not.toBeVisible();
+
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+
+    await expect(dialog).toBeVisible();
+    await expect(page.getByRole('button', { name: 'メニューを閉じる' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'メニューを開く' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  test('閉じるボタンでドロワーが閉じる', async ({ page }) => {
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'メニューを閉じる' }).click();
+
+    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'メニューを開く' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  test('Escape キーでドロワーが閉じる', async ({ page }) => {
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+  });
+
+  test('現在のツールがドロワー内でハイライトされる', async ({ page }) => {
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+
+    const currentLink = page
+      .getByRole('dialog', { name: 'ナビゲーション' })
+      .getByRole('link', { name: 'URLエンコード/デコード' });
+    await expect(currentLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('ドロワーのツールリンクで遷移できる', async ({ page }) => {
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+
+    await page
+      .getByRole('dialog', { name: 'ナビゲーション' })
+      .getByRole('link', { name: 'JWTデコーダー' })
+      .click();
+
+    await expect(page).toHaveURL('/tools/jwt-decoder');
+  });
+
+  test('背景クリックでドロワーが閉じる', async ({ page }) => {
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
+
+    // ドロワーパネル幅 (256px) より右側の背景部分をクリック
+    await page.mouse.click(350, 400);
+
+    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要

フロントエンドデザインリファクタリング Phase 4 の実装。モバイル端末でのナビゲーション UX を改善します。

## 変更内容

- **ハンバーガーメニュー**: ヘッダーに `lg` 未満のみ表示されるボタンを追加
- **モバイルドロワー** (`MobileDrawer.astro`): 左スライドのナビゲーションドロワー
  - 閉じる操作: ×ボタン・背景クリック・`Escape` キー
  - `aria-modal` / `aria-expanded` / `aria-current` による ARIA 対応
  - 現在のツールをハイライト表示
- **Focus トラップ**: ドロワーが開いている間は `Tab` キーがドロワー内を循環
- **タップ領域**: サイドバーリンク・ハンバーガーボタンを 44×44px 以上に
- **`waitForReactHydration` バグ修正**: `querySelector` → `querySelectorAll` に変更し、ハンバーガーボタンが先に見つかって全 E2E テストが 30s タイムアウトする問題を解消

## テスト

- E2E テスト `mobile-drawer.spec.ts` を新規追加（8 ケース）
- 全 89 テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)