### PR TITLE
docs(rules): 3.2 章を E2E push 前実行に再構成、worktree 整地を step 0 として昇格 (#212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 - **言語**: コミットメッセージ・PR 説明文は **必ず日本語**。
 - **スタイリング**: Tailwind カラークラスは禁止。**`colors.*` (React)** または **`var(--color-*)` (Astro)** を使用。
-- **検証**: サブエージェントは **`npm run test`**（ユニット）と `astro check`（型）まで。**`npm run test:e2e` は親が代行**（詳細: `docs/shared-agent-rules.md` 3.1 / 3.2）。
+- **検証**: `npm run test`（ユニット）と `astro check`（型）はサブエージェント / 親共通。**`npm run test:e2e` は push 前に必ず実行**（subagent worktree か親で。post-PR 代行は不要、CI が最終ゲート）。worktree では `bash scripts/agent-worktree-setup.sh` で node_modules を先に整地（詳細: `docs/shared-agent-rules.md` 3 章 / 3.2 章）。
 - **PR ベース**: `gh pr create` は **必ず `--base develop`** を明示する。`main` 向けはリリース PR のみ（`gh` のデフォルト・Claude Code system prompt の "Main branch ... main" 表示に流されないこと）。詳細は `docs/shared-agent-rules.md` 6.3 章。
 - **ATC運用**: セッション開始時に `tasks/active_context.md` を作成（superpowers の plan / conductor のタスクファイル等が「目的・ステップ・スコープ外」を明示する場合は不要。詳細は `docs/shared-agent-rules.md` 11章）。
 - **司令塔モード**: 親 Claude セッションは委譲・ベース確認・テスト確認・aria 削除検出を経て PR 作成（詳細: `docs/shared-agent-rules.md` 6.2a 章・3 章 push 前チェックリスト・10.6 章）。

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -128,7 +128,7 @@ npm run test:e2e
 
 - PR #181 / #188 で実害あり
 - 関連 issue: #194（worktree 環境で E2E timeout を早期検出して無駄待ちを削減）
-- 現行の 3 章 push 前チェックリストに位置付ける運用が固まれば、PR #192 で新設予定の 3.2 章末尾にステップ 0「worktree が古い場合は npm ci 入れ直し」として昇格する候補
+- 2026-05-02 に **本手順を `docs/shared-agent-rules.md` 3 章 push 前必須チェックリスト ステップ 0 として昇格済み**（issue #212 / `scripts/agent-worktree-setup.sh` で自動化）。
 
 ---
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -85,6 +85,8 @@ E2E (`npm run test:e2e`) は code change を含む push を行う前に **必ず
 - **環境由来の失敗**（`waitForReactHydration` timeout、`Error: connect ECONNREFUSED 127.0.0.1:4321`、`Timed out waiting for server to start`、`webServer was not ready` 等）→ ステップ 0 の整地を実施してから 1 回だけ再実行
 - 再実行でも環境由来失敗が続く場合 → **CI を最終判断とする**（push して CI 結果を待つ）
 
+> 補足: `playwright.config.ts` の `webServer.timeout` は 30s（PR #213）。env 由来失敗の発見はこのタイムアウトで早期に確定する（旧来のような長時間ハングは起きない）。
+
 #### push 前必須チェックリスト（親）
 
 親セッションが直接 push する際は、以下をすべて確認する。

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -49,55 +49,53 @@
 サブエージェント（worktree 内で動作するエージェント）は以下のルールに従う。
 
 - **E2E テストコードの追加は義務**: バグ修正・UI 挙動変更時は E2E テストコードを必ず追加する（11 章の原則と同じ）。
-- **`npm run test:e2e` の実行は禁止**: worktree 並列環境ではポート 4321 が競合して誤報告が頻発する。また sandbox 制約でサーバー起動ができないケースがある。E2E の実行は親（司令塔）が代行する。
-- **完了報告には「E2E 実行は親が代行する」と明記すること。**
-- 検証範囲は `npm run test`（ユニット）と `node_modules/.bin/astro check`（型）まで。
+- **`npm run test:e2e` の実行は必須**: push 前に 3.2 章のチェックリストに従い E2E を実行する。env 不備（古い node_modules / port 4321 占有等）で走らない場合は未完了の旨を完了報告に明記して親に引き継ぐ。
+- 検証範囲は `npm run test`（ユニット）、`node_modules/.bin/astro check`（型）、および `npm run test:e2e`（E2E）。
 
 #### push 前必須チェックリスト（サブエージェント）
 
 以下をすべて満たしてから完了報告する。**1 つでも未完了の場合は push せず、未完了の項目を完了報告に明記して親に判断を仰ぐ**。
 
-| #   | チェック項目          | コマンド                                                                      |
-| --- | --------------------- | ----------------------------------------------------------------------------- |
-| 1   | develop ベース確認    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致 |
-| 2   | ユニットテスト全 pass | `npm run test`                                                                |
-| 3   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                   |
-| 4   | E2E テスト            | **実行禁止**（テストコード追加は義務。実行は親が代行）                        |
+| #   | チェック項目                          | コマンド                                                                                                                                                                                 |
+| --- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | (worktree 環境のみ) node_modules 整地 | `bash scripts/agent-worktree-setup.sh` を実行（古い node_modules を rm → `npm ci --cache "$TMPDIR/npm-cache"` → port 4321 kill）。詳細は `docs/agent-lessons.md` 2026-05-01 エントリ参照 |
+| 1   | develop ベース確認                    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                                                                                            |
+| 2   | ユニットテスト全 pass                 | `npm run test`                                                                                                                                                                           |
+| 3   | 型チェック                            | `node_modules/.bin/astro check`（0 errors）                                                                                                                                              |
+| 4   | E2E テスト                            | `npm run test:e2e`（env 不備で走らない場合は未完了の旨を明記して親に引き継ぐ）                                                                                                           |
 
-### 3.2 親（司令塔）による E2E 代行実行
+### 3.2 E2E は push 前に必ず実行（親 / サブエージェント共通）
 
-> サブエージェントが dev server を残置している場合は、親側で kill する前に停止依頼すること（`npm run dev` のプロセスを終了するよう完了報告時に明記させる）。
+E2E (`npm run test:e2e`) は code change を含む push を行う前に **必ず実行する**。push 後は CI が自動で E2E を回すため、**親セッションによる post-PR 代行は不要**（旧運用は廃止）。
 
-サブエージェントの完了報告を受けて push する前後に、親が以下を実施する。
+#### push 前 E2E の実行責任
 
-1. 既存の dev server を kill する:
-   ```bash
-   lsof -ti:4321 | xargs kill -9 2>/dev/null || true
-   ```
-2. worktree 内で E2E を実行する（全体または影響範囲を絞って）:
-   ```bash
-   npm run test:e2e
-   # または影響範囲を絞る場合（npm run test:e2e -- <spec> でも同様）
-   npx playwright test <spec> --project chromium
-   ```
-3. **複数 worktree がある場合は同時実行しない**（ポート競合を避けるため）。1 つの worktree が完了してから次へ。
-4. 失敗パターンの判定:
-   - **テスト本来の失敗**（assertion error、要素が見つからない等）→ サブエージェントに修正依頼
-   - **環境由来の失敗**（`waitForReactHydration` timeout、`Error: connect ECONNREFUSED 127.0.0.1:4321`、`Timed out waiting for server to start`、`webServer was not ready` 等）→ 上記 1〜2 を 1 回だけ再実行
-   - 再実行でも環境由来失敗が続く場合 → **CI を最終判断とする**（push して CI 結果を待つ）
-5. unit テストは worktree 内で完結するため、サブエージェントの結果をそのまま信頼してよい。
+- **subagent worktree で push する場合**: subagent が pre-push チェックの一部として `npm run test:e2e` まで通す。env 不備（古い node_modules / port 4321 占有 / vite serving allow list エラー等）が原因で走らない場合は親に引き継ぐ
+- **親セッションが直接 push する場合**: 親が `npm run test:e2e` を pre-push で走らせる
+- **CI**: post-push の最終ゲート。pre-push で通っていれば green になることを期待
+
+#### worktree 並走時の注意
+
+- 複数 subagent worktree が同時に E2E を回すとポート 4321 が衝突する。1 worktree ずつ実行する
+- agent worktree は新規作成時 node_modules が空または不整合なため、push 前必須チェックリストのステップ 0 (worktree 整地) を必ず先行する
+
+#### 失敗パターンの判定
+
+- **テスト本来の失敗**（assertion error、要素が見つからない等）→ 修正してから再実行
+- **環境由来の失敗**（`waitForReactHydration` timeout、`Error: connect ECONNREFUSED 127.0.0.1:4321`、`Timed out waiting for server to start`、`webServer was not ready` 等）→ ステップ 0 の整地を実施してから 1 回だけ再実行
+- 再実行でも環境由来失敗が続く場合 → **CI を最終判断とする**（push して CI 結果を待つ）
 
 #### push 前必須チェックリスト（親）
 
-サブエージェントの完了報告を受けて push する際は、以下をすべて確認する。
+親セッションが直接 push する際は、以下をすべて確認する。
 
-| #   | チェック項目                                                   | コマンド                                                                                                               |
-| --- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 1   | develop ベース確認                                             | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                          |
-| 2   | サブエージェント完了報告の検証（unit / 型 / E2E スキップ理由） | 完了報告に「E2E 実行は親が代行」の明記があることを確認                                                                 |
-| 3   | スコープ外差分の確認                                           | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認 |
-| 4   | E2E 直列実行                                                   | 本節手順 1〜5 を実施                                                                                                   |
-| 5   | PR ベース                                                      | `gh pr create --base develop`                                                                                          |
+| #   | チェック項目                          | コマンド                                                                                                               |
+| --- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| 0   | (worktree 環境のみ) node_modules 整地 | `bash scripts/agent-worktree-setup.sh` を実行（worktree 内で push する場合のみ）                                       |
+| 1   | develop ベース確認                    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                          |
+| 2   | スコープ外差分の確認                  | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認 |
+| 3   | E2E 直列実行                          | `npm run test:e2e`（複数 worktree がある場合は同時実行しない）                                                         |
+| 4   | PR ベース                             | `gh pr create --base develop`                                                                                          |
 
 #### 親向けレビュー取得手順（取りこぼし防止）
 


### PR DESCRIPTION
## 背景

2026-05-02 のセッションで「E2E は push 前に必ず実行、post-PR 代行は不要」という運用が確定。`docs/shared-agent-rules.md` 3.2 章「親による E2E 代行（post-PR）」（da2efb4 で導入）と齟齬が出ていたので新運用に書き換え。

加えて、`docs/agent-lessons.md` L131 で「3 章 push 前チェックリストにステップ 0 として昇格する候補」と明記されていた worktree 整地手順が、issue #211 で `scripts/agent-worktree-setup.sh` として自動化された。これに合わせ shared-agent-rules.md の push 前必須チェックリストにステップ 0 を追加。

## ⚠️ Merge 順序の注意

本 PR は push 前必須チェックリスト ステップ 0 / 親チェックリスト ステップ 0 / CLAUDE.md 要約行で **`bash scripts/agent-worktree-setup.sh` を必須として参照**しています。当該スクリプトは **PR #214 で追加されるため、PR #214 を先に merge する**こと（または #214 → #215 を続けて merge すること）。本 PR が #214 より先に merge されると、ドキュメント上は必須なのに repo にスクリプトが存在しない期間が発生します。

## 変更内容（3 ファイル / +40 / -42）

### `docs/shared-agent-rules.md`

- **3.1 章**: 「`npm run test:e2e` の実行は禁止」→「実行は必須 / env 不備時は親に引き継ぐ」に書き換え
- **push 前必須チェックリスト（サブエージェント）**: ステップ 0「(worktree 環境のみ) node_modules 整地」を冒頭に追加。ステップ 4 E2E を「実行禁止」→「`npm run test:e2e`」に変更
- **3.2 章**: 旧「親による E2E 代行実行」を全面書き換え。新タイトル「E2E は push 前に必ず実行（親 / サブエージェント共通）」として実行責任 / worktree 並走時の注意 / 失敗パターン判定を整理
- **push 前必須チェックリスト（親）**: ステップ 0 を追加、旧「サブエージェント完了報告の検証（E2E スキップ理由確認）」行を削除

### `CLAUDE.md`

最重要ルール要約の検証行を新運用に差し替え。

### `docs/agent-lessons.md`

L131 の「昇格候補」記述を「実施済み」に更新（issue #212 / `scripts/agent-worktree-setup.sh` で自動化）。

## 検証

ドキュメント変更のみ（`scripts/`、`src/`、`tests/` には触らず）。markdown 構文の整合性は目視確認済み。

## 関連 PR / issue

- 関連 PR: #213 (#194 webServer.timeout fast-fail), #214 (#211 helper script)
- 旧運用導入: PR #192 / commit `da2efb4`
- メモリ `feedback_e2e_before_pr.md` の補足説明と整合

Closes #212