### PR TITLE
chore: dev server / Playwright をサンドボックス除外コマンドに追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,13 @@
       "gh workflow *",
       "gh api *",
       "curl*",
-      "wget*"
+      "wget*",
+      "npm run dev*",
+      "npm run preview*",
+      "npm run test:e2e*",
+      "npx astro dev*",
+      "npx astro preview*",
+      "npx playwright test*"
     ],
     "allowUnsandboxedCommands": false,
     "network": {

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ conductor/
 # Active Task Context (Temporary session notes)
 tasks/active_context.md
 .worktrees/
+.claude/worktrees/


### PR DESCRIPTION
## 概要

`.claude/settings.json` のサンドボックスが TCP `listen()` を拒否するため、`npm run dev` や `npm run test:e2e` 経由で起動する Astro dev server が `listen EPERM ::1:4321` で起動できなかった。listen が必要なコマンドだけサンドボックス外で実行できるよう `excludedCommands` を拡張する。

## 変更内容

`.claude/settings.json` の `sandbox.excludedCommands` に以下 6 件を追加:

- `npm run dev*`
- `npm run preview*`
- `npm run test:e2e*`
- `npx astro dev*`
- `npx astro preview*`
- `npx playwright test*`

サンドボックス自体は有効のまま（`enabled: true` / `allowUnsandboxedCommands: false`）で、最小権限の方針を維持。

## 動作確認

- [x] `npm run test:e2e` → 111 passed / 1 skipped
- [x] `npm run test` (vitest) → 175 passed
- [x] Prettier / TypeScript pre-commit OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)