### PR TITLE
chore(claude): .claude 配下の ask 範囲を保護対象のみに絞る

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -111,8 +111,8 @@
       "Bash(pwd)"
     ],
     "ask": [
-      "Edit(./.claude/**)",
-      "Write(./.claude/**)",
+      "Edit(./.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
+      "Write(./.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
       "Edit(./.gemini/**)",
       "Write(./.gemini/**)",
       "Bash(git push*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -111,8 +111,8 @@
       "Bash(pwd)"
     ],
     "ask": [
-      "Edit(./.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
-      "Write(./.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
+      "Edit(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
+      "Write(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
       "Edit(./.gemini/**)",
       "Write(./.gemini/**)",
       "Bash(git push*)",


### PR DESCRIPTION
## 背景

`.claude/settings.json` の `ask` で `Edit/Write(./.claude/**)` と全域指定していたため、本来保護不要な以下の領域でも毎回確認プロンプトが出ていた:

- `.claude/worktrees/**` … `superpowers:using-git-worktrees` がここに作業ツリーを作成するため、worktree 上での編集が常に ask 対象になる
- `.claude/projects/**` … auto-memory（MEMORY.md 等）の自動更新も毎回確認になる
- `.claude/image-cache/**`、`.claude/debug/**` … 一時データ

特に worktree のベース位置はスキル側で固定されており、運用側で `.claude/` の外に逃がすのは現実的でない。

## 変更内容

`Edit/Write(./.claude/**)` を **brace 展開で保護対象だけに限定**、かつ **先頭 `**/` で任意階層にマッチ**させる。最終的な差分は以下:

```diff
-      "Edit(./.claude/**)",
-      "Write(./.claude/**)",
+      "Edit(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
+      "Write(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
```

### なぜ `./.claude/{...}` ではなく `**/.claude/{...}` か

このプロジェクトでは worktree が以下 2 箇所のいずれかに作られ、いずれも内部に `.claude/settings.json` を含む:

- `.claude/worktrees/<name>/.claude/settings.json`（superpowers が作る場合）
- `.worktrees/<name>/.claude/settings.json`（標準 `git worktree` の場合）

`./.claude/{...}` 指定では先頭が `./.claude/` のパスにしかマッチしないため、worktree 内の `settings.json` への編集が ask を**素通り**してしまう。`**/.claude/{...}` にすることで、どの階層下にあろうと `.claude/` 配下のハーネス設定は ask 対象になる。

| 編集対象パス | 旧 `./.claude/**` | 中間案 `./.claude/{...}` | 採用 `**/.claude/{...}` |
|---|---|---|---|
| `.claude/settings.json`（本体） | ask | ask | ask |
| `.claude/worktrees/X/.claude/settings.json` | ask | 素通り ✗ | ask |
| `.worktrees/Y/.claude/settings.json` | 素通り ✗ | 素通り ✗ | ask |
| `.claude/worktrees/X/src/foo.ts` | ask（過剰） | 素通り ✓ | 素通り ✓ |
| `.claude/projects/.../MEMORY.md` | ask（過剰） | 素通り ✓ | 素通り ✓ |

### 引き続き ask になるもの（ハーネス挙動を変えるもの）

- `*.json` … `settings.json` / `settings.local.json`
- `*.sh` … `statusline-command.sh` 等
- `hooks/**` / `agents/**` / `skills/**` / `commands/**` / `plugins/**`

### 素通りになるもの（ノイズ削減）

- `.claude/worktrees/**`（superpowers 作業領域）の通常コード
- `.worktrees/**`（標準 worktree）の通常コード
- `.claude/projects/**`（auto-memory）
- `.claude/image-cache/**`、`.claude/debug/**`

破壊的操作の保護（`Bash(rm .claude/*)`、`Bash(sed -i* .claude/*)` 等）は別ルールなのでそのまま残す。

## コミット履歴

1. `32893d8` chore(claude): .claude 配下の ask 範囲を保護対象のみに絞る（`./.claude/{...}`）
2. `a7c0aa0` chore(claude): worktree 内の .claude/ 配下も保護対象に含めるため先頭を `**/` に変更（`**/.claude/{...}`）

## 検証

- [x] JSON valid（`node -e "JSON.parse(...)"` でパース成功）
- [x] pre-commit hook（prettier / tsc）通過
- [x] brace 展開・leading `**` ともに minimatch 標準仕様