### PR TITLE
ci: カバレッジバッジ更新を Gist 経由に変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ permissions:
 
 jobs:
   test:
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,20 +33,25 @@ jobs:
       - name: テストとカバレッジ測定を実行
         run: npm test -- --coverage
 
-      - name: カバレッジバッジを更新
+      - name: カバレッジ値とカラーを算出
+        id: coverage
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
         run: |
           COVERAGE=$(node -e "console.log(Math.round(require('./coverage/coverage-summary.json').total.statements.pct))")
           COLOR=$(COVERAGE=$COVERAGE node -e "const pct = +process.env.COVERAGE; console.log(pct >= 90 ? 'brightgreen' : pct >= 80 ? 'green' : pct >= 70 ? 'yellowgreen' : pct >= 60 ? 'yellow' : 'red')")
-          sed -i "s/coverage-[0-9.]*%25-[a-z]*/coverage-$COVERAGE%25-$COLOR/g" README.md
+          echo "coverage=$COVERAGE" >> "$GITHUB_OUTPUT"
+          echo "color=$COLOR" >> "$GITHUB_OUTPUT"
 
-      - name: 変更をコミットしてプッシュ
+      - name: カバレッジバッジ用 Gist を更新
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git diff --staged --quiet || (git commit -m "docs: カバレッジバッジを更新 [skip ci]" && git pull --rebase origin ${{ github.ref_name }} && git push)
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 69f5d57c79b9b687f7c2ef61dcda57e5
+          filename: devtools-coverage.json
+          label: coverage
+          message: ${{ steps.coverage.outputs.coverage }}%
+          color: ${{ steps.coverage.outputs.color }}
 
   e2e:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DevTools
 
 [![Test](https://github.com/fumtas1k/devtools/actions/workflows/test.yml/badge.svg)](https://github.com/fumtas1k/devtools/actions/workflows/test.yml)
-![Coverage](https://img.shields.io/badge/coverage-76%25-yellowgreen)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/fumtas1k/69f5d57c79b9b687f7c2ef61dcda57e5/raw/devtools-coverage.json)
 
 ブラウザで完結する無料の開発者ツール集。インストール不要・登録不要・データは外部送信なし。
 


### PR DESCRIPTION
## 背景

`develop` / `main` のブランチ保護ルールで「2 つの必須ステータスチェック」が要求されているため、`github-actions[bot]` からの直 push が拒否され、これまでカバレッジバッジを更新するコミットの push が失敗していた。

## 変更内容

- バッジ更新方法を **GitHub Gist + shields.io endpoint** に変更
  - workflow から `[skip ci]` 付きコミットを `develop` / `main` に push する処理を削除
  - 代わりに `schneegans/dynamic-badges-action@v1.7.0` で外部 Gist (`fumtas1k/69f5d57c...`) の `devtools-coverage.json` を更新
  - shields.io の `/endpoint` 形式で Gist 上の JSON を読んでバッジ画像を生成
- workflow から不要になった `permissions: contents: write` を削除（読み取りだけで十分になったため）
- README のバッジ URL を `https://img.shields.io/endpoint?url=...` 形式に置き換え

## 必要な事前設定

- ✅ Gist 作成済み: `69f5d57c79b9b687f7c2ef61dcda57e5` (secret, owner: fumtas1k)
- ✅ リポジトリ Secrets に `GIST_TOKEN` (Gist 書き込み権限の Fine-grained PAT) を登録済み

## 動作確認

- このブランチ自体は `push` トリガーで `main` / `develop` ではないため、Gist 更新ステップは `if` 条件によりスキップされる（テスト・フォーマット・E2E のみ実行される想定）。
- マージ後の `develop` への push 時に Gist が初めて更新される。
- バッジは shields.io が動的に Gist を読んで生成するため、リポジトリへのコミットは発生しない。

## 補足

ローカルで `npm run format:check` 実行済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)