### PR TITLE
feat(encoding-converter): ファイルバリデーションを適用

### DIFF
--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -9,6 +9,7 @@ import { DownloadButton } from '@/components/ui/DownloadButton';
 import { caption, colors } from '@/utils/styles';
 import { getErrorMessage } from '@/utils/errors';
 import { downloadBytes } from '@/utils/download';
+import { validateFile } from '@/utils/file-validation';
 import {
   detectEncoding,
   decodeToText,
@@ -29,6 +30,22 @@ import {
 
 type Mode = 'detect' | 'convert';
 type InputMethod = 'text' | 'file';
+
+const ACCEPTED_EXTENSIONS = [
+  '.txt',
+  '.csv',
+  '.tsv',
+  '.json',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.md',
+  '.html',
+  '.css',
+  '.js',
+  '.ts',
+] as const;
 
 const SAMPLE_TEXT = 'カラム名,値\nテキスト,あいうえお\n名前,山田 太郎\n住所,東京都渋谷区';
 
@@ -145,6 +162,17 @@ export function EncodingConverterTool() {
     const file = e.target.files?.[0];
     e.target.value = '';
     if (!file) return;
+
+    const validation = validateFile(file, {
+      kind: 'text',
+      maxBytes: 10 * 1024 * 1024,
+      acceptExtensions: ACCEPTED_EXTENSIONS,
+    });
+    if (!validation.ok) {
+      setError(validation.message);
+      return;
+    }
+
     file.arrayBuffer().then((buf) => {
       setFileBytes(new Uint8Array(buf));
       setFileName(file.name);
@@ -267,8 +295,12 @@ export function EncodingConverterTool() {
               className="sr-only"
               onChange={handleFileChange}
               aria-label="ファイルを選択"
+              accept=".txt,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.md,.html,.css,.js,.ts,text/*"
             />
           </label>
+          <p style={{ fontSize: '0.75rem', color: colors.muted, marginTop: '0.25rem' }}>
+            対応形式: テキストファイル（.txt / .csv / .json / .xml / .yaml / .toml 等）・最大 10 MB
+          </p>
           {fileBytes && (
             <div
               className="mt-2 rounded-lg px-3 py-2 font-mono"

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -47,6 +47,8 @@ const ACCEPTED_EXTENSIONS = [
   '.ts',
 ] as const;
 
+const ACCEPT_ATTR = `${ACCEPTED_EXTENSIONS.join(',')},text/*`;
+
 const SAMPLE_TEXT = 'カラム名,値\nテキスト,あいうえお\n名前,山田 太郎\n住所,東京都渋谷区';
 
 function hexPreview(bytes: Uint8Array, limit = 32): string {
@@ -295,7 +297,7 @@ export function EncodingConverterTool() {
               className="sr-only"
               onChange={handleFileChange}
               aria-label="ファイルを選択"
-              accept=".txt,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.md,.html,.css,.js,.ts,text/*"
+              accept={ACCEPT_ATTR}
             />
           </label>
           <p style={{ fontSize: '0.75rem', color: colors.muted, marginTop: '0.25rem' }}>

--- a/tests/e2e/encoding-converter.spec.ts
+++ b/tests/e2e/encoding-converter.spec.ts
@@ -89,15 +89,18 @@ test.describe('文字コード判定・変換', () => {
     await expect(page.getByTestId('detection-bom')).toContainText('あり');
   });
 
-  test('ケースF: 非テキストバイナリ (JPEG) → 不明または空のプレビュー', async ({ page }) => {
+  test('ケースF: 非テキストバイナリ (JPEG) → バリデーションエラーが表示される', async ({
+    page,
+  }) => {
     await page.getByRole('button', { name: 'ファイル' }).click();
     await page.getByLabel('ファイルを選択').setInputFiles({
       name: 'test.jpg',
       mimeType: 'image/jpeg',
       buffer: JPEG_MAGIC,
     });
-    // 不明 (UNKNOWN) か ASCII か、どちらにしても detection-result が表示される
-    await expect(page.getByTestId('detection-result')).toBeVisible();
+    // バリデーションで WRONG_TYPE として弾かれ、エラーメッセージが表示される
+    await expect(page.getByRole('alert')).toBeVisible();
+    await expect(page.getByTestId('detection-result')).not.toBeVisible();
   });
 
   test('ケースG: クリアボタンで入力がリセットされる', async ({ page }) => {


### PR DESCRIPTION
## 概要

`EncodingConverter` のファイル入力に、共通バリデーションユーティリティ `validateFile` を適用します。

- `handleFileChange` にサイズ・種別チェック（最大 10 MB・テキスト形式のみ）を追加
- `<input type="file">` に `accept` 属性を追加してブラウザ／OS レベルで対応形式に絞り込み
- ファイル選択欄の直下に対応形式と上限サイズの説明文を追加（`var(--color-*)` 使用）

関連 PR:
- 共通バリデーション util 追加: #154

## テスト結果

- `npm run test`: **268 件すべて成功**
- `npm run test:e2e`: **129 件成功、1 件スキップ（既存スキップ）、失敗なし**

## テスト計画

- [ ] ファイル選択モードで `.txt` / `.csv` / `.json` 等のテキストファイルを選択 → 正常読み込みされること
- [ ] 10 MB を超えるファイルを選択 → エラーメッセージが表示されること
- [ ] `.png` / `.exe` 等の非テキストファイルを選択 → エラーメッセージが表示されること（accept 属性によりダイアログ上でも絞り込まれる）
- [ ] ファイル選択欄の直下に対応形式の説明文が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)