### PR TITLE
docs(lessons): 2026-05-01 のサブエージェント運用教訓 3 件を追記

### DIFF
--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -31,3 +31,58 @@
 
 1. **表示サイズ拡大** (160px → 256px): グリッドの `minmax` も合わせて変更
 2. **アップロード時アップスケール**: `handleImageUpload` で短辺 < 512px なら 768px に拡大してから jsQR へ渡す
+
+---
+
+## [2026-05-01] サブエージェントは `isolation: "worktree"` 必須（Bash 権限の罠）
+
+### 現象
+
+PR #181 / #182 のレビュー対応で、既存 worktree を再利用させるため `Agent` ツールを `isolation` オプションなしでディスパッチしたところ、サブエージェントの `Bash` / `mcp__serena__execute_shell_command` / `mcp__serena__list_dir` / `EnterWorktree` がすべて権限拒否され、ファイル編集 (Read/Write/Edit) しかできない状態になった。git 操作・テスト実行・コミットが詰まり作業未完で停止。
+
+### 根本原因
+
+`.claude/settings.json` の権限設定が `isolation: "worktree"` 付きディスパッチを前提にしており、isolation なしでは shell 系ツールがデフォルト deny される。
+
+### 対処方針
+
+- Agent ディスパッチ時は **常に `isolation: "worktree"` を付ける**。
+- 既存 PR ブランチを引き継ぎたい場合は、新しい worktree 内で `git fetch origin && git checkout -b <branch> origin/<branch>` で **origin から再 checkout** させる（既存 worktree を共有しない）。
+- Read のみのドラフト調査でも詰まる瞬間が来るので、例外なしに isolation を付ける運用に統一。
+
+---
+
+## [2026-05-01] devDependency 追加時は `package-lock.json` を必ず同期コミット
+
+### 現象
+
+PR #181 のレビュー対応で、サブエージェントが `@testing-library/react` と `jsdom` を `package.json` の `devDependencies` に追加してテスト追加・push まで実行したが、`package-lock.json` の更新コミットが漏れていた。CI の `npm ci` は lock との不整合を検出して失敗する状態だった（手動コミット前に検出して回避）。
+
+### 根本原因
+
+サブエージェントが `npm install <pkg>` ではなく package.json を直接編集してから `npm install --no-save` 等で deps を入れたか、あるいは個別 install を回避してテストだけ走らせたため、lock ファイルが diff から漏れた。
+
+### 対処方針
+
+- 親はサブエージェント完了報告を受けたら **`git diff origin/develop --name-only` に `package.json` が含まれる場合は必ず `package-lock.json` も含まれているか確認**する。
+- 漏れていれば親で `npm install --package-lock-only --cache "$TMPDIR/npm-cache" --no-audit --no-fund` を実行し、別コミットで lock 同期を push する。
+- サブエージェント側のプロンプトでも「`package.json` を変更したら `package-lock.json` の同期コミットも作ること」と明記する余地あり（規約昇格候補）。
+
+> **補足**: `~/.npm` の所有権で `npm install` がエラーになる環境では `--cache "$TMPDIR/npm-cache"` で逃げる。
+
+---
+
+## [2026-05-01] worktree 内部 branch (`worktree-agent-<id>`) と PR ブランチの取り違え
+
+### 現象
+
+PR #181 で `isolation: "worktree"` 付きで再ディスパッチしたサブエージェントに、既存 PR ブランチ `fix/issue-149-debounce-download-disable` を引き継がせる指示を出した。worktree 作成時に `git checkout -b <pr-branch> origin/<pr-branch>` を実行させたが、worktree のデフォルト checkout が内部生成の `worktree-agent-<id>` branch のままになり、コミットがそちらに乗った。親が `git push origin <branch>` を素直に実行すると "Everything up-to-date"（PR ブランチには反映されない）。
+
+### 対処方針
+
+- 親は `git status` で **現在のブランチ名**を確認してから push する。
+- 内部 branch にコミットが乗っていた場合は ref マッピング push で PR ブランチに上げる:
+  ```bash
+  git push origin worktree-agent-<id>:<pr-branch>
+  ```
+- 完了報告で「最終コミット SHA」と並べて「コミットが乗っているブランチ名」もサブエージェントに報告させる規約にすると検出が早まる（規約昇格候補）。

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -5,6 +5,7 @@
 - 共通ルール化すべき内容は `docs/shared-agent-rules.md` に昇格させ、本ファイルから削除する。
 - セッション開始時に必ず読む必要はない（PR 作成前や定期整理時に見直す）。
 - 詳細な運用ルールは `docs/shared-agent-rules.md` 11章を参照。
+- 「（規約昇格候補）」と注記した項目は、次回 `agent-lessons.md` の整理タイミングで `shared-agent-rules.md` への昇格 / issue 化 / 削除のいずれかを判断する。
 
 ---
 
@@ -78,10 +79,14 @@ PR #181 のレビュー対応で、サブエージェントが `@testing-library
 
 PR #181 で `isolation: "worktree"` 付きで再ディスパッチしたサブエージェントに、既存 PR ブランチ `fix/issue-149-debounce-download-disable` を引き継がせる指示を出した。worktree 作成時に `git checkout -b <pr-branch> origin/<pr-branch>` を実行させたが、worktree のデフォルト checkout が内部生成の `worktree-agent-<id>` branch のままになり、コミットがそちらに乗った。親が `git push origin <branch>` を素直に実行すると "Everything up-to-date"（PR ブランチには反映されない）。
 
+### 根本原因
+
+`Agent` ツールの `isolation: "worktree"` で作成される worktree は、内部生成された `worktree-agent-<id>` branch を HEAD として checkout した状態で起動する。サブエージェントが `git checkout -b <pr-branch> origin/<pr-branch>` を実行しても、worktree の HEAD はそのまま `worktree-agent-<id>` を指し続け、後続のコミットが意図したブランチに乗らない。
+
 ### 対処方針
 
 - 親は `git status` で **現在のブランチ名**を確認してから push する。
-- 内部 branch にコミットが乗っていた場合は ref マッピング push で PR ブランチに上げる:
+- 内部 branch にコミットが乗っていた場合は refspec push で PR ブランチに上げる:
   ```bash
   git push origin worktree-agent-<id>:<pr-branch>
   ```


### PR DESCRIPTION
## 概要

2026-05-01 のサブエージェント運用で得た教訓 3 件を `docs/agent-lessons.md` に追記する。共通ルール化の判断は次回の整理時に行う。

## 追記内容

1. **サブエージェントは `isolation: "worktree"` 必須**: 省略時は `Bash` / `mcp__serena__execute_shell_command` 等が権限拒否され、ファイル編集しかできず作業未完で停止する（PR #181 / #182 で再現）
2. **devDependency 追加時の `package-lock.json` 同期**: PR #181 で lock 同期コミットが漏れて CI 失敗寸前。親側の検証手順と復旧コマンドを記載
3. **worktree 内部 branch (`worktree-agent-<id>`) と PR ブランチの取り違え**: 既存 PR ブランチ引き継ぎ指示でも worktree が内部 branch を checkout したままコミットが乗るケース。`git push origin <internal>:<pr-branch>` での復旧手順を記載

## 動機

これらは類似のケースで再発しやすい運用ハマりどころ。共通ルールに昇格させる前に、まず agent-lessons.md に記録して 1〜2 セッション様子を見る運用とする（`shared-agent-rules.md` 11 章の方針に従う）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
