### PR TITLE
chore(rules): エージェント運用ルール強化（ベース確認・push 前チェック・aria 保護）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,7 @@
 - **検証**: 変更後は **`npm run test`** および **`npm run test:e2e`** で確認。
 - **PR ベース**: `gh pr create` は **必ず `--base develop`** を明示する。`main` 向けはリリース PR のみ（`gh` のデフォルト・Claude Code system prompt の "Main branch ... main" 表示に流されないこと）。詳細は `docs/shared-agent-rules.md` 6.3 章。
 - **ATC運用**: セッション開始時に `tasks/active_context.md` を作成（superpowers の plan / conductor のタスクファイル等が「目的・ステップ・スコープ外」を明示する場合は不要。詳細は `docs/shared-agent-rules.md` 11章）。
-- **司令塔モード**: 親 Claude Code セッションは実装・テスト実行をサブエージェントに委譲し、自身はフロー制御・ベース確認・完了評価・最終報告に専念する（詳細: `docs/shared-agent-rules.md` 6.2a 章・3 章チェックリスト）。
-- **サブエージェント完了受け取り時**: `git merge-base HEAD origin/develop` でベース確認 → テスト結果を読んで未実行項目がないか確認 → `git diff origin/develop...HEAD | grep "^-.*aria-"` でスコープ外削除がないかを確認してから PR 作成。
+- **司令塔モード**: 親 Claude セッションは委譲・ベース確認・テスト確認・aria 削除検出を経て PR 作成（詳細: `docs/shared-agent-rules.md` 6.2a 章・3 章 push 前チェックリスト・10.6 章）。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@
 - **検証**: 変更後は **`npm run test`** および **`npm run test:e2e`** で確認。
 - **PR ベース**: `gh pr create` は **必ず `--base develop`** を明示する。`main` 向けはリリース PR のみ（`gh` のデフォルト・Claude Code system prompt の "Main branch ... main" 表示に流されないこと）。詳細は `docs/shared-agent-rules.md` 6.3 章。
 - **ATC運用**: セッション開始時に `tasks/active_context.md` を作成（superpowers の plan / conductor のタスクファイル等が「目的・ステップ・スコープ外」を明示する場合は不要。詳細は `docs/shared-agent-rules.md` 11章）。
+- **司令塔モード**: 親 Claude Code セッションは実装・テスト実行をサブエージェントに委譲し、自身はフロー制御・ベース確認・完了評価・最終報告に専念する（詳細: `docs/shared-agent-rules.md` 6.2a 章・3 章チェックリスト）。
+- **サブエージェント完了受け取り時**: `git merge-base HEAD origin/develop` でベース確認 → テスト結果を読んで未実行項目がないか確認 → `git diff origin/develop...HEAD | grep "^-.*aria-"` でスコープ外削除がないかを確認してから PR 作成。
 
 ---
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -64,6 +64,8 @@ lsof -ti:4321 | xargs kill -9 2>/dev/null || true
 npm run test:e2e
 ```
 
+> macOS/Linux 前提。Windows/WSL では別手段（`netstat -ano` + `taskkill` 等）が必要。
+
 > ポート 4321 以外を使う場合は `4321` を対象ポートに読み替える。
 
 ---
@@ -106,7 +108,7 @@ npm run test:e2e
 ### 6.2 ブランチ運用
 
 - **`develop` には直接コミットしない**: 必ず feature ブランチを切る。誤って始めた場合は `git stash` → ブランチ切替 → `git stash pop`。
-- **新規作業の手順**: `git checkout develop` → `git pull origin develop` → `git checkout -b feat/<topic>`（または `fix/`, `docs/`, `refactor/` 等）
+- **新規作業の手順**: `git checkout develop` → `git pull origin develop` → `git checkout -b <type>/<slug>`（例: `feat/add-tool`, `fix/issue-123-crash`）。issue がある場合は `<type>/issue-<n>-<slug>` 形式を推奨（詳細は 6.2a 参照）。
 
 ### 6.2a ブランチ作成の完成形コマンドと自己検証
 
@@ -125,6 +127,7 @@ git merge-base HEAD origin/develop
 **2 行の出力が一致しない場合は作業を停止**し、以下でリベースしてから再確認する:
 
 ```bash
+# `merge-base` が `origin/develop` の祖先（典型的には `main` 起点で worktree が切られたケース）で有効
 git rebase --onto origin/develop $(git merge-base HEAD origin/develop) HEAD
 ```
 
@@ -278,7 +281,7 @@ npx astro check --filter <file>     # 特定ファイル（Gemini CLI 等）
 - [ ] このセッションの Objective に書かれていないファイル一切
 - [ ] aria-\* / role= 属性の削除（明示的な許可なしには禁止）
 - [ ] issue 本文に記載のない機能追加・設計変更
-- [ ] （具体例を追記: 例）src/components/ui/OutputField.tsx の a11y 属性
+<!-- 具体例を追記: 例) src/components/ui/OutputField.tsx の a11y 属性 -->
 
 ## 🟢 Review & Feedback
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -46,6 +46,26 @@
 
 **E2E テストは実装と同時に書く**: バグ修正・UI 挙動の変更時はコミット前に該当ケースの E2E を追加する。後回し禁止。
 
+#### push 前必須チェックリスト（サブエージェント含む全担当者）
+
+以下をすべて満たしてから `git push` する。**1 つでも未完了の場合は push せず、未完了の項目を完了報告に明記して親に判断を仰ぐ**。
+
+| #   | チェック項目          | コマンド                                                                      |
+| --- | --------------------- | ----------------------------------------------------------------------------- |
+| 1   | develop ベース確認    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致 |
+| 2   | ユニットテスト全 pass | `npm run test`                                                                |
+| 3   | E2E テスト全 pass     | `npm run test:e2e`                                                            |
+| 4   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                   |
+
+**E2E でポート衝突した場合の復旧手順**（スキップは禁止。必ず復旧して再実行すること）:
+
+```bash
+lsof -ti:4321 | xargs kill -9 2>/dev/null || true
+npm run test:e2e
+```
+
+> ポート 4321 以外を使う場合は `4321` を対象ポートに読み替える。
+
 ---
 
 ## 4. ドキュメント更新ルール
@@ -87,6 +107,28 @@
 
 - **`develop` には直接コミットしない**: 必ず feature ブランチを切る。誤って始めた場合は `git stash` → ブランチ切替 → `git stash pop`。
 - **新規作業の手順**: `git checkout develop` → `git pull origin develop` → `git checkout -b feat/<topic>`（または `fix/`, `docs/`, `refactor/` 等）
+
+### 6.2a ブランチ作成の完成形コマンドと自己検証
+
+サブエージェントを含むすべての実装担当は、以下のコマンドをそのままコピーして実行すること。
+
+```bash
+# ブランチ作成（develop 起点を必ず明示）
+git fetch origin develop
+git switch -c <type>/issue-<n>-<slug> origin/develop
+
+# 自己検証（ベース確認）— 2 行の出力が一致しなければ作業を止めてリベースする
+git rev-parse origin/develop
+git merge-base HEAD origin/develop
+```
+
+**2 行の出力が一致しない場合は作業を停止**し、以下でリベースしてから再確認する:
+
+```bash
+git rebase --onto origin/develop $(git merge-base HEAD origin/develop) HEAD
+```
+
+> **なぜ**: CLI・Web 版を問わず `git checkout -b <branch>` だけでは worktree が `main` を起点にしてしまう既知の問題がある（過去に PR #154, #181 で発生）。ベース確認ステップがない限り発覚しない。
 
 ### 6.3 PR 作成時のベースブランチ
 
@@ -188,6 +230,17 @@ npx astro check --filter <file>     # 特定ファイル（Gemini CLI 等）
 
 外部入力をそのまま挿入すると **反射型 XSS** になる。必ずエスケープ／サニタイズしてから挿入し、可能なら React 要素として組み立てる。
 
+### 10.6 a11y 属性・role 属性の保護
+
+`aria-*` 属性（`aria-live`, `aria-expanded`, `aria-controls`, `aria-label`, `aria-hidden` 等）および
+`role=` 属性は、**明示的に許可されていない限り削除してはならない**。
+
+- ❌ 禁止: refactor・cleanup 中に「不要に見える」として aria 属性を削除する
+- ✅ 必須: `git diff` に `aria-` の削除行（`-` で始まる行）が含まれる場合は親に確認を取る
+- 誤って削除した場合は即 `git restore <file>` してから push する
+
+> **なぜ**: これらの属性は支援技術（スクリーンリーダー等）が依存する意味論的マーカー。見た目上は「余計な属性」に見えても削除すると a11y E2E テストが CI で落ちる（過去に PR #175 追加分が PR #179 の refactor で削除されて発生）。
+
 ---
 
 ## 11. 目的の維持とスコープ管理 (ATC運用)
@@ -222,7 +275,10 @@ npx astro check --filter <file>     # 特定ファイル（Gemini CLI 等）
 
 ## 🚫 Out of Scope (Do Not Touch)
 
-- [ ] 触らない領域
+- [ ] このセッションの Objective に書かれていないファイル一切
+- [ ] aria-\* / role= 属性の削除（明示的な許可なしには禁止）
+- [ ] issue 本文に記載のない機能追加・設計変更
+- [ ] （具体例を追記: 例）src/components/ui/OutputField.tsx の a11y 属性
 
 ## 🟢 Review & Feedback
 


### PR DESCRIPTION
## 概要

エージェント運用中に発生した 3 件の再発違反（ブランチベース誤り・E2E スキップ・aria 属性削除）を根本から防ぐためのルール強化を `docs/shared-agent-rules.md` と `CLAUDE.md` に適用する。

## 変更内容

- **6.2a 新設**: ブランチ作成の完成形コマンドと自己検証（`git rev-parse origin/develop` と `git merge-base HEAD origin/develop` の一致確認）を必須化
- **3章追加**: push 前必須チェックリスト（ベース確認・`npm run test`・`npm run test:e2e`・型チェック）と E2E ポート衝突復旧手順（`lsof -ti:4321 | xargs kill -9`）を明記、スキップ禁止を明示
- **10.6 新設**: `aria-*` / `role=` 属性の削除をデフォルト禁止とし、削除行が diff に出た場合は親への確認を必須化
- **11章 ATC テンプレート強化**: `Out of Scope` セクションのデフォルト内容に aria 属性保護・スコープ外ファイル禁止を追加
- **CLAUDE.md**: 司令塔モードの責務分担と、サブエージェント完了受け取り時の確認手順（ベース確認→テスト結果→aria 削除検出）を最重要ルールに追記

## 動機・経緯

PR #181（ブランチベース誤り）・PR #180 系（E2E スキップ）・PR #179（aria 属性削除による a11y テスト破壊）の根本原因分析に基づき、「何をすべきか」だけでなく「どう自己検証するか・スキップ時はどうするか」を規約に明示することで再発を防ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
