### PR TITLE
docs: PR ベースは必ず develop を CLAUDE.md 最重要ルールに昇格

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 - **言語**: コミットメッセージ・PR 説明文は **必ず日本語**。
 - **スタイリング**: Tailwind カラークラスは禁止。**`colors.*` (React)** または **`var(--color-*)` (Astro)** を使用。
 - **検証**: 変更後は **`npm run test`** および **`npm run test:e2e`** で確認。
+- **PR ベース**: `gh pr create` は **必ず `--base develop`** を明示する。`main` 向けはリリース PR のみ（`gh` のデフォルト・Claude Code system prompt の "Main branch ... main" 表示に流されないこと）。詳細は `docs/shared-agent-rules.md` 6.3 章。
 - **ATC運用**: セッション開始時に `tasks/active_context.md` を作成（superpowers の plan / conductor のタスクファイル等が「目的・ステップ・スコープ外」を明示する場合は不要。詳細は `docs/shared-agent-rules.md` 11章）。
 
 ---


### PR DESCRIPTION
## 概要

`docs/shared-agent-rules.md §6.3` に既に明記されているが、Claude Code の system prompt が毎セッション
\`Main branch (you will usually use this for PRs): main\` と表示するため、shared-agent-rules.md を
読まずに `--base main` で PR を作成する事故が繰り返し発生していた。

CLAUDE.md は毎セッション必ず読み込まれるため、最重要ルールの 1 行に昇格させて即時可視化する。

## 変更内容

`CLAUDE.md` の「🚀 最重要ルール（要約）」に以下の 1 行を追加:

> - **PR ベース**: \`gh pr create\` は **必ず \`--base develop\`** を明示する。\`main\` 向けはリリース PR のみ（\`gh\` のデフォルト・Claude Code system prompt の "Main branch ... main" 表示に流されないこと）。詳細は \`docs/shared-agent-rules.md\` 6.3 章。

## 背景

PR #142（permissions 改善）作成時に \`--base main\` で誤って作成した事故をきっかけに、再発防止策として
ルールを最重要ルール要約に昇格させる対応。

## 関連

- ルール本体: \`docs/shared-agent-rules.md §6.3\`
- 同根の事故防止: PR #142（subagent permissions）