### PR TITLE
docs(decisions): [059] 後続タスクに追跡 issue #205 / #206 をリンク

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2047,11 +2047,13 @@ PR #204 で最終的に採用する変更は以下の **1 点のみ** に絞る�
 
 ### 後続タスク
 
-- harness 側の `context7.com` / `mcp.context7.com` egress allowlist 追加が確認できたら Web で context7 を再検証する。
-- upstream issue #23737 / #17832 / #19275 の進捗を監視し、`autoInstallEnabledPlugins` 等が ship されたら本決定を更新（手動 install 手順を撤去）。
+- harness 側の `context7.com` / `mcp.context7.com` egress allowlist 追加が確認できたら Web で context7 を再検証する → issue #205 で追跡。
+- upstream issue #23737 / #17832 / #19275 の進捗を監視し、`autoInstallEnabledPlugins` / Skill 動的 reload 等が ship されたら本決定を更新（手動 install 手順を撤去）→ issue #206 で追跡。
 
 ### 関連 PR / issue
 
 - PR #204（本決定の実装、段階的真因究明を含む）
-- issue #191（症状の整理）
+- issue #191（症状の整理、本 PR で close）
+- issue #205（後続: Web context7 egress 解消後の再検証）
+- issue #206（後続: plugin auto-install / Skill 動的 reload 制約への対応見直し）
 - PR #187（context7 不在による誤レビュー事例）


### PR DESCRIPTION
## 概要

PR #204 マージ後に作成した後続 issue を `docs/decisions.md [059]` から逆参照する。

## 背景

issue #191 / PR #204 で文書化した後続タスクのうち、別 issue 化が必要な 2 件を起票した:

- issue #205: Web context7 egress 遮断解消後の再検証
- issue #206: plugin auto-install / Skill 動的 reload 制約への対応見直し

decisions [059] からこれらへ逆参照を貼ることで相互リンクを完成させる。

## 変更内容

- `docs/decisions.md [059]`「後続タスク」「関連 PR / issue」節に issue #205 / #206 へのリンクを追加

## テスト計画

- [x] Prettier / TypeScript pre-commit pass

## 関連

- PR #204（本決定の実装）
- issue #191（本 PR でクローズ済み）
- issue #205 / #206（後続）

🤖 Generated with [Claude Code](https://claude.com/claude-code)