### PR TITLE
feat(config-converter): JSON Schema 検証パネルに Cmd/Ctrl+Enter ショートカットを追加

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -240,6 +240,13 @@ export function ConfigConverterTool() {
               mono
               resize
               placeholder='{ "$schema": "...", "type": "object", ... }'
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                  if (!output || !schemaText || isValidating) return;
+                  e.preventDefault();
+                  handleValidate();
+                }
+              }}
             />
             <div className="flex items-center gap-3">
               <button
@@ -260,6 +267,7 @@ export function ConfigConverterTool() {
               >
                 {isValidating ? '検証中...' : '検証する'}
               </button>
+              <span style={{ ...caption, color: colors.muted }}>Cmd/Ctrl+Enter</span>
             </div>
             {validationResult && (
               <div

--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -241,6 +241,7 @@ export function ConfigConverterTool() {
               resize
               placeholder='{ "$schema": "...", "type": "object", ... }'
               onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing) return;
                 if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                   if (!output || !schemaText || isValidating) return;
                   e.preventDefault();
@@ -253,6 +254,7 @@ export function ConfigConverterTool() {
                 type="button"
                 onClick={handleValidate}
                 disabled={!output || !schemaText || isValidating}
+                aria-keyshortcuts="Meta+Enter Control+Enter"
                 className="rounded-lg px-4 py-2"
                 style={{
                   ...caption,
@@ -267,7 +269,12 @@ export function ConfigConverterTool() {
               >
                 {isValidating ? '検証中...' : '検証する'}
               </button>
-              <span style={{ ...caption, color: colors.muted }}>Cmd/Ctrl+Enter</span>
+              <kbd
+                style={{ ...caption, color: colors.muted, fontFamily: 'monospace' }}
+                aria-hidden="true"
+              >
+                Cmd/Ctrl+Enter
+              </kbd>
             </div>
             {validationResult && (
               <div

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -18,6 +18,7 @@ interface Props {
   readOnly?: boolean;
   mono?: boolean;
   resize?: boolean;
+  onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
 }
 
 export function InputField({
@@ -36,6 +37,7 @@ export function InputField({
   readOnly = false,
   mono = false,
   resize = false,
+  onKeyDown,
 }: Props) {
   const hintId = hint ? `${id}-hint` : undefined;
   const errorId = error ? `${id}-error` : undefined;
@@ -85,6 +87,7 @@ export function InputField({
           id={id}
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
           placeholder={placeholder}
           rows={rows}
           readOnly={readOnly}
@@ -99,6 +102,7 @@ export function InputField({
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
           placeholder={placeholder}
           readOnly={readOnly}
           maxLength={maxLength}

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -167,11 +167,6 @@ test.describe('設定ファイル相互変換', () => {
   });
 
   test('JSON Schema 検証パネル: Cmd/Ctrl+Enter でスキーマ検証が実行される', async ({ page }) => {
-    await page.goto('/');
-    await waitForReactHydration(page);
-    await page.getByRole('link', { name: /config.converter/i }).click();
-    await waitForReactHydration(page);
-
     // from=JSON, to=JSON（同一のとき "JSON (整形)" ラベル）にセット
     // デフォルトが from=JSON なので to=JSON になるよう設定
     const toGroup = page.getByRole('group', { name: '変換先フォーマット' });

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -165,4 +165,50 @@ test.describe('設定ファイル相互変換', () => {
     // 入力がクリアされること
     await expect(page.getByLabel('YAML (整形)')).toHaveValue('');
   });
+
+  test('JSON Schema 検証パネル: Cmd/Ctrl+Enter でスキーマ検証が実行される', async ({ page }) => {
+    await page.goto('/');
+    await waitForReactHydration(page);
+    await page.getByRole('link', { name: /config.converter/i }).click();
+    await waitForReactHydration(page);
+
+    // from=JSON, to=JSON（同一のとき "JSON (整形)" ラベル）にセット
+    // デフォルトが from=JSON なので to=JSON になるよう設定
+    const toGroup = page.getByRole('group', { name: '変換先フォーマット' });
+    await toGroup.getByRole('button', { name: 'JSON' }).click();
+
+    // JSON を入力して出力を得る
+    const inputTextarea = page.getByLabel('JSON (整形)');
+    await inputTextarea.fill('{"name":"Alice","age":30}');
+
+    // 出力が更新されるまで待機
+    await page.waitForFunction(() => {
+      const outputs = document.querySelectorAll('textarea[readonly]');
+      return Array.from(outputs).some((el) => (el as HTMLTextAreaElement).value.includes('"name"'));
+    });
+
+    // スキーマパネルを開く
+    await page.getByRole('button', { name: /json schema/i }).click();
+
+    // スキーマを入力
+    const schemaTextarea = page.getByLabel(/json schema/i);
+    await schemaTextarea.fill(
+      JSON.stringify({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+        required: ['name', 'age'],
+      })
+    );
+
+    // スキーマ textarea にフォーカスした状態で Cmd/Ctrl+Enter
+    await schemaTextarea.focus();
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+Enter`);
+
+    // 検証成功メッセージが表示されること
+    await expect(page.getByText('スキーマ検証成功')).toBeVisible();
+  });
 });

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -177,10 +177,7 @@ test.describe('設定ファイル相互変換', () => {
     await inputTextarea.fill('{"name":"Alice","age":30}');
 
     // 出力が更新されるまで待機
-    await page.waitForFunction(() => {
-      const outputs = document.querySelectorAll('textarea[readonly]');
-      return Array.from(outputs).some((el) => (el as HTMLTextAreaElement).value.includes('"name"'));
-    });
+    await expect(page.getByLabel('JSON', { exact: true })).toHaveValue(/"name"/);
 
     // スキーマパネルを開く
     await page.getByRole('button', { name: /json schema/i }).click();


### PR DESCRIPTION
## 概要

JSON Schema 検証パネルのスキーマ textarea にフォーカスした状態で Cmd+Enter（Mac）/ Ctrl+Enter（Windows/Linux）を押すと検証が実行されるキーボードショートカットを追加します。

## 変更内容

- `src/components/ui/InputField.tsx`
  - optional な `onKeyDown` prop を追加し、`<textarea>` / `<input>` 両方に forward
- `src/components/tools/ConfigConverter.tsx`
  - スキーマ用 `InputField` に `onKeyDown` ハンドラを追加
  - ボタンの `disabled` 条件（`!output || !schemaText || isValidating`）と完全に一致させてショートカットのガードを実装
  - ボタン横に "Cmd/Ctrl+Enter" のヒントテキストを追加（`caption` + `colors.muted` を使用）

## テスト

- `npm run test`: 256 件 pass
- `npm run test:e2e`: 127 件 pass（1 skipped）
- 新規 E2E テスト 1 件追加
  - スキーマ textarea にフォーカスした状態で `Meta+Enter` / `Control+Enter` を送信し、スキーマ検証成功メッセージが表示されることを確認

Closes #137
