### PR TITLE
refactor(useQrCamera): カメラ tick ループに AbortSignal を導入してアンマウント race を塞ぐ (#196)

### DIFF
--- a/src/hooks/__tests__/useQrCamera.test.ts
+++ b/src/hooks/__tests__/useQrCamera.test.ts
@@ -105,6 +105,57 @@ describe('useQrCamera — アンマウント後に onQrDetected が呼ばれな�
   });
 });
 
+describe('useQrCamera — QR 検出 happy-path', () => {
+  it('QR を検出したとき onQrDetected が呼ばれ cameraActive が false になる', async () => {
+    const onQrDetected = vi.fn();
+
+    // jsQR が QR コードを検出するように設定
+    const jsQR = await import('jsqr');
+    const mockJsQR = vi.mocked(jsQR.default);
+    mockJsQR.mockReturnValue({ data: 'test-qr-data' } as ReturnType<typeof jsQR.default>);
+
+    const { result } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    // video / canvas 要素を jsdom 上に作成し、ref に直接アタッチ
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'readyState', { value: 4, configurable: true });
+    Object.defineProperty(video, 'videoWidth', { value: 640, configurable: true });
+    Object.defineProperty(video, 'videoHeight', { value: 480, configurable: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (result.current.videoRef as any).current = video;
+
+    const canvas = document.createElement('canvas');
+    const fakeCtx = {
+      drawImage: vi.fn(),
+      getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4), width: 1, height: 1 })),
+    };
+    vi.spyOn(canvas, 'getContext').mockReturnValue(fakeCtx as unknown as CanvasRenderingContext2D);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (result.current.canvasRef as any).current = canvas;
+
+    await act(async () => {
+      await result.current.startCamera();
+    });
+
+    // rAF コールバック（scan）を手動で実行する
+    act(() => {
+      const scanCb = mockRaf.mock.calls[0][0] as FrameRequestCallback;
+      scanCb(0);
+    });
+
+    // onQrDetected が検出データで呼ばれること
+    expect(onQrDetected).toHaveBeenCalledWith('test-qr-data');
+    expect(onQrDetected).toHaveBeenCalledTimes(1);
+
+    // stopCamera が動いて cameraActive が false になること
+    expect(result.current.cameraActive).toBe(false);
+
+    // クリーンアップ
+    mockJsQR.mockReset();
+    mockJsQR.mockReturnValue(null);
+  });
+});
+
 describe('useQrCamera — stopCamera 後の状態確認', () => {
   it('初期状態では cameraActive が false', () => {
     const onQrDetected = vi.fn();

--- a/src/hooks/__tests__/useQrCamera.test.ts
+++ b/src/hooks/__tests__/useQrCamera.test.ts
@@ -82,26 +82,52 @@ describe('useQrCamera — アンマウント後に onQrDetected が呼ばれな�
   it('stopCamera 呼び出し後に rAF から scan が再実行されても onQrDetected は呼ばれない', async () => {
     const onQrDetected = vi.fn();
 
-    // jsQR が QR コードを検出するように設定
     const jsQR = await import('jsqr');
     const mockJsQR = vi.mocked(jsQR.default);
-    mockJsQR.mockReturnValue({ data: 'test-qr-data' } as ReturnType<typeof jsQR.default>);
 
     const { result, unmount } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    // happy-path テストと同様 video/canvas を ref にアタッチする
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'readyState', { value: 4, configurable: true });
+    Object.defineProperty(video, 'videoWidth', { value: 640, configurable: true });
+    Object.defineProperty(video, 'videoHeight', { value: 480, configurable: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (result.current.videoRef as any).current = video;
+
+    const canvas = document.createElement('canvas');
+    const fakeCtx = {
+      drawImage: vi.fn(),
+      getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4), width: 1, height: 1 })),
+    };
+    vi.spyOn(canvas, 'getContext').mockReturnValue(fakeCtx as unknown as CanvasRenderingContext2D);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (result.current.canvasRef as any).current = canvas;
 
     await act(async () => {
       await result.current.startCamera();
     });
 
-    // アンマウントして signal を abort させる（stopCamera も cleanup で呼ばれる）
+    // 最初の rAF cb（scan）を捕まえる
+    const scanCb = mockRaf.mock.calls[0][0] as FrameRequestCallback;
+
+    // jsQR が「検出する」設定に切り替える（unmount 後に scan が走った場合 onQrDetected が呼ばれそうな状況）
+    mockJsQR.mockReturnValue({ data: 'should-not-fire' } as ReturnType<typeof jsQR.default>);
+
+    // アンマウント → controller signal abort
     unmount();
 
-    // jsQR モックをリセット
+    // in-flight な scan が遅れて発火するシナリオを実際に踏む
+    act(() => {
+      scanCb(0);
+    });
+
+    // signal.aborted で scan 先頭 return → onQrDetected は呼ばれない
+    expect(onQrDetected).not.toHaveBeenCalled();
+
+    // クリーンアップ
     mockJsQR.mockReset();
     mockJsQR.mockReturnValue(null);
-
-    // アンマウント後は onQrDetected が呼ばれていない
-    expect(onQrDetected).not.toHaveBeenCalled();
   });
 });
 
@@ -187,5 +213,40 @@ describe('useQrCamera — stopCamera 後の状態確認', () => {
     });
 
     expect(result.current.cameraActive).toBe(false);
+  });
+});
+
+describe('useQrCamera — startCamera の await race を塞ぐ', () => {
+  it('getUserMedia 解決前に unmount すると、解決後に stream が破棄される', async () => {
+    const onQrDetected = vi.fn();
+
+    // getUserMedia を deferred にする
+    let resolveGetUserMedia!: (s: MediaStream) => void;
+    mockGetUserMedia.mockImplementation(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          resolveGetUserMedia = resolve;
+        })
+    );
+
+    const { result, unmount } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    // startCamera を await せず開始（pending 状態）
+    let startPromise: Promise<void>;
+    act(() => {
+      startPromise = result.current.startCamera();
+    });
+
+    // unmount → controller abort
+    unmount();
+
+    // getUserMedia を解決させる
+    await act(async () => {
+      resolveGetUserMedia(mockStream);
+      await startPromise!;
+    });
+
+    // tracks が止められていること（リーク防止）
+    expect(mockTrackStop).toHaveBeenCalled();
   });
 });

--- a/src/hooks/__tests__/useQrCamera.test.ts
+++ b/src/hooks/__tests__/useQrCamera.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useQrCamera } from '@/hooks/useQrCamera';
+
+// ────────────────────────────────────────────
+// MediaStream / mediaDevices のモック
+// ────────────────────────────────────────────
+
+const mockTrackStop = vi.fn();
+const mockStream = {
+  getTracks: () => [{ stop: mockTrackStop }],
+} as unknown as MediaStream;
+
+const mockGetUserMedia = vi.fn(async () => mockStream);
+
+// jsQR モック: デフォルトは QR コードを検出しない
+vi.mock('jsqr', () => ({
+  default: vi.fn(() => null),
+}));
+
+// requestAnimationFrame / cancelAnimationFrame はデフォルトでは jsdom に存在しないため stub
+const mockRaf = vi.fn((_cb: FrameRequestCallback) => 1);
+const mockCaf = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', {
+    mediaDevices: {
+      getUserMedia: mockGetUserMedia,
+    },
+  });
+  vi.stubGlobal('requestAnimationFrame', mockRaf);
+  vi.stubGlobal('cancelAnimationFrame', mockCaf);
+
+  mockTrackStop.mockClear();
+  mockGetUserMedia.mockClear();
+  mockRaf.mockClear();
+  mockCaf.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ────────────────────────────────────────────
+// テストケース
+// ────────────────────────────────────────────
+
+describe('useQrCamera — アンマウント後に onQrDetected が呼ばれないこと', () => {
+  it('アンマウント後は例外なく終了し onQrDetected が呼ばれていない', async () => {
+    const onQrDetected = vi.fn();
+
+    const { unmount } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    // unmount すると useEffect cleanup が走り AbortController が abort される
+    expect(() => unmount()).not.toThrow();
+
+    // startCamera を呼んでいないので onQrDetected は一切呼ばれない
+    expect(onQrDetected).not.toHaveBeenCalled();
+  });
+
+  it('stopCamera 後に scan ループが継続しない', async () => {
+    const onQrDetected = vi.fn();
+
+    const { result } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    // startCamera を呼んでカメラを起動する
+    await act(async () => {
+      await result.current.startCamera();
+    });
+
+    // カメラ起動後に stopCamera を呼ぶ
+    act(() => {
+      result.current.stopCamera();
+    });
+
+    expect(result.current.cameraActive).toBe(false);
+    // stopCamera 後は cancelAnimationFrame が呼ばれている
+    expect(mockCaf).toHaveBeenCalled();
+  });
+
+  it('stopCamera 呼び出し後に rAF から scan が再実行されても onQrDetected は呼ばれない', async () => {
+    const onQrDetected = vi.fn();
+
+    // jsQR が QR コードを検出するように設定
+    const jsQR = await import('jsqr');
+    const mockJsQR = vi.mocked(jsQR.default);
+    mockJsQR.mockReturnValue({ data: 'test-qr-data' } as ReturnType<typeof jsQR.default>);
+
+    const { result, unmount } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    await act(async () => {
+      await result.current.startCamera();
+    });
+
+    // アンマウントして signal を abort させる（stopCamera も cleanup で呼ばれる）
+    unmount();
+
+    // jsQR モックをリセット
+    mockJsQR.mockReset();
+    mockJsQR.mockReturnValue(null);
+
+    // アンマウント後は onQrDetected が呼ばれていない
+    expect(onQrDetected).not.toHaveBeenCalled();
+  });
+});
+
+describe('useQrCamera — stopCamera 後の状態確認', () => {
+  it('初期状態では cameraActive が false', () => {
+    const onQrDetected = vi.fn();
+    const { result } = renderHook(() => useQrCamera({ onQrDetected }));
+    expect(result.current.cameraActive).toBe(false);
+  });
+
+  it('startCamera 後は cameraActive が true になる', async () => {
+    const onQrDetected = vi.fn();
+    const { result } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    await act(async () => {
+      await result.current.startCamera();
+    });
+
+    expect(result.current.cameraActive).toBe(true);
+  });
+
+  it('stopCamera 後は cameraActive が false になる', async () => {
+    const onQrDetected = vi.fn();
+    const { result } = renderHook(() => useQrCamera({ onQrDetected }));
+
+    await act(async () => {
+      await result.current.startCamera();
+    });
+
+    act(() => {
+      result.current.stopCamera();
+    });
+
+    expect(result.current.cameraActive).toBe(false);
+  });
+});

--- a/src/hooks/useQrCamera.ts
+++ b/src/hooks/useQrCamera.ts
@@ -8,6 +8,7 @@ interface UseQrCameraOptions {
 /**
  * QRコードカメラスキャン用フック。
  * カメラの起動/停止と rAF ベースのスキャンループを管理する。
+ * AbortSignal によりアンマウント時の race condition を防ぐ。
  */
 export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
   const [cameraActive, setCameraActive] = useState(false);
@@ -18,13 +19,21 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
   const streamRef = useRef<MediaStream | null>(null);
   const rafRef = useRef<number | null>(null);
   const scanningRef = useRef(false);
+  // アンマウント race condition を防ぐ AbortController
+  const controllerRef = useRef<AbortController | null>(null);
   // stale closure を防ぐため ref で最新コールバックを保持
   const onQrDetectedRef = useRef(onQrDetected);
   useEffect(() => {
     onQrDetectedRef.current = onQrDetected;
   }, [onQrDetected]);
 
+  useEffect(() => {
+    controllerRef.current = new AbortController();
+    return () => controllerRef.current?.abort();
+  }, []);
+
   const stopCamera = useCallback(() => {
+    controllerRef.current?.abort();
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
@@ -73,6 +82,7 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
             const found = jsQR(imageData.data, imageData.width, imageData.height);
             if (found) {
               stopCamera();
+              if (controllerRef.current?.signal.aborted) return;
               onQrDetectedRef.current(found.data);
               return;
             }

--- a/src/hooks/useQrCamera.ts
+++ b/src/hooks/useQrCamera.ts
@@ -19,18 +19,15 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
   const streamRef = useRef<MediaStream | null>(null);
   const rafRef = useRef<number | null>(null);
   const scanningRef = useRef(false);
-  // アンマウント race condition を防ぐ AbortController
-  const controllerRef = useRef<AbortController | null>(null);
+  // アンマウント時に in-flight な非同期処理（getUserMedia / scan）を中断する AbortController
+  const controllerRef = useRef<AbortController>(new AbortController());
   // stale closure を防ぐため ref で最新コールバックを保持
   const onQrDetectedRef = useRef(onQrDetected);
   useEffect(() => {
     onQrDetectedRef.current = onQrDetected;
   }, [onQrDetected]);
 
-  useEffect(() => {
-    controllerRef.current = new AbortController();
-    return () => controllerRef.current?.abort();
-  }, []);
+  useEffect(() => () => controllerRef.current.abort(), []);
 
   const stopCamera = useCallback(() => {
     if (rafRef.current !== null) {
@@ -57,16 +54,30 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: { facingMode: 'environment' },
       });
+
+      // getUserMedia 解決後に既に unmount 済みならカメラリソースを解放して戻る
+      if (controllerRef.current.signal.aborted) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+
       streamRef.current = stream;
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
         await videoRef.current.play();
+
+        // video.play 解決後に既に unmount 済みなら状態更新を諦めてリソース解放
+        if (controllerRef.current.signal.aborted) {
+          stream.getTracks().forEach((t) => t.stop());
+          streamRef.current = null;
+          return;
+        }
       }
       setCameraActive(true);
       scanningRef.current = true;
 
       const scan = () => {
-        if (controllerRef.current?.signal.aborted) return;
+        if (controllerRef.current.signal.aborted) return;
         if (!scanningRef.current) return;
         const video = videoRef.current;
         const canvas = canvasRef.current;

--- a/src/hooks/useQrCamera.ts
+++ b/src/hooks/useQrCamera.ts
@@ -33,7 +33,6 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
   }, []);
 
   const stopCamera = useCallback(() => {
-    controllerRef.current?.abort();
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
@@ -67,6 +66,7 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
       scanningRef.current = true;
 
       const scan = () => {
+        if (controllerRef.current?.signal.aborted) return;
         if (!scanningRef.current) return;
         const video = videoRef.current;
         const canvas = canvasRef.current;
@@ -82,7 +82,6 @@ export function useQrCamera({ onQrDetected }: UseQrCameraOptions) {
             const found = jsQR(imageData.data, imageData.width, imageData.height);
             if (found) {
               stopCamera();
-              if (controllerRef.current?.signal.aborted) return;
               onQrDetectedRef.current(found.data);
               return;
             }


### PR DESCRIPTION
## 背景

PR #188 (#168) のレビューで指摘された改善余地。`useQrCamera` 内部のカメラ tick ループおよび `startCamera` の async 経路が `AbortSignal` を受け取らないため、アンマウント直後の race（`setState` on unmounted component / カメラリソースリーク）が残っていた。

## 変更内容（3 コミット）

採用案 A: `useQrCamera` 内部に `AbortController` を保持し、unmount cleanup で abort して in-flight な非同期処理（`getUserMedia` / `scan`）を中断する。

### コミット 1: 初版（後続コミットで dead-code バグ修正）
### コミット 2: dead-code 修正（`stopCamera` から abort 削除、`scan` 先頭に判定移動）
### コミット 3 (e666d4d): レビュー指摘 R1 + D2 + N3 + N5 反映

最終的な実装内容:

- `controllerRef = useRef<AbortController>(new AbortController())` でコンポーネントの生存期間と一致した controller を初期値で生成
- `useEffect` は cleanup-only（unmount 時のみ abort）
- `scan` ループ先頭で `signal.aborted` を check（`scanningRef.current` の早期 return とは別軸の防御）
- `startCamera` の **2 つの await ポイント**（`getUserMedia` / `video.play()`）直後に aborted ガード + `stream.getTracks().forEach(t => t.stop())` でリソースリークも防止

## 案 B を見送った理由

`onQrDetected` の型シグネチャ変更は呼び出し側 (`QrReader.tsx` / `QrTicket.tsx`) への波及があるため、内部実装で完結する案 A を選択。

## テスト

`src/hooks/__tests__/useQrCamera.test.ts` に **8 ケース**:

- アンマウント race（unmount 後 onQrDetected 不呼び出し）
- stopCamera 後の rAF 再実行ガード（**実 scanCb invoke で regression detector 化**: signal.aborted 判定行を消すと落ちる）
- happy-path（QR 検出 → onQrDetected が `'test-qr-data'` で呼ばれる）
- startCamera の await race（`getUserMedia` deferred → unmount → resolve で tracks が stop される）
- 状態遷移（cameraActive の初期/start/stop）

## 検証

- `npm run test`: 30 ファイル / **424 テスト** すべて pass
- `npx astro check`: エラー 0
- `npm run test:e2e`: 142 件 pass / 1 skip / **49.3s**（pre-push、`docs/agent-lessons.md` 2026-05-01 エントリの手順で worktree node_modules 整地）

Closes #196