### PR TITLE
chore(scripts): 先送り表現の issue 化忘れ検出スクリプトを追加

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,29 @@
+# scripts/
+
+このディレクトリには、開発・CI 運用を補助する bash スクリプトを配置します。
+
+---
+
+## check-followup-refs.sh
+
+PR レビュー返信や教訓記録に「先送り表現」（予定 / 候補 / follow-up 等）が含まれているのに対応する issue 番号が併記されていない場合を検出する。
+
+### 使い方
+
+```bash
+# 単一ファイル
+./scripts/check-followup-refs.sh docs/agent-lessons.md
+
+# 複数ファイル / glob
+./scripts/check-followup-refs.sh /tmp/claude/issues/reply-pr-*.md
+```
+
+### 終了コード
+
+- `0`: 先送り表現が無いか、すべてに issue 番号が併記されている
+- `1`: 起票忘れ疑いあり（標準出力に該当行、標準エラーに対応方法ヒント）
+
+### 関連
+
+- `docs/shared-agent-rules.md` 6.4 章（先送り時は issue 化必須）
+- `feedback_commander_checklist.md` F 章（メモリ）

--- a/scripts/check-followup-refs.sh
+++ b/scripts/check-followup-refs.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# check-followup-refs.sh
+# PR レビュー返信や教訓記録などに「先送り表現」が含まれているのに
+# 対応する issue 番号 (#NNN) が併記されていない行を検出する。
+#
+# 使い方:
+#   scripts/check-followup-refs.sh <file>...
+#
+# 終了コード:
+#   0 - 問題なし（先送り表現が無いか、すべてに issue 番号が併記されている）
+#   1 - 起票忘れ疑いあり（標準出力に該当行、標準エラーに対応方法ヒント）
+
+set -euo pipefail
+
+# 先送り表現の正規表現パターン
+PATTERN='(予定|別[[:space:]]*(PR|issue)|follow-?up|TBD|後で|候補|追記する|追記予定|別途|future|将来)'
+
+# issue 番号パターン
+HAS_ISSUE_REF='#[0-9]+'
+
+found=0
+
+for file in "$@"; do
+  [ -f "$file" ] || { echo "[SKIP] $file: ファイルが見つかりません" >&2; continue; }
+
+  # ファイルを配列に読み込む（前後行チェックのため）
+  mapfile -t lines < "$file"
+  total=${#lines[@]}
+
+  # grep でヒット行番号を取得（1-indexed）
+  while IFS=: read -r lineno line; do
+    lineno=$((lineno))  # 数値化
+    idx=$((lineno - 1)) # 0-indexed
+
+    # 同じ行に issue 番号があれば OK
+    if echo "$line" | grep -qE "$HAS_ISSUE_REF"; then
+      continue
+    fi
+
+    # 前行 (idx-1) をチェック
+    if [ $idx -gt 0 ]; then
+      if echo "${lines[$((idx - 1))]}" | grep -qE "$HAS_ISSUE_REF"; then
+        continue
+      fi
+    fi
+
+    # 後行 (idx+1) をチェック
+    if [ $((idx + 1)) -lt $total ]; then
+      if echo "${lines[$((idx + 1))]}" | grep -qE "$HAS_ISSUE_REF"; then
+        continue
+      fi
+    fi
+
+    # issue 番号なし → 警告出力
+    echo "[WARN] $file:$lineno: $line"
+    found=1
+  done < <(grep -nE "$PATTERN" "$file" 2>/dev/null || true)
+done
+
+if [ "$found" -eq 1 ]; then
+  cat <<'EOM' >&2
+
+[ヒント] 上記の「先送り表現」には issue 番号 (#NNN) の併記がありません。
+以下のいずれかを行ってください:
+1. gh issue create で起票し、該当行に番号を反映する
+2. 「対応不要」が確実なら、具体的な判断（例: "現状の安定度を確認しており、flaky が顕在化したら対処する"）に書き換える
+3. 先送り表現自体を削除する
+EOM
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## 概要

`scripts/check-followup-refs.sh` を新設し、PR レビュー返信や教訓記録に含まれる「先送り表現」の issue 化忘れを自動検出できるようにする。

## 変更内容

- `scripts/check-followup-refs.sh`（新規・実行権限あり）
  - 対象語: `予定` / `別 PR|issue` / `follow-up` / `TBD` / `後で` / `候補` / `追記する` / `追記予定` / `別途` / `future` / `将来`
  - 同行または前後 1 行に `#NNN` があれば OK と判定
  - 疑いがあれば `[WARN] <file>:<line>: <内容>` を stdout に出力し、対応ヒントを stderr に表示して exit 1
- `scripts/README.md`（新規）: スクリプトの使い方・終了コード・関連ドキュメントを記載

## 動機・経緯

`docs/shared-agent-rules.md` 6.4 章「先送り時は必ず issue 化する」の規約を機械的にチェックする手段がなく、見落としが発生しやすかった。ファイルを引数に渡すだけで運用できる軽量スクリプトとして切り出し、`feedback_commander_checklist.md` F 章や将来の `.claude/hooks/` から呼び出せる single source of truth とする。

実害事例:
- PR #188 reply 「別 issue で追跡候補」→ ユーザー指摘で issue #196 起票
- PR #189/#192 reply 「予定」「将来課題」→ ユーザー指摘で issue #197/#198 起票

## テスト

- 検出ケース: `echo "issue 化予定"` → `[WARN]` 出力 + exit 1 ✅
- 通過ケース: `echo "別 issue で追跡 #196"` → 出力なし + exit 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
