### PR TITLE
security: CSP / セキュリティヘッダを public/_headers で追加 (#158)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1862,6 +1862,6 @@ YAML・JSON・TOML・.env の相互変換ブラウザ完結ツールを実装す
 - ✅ `frame-ancestors 'none'` でクリックジャッキング、`X-Content-Type-Options: nosniff` で MIME sniffing、`Referrer-Policy` でリファラ漏えいを抑止。
 - ✅ Permissions-Policy で未使用機能（microphone / geolocation）を明示的に無効化し、将来追加コードでの誤利用を防止。
 - ✅ `connect-src 'self'` により、万一 XSS が成立しても外部送信経路を断つ。
-- ⚠️ `script-src` と `style-src` に `'unsafe-inline'` を残しているため、インラインスクリプト/スタイル経由の XSS 緩和効果は限定的。Astro の nonce 対応 or インラインスタイル削減を将来課題として継続的に検討する（追跡 issue: 本 PR 後に別途起票予定）。
+- ⚠️ `script-src` と `style-src` に `'unsafe-inline'` を残しているため、インラインスクリプト/スタイル経由の XSS 緩和効果は限定的。Astro の nonce 対応 or インラインスタイル削減を将来課題として継続的に検討する（追跡 issue: [#176](https://github.com/fumtas1k/devtools/issues/176)）。
 - ⚠️ Cloudflare Pages 以外のホスティング（Netlify は同形式で動作するが、Vercel は `vercel.json` 形式）に切り替える際は別途設定追加が必要。
 - ℹ️ E2E テストでのヘッダ検証は、Playwright が `npm run dev`（Astro dev server）経由で起動しており dev server は `_headers` を解釈しないため、本 PR では `public/_headers` ファイル内容の Vitest 単体テストに留めた。preview サーバーまたは実デプロイ後の検証は将来課題とする。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1822,8 +1822,9 @@ YAML・JSON・TOML・.env の相互変換ブラウザ完結ツールを実装す
 
 ```
 /*
-  Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'; upgrade-insecure-requests
   X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(self), microphone=(), geolocation=()
 ```
@@ -1845,6 +1846,8 @@ YAML・JSON・TOML・.env の相互変換ブラウザ完結ツールを実装す
 | `form-action`                                           | `'self'`                 | フォーム送信先を自身に限定（現状 form 送信は無いがゼロトラスト）                                                                                                                                                       |
 | `Permissions-Policy` `camera=(self)`                    | —                        | `qr-reader` / `qr-ticket` 用に自身のみ許可                                                                                                                                                                             |
 | `Permissions-Policy` `microphone=()` / `geolocation=()` | —                        | 利用していないため明示的に無効化                                                                                                                                                                                       |
+| `upgrade-insecure-requests`                             | —                        | PR #170 レビューで追記。Cloudflare Pages は HTTPS 既定で実害は小さいが、混在コンテンツ防止の補強としてゼロコストで採用                                                                                                 |
+| `X-Frame-Options: DENY`                                 | —                        | PR #170 レビューで追記。`frame-ancestors 'none'` でモダンブラウザはカバーされるが、業界慣習として旧ブラウザ向けに併記                                                                                                  |
 
 ### 却下した選択肢
 
@@ -1859,6 +1862,6 @@ YAML・JSON・TOML・.env の相互変換ブラウザ完結ツールを実装す
 - ✅ `frame-ancestors 'none'` でクリックジャッキング、`X-Content-Type-Options: nosniff` で MIME sniffing、`Referrer-Policy` でリファラ漏えいを抑止。
 - ✅ Permissions-Policy で未使用機能（microphone / geolocation）を明示的に無効化し、将来追加コードでの誤利用を防止。
 - ✅ `connect-src 'self'` により、万一 XSS が成立しても外部送信経路を断つ。
-- ⚠️ `script-src` と `style-src` に `'unsafe-inline'` を残しているため、インラインスクリプト/スタイル経由の XSS 緩和効果は限定的。Astro の nonce 対応 or インラインスタイル削減を将来課題として継続的に検討する。
+- ⚠️ `script-src` と `style-src` に `'unsafe-inline'` を残しているため、インラインスクリプト/スタイル経由の XSS 緩和効果は限定的。Astro の nonce 対応 or インラインスタイル削減を将来課題として継続的に検討する（追跡 issue: 本 PR 後に別途起票予定）。
 - ⚠️ Cloudflare Pages 以外のホスティング（Netlify は同形式で動作するが、Vercel は `vercel.json` 形式）に切り替える際は別途設定追加が必要。
 - ℹ️ E2E テストでのヘッダ検証は、Playwright が `npm run dev`（Astro dev server）経由で起動しており dev server は `_headers` を解釈しないため、本 PR では `public/_headers` ファイル内容の Vitest 単体テストに留めた。preview サーバーまたは実デプロイ後の検証は将来課題とする。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1803,3 +1803,62 @@ YAML・JSON・TOML・.env の相互変換ブラウザ完結ツールを実装す
 - ✅ `qr-ticket` の責務（署名検証）が明確になり、両ツールのコードが単純に保たれた。
 - ✅ URL の自動リンク化を行わず、`http:`/`https:` 以外のスキームも `text` として扱うことでフィッシング・XSS リスクを最小化した。
 - ⚠️ Wi-Fi / vCard / mailto 等の QR フォーマット解析は今回スコープ外（将来の拡張候補）。
+
+---
+
+## [054] CSP / セキュリティヘッダを `public/_headers` で付与
+
+**2026-04-30 | ステータス: 採用**
+
+### 背景
+
+ブラウザ完結型 DevTools として「ユーザーデータが外部送信されない」ことが価値の根幹だが、レスポンスヘッダレベルの多層防御（CSP / nosniff / Referrer-Policy / Permissions-Policy）が一切付与されていなかった（issue #158）。
+
+`dangerouslySetInnerHTML` を使う箇所が現状 3 箇所（`QrCode.tsx:115` / `Gs1Databar.tsx:352` / `qr-ticket/GenerateTab.tsx:459`）あり、入力源は QR/バーコード行列のため XSS は成立しないが、依存更新・機能追加で実害化する経路を残していた。また `qr-reader` / `qr-ticket` でカメラ権限を取得する一方、`connect-src` 制約が無く、万一スクリプト実行が成立した場合の二次被害（情報送信）が大きい状態だった。
+
+### 決断
+
+静的ホスティング（現在の Cloudflare Pages：`devtools-d9w.pages.dev`）向けに `public/_headers` を新設し、以下のヘッダを `/*`（全ルート）に付与する。Astro は `public/` 配下を `dist/` にそのままコピーするため、ビルド設定変更は不要。
+
+```
+/*
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(self), microphone=(), geolocation=()
+```
+
+各ディレクティブの根拠:
+
+| ディレクティブ                                          | 値                       | 根拠                                                                                                                                                                                                                   |
+| :------------------------------------------------------ | :----------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default-src`                                           | `'self'`                 | 既定で外部送信・読込を全拒否                                                                                                                                                                                           |
+| `img-src`                                               | `'self' data: blob:`     | QR/JAN/GS1/UUID 等で `<canvas>` の `toDataURL()`（`data:`）と画像変換時の `URL.createObjectURL()`（`blob:`）を使用                                                                                                     |
+| `media-src`                                             | `'self' blob:`           | `qr-reader` / `qr-ticket` のカメラ映像ストリーム（MediaStream → blob:）                                                                                                                                                |
+| `style-src`                                             | `'self' 'unsafe-inline'` | `style={{...}}` 219+ 箇所、Astro `style="..."` 多数。詳細は本決断の "却下した選択肢" 参照                                                                                                                              |
+| `script-src`                                            | `'self' 'unsafe-inline'` | Astro 6.1.5 SSG が hydration runtime と MobileDrawer/index 等の島を **インラインスクリプトとして埋め込む**ため必要（`dist/*.html` を `npm run build` 後に grep で確認済み）。`<script is:inline>` も BaseLayout に存在 |
+| `connect-src`                                           | `'self'`                 | アプリは全データをブラウザ内で処理し、外部 API 呼び出しは存在しない（`grep "fetch(" src/` で確認）                                                                                                                     |
+| `worker-src`                                            | `'self'`                 | `sw.js`（Service Worker）登録の許可                                                                                                                                                                                    |
+| `object-src`                                            | `'none'`                 | `<object>`/`<embed>`/`<applet>` 経由の埋め込みを完全禁止                                                                                                                                                               |
+| `frame-ancestors`                                       | `'none'`                 | クリックジャッキング防止（`<iframe>` 埋め込み拒否）                                                                                                                                                                    |
+| `base-uri`                                              | `'none'`                 | `<base>` タグ改ざんによる相対リソースのリダイレクトを防止                                                                                                                                                              |
+| `form-action`                                           | `'self'`                 | フォーム送信先を自身に限定（現状 form 送信は無いがゼロトラスト）                                                                                                                                                       |
+| `Permissions-Policy` `camera=(self)`                    | —                        | `qr-reader` / `qr-ticket` 用に自身のみ許可                                                                                                                                                                             |
+| `Permissions-Policy` `microphone=()` / `geolocation=()` | —                        | 利用していないため明示的に無効化                                                                                                                                                                                       |
+
+### 却下した選択肢
+
+- **`script-src 'self'` のみ（`'unsafe-inline'` 無し）**: Astro 6.1.5 の SSG 出力には hydration ブートストラップやページ固有の島制御が**インライン `<script>` / `<script type="module">`**として埋め込まれるため、CSP 違反で全ページが破壊される。Astro 標準では nonce/hash 注入機構が無く、ビルド後 HTML を後処理する独自スクリプトが必要となるため、本 PR スコープ外で先送り。
+- **`style-src 'self'`（`'unsafe-inline'` 無し）**: React TSX で `style={{...}}` を 219 箇所、Astro でも `style="..."` を多用しており、すべてを CSS Modules / `<style>` ブロックに移行するのは大規模リファクタになる。本 PR では互換性を優先。
+- **`<meta http-equiv="Content-Security-Policy">` での代替**: `frame-ancestors` / `report-uri` 等は meta 経由では効かないため、レスポンスヘッダ方式を採用。
+- **`netlify.toml` / `vercel.json` 等の併設**: 現在のホスティングは Cloudflare Pages のみ。複数ホスティングを実際に使う段階で追加する（YAGNI）。
+
+### 結果・トレードオフ
+
+- ✅ デフォルト全拒否（`default-src 'self'`）+ 利用ディレクティブの個別許可で多層防御が成立。
+- ✅ `frame-ancestors 'none'` でクリックジャッキング、`X-Content-Type-Options: nosniff` で MIME sniffing、`Referrer-Policy` でリファラ漏えいを抑止。
+- ✅ Permissions-Policy で未使用機能（microphone / geolocation）を明示的に無効化し、将来追加コードでの誤利用を防止。
+- ✅ `connect-src 'self'` により、万一 XSS が成立しても外部送信経路を断つ。
+- ⚠️ `script-src` と `style-src` に `'unsafe-inline'` を残しているため、インラインスクリプト/スタイル経由の XSS 緩和効果は限定的。Astro の nonce 対応 or インラインスタイル削減を将来課題として継続的に検討する。
+- ⚠️ Cloudflare Pages 以外のホスティング（Netlify は同形式で動作するが、Vercel は `vercel.json` 形式）に切り替える際は別途設定追加が必要。
+- ℹ️ E2E テストでのヘッダ検証は、Playwright が `npm run dev`（Astro dev server）経由で起動しており dev server は `_headers` を解釈しないため、本 PR では `public/_headers` ファイル内容の Vitest 単体テストに留めた。preview サーバーまたは実デプロイ後の検証は将来課題とする。

--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,8 @@
 # Cloudflare Pages / Netlify 互換のレスポンスヘッダ設定
 # 詳細・採用根拠は docs/decisions.md [054] を参照
 /*
-  Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'; upgrade-insecure-requests
   X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(self), microphone=(), geolocation=()

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+# Cloudflare Pages / Netlify 互換のレスポンスヘッダ設定
+# 詳細・採用根拠は docs/decisions.md [054] を参照
+/*
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(self), microphone=(), geolocation=()

--- a/src/utils/__tests__/headers.test.ts
+++ b/src/utils/__tests__/headers.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * public/_headers の内容を検証する。
+ *
+ * Cloudflare Pages / Netlify 互換のレスポンスヘッダ定義ファイル。
+ * 採用根拠と各ディレクティブの判断は docs/decisions.md [054] を参照。
+ */
+const HEADERS_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  'public',
+  '_headers'
+);
+
+const HEADERS_CONTENT = readFileSync(HEADERS_PATH, 'utf-8');
+
+/**
+ * `/*` ブロックから対象ヘッダ行を抽出するヘルパ。
+ * 行頭スペースがあること（`_headers` フォーマット仕様）と、
+ * `Header-Name:` で始まることを満たす最初の行を返す。
+ */
+function extractHeader(name: string): string {
+  const lines = HEADERS_CONTENT.split('\n');
+  const match = lines.find(
+    (line) => /^\s+/.test(line) && line.trim().toLowerCase().startsWith(`${name.toLowerCase()}:`)
+  );
+  if (!match) {
+    throw new Error(`Header "${name}" not found in public/_headers`);
+  }
+  return match.trim();
+}
+
+describe('public/_headers', () => {
+  it('`/*` パスマッチブロックを含む', () => {
+    expect(HEADERS_CONTENT).toMatch(/^\/\*\s*$/m);
+  });
+
+  describe('Content-Security-Policy', () => {
+    const csp = extractHeader('Content-Security-Policy');
+
+    it('default-src は self に限定', () => {
+      expect(csp).toContain("default-src 'self'");
+    });
+
+    it('frame-ancestors none でクリックジャッキングを防止', () => {
+      expect(csp).toContain("frame-ancestors 'none'");
+    });
+
+    it('base-uri none で <base> タグ経由の改ざんを防止', () => {
+      expect(csp).toContain("base-uri 'none'");
+    });
+
+    it('object-src none で <object>/<embed> 経由の埋め込みを禁止', () => {
+      expect(csp).toContain("object-src 'none'");
+    });
+
+    it('form-action は self に限定', () => {
+      expect(csp).toContain("form-action 'self'");
+    });
+
+    it('img-src は data: と blob: を許可（QR/ファイル変換ツール用途）', () => {
+      expect(csp).toContain('img-src');
+      expect(csp).toMatch(/img-src[^;]*'self'/);
+      expect(csp).toMatch(/img-src[^;]*data:/);
+      expect(csp).toMatch(/img-src[^;]*blob:/);
+    });
+
+    it('media-src は blob: を許可（カメラ映像ストリーム用途）', () => {
+      expect(csp).toContain('media-src');
+      expect(csp).toMatch(/media-src[^;]*blob:/);
+    });
+
+    it('connect-src は self に限定（外部送信を排除）', () => {
+      expect(csp).toContain("connect-src 'self'");
+    });
+
+    it('script-src は self を含む', () => {
+      expect(csp).toMatch(/script-src[^;]*'self'/);
+    });
+
+    it("style-src は 'unsafe-inline' を許可（React/Astro のインラインスタイル運用上必要）", () => {
+      // 219+ 箇所の React `style={{...}}` と Astro `style="..."` が存在するため許可。
+      // 中期的には CSS Modules / nonce 化を検討（docs/decisions.md [054] 参照）。
+      expect(csp).toMatch(/style-src[^;]*'self'/);
+      expect(csp).toMatch(/style-src[^;]*'unsafe-inline'/);
+    });
+  });
+
+  describe('追加のセキュリティヘッダ', () => {
+    it('X-Content-Type-Options: nosniff を含む', () => {
+      const header = extractHeader('X-Content-Type-Options');
+      expect(header).toBe('X-Content-Type-Options: nosniff');
+    });
+
+    it('Referrer-Policy: strict-origin-when-cross-origin を含む', () => {
+      const header = extractHeader('Referrer-Policy');
+      expect(header).toBe('Referrer-Policy: strict-origin-when-cross-origin');
+    });
+
+    it('Permissions-Policy で camera は self に限定', () => {
+      const header = extractHeader('Permissions-Policy');
+      expect(header).toMatch(/camera=\(self\)/);
+    });
+
+    it('Permissions-Policy で microphone は明示的に無効化', () => {
+      const header = extractHeader('Permissions-Policy');
+      expect(header).toMatch(/microphone=\(\)/);
+    });
+
+    it('Permissions-Policy で geolocation は明示的に無効化', () => {
+      const header = extractHeader('Permissions-Policy');
+      expect(header).toMatch(/geolocation=\(\)/);
+    });
+  });
+});

--- a/src/utils/__tests__/headers.test.ts
+++ b/src/utils/__tests__/headers.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 /**
@@ -8,15 +7,11 @@ import path from 'node:path';
  *
  * Cloudflare Pages / Netlify 互換のレスポンスヘッダ定義ファイル。
  * 採用根拠と各ディレクティブの判断は docs/decisions.md [054] を参照。
+ *
+ * Vitest はプロジェクトルートを `process.cwd()` として実行するため、
+ * リポジトリ構造に依存しない `process.cwd()` 起点で解決する。
  */
-const HEADERS_PATH = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '..',
-  '..',
-  '..',
-  'public',
-  '_headers'
-);
+const HEADERS_PATH = path.resolve(process.cwd(), 'public', '_headers');
 
 const HEADERS_CONTENT = readFileSync(HEADERS_PATH, 'utf-8');
 
@@ -90,12 +85,23 @@ describe('public/_headers', () => {
       expect(csp).toMatch(/style-src[^;]*'self'/);
       expect(csp).toMatch(/style-src[^;]*'unsafe-inline'/);
     });
+
+    it('upgrade-insecure-requests を含む（混在コンテンツ防止）', () => {
+      expect(csp).toContain('upgrade-insecure-requests');
+    });
   });
 
   describe('追加のセキュリティヘッダ', () => {
     it('X-Content-Type-Options: nosniff を含む', () => {
       const header = extractHeader('X-Content-Type-Options');
       expect(header).toBe('X-Content-Type-Options: nosniff');
+    });
+
+    it('X-Frame-Options: DENY を含む（旧ブラウザ補完）', () => {
+      // frame-ancestors 'none' でモダンブラウザはカバーされるが、
+      // 業界慣習として X-Frame-Options も併記する。
+      const header = extractHeader('X-Frame-Options');
+      expect(header).toBe('X-Frame-Options: DENY');
     });
 
     it('Referrer-Policy: strict-origin-when-cross-origin を含む', () => {


### PR DESCRIPTION
## 概要

ブラウザ完結型 DevTools の脅威モデル（`dangerouslySetInnerHTML` 3 箇所 + カメラ権限利用）に対する多層防御として、Cloudflare Pages / Netlify 互換の `public/_headers` を新設し、CSP / nosniff / Referrer-Policy / Permissions-Policy をレスポンスヘッダレベルで付与する。

## 変更内容

### `public/_headers`（新規）

`/*` パスマッチで以下を全ルートに付与:

```
Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(self), microphone=(), geolocation=()
```

主な根拠:

- `default-src 'self'` で既定全拒否 → 個別ディレクティブで必要箇所のみ許可。
- `img-src` に `data:` / `blob:` を許可（QR・JAN・GS1 等で `<canvas>.toDataURL()` と `URL.createObjectURL()` を使用）。
- `media-src 'self' blob:` で `qr-reader` / `qr-ticket` のカメラ映像（MediaStream）を許可。
- `connect-src 'self'` で外部送信を完全遮断（アプリは外部 fetch を一切持たない）。
- `frame-ancestors 'none'` でクリックジャッキングを防止、`object-src 'none'` で `<embed>`/`<object>` を全拒否、`base-uri 'none'` で `<base>` 改ざんを防止。
- `Permissions-Policy` で未使用機能（microphone / geolocation）を明示的に無効化。

`'unsafe-inline'` を残した箇所と理由:

- `script-src 'self' 'unsafe-inline'`: Astro 6.1.5 SSG は hydration runtime や MobileDrawer / index 等の島制御を**インライン `<script>` / `<script type="module">`**として埋め込むため必要（`npm run build` 後の `dist/*.html` を grep して確認）。BaseLayout の `<script is:inline>`（SW 登録）も同様。Astro 標準で nonce/hash 注入機構が無いため、本 PR では互換性を優先して `'unsafe-inline'` を残し、nonce 化は将来課題として `docs/decisions.md [054]` に明記。
- `style-src 'self' 'unsafe-inline'`: React TSX で `style={{...}}` を 219+ 箇所、Astro でも `style="..."` を多用しているため。

### `src/utils/__tests__/headers.test.ts`（新規）

`public/_headers` の必須ディレクティブが今後の編集で意図せず後退しないよう、Vitest で 16 ケースの構造検証を追加（CSP の各ディレクティブ・nosniff・Referrer-Policy・Permissions-Policy）。

### `docs/decisions.md`（追記）

`[054] CSP / セキュリティヘッダを public/_headers で付与` を追加。背景・採用ヘッダ一覧・各ディレクティブの根拠・却下した選択肢・トレードオフを記録。

## 関連 issue

Closes #158

## 検証

- `node_modules/.bin/astro check`: 0 errors / 0 warnings（既存 hint 10 件のみ）
- `npm run test`: 22 files / 284 tests passed（うち本 PR 追加 16 件）
- `npm run test:e2e`: 129 passed / 1 skipped（既存）
- `npm run build`: 18 ページ生成成功、`dist/_headers` に正しくコピーされることを確認
- `npm run format:check`: All files use Prettier code style

## 残課題

- **nonce / hash ベースの CSP 強化**: Astro が SSG hydration をインラインで吐く制約を回避するには、ビルド後の HTML 後処理またはアップストリームでの nonce 対応待ちが必要。本 PR スコープ外。
- **デプロイ先別の対応**: 現在は Cloudflare Pages（`devtools-d9w.pages.dev`）想定の `_headers` のみ。将来 Vercel に切り替える場合は `vercel.json` 形式が別途必要。
- **E2E でのレスポンスヘッダ実応答検証**: `playwright.config.ts` の `webServer` が `npm run dev`（Astro dev server）を使っており、dev server は `_headers` を解釈しない。本 PR では `public/_headers` の構造を Vitest 単体テストで検証する方針に倒し、本番デプロイ後の検証は将来課題とした。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
