### PR TITLE
fix(config-converter): 変換先フォーマット変更時に入力テキストを保持する

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -87,7 +87,6 @@ export function ConfigConverterTool() {
 
   const handleToChange = (next: ConfigFormat) => {
     setTo(next);
-    reset();
     setWarnings([]);
     setValidationResult(null);
   };

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -128,11 +128,6 @@ test.describe('設定ファイル相互変換', () => {
   });
 
   test('変換先のみ変更しても入力テキストが保持される', async ({ page }) => {
-    await page.goto('/');
-    await waitForReactHydration(page);
-    await page.getByRole('link', { name: /config.converter/i }).click();
-    await waitForReactHydration(page);
-
     const fromGroup = page.getByRole('group', { name: '変換元フォーマット' });
     const toGroup = page.getByRole('group', { name: '変換先フォーマット' });
 
@@ -162,11 +157,6 @@ test.describe('設定ファイル相互変換', () => {
   });
 
   test('変換元を変更すると入力テキストがクリアされる（回帰テスト）', async ({ page }) => {
-    await page.goto('/');
-    await waitForReactHydration(page);
-    await page.getByRole('link', { name: /config.converter/i }).click();
-    await waitForReactHydration(page);
-
     const fromGroup = page.getByRole('group', { name: '変換元フォーマット' });
 
     // JSON テキストを入力

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -126,4 +126,57 @@ test.describe('設定ファイル相互変換', () => {
 
     await expect(page.getByText('スキーマ検証成功')).toBeVisible();
   });
+
+  test('変換先のみ変更しても入力テキストが保持される', async ({ page }) => {
+    await page.goto('/');
+    await waitForReactHydration(page);
+    await page.getByRole('link', { name: /config.converter/i }).click();
+    await waitForReactHydration(page);
+
+    const fromGroup = page.getByRole('group', { name: '変換元フォーマット' });
+    const toGroup = page.getByRole('group', { name: '変換先フォーマット' });
+
+    // YAML → JSON にセット
+    await fromGroup.getByRole('button', { name: 'YAML' }).click();
+    await toGroup.getByRole('button', { name: 'JSON' }).click();
+
+    // YAML テキストを入力
+    const inputTextarea = page.getByLabel(/^YAML/);
+    await inputTextarea.fill('host: localhost\nport: 8080');
+
+    // 出力が JSON になるまで待機
+    await page.waitForFunction(() => {
+      const outputs = document.querySelectorAll('textarea[readonly]');
+      return Array.from(outputs).some((el) => (el as HTMLTextAreaElement).value.includes('{'));
+    });
+
+    // 変換先を TOML に切り替え
+    await toGroup.getByRole('button', { name: 'TOML' }).click();
+
+    // 入力が保持されていること
+    await expect(inputTextarea).toHaveValue('host: localhost\nport: 8080');
+
+    // 出力が TOML 形式に更新されること
+    const outputTextarea = page.locator('textarea[readonly]').first();
+    await expect(outputTextarea).toContainText('host');
+  });
+
+  test('変換元を変更すると入力テキストがクリアされる（回帰テスト）', async ({ page }) => {
+    await page.goto('/');
+    await waitForReactHydration(page);
+    await page.getByRole('link', { name: /config.converter/i }).click();
+    await waitForReactHydration(page);
+
+    const fromGroup = page.getByRole('group', { name: '変換元フォーマット' });
+
+    // JSON テキストを入力
+    const inputTextarea = page.getByLabel(/^JSON/);
+    await inputTextarea.fill('{"host":"localhost"}');
+
+    // 変換元を YAML に切り替え
+    await fromGroup.getByRole('button', { name: 'YAML' }).click();
+
+    // 入力がクリアされること
+    await expect(page.locator('textarea').first()).toHaveValue('');
+  });
 });

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -140,10 +140,7 @@ test.describe('設定ファイル相互変換', () => {
     await inputTextarea.fill('host: localhost\nport: 8080');
 
     // 出力が JSON になるまで待機
-    await page.waitForFunction(() => {
-      const outputs = document.querySelectorAll('textarea[readonly]');
-      return Array.from(outputs).some((el) => (el as HTMLTextAreaElement).value.includes('{'));
-    });
+    await expect(page.getByLabel('JSON')).toHaveValue(/\{/);
 
     // 変換先を TOML に切り替え
     await toGroup.getByRole('button', { name: 'TOML' }).click();
@@ -152,8 +149,7 @@ test.describe('設定ファイル相互変換', () => {
     await expect(inputTextarea).toHaveValue('host: localhost\nport: 8080');
 
     // 出力が TOML 形式に更新されること
-    const outputTextarea = page.locator('textarea[readonly]').first();
-    await expect(outputTextarea).toContainText('host');
+    await expect(page.getByLabel('TOML')).toHaveValue(/host/);
   });
 
   test('変換元を変更すると入力テキストがクリアされる（回帰テスト）', async ({ page }) => {
@@ -167,6 +163,6 @@ test.describe('設定ファイル相互変換', () => {
     await fromGroup.getByRole('button', { name: 'YAML' }).click();
 
     // 入力がクリアされること
-    await expect(page.locator('textarea').first()).toHaveValue('');
+    await expect(page.getByLabel('YAML (整形)')).toHaveValue('');
   });
 });


### PR DESCRIPTION
## 概要

変換先フォーマット（to）のみ変更した場合に入力テキストが消えてしまう UX バグを修正します。

## 変更内容

- `handleToChange` から `reset()` の呼び出しを削除
  - `useCodec` の deps に `to` が含まれているため、`to` の更新だけで出力は自動再計算される
  - 変換元変更（`handleFromChange`）は従来どおり入力をクリア

## テスト

- `npm run test`: 256 件 pass
- `npm run test:e2e`: 128 件 pass（1 skipped）
- 新規 E2E テスト 2 件追加
  - 変換先のみ変更しても入力テキストが保持されることを確認
  - 変換元変更時は入力がクリアされること（回帰テスト）を確認

Closes #141
