### PR TITLE
chore(claude): SessionStart hook で Playwright ブラウザを自動導入

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Claude Code on the web セッション開始時に依存関係を導入する。
+# - npm 依存関係（vitest / playwright 等）
+# - Playwright 用 Chromium バイナリ（E2E 実行に必須）
+# ローカル CLI 等の非リモート環境ではスキップ。
+set -euo pipefail
+
+# リモート環境（Claude Code on the web）以外では何もしない
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+echo "[session-start] npm install"
+npm install --no-audit --no-fund
+
+echo "[session-start] playwright install chromium"
+npx playwright install chromium
+
+echo "[session-start] done"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,18 @@
     "type": "command",
     "command": "sh .claude/statusline-command.sh"
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,


### PR DESCRIPTION
## 概要

Claude Code on the web のリモートセッションで E2E（`npm run test:e2e`）を実行可能にするため、SessionStart hook を追加します。

ローカル CLI 環境（`CLAUDE_CODE_REMOTE` が未設定）では何も実行しないため、既存ワークフローには影響しません。

## 背景

PR #144 をローカル検証する際、Playwright のブラウザバイナリが未導入で E2E を実行できませんでした:

```
Executable doesn't exist at /opt/pw-browsers/.../chrome-headless-shell
```

`npm ci` だけでは Playwright のブラウザは降りてこず、別途 `npx playwright install chromium` が必要です。CI では `.github/workflows/test.yml` 側で対応済みですが、Claude Code on the web のセッションでは未対応でした。

## 変更内容

### `.claude/hooks/session-start.sh` (新規)

- リモート環境でのみ動作（`CLAUDE_CODE_REMOTE != "true"` なら早期 exit）
- `npm install --no-audit --no-fund`
- `npx playwright install chromium`
- 冪等（再実行しても no-op で完了）

### `.claude/settings.json`

- `hooks.SessionStart` に上記スクリプトを登録
- ネットワーク allowedDomains に `cdn.playwright.dev` / `playwright.azureedge.net` は既存

## 実行モード

**同期実行**（デフォルト）。E2E 実行前にブラウザインストールが完了することを保証します。

- 利点: セッション開始直後でも `npm run test:e2e` が確実に動作
- 欠点: セッション開始までに Chromium DL 分（30-60 秒程度）待つ
- 高速化したい場合は `{"async": true}` 出力に切り替え可能（フォローアップで対応）

## 検証

ローカル（CLI 環境）での検証結果:

- ✅ `CLAUDE_CODE_REMOTE=true bash ./.claude/hooks/session-start.sh` で `npm install` 部分は成功（既導入のため up to date）
- ⚠️ `playwright install chromium` 部分は本ローカルサンドボックスのプロキシ制約により `cdn.playwright.dev` への接続が `host_not_allowed` で失敗。Claude Code on the web 環境および CI では allowlist が異なるため動作する想定
- ✅ `npm run format:check` 差分なし
- ✅ `npx vitest run` 単体ケース pass

マージ後は新規セッションで自動的にブラウザがインストールされ、E2E が即実行可能になります。

## 関連

- 補足: PR #144 で発覚した E2E 未実行の運用課題への対応

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6Dkez4wZdvQThiSXZmV3X)_