### PR TITLE
test(e2e): a11y-live-region の goto を domcontentloaded に + helpers timeout 追加 (#193)

### DIFF
--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -8,7 +8,7 @@ import { waitForReactHydration } from './helpers';
 
 test.describe('a11y live region (issue #163)', () => {
   test('JANコード: チェック結果が role="status" として読める', async ({ page }) => {
-    await page.goto('/tools/jan-code');
+    await page.goto('/tools/jan-code', { waitUntil: 'domcontentloaded' });
     await page.getByRole('button', { name: 'サンプルを入力' }).waitFor();
     await waitForReactHydration(page);
 
@@ -24,7 +24,7 @@ test.describe('a11y live region (issue #163)', () => {
   });
 
   test('UUID v7: 生成結果が role="status" として読める', async ({ page }) => {
-    await page.goto('/tools/uuid-v7');
+    await page.goto('/tools/uuid-v7', { waitUntil: 'domcontentloaded' });
     await page.getByRole('button', { name: '生成' }).waitFor();
     await waitForReactHydration(page);
 
@@ -36,7 +36,7 @@ test.describe('a11y live region (issue #163)', () => {
   });
 
   test('JWTデコーダ: デコード結果が role="status" として読める', async ({ page }) => {
-    await page.goto('/tools/jwt-decoder');
+    await page.goto('/tools/jwt-decoder', { waitUntil: 'domcontentloaded' });
     await page.getByLabel('JWTトークンを貼り付け').waitFor();
     await waitForReactHydration(page);
 
@@ -53,7 +53,7 @@ test.describe('a11y live region (issue #163)', () => {
 
 test.describe('a11y aria-expanded (issue #163)', () => {
   test('ConfigConverter: JSON Schema 折りたたみが aria-expanded を反映する', async ({ page }) => {
-    await page.goto('/tools/config-converter');
+    await page.goto('/tools/config-converter', { waitUntil: 'domcontentloaded' });
     await page.getByRole('button', { name: 'JSON Schema で検証する' }).waitFor();
     await waitForReactHydration(page);
 
@@ -70,7 +70,7 @@ test.describe('a11y aria-expanded (issue #163)', () => {
 
 test.describe('a11y CopyButton compact tap target (issue #163)', () => {
   test('UUID 一覧の compact コピーボタンは 32x32 以上の領域を持つ', async ({ page }) => {
-    await page.goto('/tools/uuid-v7');
+    await page.goto('/tools/uuid-v7', { waitUntil: 'domcontentloaded' });
     await page.getByRole('button', { name: '生成' }).waitFor();
     await waitForReactHydration(page);
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -5,11 +5,23 @@ import type { Page } from '@playwright/test';
  * React のイベントハンドラはハイドレーション後に初めて有効になる。
  * React がハイドレーション完了すると DOM 要素に __react* キーを付与するため、
  * その出現を待って「操作可能」を確認する。
+ *
+ * timeout を明示しないと per-test timeout (30s) を全消費しうるため、
+ * デフォルト 10s で打ち切って早期に失敗を顕在化させる。呼び出し側で
+ * `waitForReactHydration(page, { timeout: 20_000 })` のように override 可能。
  */
-export async function waitForReactHydration(page: Page): Promise<void> {
-  await page.waitForFunction(() => {
-    const els = document.querySelectorAll('input, textarea, button');
-    if (!els.length) return false;
-    return [...els].some((el) => Object.keys(el).some((k) => k.startsWith('__react')));
-  });
+export async function waitForReactHydration(
+  page: Page,
+  options?: { timeout?: number }
+): Promise<void> {
+  const timeout = options?.timeout ?? 10_000;
+  await page.waitForFunction(
+    () => {
+      const els = document.querySelectorAll('input, textarea, button');
+      if (!els.length) return false;
+      return [...els].some((el) => Object.keys(el).some((k) => k.startsWith('__react')));
+    },
+    null,
+    { timeout }
+  );
 }


### PR DESCRIPTION
## 概要

issue #193 (E2E テストの個別 timeout 設定方針を整理) の **短期対応** として、PR #217 で観測された \`a11y-live-region.spec.ts\` の flake (\`page.goto\` の \`load\` timeout) を緩和する 2 点修正。

## 背景

PR #217 の E2E 実行で \`tests/e2e/a11y-live-region.spec.ts:10\` が \`page.goto('/tools/jan-code')\` の \`load\` 待機で 30s timeout。即時単独再実行は 5/5 緑（同 worktree、ほぼ同時刻）。

調査結果:
- \`page.goto\` のデフォルト \`waitUntil: 'load'\` は画像・非同期スクリプト含む全サブリソースを待つ
- \`waitForReactHydration\` ヘルパに timeout 上限がなく、per-test timeout (30s) を全消費しうる
- \`fullyParallel: true\` 下で Vite dev server に並列リクエスト集中する仮説が最有力（142 件目という後半での発生と整合）

## 改修内容

### 1. \`tests/e2e/a11y-live-region.spec.ts\` の \`page.goto\` に \`{ waitUntil: 'domcontentloaded' }\` 明示

全 5 箇所の \`page.goto\` に第 2 引数を追加。直後に \`waitForReactHydration\` で React 準備を明示的に待つため、\`load\` 全待ちは不要。

### 2. \`tests/e2e/helpers.ts\` の \`waitForReactHydration\` に内部 timeout

シグネチャを \`waitForReactHydration(page, options?: { timeout?: number })\` に変更し、内部の \`page.waitForFunction\` に \`{ timeout: 10_000 }\` (default) を渡す。既存呼び出し側（引数なし）は default 10s で吸収されるため無修正で動作。

**10s timeout の根拠**: per-test timeout 30s の 1/3 を上限とすることで、goto / hydration / その後のアサーション に概ね均等な予算を割り当てる発想。CI の遅いランナーや並列負荷下で余裕を持たせつつ、無限待ちを避ける。中期対応 (#193 本対応) で実測値を集めて再調整する想定。

## スコープ外（中期対応 #193 で別途）

- \`playwright.config.ts\` に \`navigationTimeout\` / \`actionTimeout\` をグローバル明示
- \`webServer.timeout\` と per-test timeout の関係をドキュメント化
- **他 spec ファイルへの \`page.goto\` 横展開** (本 PR は \`a11y-live-region.spec.ts\` のみで横展開せず): 同じ flake 仮説が他 20 spec (\`base64\`, \`config-converter\`, \`copy-button\`, \`download-button\`, \`dummy-text\`, \`encoding-converter\`, \`filename-sanitize\`, \`gs1-databar\`, \`jan-code\`, \`json-csv\`, \`json-xml\`, \`jwt-decoder\`, \`link-styles\`, \`mobile-drawer\`, \`qr-code\`, \`qr-reader\`, \`qr-ticket\`, \`ulid-generator\`, \`url-encode\`, \`uuid-v7\`) に適用しうるが、本 PR は flake 観測点 1 件への最小修正に留め、横展開は #193 中期対応で実装方針を固めてから一括対応する
- hydration 検出が \`__react*\` 内部キーに依存している件 (React 内部実装に依存し将来 silent に壊れうる) → 中期対応の選択肢として記録

## 検証

- \`npm run test\`: 424 件全件緑
- \`astro check\`: 0 errors
- \`npm run test:e2e\`: 142 passed / 1 skipped、全件緑 (50.2s) — flake 再現せず
- \`aria-*\` / \`role=\` の削除なし

## 関連 issue

- #193 (E2E テストの個別 timeout 設定方針を整理) — 本 PR は短期対応サブセット