### PR TITLE
refactor(EncodingConverter): activeBytes を useMemo 化 (#167)

### DIFF
--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -92,9 +92,8 @@ export function EncodingConverterTool() {
   }, [inputMethod, fileBytes, textInput]);
 
   // 判定処理
-  // 依存配列は一次入力 (textInput / fileBytes / inputMethod) ベースで管理する。
-  // activeBytes はメモ化済みのため参照は安定しているが、effect 内では
-  // スナップショット値として activeBytes を直接参照する。
+  // activeBytes は useMemo で参照が安定化済みのため、依存配列にそのまま含めて
+  // react-hooks/exhaustive-deps の保護を残す。
   useEffect(() => {
     if (!activeBytes) {
       setDetection(null);
@@ -108,7 +107,7 @@ export function EncodingConverterTool() {
     }
     const timer = setTimeout(() => runDetect(activeBytes), 300);
     return () => clearTimeout(timer);
-  }, [textInput, fileBytes, inputMethod]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeBytes, inputMethod]);
 
   function runDetect(bytes: Uint8Array) {
     try {
@@ -141,7 +140,7 @@ export function EncodingConverterTool() {
     }
     const timer = setTimeout(() => runConvert(activeBytes), 300);
     return () => clearTimeout(timer);
-  }, [textInput, fileBytes, inputMethod, mode, sourceEnc, targetEnc, withBom, newlineMode]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeBytes, inputMethod, mode, sourceEnc, targetEnc, withBom, newlineMode]);
 
   function runConvert(bytes: Uint8Array) {
     try {

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { Select } from '@/components/ui/Select';
 import { InputField } from '@/components/ui/InputField';
@@ -83,10 +83,18 @@ export function EncodingConverterTool() {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const activeBytes: Uint8Array | null =
-    inputMethod === 'file' ? fileBytes : textInput ? textToUtf8Bytes(textInput) : null;
+  // activeBytes をメモ化し、テキスト入力中のキー入力ごとに新しい Uint8Array 参照が
+  // 生成されないようにする。これにより依存配列が安定し、effect の過剰スケジュールを防ぐ。
+  const activeBytes = useMemo<Uint8Array | null>(() => {
+    if (inputMethod === 'file') return fileBytes;
+    if (textInput) return textToUtf8Bytes(textInput);
+    return null;
+  }, [inputMethod, fileBytes, textInput]);
 
   // 判定処理
+  // 依存配列は一次入力 (textInput / fileBytes / inputMethod) ベースで管理する。
+  // activeBytes はメモ化済みのため参照は安定しているが、effect 内では
+  // スナップショット値として activeBytes を直接参照する。
   useEffect(() => {
     if (!activeBytes) {
       setDetection(null);
@@ -100,7 +108,7 @@ export function EncodingConverterTool() {
     }
     const timer = setTimeout(() => runDetect(activeBytes), 300);
     return () => clearTimeout(timer);
-  }, [activeBytes, inputMethod]);
+  }, [textInput, fileBytes, inputMethod]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function runDetect(bytes: Uint8Array) {
     try {
@@ -133,7 +141,7 @@ export function EncodingConverterTool() {
     }
     const timer = setTimeout(() => runConvert(activeBytes), 300);
     return () => clearTimeout(timer);
-  }, [activeBytes, inputMethod, mode, sourceEnc, targetEnc, withBom, newlineMode]);
+  }, [textInput, fileBytes, inputMethod, mode, sourceEnc, targetEnc, withBom, newlineMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function runConvert(bytes: Uint8Array) {
     try {

--- a/src/components/tools/__tests__/EncodingConverter.test.tsx
+++ b/src/components/tools/__tests__/EncodingConverter.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useState } from 'react';
+import { render, act, cleanup, fireEvent } from '@testing-library/react';
+
+// `EncodingConverterTool` 内で呼ばれる encoding ユーティリティを spy 化する。
+// 直接 `runDetect` / `runConvert` を spy する代わりに、内部から呼ばれる
+// `detectEncoding` / `convertBytes` の呼び出し回数を検証することで
+// effect の発火回数を観測する。partial mock でその他のシンボルは原型を保つ。
+vi.mock('@/utils/encoding', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/encoding')>('@/utils/encoding');
+  return {
+    ...actual,
+    detectEncoding: vi.fn(actual.detectEncoding),
+    convertBytes: vi.fn(actual.convertBytes),
+  };
+});
+
+import { EncodingConverterTool } from '@/components/tools/EncodingConverter';
+import { detectEncoding, convertBytes } from '@/utils/encoding';
+
+const DEBOUNCE_MS = 300;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(detectEncoding).mockClear();
+  vi.mocked(convertBytes).mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+// ────────────────────────────────────────────
+// debounce 中の連続入力で detect が最終 1 回だけ走ること
+// ────────────────────────────────────────────
+describe('EncodingConverterTool — debounce 中の連続入力は最終入力 1 回だけ detect する', () => {
+  it('300ms 内に複数回テキストが変化しても detectEncoding は最後の入力 1 回のみ呼ばれる', () => {
+    const { container } = render(<EncodingConverterTool />);
+    const textarea = container.querySelector(
+      'textarea#enc-text-input'
+    ) as HTMLTextAreaElement | null;
+    expect(textarea).not.toBeNull();
+
+    // 連続入力: debounce 内に 3 回値を変える
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'a' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'ab' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'abc' } });
+    });
+
+    // この時点で detect は debounce 待ち中なので呼ばれていない
+    expect(vi.mocked(detectEncoding)).not.toHaveBeenCalled();
+
+    // debounce 完了
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    // 最後の入力 'abc' に対して 1 回だけ呼ばれている
+    expect(vi.mocked(detectEncoding)).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ────────────────────────────────────────────
+// useMemo によって不要な effect 再走が起きないこと
+// ────────────────────────────────────────────
+describe('EncodingConverterTool — 入力非依存の再 render では detect が再走しない', () => {
+  it('同じ textInput のまま親由来で再 render しても detectEncoding は再呼び出しされない', () => {
+    function Harness() {
+      const [, setBump] = useState(0);
+      return (
+        <div>
+          <button type="button" data-testid="bump" onClick={() => setBump((n) => n + 1)}>
+            bump
+          </button>
+          <EncodingConverterTool />
+        </div>
+      );
+    }
+
+    const { container, getByTestId } = render(<Harness />);
+    const textarea = container.querySelector(
+      'textarea#enc-text-input'
+    ) as HTMLTextAreaElement | null;
+    expect(textarea).not.toBeNull();
+
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'hello' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    expect(vi.mocked(detectEncoding)).toHaveBeenCalledTimes(1);
+
+    // EncodingConverterTool 自身の入力は変えずに親側で state を更新して再 render を誘発。
+    // activeBytes が useMemo で安定化されていれば判定 effect は再走しない。
+    const bumpButton = getByTestId('bump') as HTMLButtonElement;
+    act(() => {
+      bumpButton.click();
+    });
+    act(() => {
+      bumpButton.click();
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(vi.mocked(detectEncoding)).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ────────────────────────────────────────────
+// 変換モードでも debounce 中の連続入力は convert 1 回に集約される
+// ────────────────────────────────────────────
+describe('EncodingConverterTool — 変換モードでも debounce で convert は最終 1 回', () => {
+  it('変換モードに切替後、連続入力中は convertBytes が 1 回のみ呼ばれる', () => {
+    const { container } = render(<EncodingConverterTool />);
+
+    // 変換モードに切替（ToggleGroup の「変換」ボタンを押す）
+    const convertToggle = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === '変換'
+    ) as HTMLButtonElement | undefined;
+    expect(convertToggle).toBeDefined();
+    act(() => {
+      convertToggle!.click();
+    });
+
+    const textarea = container.querySelector(
+      'textarea#enc-text-input'
+    ) as HTMLTextAreaElement | null;
+    expect(textarea).not.toBeNull();
+
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'x' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'xy' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'xyz' } });
+    });
+
+    expect(vi.mocked(convertBytes)).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(vi.mocked(convertBytes)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/tools/__tests__/EncodingConverter.test.tsx
+++ b/src/components/tools/__tests__/EncodingConverter.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useState } from 'react';
-import { render, act, cleanup, fireEvent } from '@testing-library/react';
+import { render, act, cleanup, fireEvent, screen } from '@testing-library/react';
 
 // `EncodingConverterTool` 内で呼ばれる encoding ユーティリティを spy 化する。
 // 直接 `runDetect` / `runConvert` を spy する代わりに、内部から呼ばれる
@@ -128,13 +128,11 @@ describe('EncodingConverterTool — 変換モードでも debounce で convert �
   it('変換モードに切替後、連続入力中は convertBytes が 1 回のみ呼ばれる', () => {
     const { container } = render(<EncodingConverterTool />);
 
-    // 変換モードに切替（ToggleGroup の「変換」ボタンを押す）
-    const convertToggle = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === '変換'
-    ) as HTMLButtonElement | undefined;
-    expect(convertToggle).toBeDefined();
+    // 変換モードに切替（ToggleGroup の「変換」ボタンを押す）。
+    // textContent 一致は i18n / ラベル変更で壊れやすいため getByRole を使う。
+    const convertToggle = screen.getByRole('button', { name: '変換' });
     act(() => {
-      convertToggle!.click();
+      convertToggle.click();
     });
 
     const textarea = container.querySelector(


### PR DESCRIPTION
## 概要

#167 のうち EncodingConverter の派生状態最適化のみを対応。QrTicket の責務分割は別 PR で対応する。

## 改修内容

`src/components/tools/EncodingConverter.tsx`:

- `activeBytes` をインライン演算から `useMemo([inputMethod, fileBytes, textInput])` に変更し、`textToUtf8Bytes(textInput)` を memo 内に封じ込めた
- 判定 effect / 変換 effect の依存配列を `[activeBytes, ...]` ベースに保つことで、`react-hooks/exhaustive-deps` の自動チェックを失わずに参照安定化の恩恵を受けられるようにした
- effect 本体のロジック（debounce 300ms / file モードは即時実行 / cleanup）は変更なし

## 期待される効果

- `useMemo` により `fileBytes` / `inputMethod` が変わらなければ `activeBytes` の参照は安定し、effect が無駄に schedule されない
- debounce 中の cleanup 連鎖発火を抑制（大入力 10MB 時の体感遅延と GC 圧の改善）
- `eslint-disable react-hooks/exhaustive-deps` を使わずに依存配列を整理することで、将来の依存追加漏れを lint で検出可能

## 回帰防止テスト

新規 `src/components/tools/__tests__/EncodingConverter.test.tsx` (commit `76bcbd4` / `c5cf49b`):

- `vi.mock('@/utils/encoding', ...)` で `detectEncoding` / `convertBytes` を partial mock spy 化
- 判定モード: debounce 内 (300ms) に 3 回入力しても `detectEncoding` は最終 1 回のみ
- 親の state 変化で再 render しても、`textInput` が同じなら `detectEncoding` は再走しない (useMemo の本質的改善の確認)
- 変換モードでも `convertBytes` が最終 1 回に集約される

## 検証

- `npm run test`: 424 → **427** 件、全件緑
- `astro check`: 0 errors
- `npm run test:e2e`: 142 passed / 1 skipped、全件緑 (59.0s)
- `aria-*` / `role=` の削除なし

## レビュー反映履歴

| commit | 内容 |
|---|---|
| `03a89a1` | 初期実装: `activeBytes` を `useMemo` 化 |
| `fb82961` | レビュー反映: effect 依存配列を `[activeBytes, ...]` ベースに戻し `eslint-disable` を撤去 |
| `76bcbd4` | レビュー反映: 回帰防止テスト追加 |
| `c5cf49b` | nit 反映: テストの button 取得を `screen.getByRole({ name })` に置換 |

## 残タスク

- #167 の QrTicket 責務分割は別 PR (subagent C 完了済) で対応
- E2E flake (#193 関連) の短期対応は #219 で別途対応中
- #169 項目 4 として記載されていた qrcode-generator 副作用 import 解消は #216 として独立起票済み