### PR TITLE
ci: developブランチへのプッシュ時もカバレッジバッジを更新する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -36,19 +36,19 @@ jobs:
         run: npm test -- --coverage
 
       - name: カバレッジバッジを更新
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
         run: |
           COVERAGE=$(node -e "console.log(Math.round(require('./coverage/coverage-summary.json').total.statements.pct))")
           COLOR=$(COVERAGE=$COVERAGE node -e "const pct = +process.env.COVERAGE; console.log(pct >= 90 ? 'brightgreen' : pct >= 80 ? 'green' : pct >= 70 ? 'yellowgreen' : pct >= 60 ? 'yellow' : 'red')")
           sed -i "s/coverage-[0-9.]*%25-[a-z]*/coverage-$COVERAGE%25-$COLOR/g" README.md
 
       - name: 変更をコミットしてプッシュ
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md
-          git diff --staged --quiet || (git commit -m "docs: カバレッジバッジを更新 [skip ci]" && git pull --rebase origin main && git push)
+          git diff --staged --quiet || (git commit -m "docs: カバレッジバッジを更新 [skip ci]" && git pull --rebase origin ${{ github.ref_name }} && git push)
 
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

- `develop` ブランチへのプッシュ時にもカバレッジバッジの更新が行われるよう CI を修正

## 変更内容

- `on.push.branches` に `develop` を追加
- カバレッジバッジ更新・コミットの `if` 条件に `refs/heads/develop` を追加
- `git pull --rebase origin main` のハードコードを `${{ github.ref_name }}` に変更（develop で main からリベースしてしまう問題を修正）

## テスト計画

- [ ] `develop` へのプッシュ後、GitHub Actions でカバレッジバッジ更新ステップが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)