### PR TITLE
fix(json-csv): デバウンス中のダウンロードを抑止 (#184)

### DIFF
--- a/src/components/tools/JsonCsv.tsx
+++ b/src/components/tools/JsonCsv.tsx
@@ -39,6 +39,7 @@ export function JsonCsvTool() {
   };
 
   const handleDownloadCsv = () => {
+    // ボタン側でも `disabled={!output}` で防御しているが念のため二重防御
     if (!output) return;
     downloadText(output, 'output.csv', 'text/csv');
   };

--- a/src/components/tools/JsonCsv.tsx
+++ b/src/components/tools/JsonCsv.tsx
@@ -49,7 +49,7 @@ export function JsonCsvTool() {
         onClick={handleDownloadCsv}
         label="CSVダウンロード"
         variant="secondary"
-        disabled={isPending}
+        disabled={isPending || !output}
       />
     ) : null;
 

--- a/src/components/tools/JsonCsv.tsx
+++ b/src/components/tools/JsonCsv.tsx
@@ -28,7 +28,7 @@ const SAMPLE: Record<Mode, string> = {
 export function JsonCsvTool() {
   const [mode, setMode] = useState<Mode>('json2csv');
 
-  const { input, setInput, output, error, reset } = useCodec(
+  const { input, setInput, output, error, isPending, reset } = useCodec(
     (text) => (mode === 'json2csv' ? jsonToCsv(text) : csvToJson(text)),
     [mode]
   );
@@ -45,7 +45,12 @@ export function JsonCsvTool() {
 
   const downloadButton =
     mode === 'json2csv' ? (
-      <DownloadButton onClick={handleDownloadCsv} label="CSVダウンロード" variant="secondary" />
+      <DownloadButton
+        onClick={handleDownloadCsv}
+        label="CSVダウンロード"
+        variant="secondary"
+        disabled={isPending}
+      />
     ) : null;
 
   return (

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -63,4 +63,23 @@ test.describe('JSON / CSV 変換', () => {
     await expect(page.getByLabel('変換結果')).toHaveValue(/'\+1\+1/);
     await expect(page.getByLabel('変換結果')).toHaveValue(/'@SUM/);
   });
+
+  test('JSON → CSV: タイピング直後はダウンロードボタンが disabled になり、デバウンス完了後に有効化される', async ({
+    page,
+  }) => {
+    const downloadBtn = page.getByRole('button', { name: 'CSVダウンロード' });
+    const inputField = page.getByLabel('入力');
+
+    // 有効な JSON を入力してボタンを表示させ、デバウンス完了を待つ
+    await inputField.fill('[{"id":1}]');
+    await expect(downloadBtn).toBeVisible({ timeout: 2000 });
+    await expect(downloadBtn).toBeEnabled({ timeout: 2000 });
+
+    // 新しい入力でデバウンス中（isPending = true）→ ボタンが disabled になる
+    await inputField.fill('[{"id":2}]');
+    await expect(downloadBtn).toBeDisabled();
+
+    // デバウンス完了（300ms）後に再び有効化される
+    await expect(downloadBtn).toBeEnabled({ timeout: 3000 });
+  });
 });

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -79,7 +79,7 @@ test.describe('JSON / CSV 変換', () => {
     await inputField.fill('[{"id":2}]');
     await expect(downloadBtn).toBeDisabled();
 
-    // デバウンス完了（300ms）後に再び有効化される
+    // デバウンス完了（useCodec の既定値）後に再び有効化される
     await expect(downloadBtn).toBeEnabled({ timeout: 3000 });
   });
 });

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -80,6 +80,7 @@ test.describe('JSON / CSV 変換', () => {
     await expect(downloadBtn).toBeDisabled();
 
     // デバウンス完了（useCodec の既定値）後に再び有効化される
+    // timeout: 3000 は useCodec の既定 debounceMs（300ms）に対する余裕
     await expect(downloadBtn).toBeEnabled({ timeout: 3000 });
   });
 });


### PR DESCRIPTION
## 概要

`JsonCsv.tsx` の `useCodec` 戻り値から `isPending` を取得し、CSV ダウンロードボタン（`DownloadButton`）の `disabled` prop に渡すことで、デバウンス中（タイピング直後）に古い変換結果をダウンロードしてしまうバグを修正する。

PR #181 (#149) で `ConfigConverter.tsx` に入れた修正の横展開。

## 変更内容

- `src/components/tools/JsonCsv.tsx`: `useCodec` から `isPending` を取得し `DownloadButton` に `disabled={isPending}` を設定
- `tests/e2e/json-csv.spec.ts`: タイピング直後にダウンロードボタンが disabled になり、デバウンス完了後に有効化されることを検証する E2E ケースを 1 件追加

## テスト

- `npm run test` 全件 pass（406 件）
- `npm run test:e2e -- tests/e2e/json-csv.spec.ts` 全件 pass（9 件）

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
