### PR TITLE
feat(utils): ファイルアップロード共通バリデーションユーティリティを追加

### DIFF
--- a/src/utils/__tests__/file-validation.test.ts
+++ b/src/utils/__tests__/file-validation.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { validateFile } from '@/utils/file-validation';
+
+const MB = 1024 * 1024;
+const MAX_BYTES = 2 * MB;
+
+function makeFile(bytes: number, name: string, type: string): File {
+  return new File([new Uint8Array(bytes)], name, { type });
+}
+
+describe('validateFile — EMPTY', () => {
+  it('0 バイトのファイルは EMPTY を返す', () => {
+    const result = validateFile(makeFile(0, 'empty.png', 'image/png'), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('EMPTY');
+  });
+});
+
+describe('validateFile — TOO_LARGE', () => {
+  it('maxBytes + 1 バイトは TOO_LARGE を返す', () => {
+    const result = validateFile(makeFile(MAX_BYTES + 1, 'big.png', 'image/png'), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('TOO_LARGE');
+  });
+
+  it('ちょうど maxBytes のファイルは ok = true（境界値）', () => {
+    const result = validateFile(makeFile(MAX_BYTES, 'exact.png', 'image/png'), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateFile — image WRONG_TYPE', () => {
+  it('type = application/pdf は WRONG_TYPE を返す', () => {
+    const result = validateFile(makeFile(100, 'doc.pdf', 'application/pdf'), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
+  });
+});
+
+describe('validateFile — image OK', () => {
+  it('type = image/png は ok = true', () => {
+    const result = validateFile(makeFile(100, 'photo.png', 'image/png'), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('type = image/webp は ok = true', () => {
+    const result = validateFile(makeFile(100, 'photo.webp', 'image/webp'), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateFile — text OK by MIME', () => {
+  it('type = text/plain は ok = true', () => {
+    const result = validateFile(makeFile(100, 'note.txt', 'text/plain'), {
+      maxBytes: MAX_BYTES,
+      kind: 'text',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('type = application/json は ok = true', () => {
+    const result = validateFile(makeFile(100, 'data.json', 'application/json'), {
+      maxBytes: MAX_BYTES,
+      kind: 'text',
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateFile — text OK by extension', () => {
+  it('type が空でも acceptExtensions に一致すれば ok = true', () => {
+    const result = validateFile(makeFile(100, 'data.csv', ''), {
+      maxBytes: MAX_BYTES,
+      kind: 'text',
+      acceptExtensions: ['.csv'],
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateFile — text WRONG_TYPE', () => {
+  it('type = image/jpeg かつ acceptExtensions = [.csv] は WRONG_TYPE', () => {
+    const result = validateFile(makeFile(100, 'photo.jpg', 'image/jpeg'), {
+      maxBytes: MAX_BYTES,
+      kind: 'text',
+      acceptExtensions: ['.csv'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
+  });
+
+  it('type = application/octet-stream かつ name = file.exe は WRONG_TYPE', () => {
+    const result = validateFile(makeFile(100, 'file.exe', 'application/octet-stream'), {
+      maxBytes: MAX_BYTES,
+      kind: 'text',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
+  });
+});

--- a/src/utils/__tests__/file-validation.test.ts
+++ b/src/utils/__tests__/file-validation.test.ts
@@ -94,6 +94,15 @@ describe('validateFile — text OK by extension', () => {
     });
     expect(result.ok).toBe(true);
   });
+
+  it('拡張子が大文字（.CSV）でも acceptExtensions に一致すれば ok = true', () => {
+    const result = validateFile(makeFile(100, 'DATA.CSV', ''), {
+      maxBytes: MAX_BYTES,
+      kind: 'text',
+      acceptExtensions: ['.csv'],
+    });
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('validateFile — text WRONG_TYPE', () => {

--- a/src/utils/file-validation.ts
+++ b/src/utils/file-validation.ts
@@ -16,12 +16,12 @@ export function validateFile(file: File, opts: ValidateOptions): ValidationResul
   }
 
   if (file.size > opts.maxBytes) {
-    const limitMB = Math.ceil(opts.maxBytes / (1024 * 1024));
-    const actualMB = Math.ceil(file.size / (1024 * 1024));
+    const limitMB = (opts.maxBytes / (1024 * 1024)).toFixed(1);
+    const actualMB = (file.size / (1024 * 1024)).toFixed(1);
     return {
       ok: false,
       code: 'TOO_LARGE',
-      message: `${limitMB} MB 以上のファイルは読み込めません（選択: ${actualMB}MB）`,
+      message: `${limitMB} MB を超えるファイルは読み込めません（選択: ${actualMB} MB）`,
     };
   }
 
@@ -42,7 +42,7 @@ export function validateFile(file: File, opts: ValidateOptions): ValidationResul
 
     const isAcceptedExtension =
       opts.acceptExtensions !== undefined &&
-      opts.acceptExtensions.some((ext) => file.name.endsWith(ext));
+      opts.acceptExtensions.some((ext) => file.name.toLowerCase().endsWith(ext.toLowerCase()));
 
     if (!isTextMime && !isAcceptedExtension) {
       return {

--- a/src/utils/file-validation.ts
+++ b/src/utils/file-validation.ts
@@ -1,0 +1,57 @@
+export type FileKind = 'image' | 'text';
+
+export interface ValidateOptions {
+  maxBytes: number;
+  kind: FileKind;
+  acceptExtensions?: readonly string[];
+}
+
+export type ValidationResult =
+  | { ok: true; file: File }
+  | { ok: false; code: 'TOO_LARGE' | 'WRONG_TYPE' | 'EMPTY'; message: string };
+
+export function validateFile(file: File, opts: ValidateOptions): ValidationResult {
+  if (file.size === 0) {
+    return { ok: false, code: 'EMPTY', message: 'ファイルが空です' };
+  }
+
+  if (file.size > opts.maxBytes) {
+    const limitMB = Math.ceil(opts.maxBytes / (1024 * 1024));
+    const actualMB = Math.ceil(file.size / (1024 * 1024));
+    return {
+      ok: false,
+      code: 'TOO_LARGE',
+      message: `${limitMB} MB 以上のファイルは読み込めません（選択: ${actualMB}MB）`,
+    };
+  }
+
+  if (opts.kind === 'image') {
+    if (!file.type.startsWith('image/')) {
+      return {
+        ok: false,
+        code: 'WRONG_TYPE',
+        message: '画像ファイルを選択してください（PNG/JPEG/WebP/GIF 等）',
+      };
+    }
+  } else {
+    const isTextMime =
+      file.type.startsWith('text/') ||
+      file.type === 'application/json' ||
+      file.type === 'application/xml' ||
+      file.type === 'application/toml';
+
+    const isAcceptedExtension =
+      opts.acceptExtensions !== undefined &&
+      opts.acceptExtensions.some((ext) => file.name.endsWith(ext));
+
+    if (!isTextMime && !isAcceptedExtension) {
+      return {
+        ok: false,
+        code: 'WRONG_TYPE',
+        message: 'テキストファイルを選択してください（.txt/.csv/.json/.xml 等）',
+      };
+    }
+  }
+
+  return { ok: true, file };
+}


### PR DESCRIPTION
## 概要

- `src/utils/file-validation.ts` を新規作成
- `src/utils/__tests__/file-validation.test.ts` を新規作成（vitest、11 ケース）
- `validateFile(file, opts)` 関数を実装し、画像・テキスト両 kind に対応したファイルバリデーションを提供

## 変更内容

- **`FileKind`**: `'image' | 'text'`
- **`ValidateOptions`**: `maxBytes`・`kind`・`acceptExtensions`（省略可）
- **`ValidationResult`**: `{ ok: true; file }` または `{ ok: false; code; message }`
- 検証順序: `EMPTY` → `TOO_LARGE` → `WRONG_TYPE` → `ok: true`
- テキスト判定は MIME (`text/*`, `application/json`, `application/xml`, `application/toml`) または `acceptExtensions` の拡張子マッチに対応

## テスト計画

- [x] 0 バイト → `EMPTY`
- [x] maxBytes + 1 → `TOO_LARGE`
- [x] maxBytes ちょうど → `ok: true`（境界値）
- [x] `application/pdf` + image kind → `WRONG_TYPE`
- [x] `image/png` → `ok: true`
- [x] `image/webp` → `ok: true`
- [x] `text/plain` → `ok: true`
- [x] `application/json` → `ok: true`
- [x] type 空 + `.csv` + `acceptExtensions=['.csv']` → `ok: true`
- [x] `image/jpeg` + text kind + `acceptExtensions=['.csv']` → `WRONG_TYPE`
- [x] `application/octet-stream` + `file.exe` → `WRONG_TYPE`
- [x] `npm run test` 全 267 テスト緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)