### PR TITLE
refactor: AstroカラークラスをCSS変数経路に統一・deprecatedエントリを解消

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,9 @@ git commit --amend  # または git reset して修正後に再コミット
 
 ## スタイル・カラーシステム
 
-Tailwind のカラークラス（`text-blue-500` 等）は**使わない**。色はすべて `src/utils/styles.ts` の `colors.*` をインラインスタイルで指定する。
+Tailwind のカラークラス（`text-blue-500` 等）は **TSX・Astro を問わず使わない**。色はすべて CSS 変数（`var(--color-*)`）経由で指定する。
+
+**TSX コンポーネント**: `src/utils/styles.ts` の `colors.*` をインラインスタイルで指定する。
 
 ```tsx
 // ✅ 正しい
@@ -83,6 +85,18 @@ import { colors, caption, bodyEmphasis } from '../../utils/styles';
 
 // ❌ 誤り
 <p className="text-gray-500 text-sm">テキスト</p>
+```
+
+**Astro コンポーネント・ページ**: `colors.*` が使えないため CSS 変数を `style` 属性に直書きする。hover 等の擬似クラスは `<style>` ブロックで CSS 変数を使用する。
+
+```astro
+// ✅ 正しい（Astro）
+<p style="color: var(--color-muted);">テキスト</p>
+<a class="footer-link">リンク</a>
+<style>.footer-link:hover { color: var(--color-neutral-100); }</style>
+
+// ❌ 誤り（Astro）
+<p class="text-gray-500">テキスト</p>
 ```
 
 レイアウト（`flex`, `gap`, `p-*`, `rounded` 等）は Tailwind クラスを使ってよい。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1192,6 +1192,36 @@ README.md にテストカバレッジのバッジを表示し、GitHub Actions �
 
 ---
 
+## [039] Astro 側の Tailwind カラークラスを CSS 変数経路に統一
+
+**2026-04-26 | ステータス: 採用**
+
+### 背景
+
+`src/components/layout/*.astro`・`src/layouts/*.astro`・`src/pages/*.astro` 等の Astro ファイルで `text-neutral-900`・`bg-blue-50`・`text-neutral-700` 等の Tailwind プリミティブカラークラスが約 30 箇所残存していた。TSX 側は [010][033][038] によって `colors.*` + CSS 変数経路に統一済みだったが、Astro では `colors.*` が使えないという事情から手つかずになっていた。ダークモード切替時（[003] 保留中）に `:root` を `.dark` でオーバーライドしても、Tailwind カラークラスはプリミティブ値のままハードコードされるため、対象箇所が取り残される問題があった。また同一要素内で Tailwind class と CSS 変数直書きが混在する箇所（`index.astro:27`）が見つかり、可読性の問題もあった。
+
+加えて、`styles.ts` の deprecated エントリ（`primaryBg`・`shadows`・`micro`・`onFocusRing`/`onBlurRing`）が [037][038] 後も TSX 5 ファイルから import されたままだった。
+
+### 決断
+
+1. **Astro 側のカラー置換**: Tailwind カラークラスを CSS 変数の `style` 属性直書きまたは `<style>` ブロックに置換。セマンティックエイリアス（`--color-text`・`--color-muted`・`--color-bg`・`--color-border` 等）が存在する場合はそれを優先し、存在しない場合はプリミティブ変数（`--color-neutral-700` 等）で 1:1 置換する。hover 等の擬似クラスは `<style>` ブロック内で CSS 変数を使用する。
+
+2. **deprecated 解消**: `micro` → `caption` に置換。`onFocusRing`/`onBlurRing` をすべての呼び出し箇所から削除（CSS の `:focus-visible` で一括適用済みのため不要）。`colors.primaryBg` → `colors.bgPrimary` に置換。置換完了後、`styles.ts` から deprecated 定義を削除。
+
+### 却下した選択肢
+
+- **完全 Tailwind 化**: `colors.*` を廃止し `bg-[var(--color-text)]` 等の arbitrary values に統一する。書き方は統一されるが、ダークモード対応で各箇所に `dark:` プレフィックスを追加する必要があり、CSS 変数一元管理の利点が失われる。
+- **現状維持**: ダークモード追加時に Astro 側のカラーが取り残される技術的負債が解消されない。
+
+### 結果・トレードオフ
+
+- ✅ Astro・TSX 共通で「色は CSS 変数経路」の原則が統一された
+- ✅ ダークモード追加時（[003]）に `:root` → `.dark` の 1 ブロック追加で全ページに波及できる
+- ✅ `styles.ts` から deprecated エントリが削除され、import 時の型補完ノイズがなくなった
+- ⚠️ Astro では `colors.*` が使えないため、CSS 変数を `style` 属性に直書きするパターンが TSX と異なる。新しく Astro ファイルを書く際は CLAUDE.md のルールを参照すること
+
+---
+
 ## [038] デザイントークン整備（secondary/tertiary/elevation/radii）
 
 **2026-04-26 | ステータス: 採用**

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1220,6 +1220,8 @@ README.md にテストカバレッジのバッジを表示し、GitHub Actions �
 - ✅ `styles.ts` から deprecated エントリが削除され、import 時の型補完ノイズがなくなった
 - ⚠️ Astro では `colors.*` が使えないため、CSS 変数を `style` 属性に直書きするパターンが TSX と異なる。新しく Astro ファイルを書く際は CLAUDE.md のルールを参照すること
 
+**補足（PRレビュー指摘対応）**: ナビ active 背景 (`bg-blue-50`) と バッジ背景 (`bg-blue-100`) にプリミティブ変数・キーカラー変数が混入していた指摘を受け、`:root` に `--color-bg-active` / `--color-badge-bg` を追加してセマンティック変数経路に揃えた。またタブの色切替を JS `classList.toggle` から CSS 属性セレクタ (`[aria-selected="true/false"]`) 宣言に移行し、詳細度競合を排除した。
+
 ---
 
 ## [038] デザイントークン整備（secondary/tertiary/elevation/radii）

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -2,24 +2,29 @@
 
 ---
 
-<footer class="bg-neutral-900 text-neutral-300">
+<footer style="background: var(--color-neutral-900); color: var(--color-neutral-300);">
   <div class="mx-auto max-w-280 px-4 sm:px-6 py-12">
     <div class="flex flex-col gap-3 sm:flex-row sm:justify-between">
-      <p class="text-sm text-neutral-500" style="letter-spacing: 0.02em;">
+      <p class="text-sm" style="letter-spacing: 0.02em; color: var(--color-neutral-500);">
         © 2026 DevTools — すべての処理はブラウザ内で完結します
       </p>
       <nav class="flex gap-6 text-sm" aria-label="フッターナビゲーション">
         <a
           href="/about"
-          class="text-neutral-400 underline hover:text-neutral-100 transition-colors"
+          class="footer-link underline transition-colors"
           style="letter-spacing: 0.02em;">About</a
         >
         <a
           href="/privacy"
-          class="text-neutral-400 underline hover:text-neutral-100 transition-colors"
+          class="footer-link underline transition-colors"
           style="letter-spacing: 0.02em;">プライバシーポリシー</a
         >
       </nav>
     </div>
   </div>
 </footer>
+
+<style>
+  .footer-link { color: var(--color-neutral-400); }
+  .footer-link:hover { color: var(--color-neutral-100); }
+</style>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -2,7 +2,7 @@
 import PageContainer from '@/components/ui/PageContainer.astro';
 ---
 
-<header class="sticky top-0 z-50 bg-white border-b border-neutral-200" style="height: 64px;">
+<header class="sticky top-0 z-50 border-b" style="height: 64px; background: var(--color-bg); border-color: var(--color-border);">
   <PageContainer class="flex h-full items-center justify-between">
     <a
       href="/"
@@ -15,8 +15,8 @@ import PageContainer from '@/components/ui/PageContainer.astro';
     <button
       id="mobile-menu-toggle"
       type="button"
-      class="lg:hidden flex items-center justify-center rounded-md transition-colors hover:bg-neutral-100"
-      style="width: 44px; height: 44px; color: #374151;"
+      class="lg:hidden flex items-center justify-center rounded-md transition-colors"
+      style="width: 44px; height: 44px; color: var(--color-neutral-700);"
       aria-label="メニューを開く"
       aria-expanded="false"
       aria-controls="mobile-drawer"
@@ -40,3 +40,7 @@ import PageContainer from '@/components/ui/PageContainer.astro';
     </button>
   </PageContainer>
 </header>
+
+<style>
+  #mobile-menu-toggle:hover { background: var(--color-bg-subtle); }
+</style>

--- a/src/components/layout/MobileDrawer.astro
+++ b/src/components/layout/MobileDrawer.astro
@@ -24,16 +24,16 @@ const { currentSlug } = Astro.props;
     role="dialog"
     aria-label="ナビゲーション"
     aria-modal="true"
-    class="absolute right-0 top-0 h-full w-64 bg-white overflow-y-auto shadow-xl"
-    style="padding: 1rem;"
+    class="absolute right-0 top-0 h-full w-64 overflow-y-auto shadow-xl"
+    style="padding: 1rem; background: var(--color-bg);"
   >
     <!-- 閉じるボタン -->
     <div class="flex justify-start mb-2">
       <button
         id="mobile-drawer-close"
         type="button"
-        class="flex items-center justify-center rounded-md transition-colors hover:bg-neutral-100"
-        style="width: 44px; height: 44px; color: #374151;"
+        class="drawer-close-btn flex items-center justify-center rounded-md transition-colors"
+        style="width: 44px; height: 44px; color: var(--color-neutral-700);"
         aria-label="メニューを閉じる"
       >
         <svg
@@ -61,7 +61,7 @@ const { currentSlug } = Astro.props;
           <div class="mb-6">
             <h2
               class="mb-2 px-3 font-bold uppercase"
-              style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: #6b7280;"
+              style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"
             >
               {categoryLabel[cat]}
             </h2>
@@ -75,7 +75,7 @@ const { currentSlug } = Astro.props;
                       <a
                         href={`/tools/${tool.slug}`}
                         aria-current={isActive ? 'page' : undefined}
-                        class={`flex items-center gap-2 rounded px-3 transition-colors ${isActive ? 'font-bold text-primary bg-blue-50' : 'text-neutral-700 hover:bg-neutral-100'}`}
+                        class={`flex items-center gap-2 rounded px-3 transition-colors drawer-link ${isActive ? 'font-bold text-primary drawer-link--active' : 'drawer-link--inactive'}`}
                         style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
                       >
                         <ToolIcon slug={tool.slug} size={16} class="shrink-0" />
@@ -91,6 +91,13 @@ const { currentSlug } = Astro.props;
     </nav>
   </div>
 </div>
+
+<style>
+  .drawer-close-btn:hover { background: var(--color-bg-subtle); }
+  .drawer-link--active { background: var(--color-background); }
+  .drawer-link--inactive { color: var(--color-neutral-700); }
+  .drawer-link--inactive:hover { background: var(--color-bg-subtle); }
+</style>
 
 <script>
   const toggle = document.getElementById('mobile-menu-toggle') as HTMLButtonElement | null;

--- a/src/components/layout/MobileDrawer.astro
+++ b/src/components/layout/MobileDrawer.astro
@@ -94,7 +94,7 @@ const { currentSlug } = Astro.props;
 
 <style>
   .drawer-close-btn:hover { background: var(--color-bg-subtle); }
-  .drawer-link--active { background: var(--color-background); }
+  .drawer-link--active { background: var(--color-bg-active); }
   .drawer-link--inactive { color: var(--color-neutral-700); }
   .drawer-link--inactive:hover { background: var(--color-bg-subtle); }
 </style>

--- a/src/components/layout/Sidebar.astro
+++ b/src/components/layout/Sidebar.astro
@@ -49,7 +49,7 @@ const { currentSlug } = Astro.props;
 </aside>
 
 <style>
-  .sidebar-link--active { background: var(--color-background); }
+  .sidebar-link--active { background: var(--color-bg-active); }
   .sidebar-link--inactive { color: var(--color-neutral-700); }
   .sidebar-link--inactive:hover { background: var(--color-bg-subtle); }
 </style>

--- a/src/components/layout/Sidebar.astro
+++ b/src/components/layout/Sidebar.astro
@@ -15,8 +15,8 @@ const { currentSlug } = Astro.props;
       categories.map((cat) => (
         <div class="mb-6">
           <h2
-            class="mb-2 px-3 font-bold text-neutral-500 uppercase"
-            style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em;"
+            class="mb-2 px-3 font-bold uppercase"
+            style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"
           >
             {categoryLabel[cat]}
           </h2>
@@ -28,11 +28,11 @@ const { currentSlug } = Astro.props;
                   <a
                     href={`/tools/${tool.slug}`}
                     aria-current={currentSlug === tool.slug ? 'page' : undefined}
-                    class={`flex items-center gap-2 rounded px-3 transition-colors
+                    class={`flex items-center gap-2 rounded px-3 transition-colors sidebar-link
                   ${
                     currentSlug === tool.slug
-                      ? 'font-bold text-primary bg-blue-50'
-                      : 'text-neutral-700 hover:bg-neutral-100'
+                      ? 'font-bold text-primary sidebar-link--active'
+                      : 'sidebar-link--inactive'
                   }`}
                     style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
                   >
@@ -47,3 +47,9 @@ const { currentSlug } = Astro.props;
     }
   </nav>
 </aside>
+
+<style>
+  .sidebar-link--active { background: var(--color-background); }
+  .sidebar-link--inactive { color: var(--color-neutral-700); }
+  .sidebar-link--inactive:hover { background: var(--color-bg-subtle); }
+</style>

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -11,7 +11,7 @@ import {
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
-import { bodyEmphasis, caption, colors, onFocusRing, onBlurRing } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { InputField } from '@/components/ui/InputField';
 import { Select } from '@/components/ui/Select';
 import { DownloadButtonGroup } from '@/components/ui/DownloadButtonGroup';
@@ -307,8 +307,6 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                         background: colors.bg,
                         color: colors.text,
                       }}
-                      onFocus={onFocusRing}
-                      onBlur={onBlurRing}
                     />
                     {field.error && (
                       <p
@@ -486,7 +484,7 @@ export function Gs1DatabarTool() {
               color: colors.primary,
               background: 'transparent',
             }}
-            onMouseEnter={(e) => (e.currentTarget.style.background = colors.primaryBg)}
+            onMouseEnter={(e) => (e.currentTarget.style.background = colors.bgPrimary)}
             onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
           >
             + バーコードを追加

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
-import { bodyEmphasis, caption, micro, colors } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { InputField } from '@/components/ui/InputField';
 import {
   parseJwt,
@@ -284,7 +284,7 @@ export function JwtDecoderTool() {
             <>
               {keyLabel}
               <span
-                style={{ ...micro, color: colors.muted, fontWeight: 400, marginLeft: '0.5rem' }}
+                style={{ ...caption, color: colors.muted, fontWeight: 400, marginLeft: '0.5rem' }}
               >
                 （任意）
               </span>
@@ -359,10 +359,10 @@ export function JwtDecoderTool() {
               <h3 style={{ ...bodyEmphasis, color: colors.text }}>Signature</h3>
               <CopyButton text={parsed.signature} label="コピー" />
             </div>
-            <p className="break-all font-mono" style={{ ...micro, color: colors.text }}>
+            <p className="break-all font-mono" style={{ ...caption, color: colors.text }}>
               {parsed.signature}
             </p>
-            <p className="mt-2" style={{ ...micro, color: colors.muted }}>
+            <p className="mt-2" style={{ ...caption, color: colors.muted }}>
               {secretKey.trim()
                 ? '上記のキーで署名を検証しています'
                 : 'キーを入力すると署名を検証します'}

--- a/src/components/tools/qr-ticket/ActionButton.tsx
+++ b/src/components/tools/qr-ticket/ActionButton.tsx
@@ -1,4 +1,4 @@
-import { colors, caption, onFocusRing, onBlurRing } from '@/utils/styles';
+import { colors, caption } from '@/utils/styles';
 
 interface ActionButtonProps {
   onClick: () => void;
@@ -45,8 +45,6 @@ export function ActionButton({
         cursor: disabled ? 'not-allowed' : 'pointer',
         whiteSpace: 'nowrap' as const,
       }}
-      onFocus={onFocusRing}
-      onBlur={onBlurRing}
     >
       {children}
     </button>

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -1,7 +1,7 @@
 import { CopyButton } from '@/components/ui/CopyButton';
 import { InputField } from '@/components/ui/InputField';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
-import { bodyEmphasis, caption, micro, colors, onFocusRing, onBlurRing } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { generateTicketId } from '@/utils/qr-ticket';
 import { ActionButton } from './ActionButton';
 import { MAX_TICKETS, sectionStyle, sectionHeaderStyle, sectionBodyStyle } from './index';
@@ -79,7 +79,7 @@ export function GenerateTab({
             <button
               type="button"
               onClick={onToggleImport}
-              style={{ ...micro, color: colors.link, background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+              style={{ ...caption, color: colors.link, background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
             >
               {showImport ? '▲ 秘密鍵インポートを閉じる' : '▼ 既存の秘密鍵をインポート'}
             </button>
@@ -189,8 +189,6 @@ export function GenerateTab({
                 color: colors.text,
                 outline: 'none',
               }}
-              onFocus={onFocusRing}
-              onBlur={onBlurRing}
             />
           </div>
         </div>
@@ -207,7 +205,7 @@ export function GenerateTab({
               style={{ gridTemplateColumns: '1fr 1fr 1fr auto', alignItems: 'center' }}
             >
               {(['チケットID', '参加者名（任意）', '料金区分（任意）', ''] as const).map((h) => (
-                <span key={h} style={{ ...micro, color: colors.muted, fontWeight: 600 }}>
+                <span key={h} style={{ ...caption, color: colors.muted, fontWeight: 600 }}>
                   {h}
                 </span>
               ))}
@@ -234,8 +232,6 @@ export function GenerateTab({
                     width: '100%',
                   }}
                   aria-label={`チケットID ${i + 1}`}
-                  onFocus={onFocusRing}
-                  onBlur={onBlurRing}
                 />
                 <input
                   value={row.name}
@@ -252,8 +248,6 @@ export function GenerateTab({
                     width: '100%',
                   }}
                   aria-label={`参加者名 ${i + 1}`}
-                  onFocus={onFocusRing}
-                  onBlur={onBlurRing}
                 />
                 <input
                   value={row.category}
@@ -270,8 +264,6 @@ export function GenerateTab({
                     width: '100%',
                   }}
                   aria-label={`料金区分 ${i + 1}`}
-                  onFocus={onFocusRing}
-                  onBlur={onBlurRing}
                 />
                 <button
                   type="button"
@@ -346,16 +338,16 @@ export function GenerateTab({
                   style={{ width: '160px', height: '160px' }}
                   dangerouslySetInnerHTML={{ __html: qr.svg }}
                 />
-                <span style={{ ...micro, color: colors.text, fontFamily: 'monospace', fontWeight: 600 }}>
+                <span style={{ ...caption, color: colors.text, fontFamily: 'monospace', fontWeight: 600 }}>
                   {qr.ticket.t}
                 </span>
                 {qr.ticket.n && (
-                  <span style={{ ...micro, color: colors.muted }}>{qr.ticket.n}</span>
+                  <span style={{ ...caption, color: colors.muted }}>{qr.ticket.n}</span>
                 )}
                 {qr.ticket.p && (
                   <span
                     style={{
-                      ...micro,
+                      ...caption,
                       color: colors.primary,
                       border: `1px solid ${colors.primary}`,
                       borderRadius: '9999px',

--- a/src/components/tools/qr-ticket/TicketDetail.tsx
+++ b/src/components/tools/qr-ticket/TicketDetail.tsx
@@ -1,4 +1,4 @@
-import { colors, caption, micro } from '@/utils/styles';
+import { colors, caption } from '@/utils/styles';
 import type { TicketPayload } from '@/utils/qr-ticket';
 
 function formatExpiry(iso: string): string {
@@ -31,7 +31,7 @@ export function TicketDetail({ ticket }: { ticket: TicketPayload }) {
           <tr key={label}>
             <td
               style={{
-                ...micro,
+                ...caption,
                 color: colors.muted,
                 paddingRight: '1rem',
                 paddingBottom: '0.25rem',

--- a/src/components/tools/qr-ticket/VerifyTab.tsx
+++ b/src/components/tools/qr-ticket/VerifyTab.tsx
@@ -1,7 +1,7 @@
 import { InputField } from '@/components/ui/InputField';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
-import { bodyEmphasis, caption, micro, colors } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import type { VerificationResult } from '@/utils/qr-ticket';
 import { ActionButton } from './ActionButton';
 import { TicketDetail } from './TicketDetail';
@@ -85,7 +85,7 @@ export function VerifyTab({
                 </ActionButton>
               )}
               {!verifyPubKeyStr.trim() && (
-                <p style={{ ...micro, color: colors.muted }}>
+                <p style={{ ...caption, color: colors.muted }}>
                   公開鍵を入力してからカメラを起動してください
                 </p>
               )}
@@ -139,7 +139,7 @@ export function VerifyTab({
                 />
               </label>
               {!verifyPubKeyStr.trim() && (
-                <p style={{ ...micro, color: colors.muted }}>公開鍵を入力してください</p>
+                <p style={{ ...caption, color: colors.muted }}>公開鍵を入力してください</p>
               )}
             </div>
           )}

--- a/src/components/ui/CategoryBadge.astro
+++ b/src/components/ui/CategoryBadge.astro
@@ -6,8 +6,8 @@ interface Props {
 const { label, class: extraClass = '' } = Astro.props;
 ---
 <span
-  class:list={['rounded-full px-3 font-bold text-blue-800 bg-blue-100', extraClass]}
-  style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em;"
+  class:list={['rounded-full px-3 font-bold', extraClass]}
+  style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em; color: var(--color-tertiary); background: var(--color-blue-100);"
 >
   {label}
 </span>

--- a/src/components/ui/CategoryBadge.astro
+++ b/src/components/ui/CategoryBadge.astro
@@ -7,7 +7,7 @@ const { label, class: extraClass = '' } = Astro.props;
 ---
 <span
   class:list={['rounded-full px-3 font-bold', extraClass]}
-  style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em; color: var(--color-tertiary); background: var(--color-blue-100);"
+  style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em; color: var(--color-tertiary); background: var(--color-badge-bg);"
 >
   {label}
 </span>

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -1,5 +1,5 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
-import { bodyEmphasis, caption, micro, colors } from '@/utils/styles';
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 
 interface Props {
@@ -64,7 +64,7 @@ export function InputField({
             type="button"
             onClick={onSampleClick}
             style={{
-              ...micro,
+              ...caption,
               color: colors.link,
               background: 'none',
               border: 'none',
@@ -109,7 +109,7 @@ export function InputField({
       {error ? (
         <ErrorMessage id={errorId} message={error} />
       ) : hint ? (
-        <p id={hintId} style={{ ...micro, color: colors.muted, marginTop: '0.25rem' }}>
+        <p id={hintId} style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}>
           {hint}
         </p>
       ) : null}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,7 +37,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).href;
     <meta name="theme-color" content="#1A56DB" />
     {jsonLd && <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
   </head>
-  <body class="bg-neutral-50 text-neutral-900 min-h-screen">
+  <body class="min-h-screen" style="background: var(--color-bg-surface); color: var(--color-text);">
     <a href="#main-content" class="skip-link">本文へスキップ</a>
     <Header />
     <MobileDrawer currentSlug={currentSlug} />

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -42,14 +42,14 @@ const jsonLd = {
       <!-- パンくずリスト -->
       <nav
         aria-label="パンくずリスト"
-        class="mb-6 flex items-center gap-1.5 text-neutral-500"
-        style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+        class="mb-6 flex items-center gap-1.5"
+        style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"
       >
         <a href="/" class="text-link underline hover:no-underline transition-colors">ホーム</a>
         <span aria-hidden="true">›</span>
         <span>{categoryLabel[tool.category]}</span>
         <span aria-hidden="true">›</span>
-        <span class="text-neutral-900">{tool.name}</span>
+        <span style="color: var(--color-text);">{tool.name}</span>
       </nav>
 
       <!-- ツールヘッダー -->
@@ -57,14 +57,14 @@ const jsonLd = {
         <ToolIcon slug={tool.slug} size={32} class="text-primary shrink-0" />
         <div class="min-w-0 flex-1">
           <h1
-            class="font-bold text-neutral-900"
-            style="font-size: 1.625rem; line-height: 1.5; letter-spacing: 0.02em;"
+            class="font-bold"
+            style="font-size: 1.625rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
           >
             {tool.name}
           </h1>
           <p
-            class="mt-1 text-neutral-500"
-            style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+            class="mt-1"
+            style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"
           >
             {tool.description}
           </p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -19,22 +19,21 @@ const jsonLd = {
 >
   <main class="mx-auto max-w-2xl px-6 py-12" id="main-content">
     <h1
-      class="mb-8 font-bold text-neutral-900"
-      style="font-size: 1.75rem; line-height: 1.4; letter-spacing: 0.02em;"
+      class="mb-8 font-bold"
+      style="font-size: 1.75rem; line-height: 1.4; letter-spacing: 0.02em; color: var(--color-text);"
     >
       About
     </h1>
 
     <section class="mb-10">
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         DevTools とは
       </h2>
       <p
-        class="text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         DevTools は、ブラウザだけで完結する無料の開発者向けユーティリティです。
         インストール不要・ユーザー登録不要で、すべての処理をクライアントサイドで実行します。
@@ -44,14 +43,14 @@ const jsonLd = {
 
     <section class="mb-10">
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         設計方針
       </h2>
       <ul
-        class="space-y-2 text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        class="space-y-2"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         <li>
           <strong>ブラウザ完結</strong> — すべての処理はブラウザ内で完結します。データは外部に送信されません。
@@ -68,8 +67,8 @@ const jsonLd = {
 
     <section class="mb-10">
       <h2
-        class="mb-4 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-4 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         ツール一覧
       </h2>
@@ -85,8 +84,8 @@ const jsonLd = {
                 {tool.name}
               </a>
               <span
-                class="ml-2 text-neutral-500"
-                style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+                class="ml-2"
+                style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"
               >
                 — {tool.description}
               </span>
@@ -98,14 +97,14 @@ const jsonLd = {
 
     <section>
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         技術スタック
       </h2>
       <ul
-        class="space-y-1 text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        class="space-y-1"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         <li><strong>フレームワーク:</strong> Astro 6 + React 19</li>
         <li><strong>スタイリング:</strong> Tailwind CSS v4</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ const jsonLd = {
         aria-selected="true"
         aria-controls="panel-0"
         data-index="0"
-        class="tab-btn px-4 py-2 font-bold text-primary border-b-2 border-primary -mb-px transition-colors"
+        class="tab-btn px-4 py-2 font-bold border-b-2 -mb-px transition-colors"
         style="font-size: 0.875rem; letter-spacing: 0.02em;"
       >
         すべて
@@ -66,7 +66,7 @@ const jsonLd = {
             aria-selected="false"
             aria-controls={`panel-${i + 1}`}
             data-index={i + 1}
-            class="tab-btn px-4 py-2 font-bold border-b-2 border-transparent -mb-px hover:text-primary hover:border-primary transition-colors"
+            class="tab-btn px-4 py-2 font-bold border-b-2 -mb-px transition-colors"
             style="font-size: 0.875rem; letter-spacing: 0.02em;"
           >
             {categoryLabel[cat]}
@@ -135,7 +135,9 @@ const jsonLd = {
   #panels::-webkit-scrollbar {
     display: none;
   }
-  .tab-btn[aria-selected="false"] { color: var(--color-muted); }
+  .tab-btn[aria-selected="true"]  { color: var(--color-primary); border-color: var(--color-primary); }
+  .tab-btn[aria-selected="false"] { color: var(--color-muted);   border-color: transparent; }
+  .tab-btn[aria-selected="false"]:hover { color: var(--color-primary); border-color: var(--color-primary); }
 </style>
 
 <script>
@@ -144,11 +146,7 @@ const jsonLd = {
 
   function activateTab(index: number) {
     tabs.forEach((t, i) => {
-      const active = i === index;
-      t.setAttribute('aria-selected', String(active));
-      t.classList.toggle('text-primary', active);
-      t.classList.toggle('border-primary', active);
-      t.classList.toggle('border-transparent', !active);
+      t.setAttribute('aria-selected', String(i === index));
     });
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,14 +24,14 @@ const jsonLd = {
   jsonLd={jsonLd}
 >
   <!-- ヒーロー -->
-  <section class="bg-blue-50 text-center px-4 py-8" style="border-bottom: 1px solid var(--color-blue-100);">
+  <section class="text-center px-4 py-8" style="background: var(--color-background); border-bottom: 1px solid var(--color-blue-100);">
     <h1
-      class="mb-2 font-bold text-neutral-900"
-      style="font-size: 2rem; line-height: 1.4; letter-spacing: 0.01em;"
+      class="mb-2 font-bold"
+      style="font-size: 2rem; line-height: 1.4; letter-spacing: 0.01em; color: var(--color-text);"
     >
       DevTools
     </h1>
-    <p class="text-neutral-600" style="font-size: 1rem; line-height: 1.7; letter-spacing: 0.02em;">
+    <p style="font-size: 1rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-neutral-600);">
       ブラウザで完結する無料の開発者ツール集
     </p>
   </section>
@@ -44,7 +44,8 @@ const jsonLd = {
       id="tab-bar"
       role="tablist"
       aria-label="カテゴリ絞り込み"
-      class="mb-6 flex gap-1 border-b border-neutral-200"
+      class="mb-6 flex gap-1 border-b"
+      style="border-color: var(--color-border);"
     >
       <button
         role="tab"
@@ -65,7 +66,7 @@ const jsonLd = {
             aria-selected="false"
             aria-controls={`panel-${i + 1}`}
             data-index={i + 1}
-            class="tab-btn px-4 py-2 font-bold text-neutral-500 border-b-2 border-transparent -mb-px hover:text-primary hover:border-primary transition-colors"
+            class="tab-btn px-4 py-2 font-bold border-b-2 border-transparent -mb-px hover:text-primary hover:border-primary transition-colors"
             style="font-size: 0.875rem; letter-spacing: 0.02em;"
           >
             {categoryLabel[cat]}
@@ -102,14 +103,14 @@ const jsonLd = {
                       <CategoryBadge label={categoryLabel[tool.category]} class="py-0.5" />
                     </div>
                     <h2
-                      class="mb-2 font-bold text-neutral-900 group-hover:text-primary transition-colors"
-                      style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+                      class="mb-2 font-bold group-hover:text-primary transition-colors"
+                      style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
                     >
                       {tool.name}
                     </h2>
                     <p
-                      class="mb-4 text-neutral-500"
-                      style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+                      class="mb-4"
+                      style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"
                     >
                       {tool.description}
                     </p>
@@ -134,6 +135,7 @@ const jsonLd = {
   #panels::-webkit-scrollbar {
     display: none;
   }
+  .tab-btn[aria-selected="false"] { color: var(--color-muted); }
 </style>
 
 <script>
@@ -146,7 +148,6 @@ const jsonLd = {
       t.setAttribute('aria-selected', String(active));
       t.classList.toggle('text-primary', active);
       t.classList.toggle('border-primary', active);
-      t.classList.toggle('text-neutral-500', !active);
       t.classList.toggle('border-transparent', !active);
     });
   }

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -20,28 +20,27 @@ const lastUpdated = '2026年4月12日';
 >
   <main class="mx-auto max-w-2xl px-6 py-12" id="main-content">
     <h1
-      class="mb-2 font-bold text-neutral-900"
-      style="font-size: 1.75rem; line-height: 1.4; letter-spacing: 0.02em;"
+      class="mb-2 font-bold"
+      style="font-size: 1.75rem; line-height: 1.4; letter-spacing: 0.02em; color: var(--color-text);"
     >
       プライバシーポリシー
     </h1>
     <p
-      class="mb-10 text-neutral-500"
-      style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+      class="mb-10"
+      style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"
     >
       最終更新: {lastUpdated}
     </p>
 
     <section class="mb-10">
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         データの収集について
       </h2>
       <p
-        class="text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         DevTools は、いかなる個人情報・入力データも収集・保存・送信しません。
         すべての処理はお使いのブラウザ内で完結し、入力した内容が外部サーバーに送信されることはありません。
@@ -50,14 +49,13 @@ const lastUpdated = '2026年4月12日';
 
     <section class="mb-10">
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         Cookie・ローカルストレージ
       </h2>
       <p
-        class="text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         本サービスは Cookie を使用していません。
         ローカルストレージへの保存も現時点では行っておりません。
@@ -66,14 +64,13 @@ const lastUpdated = '2026年4月12日';
 
     <section class="mb-10">
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         アクセス解析・広告
       </h2>
       <p
-        class="text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         アクセス解析ツール・広告サービス・サードパーティのトラッキングスクリプトは一切使用していません。
       </p>
@@ -81,14 +78,13 @@ const lastUpdated = '2026年4月12日';
 
     <section class="mb-10">
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         ホスティング
       </h2>
       <p
-        class="text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         本サービスは Cloudflare Pages でホストされています。 Cloudflare
         のサーバーはリクエストに伴う標準的なサーバーログ（IPアドレス等）を一時的に記録する場合があります。
@@ -103,14 +99,13 @@ const lastUpdated = '2026年4月12日';
 
     <section>
       <h2
-        class="mb-3 font-bold text-neutral-900"
-        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em;"
+        class="mb-3 font-bold"
+        style="font-size: 1.125rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
       >
         ポリシーの変更
       </h2>
       <p
-        class="text-neutral-700"
-        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em;"
+        style="font-size: 1rem; line-height: 1.8; letter-spacing: 0.02em; color: var(--color-neutral-700);"
       >
         本ポリシーを変更する場合は、このページを更新します。
       </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,6 +85,8 @@
   --color-border-input: #d1d5db; /* neutral-300 */
   --color-error-text: #b91c1c; /* red-700 */
   --color-text-on-primary: #ffffff; /* プライマリ色背景上の文字（白抜き）。ダークモード時も白を維持 */
+  --color-bg-active: #eff6ff; /* アクティブなナビ項目背景（blue-50） */
+  --color-badge-bg: #dbeafe; /* カテゴリバッジ背景（blue-100） */
 }
 
 /* ボタン・リンク類のカーソルを pointer に統一 */

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, FocusEvent } from 'react';
+import type { CSSProperties } from 'react';
 
 /**
  * DADSカラーシステム
@@ -16,8 +16,6 @@ export const colors = {
   bgSurface: 'var(--color-bg-surface)',
   bgSubtle: 'var(--color-bg-subtle)',
   bgPrimary: 'var(--color-background)',
-  /** @deprecated `bgPrimary` を使用してください */
-  primaryBg: 'var(--color-background)',
   /** プライマリ色背景上のテキスト（白抜き文字）。ダークモード時も白を維持する意図 */
   textOnPrimary: 'var(--color-text-on-primary)',
   border: 'var(--color-border)',
@@ -48,11 +46,6 @@ export const radii = {
   full: 'var(--radius-full)',
 } as const;
 
-/** @deprecated `elevation.level2` を使用してください */
-export const shadows = {
-  tab: 'var(--elevation-2)',
-} as const;
-
 /** 本文強調: 17px Bold */
 export const bodyEmphasis: CSSProperties = {
   fontSize: '1.0625rem',
@@ -69,22 +62,3 @@ export const caption: CSSProperties = {
   letterSpacing: '0.02em',
 };
 
-/** @deprecated {@link caption} を使用してください */
-export const micro = caption;
-
-/**
- * @deprecated focus-visible は global.css の CSS ルールで一括適用されています。
- * このハンドラを onFocus に渡す必要はありません。
- */
-export function onFocusRing(e: FocusEvent<HTMLElement>): void {
-  e.currentTarget.style.outline = `2px solid ${colors.link}`;
-  e.currentTarget.style.outlineOffset = '2px';
-}
-
-/**
- * @deprecated focus-visible は global.css の CSS ルールで一括適用されています。
- * このハンドラを onBlur に渡す必要はありません。
- */
-export function onBlurRing(e: FocusEvent<HTMLElement>): void {
-  e.currentTarget.style.outline = 'none';
-}


### PR DESCRIPTION
## 概要

- Astro コンポーネント・ページの Tailwind カラークラス（`text-neutral-*`, `bg-blue-50` 等）をすべて CSS 変数経路（`style="color: var(--color-*)"` または `<style>` ブロック）に置換
- `src/utils/styles.ts` の deprecated エントリ（`primaryBg`, `shadows`, `micro`, `onFocusRing`, `onBlurRing`）を削除
- `CLAUDE.md` のスタイルルールを Astro にも明示的に適用するよう更新
- `docs/decisions.md` に設計判断 [039] を追記

## 変更ファイル

**Astro カラー置換（10ファイル）**
- `src/components/layout/Header.astro`
- `src/components/layout/Footer.astro`
- `src/components/layout/Sidebar.astro`
- `src/components/layout/MobileDrawer.astro`
- `src/layouts/BaseLayout.astro`
- `src/layouts/ToolLayout.astro`
- `src/components/ui/CategoryBadge.astro`
- `src/pages/index.astro`
- `src/pages/about.astro`
- `src/pages/privacy.astro`

**TSX deprecated 解消（7ファイル）**
- `src/components/ui/InputField.tsx` — `micro` → `caption`
- `src/components/tools/JwtDecoder.tsx` — `micro` → `caption`
- `src/components/tools/Gs1Databar.tsx` — `onFocusRing/onBlurRing` 削除、`primaryBg` → `bgPrimary`
- `src/components/tools/qr-ticket/ActionButton.tsx` — `onFocusRing/onBlurRing` 削除
- `src/components/tools/qr-ticket/GenerateTab.tsx` — `micro` → `caption`、`onFocusRing/onBlurRing` 削除
- `src/components/tools/qr-ticket/VerifyTab.tsx` — `micro` → `caption`
- `src/components/tools/qr-ticket/TicketDetail.tsx` — `micro` → `caption`

**定義削除**
- `src/utils/styles.ts` — deprecated エントリをすべて削除

## テスト確認

- `astro check` にてエラーゼロを確認
- Playwright でPC（1280×800）・スマホ（390×844）両サイズの目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)