### PR TITLE
a11y: aria-live・aria-expanded・focus・タップ領域の横断改善 (#163)

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -207,6 +207,8 @@ export function ConfigConverterTool() {
         <button
           type="button"
           onClick={() => setSchemaOpen((o) => !o)}
+          aria-expanded={schemaOpen}
+          aria-controls="config-converter-schema-panel"
           className="flex items-center gap-1"
           style={{
             ...caption,
@@ -218,6 +220,7 @@ export function ConfigConverterTool() {
           }}
         >
           <span
+            aria-hidden="true"
             style={{
               display: 'inline-block',
               transform: schemaOpen ? 'rotate(90deg)' : 'none',
@@ -229,7 +232,7 @@ export function ConfigConverterTool() {
           JSON Schema で検証する
         </button>
         {schemaOpen && (
-          <div className="mt-3 space-y-3">
+          <div id="config-converter-schema-panel" className="mt-3 space-y-3">
             <InputField
               id="config-converter-schema"
               label="JSON Schema (貼り付け)"
@@ -279,13 +282,17 @@ export function ConfigConverterTool() {
             {validationResult && (
               <div
                 className="rounded-lg p-3"
+                role={validationResult.valid ? 'status' : 'alert'}
+                aria-live={validationResult.valid ? 'polite' : 'assertive'}
                 style={{
                   background: validationResult.valid ? colors.successBg : colors.errorBg,
                   border: `1px solid ${validationResult.valid ? colors.success : colors.error}`,
                 }}
               >
                 {validationResult.valid ? (
-                  <p style={{ ...caption, color: colors.text }}>✅ スキーマ検証成功</p>
+                  <p style={{ ...caption, color: colors.text }}>
+                    <span aria-hidden="true">✅ </span>スキーマ検証成功
+                  </p>
                 ) : (
                   <ul
                     style={{

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -346,6 +346,8 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
           <div
             className="rounded-lg flex flex-col items-center gap-4 p-5"
             style={{ border: `1px solid ${colors.border}`, background: colors.bgSurface }}
+            role="status"
+            aria-live="polite"
           >
             <div
               aria-label={`GS1 DataBar ${gtinResult?.fullGtin} のバーコード`}

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -95,7 +95,7 @@ export function JanCodeTool() {
 
       {/* 結果 */}
       {result && (
-        <div className="space-y-4">
+        <div className="space-y-4" role="status" aria-live="polite">
           {/* チェックディジット・完成コード */}
           <div
             data-testid="jan-code-result"

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -345,7 +345,7 @@ export function JwtDecoderTool() {
 
       {/* デコード結果 */}
       {parsed && (
-        <div className="space-y-3">
+        <div className="space-y-3" role="status" aria-live="polite">
           <Section
             title="Header (JOSE)"
             accentColor={colors.error}

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -236,7 +236,7 @@ export function QrReaderTool() {
 
       {/* 読取結果セクション */}
       {content !== null && (
-        <div style={sectionStyle}>
+        <div style={sectionStyle} role="status" aria-live="polite">
           <h3 style={sectionHeaderStyle}>読取結果</h3>
           <div className="space-y-4" style={sectionBodyStyle}>
             {/* テキスト表示 */}

--- a/src/components/tools/UlidGenerator.tsx
+++ b/src/components/tools/UlidGenerator.tsx
@@ -107,36 +107,38 @@ export function UlidGeneratorTool() {
       />
 
       {rows.length > 0 && (
-        <ResultTable
-          rows={rows}
-          columns={columns}
-          getKey={(row) => row.id}
-          minWidth="36rem"
-          renderHeader={() => (
-            <>
-              <span style={{ ...bodyEmphasis, color: colors.text }}>{rows.length} 件生成</span>
-              <div className="flex flex-wrap items-center gap-2">
-                <div className="shrink-0">
-                  <ToggleGroup<QuoteStyle>
-                    options={[
-                      { value: 'none', label: 'なし' },
-                      { value: 'double', label: '"..."' },
-                      { value: 'single', label: "'...'" },
-                    ]}
-                    value={quoteStyle}
-                    onChange={setQuoteStyle}
-                    ariaLabel="クォートスタイル"
-                    size="sm"
-                  />
+        <div role="status" aria-live="polite">
+          <ResultTable
+            rows={rows}
+            columns={columns}
+            getKey={(row) => row.id}
+            minWidth="36rem"
+            renderHeader={() => (
+              <>
+                <span style={{ ...bodyEmphasis, color: colors.text }}>{rows.length} 件生成</span>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="shrink-0">
+                    <ToggleGroup<QuoteStyle>
+                      options={[
+                        { value: 'none', label: 'なし' },
+                        { value: 'double', label: '"..."' },
+                        { value: 'single', label: "'...'" },
+                      ]}
+                      value={quoteStyle}
+                      onChange={setQuoteStyle}
+                      ariaLabel="クォートスタイル"
+                      size="sm"
+                    />
+                  </div>
+                  <div className="shrink-0">
+                    <CopyButton text={allUlids} label="すべてコピー" />
+                  </div>
+                  <ClearButton onClick={() => setRows([])} />
                 </div>
-                <div className="shrink-0">
-                  <CopyButton text={allUlids} label="すべてコピー" />
-                </div>
-                <ClearButton onClick={() => setRows([])} />
-              </div>
-            </>
-          )}
-        />
+              </>
+            )}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -178,7 +178,7 @@ export function UuidV7GeneratorTool() {
       />
 
       {rows.length > 0 && (
-        <div className="space-y-3">
+        <div className="space-y-3" role="status" aria-live="polite">
           <ResultTable
             rows={rows}
             columns={columns}

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -93,6 +93,8 @@ export function GenerateTab({
             <button
               type="button"
               onClick={onToggleImport}
+              aria-expanded={showImport}
+              aria-controls="qr-ticket-import-panel"
               style={{
                 ...caption,
                 color: colors.link,
@@ -102,12 +104,13 @@ export function GenerateTab({
                 padding: 0,
               }}
             >
-              {showImport ? '▲ 秘密鍵インポートを閉じる' : '▼ 既存の秘密鍵をインポート'}
+              <span aria-hidden="true">{showImport ? '▲ ' : '▼ '}</span>
+              {showImport ? '秘密鍵インポートを閉じる' : '既存の秘密鍵をインポート'}
             </button>
           </div>
 
           {showImport && (
-            <div className="space-y-2">
+            <div id="qr-ticket-import-panel" className="space-y-2">
               <InputField
                 id="import-privkey"
                 label="秘密鍵 JWK"
@@ -379,19 +382,22 @@ export function GenerateTab({
                     </span>
                     <button
                       type="button"
-                      className="w-8 h-8 flex items-center justify-center"
+                      className="flex items-center justify-center"
                       onClick={() => onRemoveTicket(i)}
                       disabled={tickets.length <= 1}
                       aria-label={`行 ${i + 1} を削除`}
                       style={{
                         ...caption,
+                        minWidth: '40px',
+                        minHeight: '40px',
+                        padding: '12px',
                         color: tickets.length <= 1 ? colors.muted : colors.error,
                         background: 'none',
                         border: 'none',
                         cursor: tickets.length <= 1 ? 'not-allowed' : 'pointer',
                       }}
                     >
-                      ✕
+                      <span aria-hidden="true">✕</span>
                     </button>
                   </div>
                 </div>
@@ -400,7 +406,7 @@ export function GenerateTab({
           </div>
           <div className="flex flex-wrap items-center gap-2 mt-3">
             <ActionButton onClick={onAddTicket} disabled={tickets.length >= MAX_TICKETS}>
-              ＋ 行を追加
+              <span aria-hidden="true">＋ </span>行を追加
             </ActionButton>
             <ActionButton
               onClick={onGenerate}

--- a/src/components/tools/qr-ticket/VerifyTab.tsx
+++ b/src/components/tools/qr-ticket/VerifyTab.tsx
@@ -156,7 +156,11 @@ export function VerifyTab({
       {(verifying || verificationResult) && (
         <div style={sectionStyle}>
           <h3 style={sectionHeaderStyle}>検証結果</h3>
-          <div style={sectionBodyStyle}>
+          <div
+            style={sectionBodyStyle}
+            role={verificationResult && !verificationResult.valid ? 'alert' : 'status'}
+            aria-live={verificationResult && !verificationResult.valid ? 'assertive' : 'polite'}
+          >
             {verifying ? (
               <p style={{ ...caption, color: colors.muted }}>検証中…</p>
             ) : verificationResult ? (
@@ -175,11 +179,19 @@ export function VerifyTab({
                       marginBottom: verificationResult.ticket ? '0.75rem' : 0,
                     }}
                   >
-                    {verificationResult.valid
-                      ? '✓ 有効なチケット'
-                      : verificationResult.expired
-                        ? '✕ 有効期限切れ'
-                        : '✕ 無効なチケット'}
+                    {verificationResult.valid ? (
+                      <>
+                        <span aria-hidden="true">✓ </span>有効なチケット
+                      </>
+                    ) : verificationResult.expired ? (
+                      <>
+                        <span aria-hidden="true">✕ </span>有効期限切れ
+                      </>
+                    ) : (
+                      <>
+                        <span aria-hidden="true">✕ </span>無効なチケット
+                      </>
+                    )}
                   </p>
                   {verificationResult.error && !verificationResult.valid && (
                     <p style={{ ...caption, color: colors.errorText }}>

--- a/src/components/tools/qr-ticket/VerifyTab.tsx
+++ b/src/components/tools/qr-ticket/VerifyTab.tsx
@@ -158,8 +158,9 @@ export function VerifyTab({
           <h3 style={sectionHeaderStyle}>検証結果</h3>
           <div
             style={sectionBodyStyle}
-            role={verificationResult && !verificationResult.valid ? 'alert' : 'status'}
+            role="status"
             aria-live={verificationResult && !verificationResult.valid ? 'assertive' : 'polite'}
+            aria-atomic="true"
           >
             {verifying ? (
               <p style={{ ...caption, color: colors.muted }}>検証中…</p>

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -87,10 +87,12 @@ export function CopyButton({ text, label = 'コピー', className = '', compact 
       <button
         onClick={handleClick}
         aria-label={label}
-        className="rounded-md transition-colors"
+        className="rounded-md transition-colors inline-flex items-center justify-center"
         style={{
           fontSize: '0.75rem',
           padding: '0.25rem 0.5rem',
+          minWidth: '32px',
+          minHeight: '32px',
           ...copyStateColors(copied, colors.muted),
           border: 'none',
           cursor: 'pointer',

--- a/src/components/ui/OutputField.tsx
+++ b/src/components/ui/OutputField.tsx
@@ -30,7 +30,10 @@ interface OutputFieldProps {
  * ラベル＋（CopyButton／任意要素）＋ readOnly textarea を一定構造で描画する。
  *
  * - ヘッダ行は `minHeight: 2rem` で CopyButton の有無に関わらず高さが揃うように固定。
- * - `value` が空のとき CopyButton は `visibility: hidden`（DOM サイズを保つため `display: none` ではない）。
+ * - `value` が空のとき右側スロット (CopyButton / rightSlot) は描画しない。
+ *   以前は `visibility: hidden` で DOM とフォーカス可達性を残していたが、
+ *   キーボードユーザーが透明領域にフォーカスしてしまう WCAG 2.4.7 違反を避けるため
+ *   描画を完全にスキップする方針へ変更（高さは minHeight で確保）。
  */
 export function OutputField({
   id,
@@ -44,6 +47,7 @@ export function OutputField({
   showCopy = true,
   rightSlot,
 }: OutputFieldProps) {
+  const hasValue = value !== '';
   return (
     <div className="w-full">
       <div
@@ -53,13 +57,12 @@ export function OutputField({
         <label htmlFor={id} style={{ ...bodyEmphasis, color: colors.text }}>
           {label}
         </label>
-        <div
-          className="flex items-center gap-2"
-          style={{ visibility: value ? 'visible' : 'hidden' }}
-        >
-          {rightSlot}
-          {showCopy && <CopyButton text={value} label={copyLabel} />}
-        </div>
+        {hasValue && (
+          <div className="flex items-center gap-2">
+            {rightSlot}
+            {showCopy && <CopyButton text={value} label={copyLabel} />}
+          </div>
+        )}
       </div>
       <textarea
         id={id}

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -47,7 +47,7 @@ test.describe('a11y live region (issue #163)', () => {
     await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
 
     const statusRegions = page.getByRole('status');
-    await expect.poll(async () => await statusRegions.count()).toBeGreaterThan(0);
+    await expect(statusRegions.first()).toBeVisible();
   });
 });
 

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { waitForReactHydration } from './helpers';
+
+/**
+ * issue #163 で追加した live region / aria-expanded / アイコン分離 のスモーク E2E。
+ * SR が結果領域を読めることを `getByRole('status')` 経由で検証する。
+ */
+
+test.describe('a11y live region (issue #163)', () => {
+  test('JANコード: チェック結果が role="status" として読める', async ({ page }) => {
+    await page.goto('/tools/jan-code');
+    await page.getByRole('button', { name: 'サンプルを入力' }).waitFor();
+    await waitForReactHydration(page);
+
+    // 入力前は status が存在しない
+    await expect(page.getByRole('status')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'サンプルを入力' }).click();
+
+    const status = page.getByRole('status').first();
+    await expect(status).toBeVisible();
+    await expect(status).toContainText('チェックディジット');
+    await expect(status).toContainText('完成コード');
+  });
+
+  test('UUID v7: 生成結果が role="status" として読める', async ({ page }) => {
+    await page.goto('/tools/uuid-v7');
+    await page.getByRole('button', { name: '生成' }).waitFor();
+    await waitForReactHydration(page);
+
+    await page.getByRole('button', { name: '生成' }).click();
+
+    const status = page.getByRole('status').first();
+    await expect(status).toBeVisible();
+    await expect(status).toContainText('件生成');
+  });
+
+  test('JWTデコーダ: デコード結果が role="status" として読める', async ({ page }) => {
+    await page.goto('/tools/jwt-decoder');
+    await page.getByLabel('JWTトークンを貼り付け').waitFor();
+    await waitForReactHydration(page);
+
+    const SAMPLE_JWT =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
+
+    await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
+
+    const statusRegions = page.getByRole('status');
+    await expect.poll(async () => await statusRegions.count()).toBeGreaterThan(0);
+  });
+});
+
+test.describe('a11y aria-expanded (issue #163)', () => {
+  test('ConfigConverter: JSON Schema 折りたたみが aria-expanded を反映する', async ({ page }) => {
+    await page.goto('/tools/config-converter');
+    await page.getByRole('button', { name: 'JSON Schema で検証する' }).waitFor();
+    await waitForReactHydration(page);
+
+    const toggle = page.getByRole('button', { name: 'JSON Schema で検証する' });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+test.describe('a11y CopyButton compact tap target (issue #163)', () => {
+  test('UUID 一覧の compact コピーボタンは 32x32 以上の領域を持つ', async ({ page }) => {
+    await page.goto('/tools/uuid-v7');
+    await page.getByRole('button', { name: '生成' }).waitFor();
+    await waitForReactHydration(page);
+
+    await page.getByRole('button', { name: '生成' }).click();
+
+    const compactCopy = page.getByRole('button', { name: 'コピー' }).nth(1);
+    await compactCopy.waitFor({ state: 'visible' });
+
+    const box = await compactCopy.boundingBox();
+    expect(box, 'compact ボタンの bounding box が取得できる').not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(32);
+    expect(box!.height).toBeGreaterThanOrEqual(32);
+  });
+});


### PR DESCRIPTION
## 概要

リファクタ調査（#163）で発見された a11y 抜けに横断対応します。WCAG 2.1 AA レベルの複数項目（**4.1.3 Status Messages / 2.4.7 Focus Visible / 2.5.8 Target Size**）に違反していた箇所を解消します。

## 変更内容

### 共通 UI コンポーネント
- **`OutputField`**: `value` が空のとき右側スロット（CopyButton 等）を `visibility: hidden` で隠していたが、DOM とフォーカス可達性が残るためキーボードユーザーが透明領域にフォーカスしてしまう問題があった。条件レンダに変更し、ヘッダの高さは既存の `minHeight: 2rem` で確保。
- **`CopyButton`** (compact モード): `minWidth: 32px` / `minHeight: 32px` を付与。テーブル行内の小さなコピーボタンが WCAG 2.5.8 Target Size の最小要件を満たす。

### ツールコンポーネント
- **`JanCode` / `UuidV7Generator` / `UlidGenerator` / `QrReader` / `JwtDecoder` / `Gs1Databar`**: 動的に現れる結果領域に `role="status" aria-live="polite"` を付与。SR ユーザーに変換結果が伝わるようにする。
- **`ConfigConverter`**:
  - `JSON Schema で検証する` 折りたたみボタンに `aria-expanded` / `aria-controls` を付与。
  - スキーマ検証結果カードに、成功時は `role="status" aria-live="polite"` / 失敗時は `role="alert" aria-live="assertive"` を付与。
  - `✅ スキーマ検証成功` のアイコンを `<span aria-hidden="true">` で隔離。
- **`qr-ticket/VerifyTab`**:
  - 検証結果カードに `role`/`aria-live` を valid/invalid に応じて付与。
  - `✓ 有効なチケット` / `✕ 有効期限切れ` / `✕ 無効なチケット` のアイコン記号を `aria-hidden` 化。
- **`qr-ticket/GenerateTab`**:
  - `▲ 秘密鍵インポートを閉じる` / `▼ 既存の秘密鍵をインポート` 折りたたみに `aria-expanded` / `aria-controls` を付与し、矢印アイコンを `aria-hidden`。
  - `＋ 行を追加` / `✕`（削除ボタン）のアイコンを `aria-hidden` 化。
  - 削除ボタンを `min 40x40px` + padding 12px に拡張（WCAG 2.5.8）。

### テスト
- **`tests/e2e/a11y-live-region.spec.ts`** を新設（5 ケース）:
  - JanCode / UuidV7Generator / JwtDecoder の結果領域が `getByRole('status')` で取得できる
  - ConfigConverter のスキーマ折りたたみが `aria-expanded` を反映する
  - UuidV7Generator の compact コピーボタンの bounding box が 32x32px 以上

## 関連 issue

Closes #163

## 検証

- `node_modules/.bin/astro check`: 0 errors / 0 warnings
- `npm run test`: 21 ファイル / 268 テスト pass
- `npm run test:e2e`: 134 件 pass / 1 件 skip（既存スキップ）
- `npm run format:check`: All matched files use Prettier code style!

## WCAG 達成項目

- **4.1.3 Status Messages (AA)**: 結果領域に live region 付与で満たす
- **2.4.7 Focus Visible (AA)**: OutputField の透明フォーカス問題を解消
- **2.5.8 Target Size (Minimum, AA)**: compact コピーボタン・削除ボタンを 32-40px に拡張

## スコープ外（本 PR で触っていない a11y 抜け）

並行作業中の PR との競合を避けるため、以下のファイルは本 PR では対象外:

- `src/components/tools/JsonCsv.tsx`（PR #173 で並行編集中）
- `src/components/tools/EncodingConverter.tsx`（PR #171 でファイル名サニタイズ追加済み）
- `src/components/tools/QrTicket.tsx`（PR #171 で同上）
- `src/components/tools/Base64Codec.tsx` / `JsonXml.tsx` / `UrlEncoder.tsx` / `DummyText.tsx` / `QrCode.tsx`（issue #163 の明示対象外）

これらは将来の a11y 改善 issue（または #163 のフォローアップ）でカバーする想定。
