### PR TITLE
chore(e2e): webServer.timeout を 30s に短縮して env 由来失敗を fail-fast (#194)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev',
     url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4321',
+    // dev server が 30s 以内に起動しなければ env 由来失敗として fail-fast（issue #194）
+    timeout: 30_000,
     reuseExistingServer: true,
   },
 });


### PR DESCRIPTION
## 背景

issue #194 の採用案 A。`playwright.config.ts` の `webServer` ブロックに `timeout: 30_000` を追加し、dev server が 30 秒以内に起動しない場合は env 由来失敗として E2E を fail-fast させる。

PR #210 (#196) のレビュー修正検証で実踏した「worktree node_modules 不整合 → 14s で vite serving allow list エラー」のような dev server 起動段階のエラーや、本 issue 本文の hydration timeout 30s × N tests の無駄待ちを抑制できる。

## 変更内容

\`playwright.config.ts\` のみ +2 行:

\`\`\`diff
   webServer: {
     command: 'npm run dev',
     url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4321',
+    // dev server が 30s 以内に起動しなければ env 由来失敗として fail-fast（issue #194）
+    timeout: 30_000,
     reuseExistingServer: true,
   },
\`\`\`

他の timeout 設定（`expect.timeout` / 各 test の timeout）には触らない。issue #194 の B 案 / C 案は本 PR では採用せず、必要なら別 PR で重ねる方針。

## 検証

- `npm run test`: 30 ファイル / 424 件 all pass
- `npx astro check`: エラー 0
- `npm run test:e2e` (pre-push): 142 件 pass / 1 skip / 44.6s（normal env でも 30s timeout は影響なし、想定通り）

## 関連

- issue #194 (E2E timeout 早期検出)
- 関連 issue: #211 (subagent worktree node_modules 自動整地), #212 (rules 文書再構成)

Closes #194