### PR TITLE
chore(rules): E2E 実行責務をサブエージェントから親に移管

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 - **言語**: コミットメッセージ・PR 説明文は **必ず日本語**。
 - **スタイリング**: Tailwind カラークラスは禁止。**`colors.*` (React)** または **`var(--color-*)` (Astro)** を使用。
-- **検証**: 変更後は **`npm run test`** および **`npm run test:e2e`** で確認。
+- **検証**: サブエージェントは **`npm run test`**（ユニット）と `astro check`（型）まで。**`npm run test:e2e` は親が代行**（詳細: `docs/shared-agent-rules.md` 3.1 / 3.2）。
 - **PR ベース**: `gh pr create` は **必ず `--base develop`** を明示する。`main` 向けはリリース PR のみ（`gh` のデフォルト・Claude Code system prompt の "Main branch ... main" 表示に流されないこと）。詳細は `docs/shared-agent-rules.md` 6.3 章。
 - **ATC運用**: セッション開始時に `tasks/active_context.md` を作成（superpowers の plan / conductor のタスクファイル等が「目的・ステップ・スコープ外」を明示する場合は不要。詳細は `docs/shared-agent-rules.md` 11章）。
 - **司令塔モード**: 親 Claude セッションは委譲・ベース確認・テスト確認・aria 削除検出を経て PR 作成（詳細: `docs/shared-agent-rules.md` 6.2a 章・3 章 push 前チェックリスト・10.6 章）。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1923,6 +1923,10 @@ worktree 並列実行を採用しているため、複数のサブエージェ�
 
 - CI で port 動的割り当てが導入された場合は 3.1 の「実行禁止」を緩和できる（playwright config と Astro dev server の連携が自動化されることが前提）。
 
+### 経緯追記
+
+- **レビュー取得の取りこぼし事故** (2026-05-01): PR #187 / #188 / #189 で親が `gh api .../issues/<n>/comments` のみ確認し、GitHub の "Submit review" 機能経由の正式レビュー（`gh api .../pulls/<n>/reviews`）を 3 件取りこぼした。再発防止として 3.2 章「親向けレビュー取得手順」を追記。
+
 ### 関連 PR
 
 - PR #192（本 PR、`docs/shared-agent-rules.md` 3 章改訂）

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1895,45 +1895,32 @@ devtools リポジトリの issue 活動量（新規作成数・クローズ率�
 
 ---
 
-## [056] `.claude/settings.json` permissions allow を git 典型コマンドに拡張（hook bypass 防止・ベース切替制限）
+## [057] 2026-05-01 — E2E 実行責務をサブエージェントから親（司令塔）に移管
 
 **2026-05-01 | ステータス: 採用**
 
 ### 背景
 
-サブエージェント運用において `git checkout -b` / `git commit` / `git rebase --onto` などが ask 行きとなり、非対話のサブエージェントでは事実上 deny になっていた（PR #181 / #182 / #168 デバッグで再現）。PR #189 で典型操作を allow に追加したが、ワイルドカードが過広で危険なパターンを無確認で通してしまう問題が PR レビューで指摘された。
+worktree 並列実行を採用しているため、複数のサブエージェントが同時に `npm run test:e2e` を起動すると port 4321 を奪い合い、`waitForReactHydration` timeout として誤報告される事故が頻発した（PR #181 / #188 で実害発生）。また sandbox 制約で dev server を起動できないケースもあり、サブエージェント側の E2E 実行は信頼性が低い。
 
 ### 決断
 
-- `git commit *` → `git commit -m *` / `git commit -am *` に限定（`--no-verify` / `-n` によるフックバイパスを防止）
-- `git checkout *` → `git switch *` / `git checkout -b *` / `git checkout -B worktree-agent-*` に限定（ベース切替・ファイル復元は ask に残す）
-- `git add *` は allow に残しつつ、`git add -A*` / `git add --all*` / `git add .` を ask に追加（`.env` 等の機密ファイル混入リスク対応）
-
-### 安全性確認
-
-Claude Code の permission matching は **`deny` > `ask` > `allow` の優先順**で評価される（[公式ドキュメント](https://code.claude.com/docs/en/settings) 参照。deny が最初にマッチすれば即ブロック、次に ask、最後に allow の順で評価され、最初にマッチしたルールが適用される）。したがって、`git add -A*`（ask）は `git add *`（allow）より優先され、`git add -A` を実行した際は ask が確実に発火する。同様に `git commit -am "msg" --no-verify`（ask パターン `git commit * --no-verify*` にマッチ）も、`git commit -am *`（allow）より ask が優先されるため、hook bypass が無確認で通る恐れはない。
-
-- `git push --force*` → deny（変更なし）
-- `git reset --hard*` → ask（変更なし）
-- `git push*` → ask（変更なし）
-- `git commit --no-verify*` / `git commit -n *` / `git commit * -n` / `git commit * --no-verify*` → ask（新規追加）
-- `git add -A*` / `git add --all*` / `git add .` → ask（新規追加）
-- `git checkout <branch>`（ベース切替）/ `git checkout -- *`（ファイル復元） → ask に残置
-- `git rebase`（--onto 以外）/ `git merge`（--ff-only 以外）→ ask に残置
-
-#### 実機確認
-
-- `git commit -am "msg" --no-verify` 実行時に ask が発火することを確認予定（issue 化推奨、ただし本 PR 必須ではない）。
+- サブエージェント: **E2E テストコードの追加義務は維持**（11 章原則）。`npm run test:e2e` の **実行は禁止**。検証範囲を unit + 型チェックに限定。
+- 親（司令塔）: push 前後に worktree 内で 1 回だけ E2E を serial 実行。複数 worktree がある場合は同時実行禁止（直列化）。環境由来の失敗が続く場合は CI を最終判断とする。
 
 ### 却下した選択肢
 
-- `git add *` を削除して path-prefix 形のみ allow: 実用性を大きく損なうため却下。ask での警告追加で対応。
-- `git commit --amend *` を allow に追加: 現時点で明示的な要件なし（YAGNI）。
+- **サブエージェント側で port を可変化**: playwright config と Astro dev server の双方を同期する必要があり、複雑性に見合わない。直列化で十分。
+- **E2E テスト自体を unit 化**: `waitForReactHydration` を含む WCAG / アクセシビリティ系の挙動はブラウザでないと検証できない。
 
-### 将来課題
+### 安全性確認
 
-- `Bash(git switch *)` は allow に残置（新規ブランチ作成 `-b` だけでなく既存ブランチ切替も含む）。`git checkout <branch>` (ask) との非対称性が将来「allow が広すぎてベース汚染」の原因となり得るため、運用で問題が顕在化したら `git switch -b *` 限定への縮退を別 PR で再検討する。
+- E2E **実装義務**は維持されるため、テストカバレッジは低下しない（実装コードと同時にテストコードが PR に入る原則は変更なし）。
+- CI が最終ゲートとして機能（`.github/workflows/` の e2e ジョブで全件検証）。
+- 親による代行実行は復旧コマンド（`lsof -ti:4321 | xargs kill -9`）と直列化を含むため、port 衝突起因の誤報告は排除される。
 
 ### 関連 PR
 
-- PR #189
+- PR #192（本 PR、`docs/shared-agent-rules.md` 3 章改訂）
+- PR #181（fix #149: 元の手順では E2E 待ちで時間切れ）
+- PR #188（refactor #168: worktree 並列で E2E が誤 timeout）

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1919,6 +1919,10 @@ worktree 並列実行を採用しているため、複数のサブエージェ�
 - CI が最終ゲートとして機能（`.github/workflows/` の e2e ジョブで全件検証）。
 - 親による代行実行は復旧コマンド（`lsof -ti:4321 | xargs kill -9`）と直列化を含むため、port 衝突起因の誤報告は排除される。
 
+### 将来の見直しトリガー
+
+- CI で port 動的割り当てが導入された場合は 3.1 の「実行禁止」を緩和できる（playwright config と Astro dev server の連携が自動化されることが前提）。
+
 ### 関連 PR
 
 - PR #192（本 PR、`docs/shared-agent-rules.md` 3 章改訂）

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -99,6 +99,20 @@
 | 4   | E2E 直列実行                                                   | 本節手順 1〜5 を実施                                                                                                   |
 | 5   | PR ベース                                                      | `gh pr create --base develop`                                                                                          |
 
+#### 親向けレビュー取得手順（取りこぼし防止）
+
+PR には **2 系統のコメント**があり、両方確認すること。**Issue comments API だけを見ると、GitHub の "Submit review" 機能で投稿された正式レビューを完全に取りこぼす**（過去に PR #187 / #188 / #189 で発生 — 2026-05-01）。
+
+```bash
+# (1) Issue comments（`gh pr comment` で投稿されるもの）
+gh api "repos/<owner>/<repo>/issues/<n>/comments" --jq '.[].body'
+
+# (2) Pull Request reviews（"Submit review" 機能で投稿されるもの）
+gh api "repos/<owner>/<repo>/pulls/<n>/reviews" --jq '.[].body'
+```
+
+`gh pr view <n> --json reviews` も内部的に (2) を取得するため、`gh api` を使う場合は両方を読むこと。返信は `gh pr comment <n> --body-file` で OK（Issue comment として投稿される）。
+
 > 関連: issue #193（E2E web-first assertions のテスト記述ガイドライン）
 
 > macOS/Linux 前提。Windows/WSL では別手段（`netstat -ano` + `taskkill` 等）が必要。

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -66,6 +66,8 @@
 
 ### 3.2 親（司令塔）による E2E 代行実行
 
+> サブエージェントが dev server を残置している場合は、親側で kill する前に停止依頼すること（`npm run dev` のプロセスを終了するよう完了報告時に明記させる）。
+
 サブエージェントの完了報告を受けて push する前後に、親が以下を実施する。
 
 1. 既存の dev server を kill する:
@@ -75,15 +77,29 @@
 2. worktree 内で E2E を実行する（全体または影響範囲を絞って）:
    ```bash
    npm run test:e2e
-   # または影響範囲を絞る場合
+   # または影響範囲を絞る場合（npm run test:e2e -- <spec> でも同様）
    npx playwright test <spec> --project chromium
    ```
 3. **複数 worktree がある場合は同時実行しない**（ポート競合を避けるため）。1 つの worktree が完了してから次へ。
 4. 失敗パターンの判定:
    - **テスト本来の失敗**（assertion error、要素が見つからない等）→ サブエージェントに修正依頼
-   - **環境由来の失敗**（`waitForReactHydration` timeout、`Error: connect ECONNREFUSED 127.0.0.1:4321` 等）→ 上記 1〜2 を 1 回だけ再実行
+   - **環境由来の失敗**（`waitForReactHydration` timeout、`Error: connect ECONNREFUSED 127.0.0.1:4321`、`Timed out waiting for server to start`、`webServer was not ready` 等）→ 上記 1〜2 を 1 回だけ再実行
    - 再実行でも環境由来失敗が続く場合 → **CI を最終判断とする**（push して CI 結果を待つ）
 5. unit テストは worktree 内で完結するため、サブエージェントの結果をそのまま信頼してよい。
+
+#### push 前必須チェックリスト（親）
+
+サブエージェントの完了報告を受けて push する際は、以下をすべて確認する。
+
+| #   | チェック項目                                                   | コマンド                                                                                                               |
+| --- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| 1   | develop ベース確認                                             | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                          |
+| 2   | サブエージェント完了報告の検証（unit / 型 / E2E スキップ理由） | 完了報告に「E2E 実行は親が代行」の明記があることを確認                                                                 |
+| 3   | スコープ外差分の確認                                           | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認 |
+| 4   | E2E 直列実行                                                   | 本節手順 1〜5 を実施                                                                                                   |
+| 5   | PR ベース                                                      | `gh pr create --base develop`                                                                                          |
+
+> 関連: issue #193（E2E web-first assertions のテスト記述ガイドライン）
 
 > macOS/Linux 前提。Windows/WSL では別手段（`netstat -ano` + `taskkill` 等）が必要。
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -42,27 +42,48 @@
 
 ## 3. 実装後の検証義務
 
-実装完了後（コミット前）に **`npm run test`** と **`npm run test:e2e`** を必ず実行し、デグレード無しを確認すること。
-
 **E2E テストは実装と同時に書く**: バグ修正・UI 挙動の変更時はコミット前に該当ケースの E2E を追加する。後回し禁止。
 
-#### push 前必須チェックリスト（サブエージェント含む全担当者）
+### 3.1 サブエージェントの検証範囲
 
-以下をすべて満たしてから `git push` する。**1 つでも未完了の場合は push せず、未完了の項目を完了報告に明記して親に判断を仰ぐ**。
+サブエージェント（worktree 内で動作するエージェント）は以下のルールに従う。
+
+- **E2E テストコードの追加は義務**: バグ修正・UI 挙動変更時は E2E テストコードを必ず追加する（11 章の原則と同じ）。
+- **`npm run test:e2e` の実行は禁止**: worktree 並列環境ではポート 4321 が競合して誤報告が頻発する。また sandbox 制約でサーバー起動ができないケースがある。E2E の実行は親（司令塔）が代行する。
+- **完了報告には「E2E 実行は親が代行する」と明記すること。**
+- 検証範囲は `npm run test`（ユニット）と `node_modules/.bin/astro check`（型）まで。
+
+#### push 前必須チェックリスト（サブエージェント）
+
+以下をすべて満たしてから完了報告する。**1 つでも未完了の場合は push せず、未完了の項目を完了報告に明記して親に判断を仰ぐ**。
 
 | #   | チェック項目          | コマンド                                                                      |
 | --- | --------------------- | ----------------------------------------------------------------------------- |
 | 1   | develop ベース確認    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致 |
 | 2   | ユニットテスト全 pass | `npm run test`                                                                |
-| 3   | E2E テスト全 pass     | `npm run test:e2e`                                                            |
-| 4   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                   |
+| 3   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                   |
+| 4   | E2E テスト            | **実行禁止**（テストコード追加は義務。実行は親が代行）                        |
 
-**E2E でポート衝突した場合の復旧手順**（スキップは禁止。必ず復旧して再実行すること）:
+### 3.2 親（司令塔）による E2E 代行実行
 
-```bash
-lsof -ti:4321 | xargs kill -9 2>/dev/null || true
-npm run test:e2e
-```
+サブエージェントの完了報告を受けて push する前後に、親が以下を実施する。
+
+1. 既存の dev server を kill する:
+   ```bash
+   lsof -ti:4321 | xargs kill -9 2>/dev/null || true
+   ```
+2. worktree 内で E2E を実行する（全体または影響範囲を絞って）:
+   ```bash
+   npm run test:e2e
+   # または影響範囲を絞る場合
+   npx playwright test <spec> --project chromium
+   ```
+3. **複数 worktree がある場合は同時実行しない**（ポート競合を避けるため）。1 つの worktree が完了してから次へ。
+4. 失敗パターンの判定:
+   - **テスト本来の失敗**（assertion error、要素が見つからない等）→ サブエージェントに修正依頼
+   - **環境由来の失敗**（`waitForReactHydration` timeout、`Error: connect ECONNREFUSED 127.0.0.1:4321` 等）→ 上記 1〜2 を 1 回だけ再実行
+   - 再実行でも環境由来失敗が続く場合 → **CI を最終判断とする**（push して CI 結果を待つ）
+5. unit テストは worktree 内で完結するため、サブエージェントの結果をそのまま信頼してよい。
 
 > macOS/Linux 前提。Windows/WSL では別手段（`netstat -ano` + `taskkill` 等）が必要。
 


### PR DESCRIPTION
## 概要

`docs/shared-agent-rules.md` の 3 章を改訂し、**E2E 実行責務をサブエージェントから親（司令塔）に移管**するルールを明文化する。

## 変更内容

- **3.1 サブエージェントの検証範囲**（新設）: E2E **テストコード追加は義務を維持**しつつ、`npm run test:e2e` の **実行を禁止**。検証範囲を unit + 型チェックに限定。完了報告には「E2E は親が代行する旨」を明記する義務を追加。
- **3.2 親（司令塔）による E2E 代行実行**（新設）: 以下 5 ステップ:
  1. `lsof -ti:4321 | xargs kill -9 2>/dev/null || true`
  2. `npm run test:e2e` または影響範囲を絞った `npx playwright test <spec> --project chromium`
  3. 複数 worktree の **同時実行禁止**（直列化）
  4. 失敗パターン判定（本来の失敗 vs 環境由来）
  5. 環境由来失敗継続時は **CI を最終判断**
- 旧「E2E でポート衝突した場合の復旧手順」節を 3.2 に統合（親向けの手順として再配置）

## 動機・経緯

worktree 並列実行環境で port 4321 の競合により E2E が誤報告を返すケースが頻発（PR #181 / #188 等）。また sandbox 制約で dev server 起動自体ができないケースもあった。サブエージェントが E2E を実行しないことで誤報告を排除し、親が serial に 1 回だけ実行することで信頼性を確保する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
