### PR TITLE
security: ajv 厳格化と flattenObject のプロトタイプ汚染保護 (#161)

### DIFF
--- a/src/utils/__tests__/json-csv.test.ts
+++ b/src/utils/__tests__/json-csv.test.ts
@@ -124,6 +124,45 @@ describe('jsonToCsv', () => {
       expect(result).toMatch(/'=cmd/);
     });
   });
+
+  describe('プロトタイプ汚染対策（CWE-1321）', () => {
+    it('__proto__ キーを含む JSON を渡しても Object.prototype は変化しない', () => {
+      // 攻撃ペイロード: __proto__ 経由で polluted を仕込もうとする入力
+      const json = '[{"__proto__":{"polluted":true},"safe":"ok"}]';
+      jsonToCsv(json);
+      // 全オブジェクトに polluted が漏れていないこと（プロトタイプ汚染なし）
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('constructor / prototype キーは CSV 出力に流れない（多重防御）', () => {
+      const json = '[{"constructor":"x","prototype":"y","name":"太郎"}]';
+      const result = jsonToCsv(json);
+      const lines = result.split(/\r?\n/);
+      // ヘッダーは name のみ（constructor / prototype はスキップ）
+      expect(lines[0]).toBe('name');
+      expect(lines[1]).toContain('太郎');
+      // プロトタイプ汚染が起きていないこと
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('ネストされた __proto__ も無視される', () => {
+      const json = '[{"a":{"__proto__":{"polluted":42},"keep":"ok"}}]';
+      const result = jsonToCsv(json);
+      // ネスト内の通常キーは出力される
+      expect(result).toContain('a.keep');
+      expect(result).toContain('ok');
+      // __proto__ は出力されず、Object.prototype も汚染されない
+      expect(result).not.toContain('a.polluted');
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('Object.prototype.toString が攻撃前後で同一であること', () => {
+      const before = Object.prototype.toString;
+      const json = '[{"__proto__":{"toString":"hacked"}}]';
+      jsonToCsv(json);
+      expect(Object.prototype.toString).toBe(before);
+    });
+  });
 });
 
 describe('escapeCsvFormula', () => {

--- a/src/utils/config-converter/__tests__/schema-validator.test.ts
+++ b/src/utils/config-converter/__tests__/schema-validator.test.ts
@@ -41,4 +41,56 @@ describe('validateWithSchema', () => {
       'スキーマはオブジェクトである必要があります'
     );
   });
+
+  describe('strict モード（不正なスキーマの拒否）', () => {
+    it('未知のキーワードを含むスキーマは valid:false で返す', () => {
+      // `unknownKeyword` は JSON Schema に存在しないキーワード。
+      // strict:true により Ajv はコンパイル時に例外を投げ、
+      // ValidationResult.errors に流れる。
+      const schema = {
+        type: 'object',
+        properties: { name: { type: 'string', unknownKeyword: 'oops' } },
+      };
+      const result = validateWithSchema({ name: '太郎' }, schema);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].message).toMatch(/スキーマが無効です/);
+    });
+
+    it('解決できない $ref を含むスキーマは valid:false で返す', () => {
+      // 外部 URL の $ref は loadSchema 未提供のため解決できず compile で失敗する。
+      const schema = {
+        type: 'object',
+        properties: {
+          x: { $ref: 'https://example.com/does-not-exist.json' },
+        },
+      };
+      const result = validateWithSchema({ x: 1 }, schema);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].message).toMatch(/スキーマが無効です/);
+    });
+
+    it('型と矛盾する制約（type:number に minLength）は valid:false で返す', () => {
+      // strict:true により、型と矛盾するキーワードはコンパイル時エラーになる。
+      const schema = {
+        type: 'object',
+        properties: { v: { type: 'number', minLength: 3 } },
+      };
+      const result = validateWithSchema({ v: 1 }, schema);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toMatch(/スキーマが無効です/);
+    });
+
+    it('draft-04 スキーマでも未知のキーワードを拒否する', () => {
+      const schema = {
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'object',
+        properties: { x: { type: 'integer', unknownKeyword: 'oops' } },
+      };
+      const result = validateWithSchema({ x: 1 }, schema);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toMatch(/スキーマが無効です/);
+    });
+  });
 });

--- a/src/utils/config-converter/schema-validator.ts
+++ b/src/utils/config-converter/schema-validator.ts
@@ -8,7 +8,15 @@ export interface ValidationResult {
 }
 
 /**
- * JSON Schema (draft 7 or draft 4) でデータを検証する
+ * JSON Schema (draft 7 or draft 4) でデータを検証する。
+ *
+ * セキュリティ:
+ * - Ajv は `strict: true` と `validateSchema: true` で初期化する。これにより、
+ *   未知のキーワード・無効な型・矛盾した制約・解決できない `$ref` などを
+ *   コンパイル時にエラーとして検出する（loadSchema は意図的に未提供。
+ *   外部スキーマの自動取得は SSRF 等のリスクを避けるため許可しない）。
+ * - コンパイル時に投げられた例外は `valid: false` として `errors` に整形して返す。
+ *
  * @param data 検証対象データ (JS値)
  * @param schema JSON Schemaオブジェクト
  */
@@ -21,14 +29,25 @@ export function validateWithSchema(data: unknown, schema: unknown): ValidationRe
 
   let validate: ReturnType<Ajv['compile']>;
 
-  if (isDraft04) {
-    const ajv4 = new Ajv4({ allErrors: true, strict: false });
-    (addFormats as (ajv: unknown) => void)(ajv4);
-    validate = ajv4.compile(schemaObj);
-  } else {
-    const ajv = new Ajv({ allErrors: true, strict: false });
-    addFormats(ajv);
-    validate = ajv.compile(schemaObj);
+  try {
+    if (isDraft04) {
+      const ajv4 = new Ajv4({ allErrors: true, strict: true, validateSchema: true });
+      (addFormats as (ajv: unknown) => void)(ajv4);
+      validate = ajv4.compile(schemaObj);
+    } else {
+      const ajv = new Ajv({ allErrors: true, strict: true, validateSchema: true });
+      addFormats(ajv);
+      validate = ajv.compile(schemaObj);
+    }
+  } catch (err) {
+    // Ajv は不正なスキーマ（未知のキーワード・解決できない $ref 等）に対し
+    // コンパイル時に例外を投げる。これを ValidationResult.errors に流して
+    // 呼び出し側の通常エラー表示経路に乗せる。
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      valid: false,
+      errors: [{ path: '/', message: `スキーマが無効です: ${message}` }],
+    };
   }
 
   const valid = validate(data) as boolean;

--- a/src/utils/json-csv.ts
+++ b/src/utils/json-csv.ts
@@ -27,13 +27,23 @@ export function escapeCsvFormula<T>(value: T): T | string {
   return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
 }
 
-/** ネストされたオブジェクトをドット記法でフラット化する */
+/**
+ * ネストされたオブジェクトをドット記法でフラット化する。
+ *
+ * セキュリティ:
+ * - プロトタイプ汚染（CWE-1321）対策として、戻り値は null-prototype オブジェクト
+ *   （`Object.create(null)`）で構築する。
+ * - 加えて `__proto__` / `constructor` / `prototype` という危険なキーは
+ *   多重防御として明示的にスキップする。これにより、悪意ある JSON 入力が
+ *   Papaparse 経由で他のコードへ伝播してもプロトタイプチェーンへ影響しない。
+ */
 function flattenObject(
   obj: Record<string, unknown>,
   prefix = ''
 ): Record<string, string | number | boolean | null> {
-  const result: Record<string, string | number | boolean | null> = {};
+  const result = Object.create(null) as Record<string, string | number | boolean | null>;
   for (const [key, value] of Object.entries(obj)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     const fullKey = prefix ? `${prefix}.${key}` : key;
     if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
       Object.assign(result, flattenObject(value as Record<string, unknown>, fullKey));


### PR DESCRIPTION
## 概要

ajv による JSON Schema 検証で `strict` / `validateSchema` を有効化し、不正なスキーマを偽陽性なくコンパイル時に拒否します。あわせて JSON→CSV 変換の `flattenObject` をプロトタイプ汚染（CWE-1321）から保護します。

## 変更内容

- `src/utils/config-converter/schema-validator.ts`
  - `Ajv` / `Ajv4` の初期化を `{ allErrors: true, strict: true, validateSchema: true }` に変更
  - `loadSchema` は意図的に未提供（外部 schema 自動取得は SSRF リスク回避のため）
  - `compile()` 例外を `ValidationResult.errors` に流す（未知のキーワード・解決不能な `$ref` 等を `valid:false` として扱う）
- `src/utils/json-csv.ts`
  - `flattenObject` の戻り値を `Object.create(null)` で構築
  - `__proto__` / `constructor` / `prototype` キーは多重防御として明示的にスキップ

## テスト

- ユニットテスト: schema-validator strict 4 件・json-csv プロトタイプ保護 4 件を追加（351/351 pass）
- E2E: Config Converter / JSON↔CSV を含む全 140 件 pass（1 skipped）
- `astro check`: 0 errors / 0 warnings（変更ファイル分）

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
