### PR TITLE
chore(claude): Web セッションでのみ npm ci を走らせる SessionStart hook を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then npm ci; fi"
+            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && [ ! -d node_modules ]; then npm ci; fi"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,19 @@
     "frontend-design@claude-plugins-official": true,
     "context7@claude-plugins-official": true
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then npm ci; fi"
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "sh .claude/statusline-command.sh"


### PR DESCRIPTION
## 概要

Claude Code on the web のクラウド環境では `node_modules` が初期状態で配置されていないため、セッション開始時に `npm ci` で依存関係をインストールする必要がある。一方、ローカル開発では既に依存が揃っているため毎回の `npm ci` は不要かつ邪魔になる。

公式ドキュメント [Claude Code on the web > Install dependencies with a SessionStart hook](https://code.claude.com/docs/en/claude-code-on-the-web#install-dependencies-with-a-sessionstart-hook) で規定されている `CLAUDE_CODE_REMOTE` 環境変数（クラウドセッションでは `"true"` がセットされる）をシェル側で判定し、Web 環境のみで `npm ci` を実行するように `.claude/settings.json` に SessionStart hook を追加する。

## 変更内容

`.claude/settings.json` の `hooks.SessionStart` を新規追加：

\`\`\`json
{
  \"matcher\": \"startup|resume\",
  \"hooks\": [
    {
      \"type\": \"command\",
      \"command\": \"if [ \\\"\$CLAUDE_CODE_REMOTE\\\" = \\\"true\\\" ]; then npm ci; fi\"
    }
  ]
}
\`\`\`

- `matcher` は公式サンプルに合わせて `startup|resume` を指定（startup と resume の両方で発火）。
- 公式ドキュメントの判定式 `[ "$CLAUDE_CODE_REMOTE" != "true" ]` と等価な肯定形（`= "true"` のときのみ実行）を採用。

## ローカル開発への影響

- 環境変数 `CLAUDE_CODE_REMOTE` はローカルでは未定義のため、シェル条件は false → 何も実行されない。
- 既存の `enabledPlugins` / `sandbox` / `permissions` などには一切手を加えていない。

## 検証

- JSON 構文チェック:
  \`\`\`
  $ python3 -m json.tool .claude/settings.json > /dev/null && echo OK
  OK
  \`\`\`
- ローカルでの no-op 確認（環境変数なし）:
  \`\`\`
  $ bash -c 'if [ \"\$CLAUDE_CODE_REMOTE\" = \"true\" ]; then npm ci; fi'; echo \"exit=\$?\"
  exit=0
  \`\`\`
  → 出力なし、exit=0。
- 環境変数 `CLAUDE_CODE_REMOTE=true` セット時の dry-run:
  \`\`\`
  $ CLAUDE_CODE_REMOTE=true bash -c 'if [ \"\$CLAUDE_CODE_REMOTE\" = \"true\" ]; then echo would-run-npm-ci; fi'
  would-run-npm-ci
  \`\`\`
  → 期待通り条件分岐が成立し、Web セッションでのみ `npm ci` が走る。
- `git diff develop..HEAD --stat` で変更が `.claude/settings.json` の 13 行追加のみであることを確認済み。

## 参考

- Claude Code on the web: https://code.claude.com/docs/en/claude-code-on-the-web