### PR TITLE
chore(scripts): subagent worktree の node_modules 整地ヘルパースクリプトを追加 (#211)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,3 +35,9 @@ bash tests/scripts/check-followup-refs.test.sh
 
 - `docs/shared-agent-rules.md` 6.4 章（先送り時は issue 化必須）
 - `feedback_commander_checklist.md` F 章（メモリ）
+
+---
+
+## agent-worktree-setup.sh
+
+- `agent-worktree-setup.sh` — subagent isolation worktree で E2E 前に node_modules を整地するヘルパー。詳細: issue #211 / `docs/agent-lessons.md` 2026-05-01 エントリ

--- a/scripts/agent-worktree-setup.sh
+++ b/scripts/agent-worktree-setup.sh
@@ -16,9 +16,21 @@
 # 関連: issue #194, #211, #212 / docs/agent-lessons.md
 set -euo pipefail
 
+# リポジトリルートで実行されていることを確認（cd ミスでの誤削除事故対策）
+[[ -f package.json ]] || {
+  echo "[agent-worktree-setup] package.json が見つかりません。リポジトリルートで実行してください" >&2
+  exit 1
+}
+
 chmod -R u+w node_modules 2>/dev/null || true
 rm -rf node_modules
-npm ci --cache "${TMPDIR%/}/npm-cache"
-lsof -ti:4321 | xargs kill -9 2>/dev/null || true
+
+# $TMPDIR が未設定 (Linux 等) の場合は /tmp をデフォルトにし、末尾スラッシュを除去
+tmp="${TMPDIR:-/tmp}"
+tmp="${tmp%/}"
+npm ci --cache "${tmp}/npm-cache"
+
+# ポート未使用時の `kill: usage:` エラーを避けるため -r で空入力時起動しない
+lsof -ti:4321 | xargs -r kill -9 2>/dev/null || true
 
 echo "[agent-worktree-setup] node_modules 整地完了"

--- a/scripts/agent-worktree-setup.sh
+++ b/scripts/agent-worktree-setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# scripts/agent-worktree-setup.sh
+#
+# subagent isolation worktree (.claude/worktrees/agent-<id>/) で
+# E2E / unit テストを走らせる前に node_modules を整地するヘルパー。
+#
+# docs/agent-lessons.md 2026-05-01 エントリの手順をスクリプト化したもの:
+# - sandbox 由来の read-only ファイルを書き込み可能化
+# - 古い node_modules を完全削除
+# - $TMPDIR 配下のキャッシュで npm ci（~/.npm が root-owned 問題を回避）
+# - port 4321 を解放（並列 worktree でのポート衝突対策）
+#
+# 使い方:
+#   bash scripts/agent-worktree-setup.sh
+#
+# 関連: issue #194, #211, #212 / docs/agent-lessons.md
+set -euo pipefail
+
+chmod -R u+w node_modules 2>/dev/null || true
+rm -rf node_modules
+npm ci --cache "${TMPDIR%/}/npm-cache"
+lsof -ti:4321 | xargs kill -9 2>/dev/null || true
+
+echo "[agent-worktree-setup] node_modules 整地完了"


### PR DESCRIPTION
## 背景

issue #211 の採用案 A。subagent isolation worktree (`.claude/worktrees/agent-<id>/`) の初期 node_modules が空または不整合な状態で `npm run test:e2e` を回すと vite serving allow list エラーや hydration timeout で fail する既知問題（PR #210 で実踏、issue #194 / `docs/agent-lessons.md` 2026-05-01 エントリ参照）に対応。

`docs/agent-lessons.md` 2026-05-01 エントリに記載の手順をスクリプト化し、agent プロンプトの先頭で 1 行呼ぶだけで済むようにする。

## 変更内容

新規作成: `scripts/agent-worktree-setup.sh` (+ `scripts/README.md` に 1 行追記)

\`\`\`bash
#!/usr/bin/env bash
set -euo pipefail

chmod -R u+w node_modules 2>/dev/null || true
rm -rf node_modules
npm ci --cache "\${TMPDIR%/}/npm-cache"
lsof -ti:4321 | xargs kill -9 2>/dev/null || true
\`\`\`

ポイント:

- `chmod -R u+w` で sandbox 由来の read-only ファイルを書き込み可能化（agent-lessons.md L113 と整合）
- `npm ci --cache "\${TMPDIR%/}/npm-cache"` で `~/.npm` の root-owned 問題を回避
- `lsof -ti:4321 | xargs kill -9` で並列 worktree のポート衝突対策
- shebang は `#!/usr/bin/env bash`、`set -euo pipefail` でエラー時に止まる

## 使い方

agent プロンプトの先頭で:

\`\`\`bash
bash scripts/agent-worktree-setup.sh
\`\`\`

を実行する運用に統一。`docs/shared-agent-rules.md` 3 章 push 前チェックリストへのステップ 0 昇格は別 PR (#212) で実施する。

## 検証

- 構文チェック (`bash -n`): OK
- 実行権限: `-rwxr-xr-x` 確認済み
- `npm run test`: 30 ファイル / 424 件 all pass
- `npx astro check`: エラー 0
- `npm run test:e2e` (pre-push): 142 件 pass / 1 skip / 1.3m

## 関連

- issue #211（本 PR で対応）
- 関連 issue: #194 (E2E timeout 早期検出), #212 (rules 文書再構成、本スクリプトを参照)
- `docs/agent-lessons.md` 2026-05-01「worktree の node_modules が古いと E2E が hydration timeout で大量失敗する」

Closes #211