### PR TITLE
refactor(hooks): mountedRef を AbortController + useAbortableEffect に移行 (#168)

### DIFF
--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
@@ -101,10 +101,15 @@ export function QrReaderTool() {
   const camera = useQrCamera({ onQrDetected: handleQrDetected });
   const { stopCamera } = camera;
 
-  // アンマウント時にカメラを停止する
+  // 画像アップロード処理の AbortController を保持する ref。
+  // アンマウント時・連打時に前回の処理をキャンセルする。
+  const uploadAbortRef = useRef<AbortController | null>(null);
+
+  // アンマウント時にカメラを停止し、進行中のアップロードをキャンセルする
   useAbortableEffect(() => {
     return () => {
       stopCamera();
+      uploadAbortRef.current?.abort();
     };
   }, [stopCamera]);
 
@@ -129,7 +134,10 @@ export function QrReaderTool() {
     setDecodeError('');
     setDecoded(null);
 
+    // 連打時に前回のアップロードをキャンセルし、新しい controller を設定する
+    uploadAbortRef.current?.abort();
     const controller = new AbortController();
+    uploadAbortRef.current = controller;
     let result;
     try {
       result = await decodeQrFromFile(file, {
@@ -142,7 +150,7 @@ export function QrReaderTool() {
       return;
     }
 
-    if (result.ok === false) {
+    if (!result.ok) {
       if (result.reason === 'load-error') {
         setDecodeError('画像を読み込めませんでした');
       } else {

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { useQrCamera } from '@/hooks/useQrCamera';
+import { useAbortableEffect } from '@/hooks/useAbortableEffect';
 import { detectQrContent, decodeQrFromFile, DEFAULT_QR_MAX_DIM } from '@/utils/qr-reader';
 import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { validateFile } from '@/utils/file-validation';
@@ -91,10 +92,8 @@ export function QrReaderTool() {
   const [scanMode, setScanMode] = useState<'camera' | 'upload'>('camera');
   const [decoded, setDecoded] = useState<string | null>(null);
   const [decodeError, setDecodeError] = useState('');
-  const mountedRef = useRef(true);
 
   const handleQrDetected = useCallback((data: string) => {
-    if (!mountedRef.current) return;
     setDecoded(data);
     setDecodeError('');
   }, []);
@@ -102,15 +101,15 @@ export function QrReaderTool() {
   const camera = useQrCamera({ onQrDetected: handleQrDetected });
   const { stopCamera } = camera;
 
-  useEffect(() => {
-    mountedRef.current = true;
+  // アンマウント時にカメラを停止する
+  useAbortableEffect(() => {
     return () => {
-      mountedRef.current = false;
       stopCamera();
     };
   }, [stopCamera]);
 
-  useEffect(() => {
+  // scanMode が camera 以外に切り替わった時にカメラを停止する
+  useAbortableEffect(() => {
     if (scanMode !== 'camera') stopCamera();
   }, [scanMode, stopCamera]);
 
@@ -122,7 +121,7 @@ export function QrReaderTool() {
 
     const validation = validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
     if (!validation.ok) {
-      if (mountedRef.current) setDecodeError(validation.message);
+      setDecodeError(validation.message);
       return;
     }
 
@@ -130,9 +129,20 @@ export function QrReaderTool() {
     setDecodeError('');
     setDecoded(null);
 
-    const result = await decodeQrFromFile(file, { maxDim: DEFAULT_QR_MAX_DIM });
-    if (!mountedRef.current) return;
-    if (!result.ok) {
+    const controller = new AbortController();
+    let result;
+    try {
+      result = await decodeQrFromFile(file, {
+        maxDim: DEFAULT_QR_MAX_DIM,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      setDecodeError('画像を読み込めませんでした');
+      return;
+    }
+
+    if (result.ok === false) {
       if (result.reason === 'load-error') {
         setDecodeError('画像を読み込めませんでした');
       } else {

--- a/src/components/tools/QrTicket.tsx
+++ b/src/components/tools/QrTicket.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import {
   generateKeyPair,
   exportKeyPair,
@@ -21,6 +21,7 @@ import { sanitizeFilename, isSafeTicketId } from '@/utils/filename';
 import { decodeQrFromFile, DEFAULT_QR_MAX_DIM } from '@/utils/qr-reader';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { useQrCamera } from '@/hooks/useQrCamera';
+import { useAbortableEffect } from '@/hooks/useAbortableEffect';
 import { MODE_OPTIONS, GenerateTab, VerifyTab } from './qr-ticket/index';
 import type { TicketRow, GeneratedQr } from './qr-ticket/types';
 
@@ -67,25 +68,22 @@ export function QrTicketTool() {
   const [verificationResult, setVerificationResult] = useState<VerificationResult | null>(null);
   const [verifying, setVerifying] = useState(false);
 
-  // アンマウント検知 ref（非同期処理後のステート更新ガード用）
-  const mountedRef = useRef(true);
-
   // マウント後に初期値をセット
-  useEffect(() => {
+  useAbortableEffect(() => {
     setExpiry(getDefaultExpiry());
   }, []);
 
   // ─── QR検証（カメラ/アップロード共通） ───────────────────
 
   const handleVerify = useCallback(
-    async (rawData: string) => {
+    async (rawData: string, signal?: AbortSignal) => {
       setVerifying(true);
       let pubKey: CryptoKey;
       try {
         const jwk = JSON.parse(verifyPubKeyStr) as JsonWebKey;
         pubKey = await importPublicKey(jwk);
       } catch {
-        if (!mountedRef.current) return;
+        if (signal?.aborted) return;
         setVerificationResult({
           valid: false,
           ticket: null,
@@ -96,7 +94,7 @@ export function QrTicketTool() {
         return;
       }
       const result = await verifyTicket(rawData, pubKey);
-      if (!mountedRef.current) return;
+      if (signal?.aborted) return;
       setVerificationResult(result);
       setVerifying(false);
     },
@@ -104,20 +102,19 @@ export function QrTicketTool() {
   );
 
   const camera = useQrCamera({ onQrDetected: handleVerify });
+  const { stopCamera } = camera;
 
-  // モード切替時にカメラを停止
-  useEffect(() => {
-    if (mode !== 'verify') camera.stopCamera();
-  }, [mode, camera.stopCamera]);
+  // モード切替時にカメラを停止する
+  useAbortableEffect(() => {
+    if (mode !== 'verify') stopCamera();
+  }, [mode, stopCamera]);
 
-  // アンマウント時にカメラを停止 + mountedRef をリセット
-  useEffect(() => {
-    mountedRef.current = true;
+  // アンマウント時にカメラを停止する
+  useAbortableEffect(() => {
     return () => {
-      mountedRef.current = false;
-      camera.stopCamera();
+      stopCamera();
     };
-  }, [camera.stopCamera]);
+  }, [stopCamera]);
 
   // ─── 鍵操作 ──────────────────────────────────────────────
 
@@ -314,7 +311,6 @@ export function QrTicketTool() {
 
     const validation = validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
     if (!validation.ok) {
-      if (!mountedRef.current) return;
       camera.setCameraError(validation.message);
       return;
     }
@@ -322,9 +318,20 @@ export function QrTicketTool() {
     camera.setCameraError('');
     setVerificationResult(null);
 
-    const result = await decodeQrFromFile(file, { maxDim: DEFAULT_QR_MAX_DIM });
-    if (!mountedRef.current) return;
-    if (!result.ok) {
+    const controller = new AbortController();
+    let result;
+    try {
+      result = await decodeQrFromFile(file, {
+        maxDim: DEFAULT_QR_MAX_DIM,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      camera.setCameraError('画像を読み込めませんでした');
+      return;
+    }
+
+    if (result.ok === false) {
       if (result.reason === 'load-error') {
         camera.setCameraError('画像を読み込めませんでした');
       } else {
@@ -337,7 +344,7 @@ export function QrTicketTool() {
       }
       return;
     }
-    handleVerify(result.data);
+    await handleVerify(result.data, controller.signal);
   };
 
   const handleRescan = () => {

--- a/src/components/tools/QrTicket.tsx
+++ b/src/components/tools/QrTicket.tsx
@@ -77,6 +77,7 @@ export function QrTicketTool() {
 
   const handleVerify = useCallback(
     async (rawData: string, signal?: AbortSignal) => {
+      if (signal?.aborted) return;
       setVerifying(true);
       let pubKey: CryptoKey;
       try {

--- a/src/components/tools/QrTicket.tsx
+++ b/src/components/tools/QrTicket.tsx
@@ -104,15 +104,20 @@ export function QrTicketTool() {
   const camera = useQrCamera({ onQrDetected: handleVerify });
   const { stopCamera } = camera;
 
+  // 画像アップロード処理の AbortController を保持する ref。
+  // アンマウント時・連打時に前回の処理をキャンセルする。
+  const uploadAbortRef = useRef<AbortController | null>(null);
+
   // モード切替時にカメラを停止する
   useAbortableEffect(() => {
     if (mode !== 'verify') stopCamera();
   }, [mode, stopCamera]);
 
-  // アンマウント時にカメラを停止する
+  // アンマウント時にカメラを停止し、進行中のアップロードをキャンセルする
   useAbortableEffect(() => {
     return () => {
       stopCamera();
+      uploadAbortRef.current?.abort();
     };
   }, [stopCamera]);
 
@@ -318,7 +323,10 @@ export function QrTicketTool() {
     camera.setCameraError('');
     setVerificationResult(null);
 
+    // 連打時に前回のアップロードをキャンセルし、新しい controller を設定する
+    uploadAbortRef.current?.abort();
     const controller = new AbortController();
+    uploadAbortRef.current = controller;
     let result;
     try {
       result = await decodeQrFromFile(file, {
@@ -331,7 +339,7 @@ export function QrTicketTool() {
       return;
     }
 
-    if (result.ok === false) {
+    if (!result.ok) {
       if (result.reason === 'load-error') {
         camera.setCameraError('画像を読み込めませんでした');
       } else {

--- a/src/hooks/__tests__/useAbortableEffect.test.ts
+++ b/src/hooks/__tests__/useAbortableEffect.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAbortableEffect } from '@/hooks/useAbortableEffect';
+
+describe('useAbortableEffect', () => {
+  it('effect 関数に AbortSignal が渡される', () => {
+    const capturedSignals: AbortSignal[] = [];
+
+    renderHook(() =>
+      useAbortableEffect((signal) => {
+        capturedSignals.push(signal);
+      }, [])
+    );
+
+    expect(capturedSignals).toHaveLength(1);
+    expect(capturedSignals[0]).toBeInstanceOf(AbortSignal);
+    expect(capturedSignals[0].aborted).toBe(false);
+  });
+
+  it('クリーンアップ時に signal が abort される', () => {
+    let capturedSignal: AbortSignal | null = null;
+
+    const { unmount } = renderHook(() =>
+      useAbortableEffect((signal) => {
+        capturedSignal = signal;
+      }, [])
+    );
+
+    expect(capturedSignal!.aborted).toBe(false);
+    unmount();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  it('deps が変化すると前の signal が abort され、新しい signal が渡される', () => {
+    const signals: AbortSignal[] = [];
+
+    const { rerender } = renderHook(
+      ({ dep }: { dep: number }) =>
+        useAbortableEffect(
+          (signal) => {
+            signals.push(signal);
+          },
+          [dep]
+        ),
+      { initialProps: { dep: 0 } }
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0].aborted).toBe(false);
+
+    act(() => {
+      rerender({ dep: 1 });
+    });
+
+    // 最初の signal が abort され、新しい signal が追加されている
+    expect(signals).toHaveLength(2);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it('effect が同期的なクリーンアップ関数を返した場合、クリーンアップ時に呼ばれる', () => {
+    const cleanup = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useAbortableEffect(() => {
+        return cleanup;
+      }, [])
+    );
+
+    expect(cleanup).not.toHaveBeenCalled();
+    unmount();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('クリーンアップ関数を返さない場合はエラーが発生しない', () => {
+    expect(() => {
+      const { unmount } = renderHook(() =>
+        useAbortableEffect(() => {
+          // cleanup なし
+        }, [])
+      );
+      unmount();
+    }).not.toThrow();
+  });
+
+  it('非同期 effect でも signal.aborted を使ってキャンセルを検知できる', async () => {
+    const results: string[] = [];
+
+    const { unmount } = renderHook(() =>
+      useAbortableEffect((signal) => {
+        const run = async () => {
+          await Promise.resolve(); // 非同期ポイント
+          if (signal.aborted) {
+            results.push('aborted');
+            return;
+          }
+          results.push('completed');
+        };
+        void run();
+      }, [])
+    );
+
+    // アンマウント前に完了
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(results).toContain('completed');
+
+    unmount();
+    results.length = 0;
+
+    // 次のレンダでアンマウントを即座に行うケース
+    const { unmount: unmount2 } = renderHook(() =>
+      useAbortableEffect((signal) => {
+        const run = async () => {
+          await Promise.resolve();
+          if (signal.aborted) {
+            results.push('aborted');
+            return;
+          }
+          results.push('completed');
+        };
+        void run();
+      }, [])
+    );
+    unmount2(); // 非同期処理の完了前にアンマウント
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(results).toContain('aborted');
+  });
+});

--- a/src/hooks/useAbortableEffect.ts
+++ b/src/hooks/useAbortableEffect.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+/**
+ * AbortController を自動管理する useEffect ラッパー。
+ * effect 関数に AbortSignal を渡し、クリーンアップ時に abort() を呼ぶ。
+ * effect が同期的なクリーンアップ関数を返した場合は通常の useEffect と同様に呼び出す。
+ */
+export function useAbortableEffect(
+  effect: (signal: AbortSignal) => void | Promise<void> | (() => void | Promise<void>),
+  deps: React.DependencyList
+): void {
+  useEffect(() => {
+    const controller = new AbortController();
+    const result = effect(controller.signal);
+
+    return () => {
+      controller.abort();
+      // 同期的なクリーンアップ関数が返された場合は呼び出す
+      if (typeof result === 'function') {
+        void result();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/src/hooks/useAbortableEffect.ts
+++ b/src/hooks/useAbortableEffect.ts
@@ -7,6 +7,11 @@ import { useEffect } from 'react';
  *
  * 非同期処理を実行する場合は `void run()` パターンを使用すること。
  * async 関数を直接渡しても Promise は無視される（キャンセルは signal.aborted で検知する）。
+ * **注意**: async 関数を直接渡しても TypeScript のエラーにならない（Promise<void> は void に代入可能）が、
+ * cleanup 関数を返したつもりでもスキップされるため、必ず `void run()` パターンを使うこと。
+ *
+ * クリーンアップ順序: `controller.abort()` を先に呼び、その後 effect の戻り値 cleanup を呼ぶ。
+ * cleanup 内で `signal.aborted` を参照して分岐したい場合はこの順序を前提にすること。
  */
 export function useAbortableEffect(
   effect: (signal: AbortSignal) => void | (() => void),

--- a/src/hooks/useAbortableEffect.ts
+++ b/src/hooks/useAbortableEffect.ts
@@ -4,9 +4,12 @@ import { useEffect } from 'react';
  * AbortController を自動管理する useEffect ラッパー。
  * effect 関数に AbortSignal を渡し、クリーンアップ時に abort() を呼ぶ。
  * effect が同期的なクリーンアップ関数を返した場合は通常の useEffect と同様に呼び出す。
+ *
+ * 非同期処理を実行する場合は `void run()` パターンを使用すること。
+ * async 関数を直接渡しても Promise は無視される（キャンセルは signal.aborted で検知する）。
  */
 export function useAbortableEffect(
-  effect: (signal: AbortSignal) => void | Promise<void> | (() => void | Promise<void>),
+  effect: (signal: AbortSignal) => void | (() => void),
   deps: React.DependencyList
 ): void {
   useEffect(() => {

--- a/src/hooks/useQrCamera.ts
+++ b/src/hooks/useQrCamera.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import jsQR from 'jsqr';
 
 interface UseQrCameraOptions {
@@ -93,13 +93,19 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
     }
   }, [stopCamera]);
 
-  return {
-    cameraActive,
-    cameraError,
-    setCameraError,
-    videoRef,
-    canvasRef,
-    startCamera,
-    stopCamera,
-  };
+  // 毎レンダでオブジェクトが再生成されないよう useMemo で安定化する。
+  // stopCamera は useCallback(..., []) で安定しており、startCamera は useCallback(..., [stopCamera]) で安定している。
+  // cameraActive / cameraError はステート変化時のみ新しいオブジェクトを生成する。
+  return useMemo(
+    () => ({
+      cameraActive,
+      cameraError,
+      setCameraError,
+      videoRef,
+      canvasRef,
+      startCamera,
+      stopCamera,
+    }),
+    [cameraActive, cameraError, setCameraError, videoRef, canvasRef, startCamera, stopCamera]
+  );
 }

--- a/src/utils/__tests__/qr-reader.test.ts
+++ b/src/utils/__tests__/qr-reader.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { detectQrContent, decodeQrFromFile } from '@/utils/qr-reader';
 
 describe('detectQrContent', () => {
@@ -166,6 +166,52 @@ describe('decodeQrFromFile — AbortSignal キャンセル', () => {
       decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal })
     ).rejects.toMatchObject({ name: 'AbortError' });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.Image = OrigImage as any;
+  });
+
+  it('canvas.getContext が null の場合でも load-error として解決し、abort リスナーが残らない', async () => {
+    const controller = new AbortController();
+    const revokeCount = { count: 0 };
+
+    // canvas.getContext を null 返しにする
+    const origCreateElement = document.createElement.bind(document);
+    const spy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = origCreateElement(tag);
+      if (tag === 'canvas') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (el as any).getContext = () => null;
+      }
+      return el;
+    });
+
+    const OrigImage = globalThis.Image;
+    class CanvasNullImage {
+      onerror: (() => void) | null = null;
+      onload: (() => void) | null = null;
+      width = 100;
+      height = 100;
+      set src(_: string) {
+        Promise.resolve().then(() => this.onload?.());
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.Image = CanvasNullImage as any;
+
+    URL.createObjectURL = () => 'blob:stub';
+    URL.revokeObjectURL = () => {
+      revokeCount.count += 1;
+    };
+
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    const result = await decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal });
+
+    // load-error として解決すること
+    expect(result).toEqual({ ok: false, reason: 'load-error' });
+    // onload 内で 1 回だけ revoke されること（abort リスナーによる二重 revoke がないこと）
+    expect(revokeCount.count).toBe(1);
+
+    spy.mockRestore();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     globalThis.Image = OrigImage as any;
   });

--- a/src/utils/__tests__/qr-reader.test.ts
+++ b/src/utils/__tests__/qr-reader.test.ts
@@ -1,5 +1,6 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { detectQrContent } from '@/utils/qr-reader';
+import { detectQrContent, decodeQrFromFile } from '@/utils/qr-reader';
 
 describe('detectQrContent', () => {
   describe('HTTP/HTTPS URL', () => {
@@ -91,5 +92,81 @@ describe('detectQrContent', () => {
       const result = detectQrContent(input);
       expect(result.raw).toBe(input);
     });
+  });
+});
+
+describe('decodeQrFromFile — AbortSignal キャンセル', () => {
+  it('既にキャンセル済みの signal を渡すと AbortError が reject される', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    // jsdom では URL.createObjectURL が未実装なので stub する
+    const origCreateObjectURL = URL.createObjectURL;
+    URL.createObjectURL = () => 'blob:stub';
+    URL.revokeObjectURL = () => {};
+
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    await expect(
+      decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    URL.createObjectURL = origCreateObjectURL;
+  });
+
+  it('キャンセルされていない signal を渡した場合は通常処理を試みる（load-error で解決）', async () => {
+    const controller = new AbortController();
+
+    // jsdom 環境で Image.onload/onerror を制御するため、
+    // Image のコンストラクタを stub して即 onerror を呼ぶ
+    const OrigImage = globalThis.Image;
+    class FakeImage {
+      onerror: (() => void) | null = null;
+      onload: (() => void) | null = null;
+      set src(_: string) {
+        // 次のマイクロタスクで onerror を発火させてロードエラーをシミュレート
+        Promise.resolve().then(() => this.onerror?.());
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.Image = FakeImage as any;
+
+    URL.createObjectURL = () => 'blob:stub';
+    URL.revokeObjectURL = () => {};
+
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    const result = await decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal });
+    expect(result).toEqual({ ok: false, reason: 'load-error' });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.Image = OrigImage as any;
+  });
+
+  it('signal が abort されると処理中の Promise が AbortError で reject される', async () => {
+    const controller = new AbortController();
+
+    // Image が src セット後に abort が飛んでくるケースをシミュレート
+    const OrigImage = globalThis.Image;
+    class SlowImage {
+      onerror: (() => void) | null = null;
+      onload: (() => void) | null = null;
+      set src(_: string) {
+        // abort を先に呼び、その後 onload を発火させる（onload は abort 後なので無視される）
+        controller.abort();
+        Promise.resolve().then(() => this.onload?.());
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.Image = SlowImage as any;
+
+    URL.createObjectURL = () => 'blob:stub';
+    URL.revokeObjectURL = () => {};
+
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    await expect(
+      decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.Image = OrigImage as any;
   });
 });

--- a/src/utils/__tests__/qr-reader.test.ts
+++ b/src/utils/__tests__/qr-reader.test.ts
@@ -134,11 +134,13 @@ describe('decodeQrFromFile — AbortSignal キャンセル', () => {
     URL.revokeObjectURL = () => {};
 
     const file = new File(['dummy'], 'test.png', { type: 'image/png' });
-    const result = await decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal });
-    expect(result).toEqual({ ok: false, reason: 'load-error' });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    globalThis.Image = OrigImage as any;
+    try {
+      const result = await decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal });
+      expect(result).toEqual({ ok: false, reason: 'load-error' });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      globalThis.Image = OrigImage as any;
+    }
   });
 
   it('signal が abort されると処理中の Promise が AbortError で reject される', async () => {
@@ -162,12 +164,14 @@ describe('decodeQrFromFile — AbortSignal キャンセル', () => {
     URL.revokeObjectURL = () => {};
 
     const file = new File(['dummy'], 'test.png', { type: 'image/png' });
-    await expect(
-      decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal })
-    ).rejects.toMatchObject({ name: 'AbortError' });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    globalThis.Image = OrigImage as any;
+    try {
+      await expect(
+        decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal })
+      ).rejects.toMatchObject({ name: 'AbortError' });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      globalThis.Image = OrigImage as any;
+    }
   });
 
   it('canvas.getContext が null の場合でも load-error として解決し、abort リスナーが残らない', async () => {
@@ -204,15 +208,17 @@ describe('decodeQrFromFile — AbortSignal キャンセル', () => {
     };
 
     const file = new File(['dummy'], 'test.png', { type: 'image/png' });
-    const result = await decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal });
+    try {
+      const result = await decodeQrFromFile(file, { maxDim: 1600, signal: controller.signal });
 
-    // load-error として解決すること
-    expect(result).toEqual({ ok: false, reason: 'load-error' });
-    // onload 内で 1 回だけ revoke されること（abort リスナーによる二重 revoke がないこと）
-    expect(revokeCount.count).toBe(1);
-
-    spy.mockRestore();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    globalThis.Image = OrigImage as any;
+      // load-error として解決すること
+      expect(result).toEqual({ ok: false, reason: 'load-error' });
+      // onload 内で 1 回だけ revoke されること（abort リスナーによる二重 revoke がないこと）
+      expect(revokeCount.count).toBe(1);
+    } finally {
+      spy.mockRestore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      globalThis.Image = OrigImage as any;
+    }
   });
 });

--- a/src/utils/qr-reader.ts
+++ b/src/utils/qr-reader.ts
@@ -13,17 +13,39 @@ export const DEFAULT_QR_MAX_DIM = 1600;
 /**
  * ファイルからQRコードをデコードする。
  * 長辺が maxDim を超える場合はアスペクト比を維持してダウンスケールする。
+ * opts.signal が渡された場合、各 await ポイントでキャンセルを確認する。
  */
 export async function decodeQrFromFile(
   file: File,
-  opts: { maxDim: number }
+  opts: { maxDim: number; signal?: AbortSignal }
 ): Promise<DecodeQrResult> {
-  return new Promise<DecodeQrResult>((resolve) => {
+  return new Promise<DecodeQrResult>((resolve, reject) => {
+    // 開始前にキャンセル済みか確認
+    if (opts.signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
     const objectUrl = URL.createObjectURL(file);
     const img = new Image();
 
-    img.onload = () => {
+    // AbortSignal のリスナーを登録してキャンセル時に即座にリジェクト
+    const onAbort = () => {
       URL.revokeObjectURL(objectUrl);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    opts.signal?.addEventListener('abort', onAbort, { once: true });
+
+    img.onload = () => {
+      opts.signal?.removeEventListener('abort', onAbort);
+      URL.revokeObjectURL(objectUrl);
+
+      // 画像ロード完了後にもキャンセルを確認
+      if (opts.signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+
       const scale = Math.min(1, opts.maxDim / Math.max(img.width, img.height));
       const w = Math.round(img.width * scale);
       const h = Math.round(img.height * scale);
@@ -36,8 +58,29 @@ export async function decodeQrFromFile(
         return;
       }
       ctx.drawImage(img, 0, 0, w, h);
+
+      // ImageData 取得前にキャンセルを確認
+      if (opts.signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+
       const imageData = ctx.getImageData(0, 0, w, h);
+
+      // jsQR 呼び出し前にキャンセルを確認
+      if (opts.signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+
       const found = jsQR(imageData.data, imageData.width, imageData.height);
+
+      // jsQR 呼び出し後にキャンセルを確認
+      if (opts.signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+
       if (!found) {
         resolve({ ok: false, reason: 'not-found' });
         return;
@@ -46,6 +89,7 @@ export async function decodeQrFromFile(
     };
 
     img.onerror = () => {
+      opts.signal?.removeEventListener('abort', onAbort);
       URL.revokeObjectURL(objectUrl);
       resolve({ ok: false, reason: 'load-error' });
     };


### PR DESCRIPTION
## 概要

- `mountedRef` パターン（アンマウント後の setState ガード）を AbortController ベースに移行
- 共通フック `useAbortableEffect` を新設し、今後の非同期 effect でコピペ不要な基盤を整備
- `useQrCamera` の戻り値を `useMemo` で安定化し、毎レンダ再生成を回避

## 変更内容

- **`src/hooks/useAbortableEffect.ts`（新規）**: `effect(signal)` の形で AbortSignal を渡し、cleanup 時に `controller.abort()` を呼ぶ共通フック
- **`src/utils/qr-reader.ts`**: `decodeQrFromFile` に `opts.signal?: AbortSignal` を追加。画像ロード・ImageData 取得・jsQR 呼び出し前後の各ポイントでキャンセル確認
- **`src/components/tools/QrReader.tsx` / `QrTicket.tsx`**: `mountedRef` を完全排除し `useAbortableEffect` に置換。`handleImageUpload` には `AbortController` を渡して signal 経由でキャンセル
- **`src/hooks/useQrCamera.ts`**: 戻り値を `useMemo` でメモ化し安定性を明示。`QrTicket` の依存表記を `QrReader` と統一（`camera.stopCamera` → `stopCamera`）

## テスト

- `npm run test`: 415 件 pass（29 ファイル）
- `decodeQrFromFile` の AbortSignal 単体テスト 3 件追加
- `useAbortableEffect` の renderHook ベーステスト 5 件追加
- `npm run test:e2e`: 141 件 pass / 1 skipped（QR 関連 18 件含む全件 pass）
- `astro check`: 0 errors

`mountedRef` の最終的な利用箇所数: 0 件

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
