### PR TITLE
refactor: QrTicket を 3 ドメインフックに分割 (#167)

### DIFF
--- a/src/components/tools/QrTicket.tsx
+++ b/src/components/tools/QrTicket.tsx
@@ -1,29 +1,10 @@
-import { useState, useRef, useCallback } from 'react';
-import {
-  generateKeyPair,
-  exportKeyPair,
-  importPrivateKey,
-  importPublicKey,
-  signTicket,
-  verifyTicket,
-  generateQrSvg,
-  ticketToQrString,
-  generateTicketId,
-  estimateTicketByteSize,
-  MAX_QR_BYTE_SIZE,
-  type TicketPayload,
-  type VerificationResult,
-} from '@/utils/qr-ticket';
-import { downloadSvg } from '@/utils/download';
-import { downloadZip } from '@/utils/zip';
-import { validateFile } from '@/utils/file-validation';
-import { sanitizeFilename, isSafeTicketId } from '@/utils/filename';
-import { decodeQrFromFile, DEFAULT_QR_MAX_DIM } from '@/utils/qr-reader';
-import { ToggleGroup } from '@/components/ui/ToggleGroup';
-import { useQrCamera } from '@/hooks/useQrCamera';
+import { useState } from 'react';
 import { useAbortableEffect } from '@/hooks/useAbortableEffect';
+import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { MODE_OPTIONS, GenerateTab, VerifyTab } from './qr-ticket/index';
-import type { TicketRow, GeneratedQr } from './qr-ticket/types';
+import { useTicketKeyPair } from './qr-ticket/useTicketKeyPair';
+import { useTicketGeneration } from './qr-ticket/useTicketGeneration';
+import { useTicketVerification } from './qr-ticket/useTicketVerification';
 
 /**
  * 有効期限の初期値（1週間後の00:00）を取得する
@@ -40,329 +21,40 @@ const getDefaultExpiry = () => {
 export function QrTicketTool() {
   const [mode, setMode] = useState<'generate' | 'verify'>('generate');
 
-  // 鍵ペア状態
-  const [cryptoKeyPair, setCryptoKeyPair] = useState<CryptoKeyPair | null>(null);
-  const [privateKeyJwkStr, setPrivateKeyJwkStr] = useState('');
-  const [publicKeyJwkStr, setPublicKeyJwkStr] = useState('');
-  const [keyGenerating, setKeyGenerating] = useState(false);
-  const [keyError, setKeyError] = useState('');
-  const [showImport, setShowImport] = useState(false);
-  const [importStr, setImportStr] = useState('');
-
-  // 生成タブ状態
-  const [eventId, setEventId] = useState('');
-  const [expiry, setExpiry] = useState('');
-  const ticketKeyRef = useRef(1);
-  const [tickets, setTickets] = useState<TicketRow[]>([
-    { _key: 1, id: generateTicketId(1), name: '', category: '' },
-  ]);
-  const [generating, setGenerating] = useState(false);
-  const [generateError, setGenerateError] = useState('');
-  const [generatedQrs, setGeneratedQrs] = useState<GeneratedQr[]>([]);
-  const [zipping, setZipping] = useState(false);
-  const [zipError, setZipError] = useState('');
-
-  // 検証タブ状態
+  // 検証タブの公開鍵欄（生成タブで鍵生成時に自動設定）
   const [verifyPubKeyStr, setVerifyPubKeyStr] = useState('');
-  const [scanMode, setScanMode] = useState<'camera' | 'upload'>('camera');
-  const [verificationResult, setVerificationResult] = useState<VerificationResult | null>(null);
-  const [verifying, setVerifying] = useState(false);
 
-  // マウント後に初期値をセット
+  // 鍵ペア管理
+  const keyPair = useTicketKeyPair({
+    onPubKeyGenerated: setVerifyPubKeyStr,
+  });
+
+  // チケット生成管理
+  const generation = useTicketGeneration({
+    cryptoKeyPair: keyPair.cryptoKeyPair,
+  });
+
+  // QR検証管理
+  const verification = useTicketVerification({
+    pubKeyStr: verifyPubKeyStr,
+  });
+
+  // マウント後に有効期限の初期値をセット
   useAbortableEffect(() => {
-    setExpiry(getDefaultExpiry());
+    generation.setExpiry(getDefaultExpiry());
   }, []);
-
-  // ─── QR検証（カメラ/アップロード共通） ───────────────────
-
-  const handleVerify = useCallback(
-    async (rawData: string, signal?: AbortSignal) => {
-      if (signal?.aborted) return;
-      setVerifying(true);
-      let pubKey: CryptoKey;
-      try {
-        const jwk = JSON.parse(verifyPubKeyStr) as JsonWebKey;
-        pubKey = await importPublicKey(jwk);
-      } catch {
-        if (signal?.aborted) return;
-        setVerificationResult({
-          valid: false,
-          ticket: null,
-          expired: false,
-          error: '公開鍵の形式が不正です。有効なECDSA P-256 JWKを貼り付けてください。',
-        });
-        setVerifying(false);
-        return;
-      }
-      const result = await verifyTicket(rawData, pubKey);
-      if (signal?.aborted) return;
-      setVerificationResult(result);
-      setVerifying(false);
-    },
-    [verifyPubKeyStr]
-  );
-
-  const camera = useQrCamera({ onQrDetected: handleVerify });
-  const { stopCamera } = camera;
-
-  // 画像アップロード処理の AbortController を保持する ref。
-  // アンマウント時・連打時に前回の処理をキャンセルする。
-  const uploadAbortRef = useRef<AbortController | null>(null);
 
   // モード切替時にカメラを停止する
   useAbortableEffect(() => {
-    if (mode !== 'verify') stopCamera();
-  }, [mode, stopCamera]);
+    if (mode !== 'verify') verification.camera.stopCamera();
+  }, [mode, verification.camera.stopCamera]);
 
   // アンマウント時にカメラを停止し、進行中のアップロードをキャンセルする
   useAbortableEffect(() => {
     return () => {
-      stopCamera();
-      uploadAbortRef.current?.abort();
+      verification.camera.stopCamera();
     };
-  }, [stopCamera]);
-
-  // ─── 鍵操作 ──────────────────────────────────────────────
-
-  const handleGenerateKeys = async () => {
-    setKeyGenerating(true);
-    setKeyError('');
-    try {
-      const pair = await generateKeyPair();
-      const exported = await exportKeyPair(pair);
-      const privStr = JSON.stringify(exported.privateKey, null, 2);
-      const pubStr = JSON.stringify(exported.publicKey, null, 2);
-      setCryptoKeyPair(pair);
-      setPrivateKeyJwkStr(privStr);
-      setPublicKeyJwkStr(pubStr);
-      setVerifyPubKeyStr(pubStr);
-      setGenerateError('');
-    } catch {
-      setKeyError('鍵の生成に失敗しました');
-    } finally {
-      setKeyGenerating(false);
-    }
-  };
-
-  const handleImportKey = async () => {
-    setKeyError('');
-    let jwk: JsonWebKey;
-    try {
-      jwk = JSON.parse(importStr) as JsonWebKey;
-    } catch {
-      setKeyError('JSON形式が不正です');
-      return;
-    }
-    if (!('d' in jwk)) {
-      setKeyError('これは公開鍵です。秘密鍵（"d" フィールドを含むJWK）を入力してください。');
-      return;
-    }
-    try {
-      const privKey = await importPrivateKey(jwk);
-      // ECDSA JWK から公開鍵部分を抽出（d フィールドを除去）
-      const { d: _d, key_ops: _ops, ...pubJwk } = jwk as Record<string, unknown>;
-      const pubKeyJwk = { ...pubJwk, key_ops: ['verify'] } as JsonWebKey;
-      const pubKey = await importPublicKey(pubKeyJwk);
-      const privStr = JSON.stringify(jwk, null, 2);
-      const pubStr = JSON.stringify(pubKeyJwk, null, 2);
-      setCryptoKeyPair({ privateKey: privKey, publicKey: pubKey });
-      setPrivateKeyJwkStr(privStr);
-      setPublicKeyJwkStr(pubStr);
-      setVerifyPubKeyStr(pubStr);
-      setShowImport(false);
-      setImportStr('');
-    } catch {
-      setKeyError('秘密鍵のインポートに失敗しました。有効なECDSA P-256 JWKを入力してください。');
-    }
-  };
-
-  // ─── チケット編集 ─────────────────────────────────────────
-
-  const addTicket = () => {
-    if (tickets.length >= 20) return;
-    ticketKeyRef.current += 1;
-    const newKey = ticketKeyRef.current;
-    setTickets((prev) => [
-      ...prev,
-      { _key: newKey, id: generateTicketId(prev.length + 1), name: '', category: '' },
-    ]);
-  };
-
-  const removeTicket = (index: number) => {
-    setTickets((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  const updateTicket = (index: number, field: keyof TicketRow, value: string) => {
-    setTickets((prev) => prev.map((t, i) => (i === index ? { ...t, [field]: value } : t)));
-  };
-
-  // ─── QR生成 ───────────────────────────────────────────────
-
-  const handleGenerate = async () => {
-    // 状態を即座にリセットしてクリック反応を確保
-    setGenerateError('');
-
-    if (!cryptoKeyPair) {
-      setGenerateError('先に鍵ペアを生成またはインポートしてください');
-      return;
-    }
-    if (!eventId.trim()) {
-      setGenerateError('イベントIDを入力してください');
-      return;
-    }
-    if (!expiry) {
-      setGenerateError('有効期限を設定してください');
-      return;
-    }
-    if (tickets.length === 0) {
-      setGenerateError('チケットを1件以上追加してください');
-      return;
-    }
-    const emptyId = tickets.find((t) => !t.id.trim());
-    if (emptyId) {
-      setGenerateError('チケットIDが空の行があります');
-      return;
-    }
-    // チケット ID は ZIP/ダウンロードのファイル名にも使われるため、
-    // 危険文字（path separator、`..`、制御文字、日本語等）を含む場合は拒否する。
-    const unsafeIdRow = tickets.find((t) => !isSafeTicketId(t.id.trim()));
-    if (unsafeIdRow) {
-      setGenerateError(
-        'チケットIDは英数字・ピリオド・アンダースコア・ハイフンのみ、64 文字以内で入力してください'
-      );
-      return;
-    }
-
-    // データ量制限チェック (全データの合計が MAX_QR_BYTE_SIZE バイト以内)
-    const longTicket = tickets.find((t) => {
-      const payload: TicketPayload = {
-        e: eventId.trim(),
-        t: t.id.trim(),
-        timestamp: Math.floor(new Date(expiry).getTime() / 1000),
-        n: t.name.trim() || undefined,
-        p: t.category.trim() || undefined,
-      };
-      return estimateTicketByteSize(payload) > MAX_QR_BYTE_SIZE;
-    });
-
-    if (longTicket) {
-      setGenerateError(
-        `データ量が上限（${MAX_QR_BYTE_SIZE}バイト）を超えているチケットがあります。`
-      );
-      return;
-    }
-
-    setGenerating(true);
-    try {
-      const results: GeneratedQr[] = [];
-      for (const row of tickets) {
-        const payload: TicketPayload = {
-          e: eventId.trim(),
-          t: row.id.trim(),
-          timestamp: Math.floor(new Date(expiry).getTime() / 1000),
-          ...(row.name.trim() ? { n: row.name.trim() } : {}),
-          ...(row.category.trim() ? { p: row.category.trim() } : {}),
-        };
-        const signed = await signTicket(payload, cryptoKeyPair.privateKey);
-        const qrString = ticketToQrString(signed);
-        const svg = generateQrSvg(qrString);
-        if (!svg) {
-          setGenerateError(`チケット ${row.id} のQRコード生成に失敗しました（データが長すぎます）`);
-          setGenerating(false);
-          return;
-        }
-        results.push({ _key: row._key, ticket: signed, svg, qrString });
-      }
-      setGeneratedQrs(results);
-    } catch {
-      setGenerateError('QRコードの生成中にエラーが発生しました');
-    } finally {
-      setGenerating(false);
-    }
-  };
-
-  const handleDownloadSvg = (qr: GeneratedQr) => {
-    // ticket.t は UI 入力（信頼できない）なのでサニタイズしてから filename に組み込む
-    const safeName = sanitizeFilename(`ticket-${qr.ticket.t}.svg`, ['svg']);
-    downloadSvg(qr.svg.replace('<svg ', '<svg width="160" height="160" '), safeName);
-  };
-
-  const handleDownloadZip = async () => {
-    if (generatedQrs.length === 0 || zipping) return;
-    setZipping(true);
-    setZipError('');
-    try {
-      // ZIP エントリ名は Zip Slip 類似の攻撃媒体になり得るため必ずサニタイズする。
-      // `tickets/` サブフォルダ配下に格納して従来の ZIP 構造を維持する。
-      const files = generatedQrs.map(({ ticket, svg }) => ({
-        name: sanitizeFilename(`ticket-${ticket.t}.svg`, ['svg']),
-        content: svg.replace('<svg ', '<svg width="160" height="160" '),
-        folder: 'tickets',
-      }));
-      await downloadZip(files, 'tickets.zip');
-    } catch {
-      setZipError('ZIPの作成に失敗しました');
-    } finally {
-      setZipping(false);
-    }
-  };
-
-  // ─── 画像アップロードからQR検証 ──────────────────────────
-
-  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    // 同じファイルを再選択できるようにリセット
-    e.target.value = '';
-
-    const validation = validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
-    if (!validation.ok) {
-      camera.setCameraError(validation.message);
-      return;
-    }
-
-    camera.setCameraError('');
-    setVerificationResult(null);
-
-    // 連打時に前回のアップロードをキャンセルし、新しい controller を設定する
-    uploadAbortRef.current?.abort();
-    const controller = new AbortController();
-    uploadAbortRef.current = controller;
-    let result;
-    try {
-      result = await decodeQrFromFile(file, {
-        maxDim: DEFAULT_QR_MAX_DIM,
-        signal: controller.signal,
-      });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') return;
-      camera.setCameraError('画像を読み込めませんでした');
-      return;
-    }
-
-    if (!result.ok) {
-      if (result.reason === 'load-error') {
-        camera.setCameraError('画像を読み込めませんでした');
-      } else {
-        setVerificationResult({
-          valid: false,
-          ticket: null,
-          expired: false,
-          error: 'QRコードが見つかりませんでした',
-        });
-      }
-      return;
-    }
-    await handleVerify(result.data, controller.signal);
-  };
-
-  const handleRescan = () => {
-    setVerificationResult(null);
-    camera.setCameraError('');
-    if (scanMode === 'camera') camera.startCamera();
-  };
-
-  // ─── レンダリング ─────────────────────────────────────────
+  }, [verification.camera.stopCamera]);
 
   return (
     <div className="space-y-6">
@@ -370,45 +62,45 @@ export function QrTicketTool() {
 
       {mode === 'generate' ? (
         <GenerateTab
-          cryptoKeyPair={cryptoKeyPair}
-          privateKeyJwkStr={privateKeyJwkStr}
-          publicKeyJwkStr={publicKeyJwkStr}
-          keyGenerating={keyGenerating}
-          keyError={keyError}
-          showImport={showImport}
-          importStr={importStr}
-          eventId={eventId}
-          expiry={expiry}
-          tickets={tickets}
-          generating={generating}
-          generateError={generateError}
-          generatedQrs={generatedQrs}
-          zipping={zipping}
-          zipError={zipError}
-          onGenerateKeys={handleGenerateKeys}
-          onToggleImport={() => setShowImport((v) => !v)}
-          onImportStrChange={setImportStr}
-          onImportKey={handleImportKey}
-          onEventIdChange={setEventId}
-          onExpiryChange={setExpiry}
-          onAddTicket={addTicket}
-          onRemoveTicket={removeTicket}
-          onUpdateTicket={updateTicket}
-          onGenerate={handleGenerate}
-          onDownloadSvg={handleDownloadSvg}
-          onDownloadZip={handleDownloadZip}
+          cryptoKeyPair={keyPair.cryptoKeyPair}
+          privateKeyJwkStr={keyPair.privateKeyJwkStr}
+          publicKeyJwkStr={keyPair.publicKeyJwkStr}
+          keyGenerating={keyPair.keyGenerating}
+          keyError={keyPair.keyError}
+          showImport={keyPair.showImport}
+          importStr={keyPair.importStr}
+          eventId={generation.eventId}
+          expiry={generation.expiry}
+          tickets={generation.tickets}
+          generating={generation.generating}
+          generateError={generation.generateError}
+          generatedQrs={generation.generatedQrs}
+          zipping={generation.zipping}
+          zipError={generation.zipError}
+          onGenerateKeys={keyPair.generateKeys}
+          onToggleImport={keyPair.toggleImport}
+          onImportStrChange={keyPair.setImportStr}
+          onImportKey={keyPair.importKey}
+          onEventIdChange={generation.setEventId}
+          onExpiryChange={generation.setExpiry}
+          onAddTicket={generation.addTicket}
+          onRemoveTicket={generation.removeTicket}
+          onUpdateTicket={generation.updateTicket}
+          onGenerate={generation.generate}
+          onDownloadSvg={generation.downloadSvgQr}
+          onDownloadZip={generation.downloadZipQrs}
         />
       ) : (
         <VerifyTab
           verifyPubKeyStr={verifyPubKeyStr}
-          scanMode={scanMode}
-          camera={camera}
-          verificationResult={verificationResult}
-          verifying={verifying}
+          scanMode={verification.scanMode}
+          camera={verification.camera}
+          verificationResult={verification.verificationResult}
+          verifying={verification.verifying}
           onVerifyPubKeyStrChange={setVerifyPubKeyStr}
-          onScanModeChange={setScanMode}
-          onImageUpload={handleImageUpload}
-          onRescan={handleRescan}
+          onScanModeChange={verification.setScanMode}
+          onImageUpload={verification.handleImageUpload}
+          onRescan={verification.handleRescan}
         />
       )}
     </div>

--- a/src/components/tools/QrTicket.tsx
+++ b/src/components/tools/QrTicket.tsx
@@ -49,7 +49,7 @@ export function QrTicketTool() {
     if (mode !== 'verify') verification.camera.stopCamera();
   }, [mode, verification.camera.stopCamera]);
 
-  // アンマウント時にカメラを停止し、進行中のアップロードをキャンセルする
+  // アンマウント時にカメラを停止する
   useAbortableEffect(() => {
     return () => {
       verification.camera.stopCamera();
@@ -62,33 +62,37 @@ export function QrTicketTool() {
 
       {mode === 'generate' ? (
         <GenerateTab
-          cryptoKeyPair={keyPair.cryptoKeyPair}
-          privateKeyJwkStr={keyPair.privateKeyJwkStr}
-          publicKeyJwkStr={keyPair.publicKeyJwkStr}
-          keyGenerating={keyPair.keyGenerating}
-          keyError={keyPair.keyError}
-          showImport={keyPair.showImport}
-          importStr={keyPair.importStr}
-          eventId={generation.eventId}
-          expiry={generation.expiry}
-          tickets={generation.tickets}
-          generating={generation.generating}
-          generateError={generation.generateError}
-          generatedQrs={generation.generatedQrs}
-          zipping={generation.zipping}
-          zipError={generation.zipError}
-          onGenerateKeys={keyPair.generateKeys}
-          onToggleImport={keyPair.toggleImport}
-          onImportStrChange={keyPair.setImportStr}
-          onImportKey={keyPair.importKey}
-          onEventIdChange={generation.setEventId}
-          onExpiryChange={generation.setExpiry}
-          onAddTicket={generation.addTicket}
-          onRemoveTicket={generation.removeTicket}
-          onUpdateTicket={generation.updateTicket}
-          onGenerate={generation.generate}
-          onDownloadSvg={generation.downloadSvgQr}
-          onDownloadZip={generation.downloadZipQrs}
+          keyPair={{
+            cryptoKeyPair: keyPair.cryptoKeyPair,
+            privateKeyJwkStr: keyPair.privateKeyJwkStr,
+            publicKeyJwkStr: keyPair.publicKeyJwkStr,
+            keyGenerating: keyPair.keyGenerating,
+            keyError: keyPair.keyError,
+            showImport: keyPair.showImport,
+            importStr: keyPair.importStr,
+            onGenerateKeys: keyPair.generateKeys,
+            onToggleImport: keyPair.toggleImport,
+            onImportStrChange: keyPair.setImportStr,
+            onImportKey: keyPair.importKey,
+          }}
+          generation={{
+            eventId: generation.eventId,
+            expiry: generation.expiry,
+            tickets: generation.tickets,
+            generating: generation.generating,
+            generateError: generation.generateError,
+            generatedQrs: generation.generatedQrs,
+            zipping: generation.zipping,
+            zipError: generation.zipError,
+            onEventIdChange: generation.setEventId,
+            onExpiryChange: generation.setExpiry,
+            onAddTicket: generation.addTicket,
+            onRemoveTicket: generation.removeTicket,
+            onUpdateTicket: generation.updateTicket,
+            onGenerate: generation.generate,
+            onDownloadSvg: generation.downloadSvgQr,
+            onDownloadZip: generation.downloadZipQrs,
+          }}
         />
       ) : (
         <VerifyTab

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -12,7 +12,8 @@ import type { TicketPayload } from '@/utils/qr-ticket';
 /** プレビューやバイト数見積もりで使用するデフォルトの有効期限（2025-01-01T00:00:00Z） */
 const PREVIEW_FALLBACK_TIMESTAMP = 1735689600;
 
-interface GenerateTabProps {
+/** 鍵ペアセクションに渡す props */
+export interface KeyPairSectionProps {
   cryptoKeyPair: CryptoKeyPair | null;
   privateKeyJwkStr: string;
   publicKeyJwkStr: string;
@@ -20,6 +21,14 @@ interface GenerateTabProps {
   keyError: string;
   showImport: boolean;
   importStr: string;
+  onGenerateKeys: () => void;
+  onToggleImport: () => void;
+  onImportStrChange: (v: string) => void;
+  onImportKey: () => void;
+}
+
+/** チケット生成・編集・ZIPに渡す props */
+export interface GenerationSectionProps {
   eventId: string;
   expiry: string;
   tickets: TicketRow[];
@@ -28,10 +37,6 @@ interface GenerateTabProps {
   generatedQrs: GeneratedQr[];
   zipping: boolean;
   zipError: string;
-  onGenerateKeys: () => void;
-  onToggleImport: () => void;
-  onImportStrChange: (v: string) => void;
-  onImportKey: () => void;
   onEventIdChange: (v: string) => void;
   onExpiryChange: (v: string) => void;
   onAddTicket: () => void;
@@ -42,35 +47,45 @@ interface GenerateTabProps {
   onDownloadZip: () => void;
 }
 
-export function GenerateTab({
-  cryptoKeyPair,
-  privateKeyJwkStr,
-  publicKeyJwkStr,
-  keyGenerating,
-  keyError,
-  showImport,
-  importStr,
-  eventId,
-  expiry,
-  tickets,
-  generating,
-  generateError,
-  generatedQrs,
-  zipping,
-  zipError,
-  onGenerateKeys,
-  onToggleImport,
-  onImportStrChange,
-  onImportKey,
-  onEventIdChange,
-  onExpiryChange,
-  onAddTicket,
-  onRemoveTicket,
-  onUpdateTicket,
-  onGenerate,
-  onDownloadSvg,
-  onDownloadZip,
-}: GenerateTabProps) {
+interface GenerateTabProps {
+  keyPair: KeyPairSectionProps;
+  generation: GenerationSectionProps;
+}
+
+export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
+  const {
+    cryptoKeyPair,
+    privateKeyJwkStr,
+    publicKeyJwkStr,
+    keyGenerating,
+    keyError,
+    showImport,
+    importStr,
+    onGenerateKeys,
+    onToggleImport,
+    onImportStrChange,
+    onImportKey,
+  } = keyPair;
+
+  const {
+    eventId,
+    expiry,
+    tickets,
+    generating,
+    generateError,
+    generatedQrs,
+    zipping,
+    zipError,
+    onEventIdChange,
+    onExpiryChange,
+    onAddTicket,
+    onRemoveTicket,
+    onUpdateTicket,
+    onGenerate,
+    onDownloadSvg,
+    onDownloadZip,
+  } = generation;
+
   /** 共通のペイロードを構築 */
   const buildCurrentPayload = (row: TicketRow): TicketPayload => ({
     e: eventId.trim(),

--- a/src/components/tools/qr-ticket/__tests__/useTicketGeneration.test.tsx
+++ b/src/components/tools/qr-ticket/__tests__/useTicketGeneration.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTicketGeneration } from '../useTicketGeneration';
+import type { GeneratedQr } from '../types';
+
+// ────────────────────────────────────────────
+// 依存モジュールのモック
+// ────────────────────────────────────────────
+
+const mockSignedTicket = {
+  e: 'event-test',
+  t: 'T-00001',
+  timestamp: 9999999999,
+  s: 'dummysig',
+};
+
+vi.mock('@/utils/qr-ticket', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/utils/qr-ticket')>();
+  return {
+    ...original,
+    signTicket: vi.fn(async () => mockSignedTicket),
+    generateQrSvg: vi.fn(() => '<svg>dummy</svg>'),
+    ticketToQrString: vi.fn(() => 'event-test|T-00001|9999999999|||dummysig'),
+  };
+});
+
+vi.mock('@/utils/download', () => ({
+  downloadSvg: vi.fn(),
+}));
+
+vi.mock('@/utils/zip', () => ({
+  downloadZip: vi.fn(async () => undefined),
+}));
+
+const mockCryptoKeyPair: CryptoKeyPair = {
+  privateKey: { type: 'private' } as CryptoKey,
+  publicKey: { type: 'public' } as CryptoKey,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useTicketGeneration — 初期状態', () => {
+  it('初期チケットが1行セットされている', () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    expect(result.current.tickets).toHaveLength(1);
+    expect(result.current.tickets[0].id).toBe('T-00001');
+    expect(result.current.generating).toBe(false);
+    expect(result.current.generateError).toBe('');
+    expect(result.current.generatedQrs).toHaveLength(0);
+    expect(result.current.zipping).toBe(false);
+    expect(result.current.zipError).toBe('');
+  });
+});
+
+describe('useTicketGeneration — チケット編集', () => {
+  it('addTicket でチケットが追加される', () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => result.current.addTicket());
+
+    expect(result.current.tickets).toHaveLength(2);
+    expect(result.current.tickets[1].id).toBe('T-00002');
+  });
+
+  it('removeTicket でチケットが削除される', () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => result.current.addTicket());
+    act(() => result.current.removeTicket(0));
+
+    expect(result.current.tickets).toHaveLength(1);
+    expect(result.current.tickets[0].id).toBe('T-00002');
+  });
+
+  it('updateTicket でフィールドが更新される', () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => result.current.updateTicket(0, 'name', '山田 太郎'));
+
+    expect(result.current.tickets[0].name).toBe('山田 太郎');
+  });
+
+  it('MAX_TICKETS（20件）を超えると addTicket しても増えない', () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    // 毎回 act を分けることで tickets.length の stale closure 問題を回避
+    for (let i = 0; i < 25; i++) {
+      act(() => result.current.addTicket());
+    }
+
+    expect(result.current.tickets).toHaveLength(20);
+  });
+});
+
+describe('useTicketGeneration — generate', () => {
+  it('鍵ペアなしで generate するとエラーメッセージがセットされる', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: null }));
+
+    act(() => result.current.setEventId('event-test'));
+    act(() => result.current.setExpiry('2099-12-31T23:59'));
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('鍵ペアを生成またはインポートしてください');
+    expect(result.current.generatedQrs).toHaveLength(0);
+  });
+
+  it('イベントIDが空で generate するとエラーメッセージがセットされる', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => result.current.setExpiry('2099-12-31T23:59'));
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('イベントIDを入力してください');
+  });
+
+  it('有効期限が未設定で generate するとエラーメッセージがセットされる', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => result.current.setEventId('event-test'));
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('有効期限を設定してください');
+  });
+
+  it('正常な入力で generate すると generatedQrs が返される', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toBe('');
+    expect(result.current.generatedQrs).toHaveLength(1);
+    expect(result.current.generatedQrs[0].svg).toBe('<svg>dummy</svg>');
+  });
+
+  it('generateQrSvg が null を返すとエラーメッセージがセットされる', async () => {
+    const { generateQrSvg } = await import('@/utils/qr-ticket');
+    vi.mocked(generateQrSvg).mockReturnValueOnce(null);
+
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('QRコード生成に失敗しました');
+    expect(result.current.generatedQrs).toHaveLength(0);
+  });
+});
+
+describe('useTicketGeneration — downloadSvgQr', () => {
+  it('downloadSvgQr が downloadSvg を呼び出す', async () => {
+    const { downloadSvg } = await import('@/utils/download');
+
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    const mockQr: GeneratedQr = {
+      _key: 1,
+      ticket: mockSignedTicket,
+      svg: '<svg>dummy</svg>',
+      qrString: 'qrdata',
+    };
+
+    act(() => result.current.downloadSvgQr(mockQr));
+
+    expect(downloadSvg).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useTicketGeneration — downloadZipQrs', () => {
+  it('generatedQrs がない状態では downloadZip が呼ばれない', async () => {
+    const { downloadZip } = await import('@/utils/zip');
+
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    await act(async () => {
+      await result.current.downloadZipQrs();
+    });
+
+    expect(downloadZip).not.toHaveBeenCalled();
+  });
+
+  it('generate 後に downloadZipQrs を呼ぶと downloadZip が呼ばれる', async () => {
+    const { downloadZip } = await import('@/utils/zip');
+
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    await act(async () => {
+      await result.current.downloadZipQrs();
+    });
+
+    expect(downloadZip).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloadZip がエラーを投げると zipError がセットされる', async () => {
+    const { downloadZip } = await import('@/utils/zip');
+    vi.mocked(downloadZip).mockRejectedValueOnce(new Error('zip error'));
+
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    await act(async () => {
+      await result.current.downloadZipQrs();
+    });
+
+    expect(result.current.zipError).toBe('ZIPの作成に失敗しました');
+  });
+});

--- a/src/components/tools/qr-ticket/__tests__/useTicketKeyPair.test.tsx
+++ b/src/components/tools/qr-ticket/__tests__/useTicketKeyPair.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTicketKeyPair } from '../useTicketKeyPair';
+
+// ────────────────────────────────────────────
+// Web Crypto API のモック
+// ────────────────────────────────────────────
+
+const mockPrivateKey = { type: 'private' } as CryptoKey;
+const mockPublicKey = { type: 'public' } as CryptoKey;
+
+const mockCryptoKeyPair: CryptoKeyPair = {
+  privateKey: mockPrivateKey,
+  publicKey: mockPublicKey,
+};
+
+const mockPrivateJwk: JsonWebKey = {
+  kty: 'EC',
+  crv: 'P-256',
+  d: 'private-d',
+  x: 'pub-x',
+  y: 'pub-y',
+  key_ops: ['sign'],
+};
+
+const mockPublicJwk: JsonWebKey = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'pub-x',
+  y: 'pub-y',
+  key_ops: ['verify'],
+};
+
+vi.mock('@/utils/qr-ticket', () => ({
+  generateKeyPair: vi.fn(async () => mockCryptoKeyPair),
+  exportKeyPair: vi.fn(async () => ({
+    privateKey: mockPrivateJwk,
+    publicKey: mockPublicJwk,
+  })),
+  importPrivateKey: vi.fn(async () => mockPrivateKey),
+  importPublicKey: vi.fn(async () => mockPublicKey),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useTicketKeyPair — 初期状態', () => {
+  it('初期値がすべて空・false であること', () => {
+    const { result } = renderHook(() => useTicketKeyPair());
+    expect(result.current.cryptoKeyPair).toBeNull();
+    expect(result.current.privateKeyJwkStr).toBe('');
+    expect(result.current.publicKeyJwkStr).toBe('');
+    expect(result.current.keyGenerating).toBe(false);
+    expect(result.current.keyError).toBe('');
+    expect(result.current.showImport).toBe(false);
+    expect(result.current.importStr).toBe('');
+  });
+});
+
+describe('useTicketKeyPair — generateKeys', () => {
+  it('鍵生成後に cryptoKeyPair・privateKeyJwkStr・publicKeyJwkStr がセットされる', async () => {
+    const { result } = renderHook(() => useTicketKeyPair());
+
+    await act(async () => {
+      await result.current.generateKeys();
+    });
+
+    expect(result.current.cryptoKeyPair).toBe(mockCryptoKeyPair);
+    expect(result.current.privateKeyJwkStr).toContain('"kty": "EC"');
+    expect(result.current.publicKeyJwkStr).toContain('"kty": "EC"');
+    expect(result.current.keyError).toBe('');
+  });
+
+  it('onPubKeyGenerated コールバックが生成した公開鍵文字列で呼ばれる', async () => {
+    const onPubKeyGenerated = vi.fn();
+    const { result } = renderHook(() => useTicketKeyPair({ onPubKeyGenerated }));
+
+    await act(async () => {
+      await result.current.generateKeys();
+    });
+
+    expect(onPubKeyGenerated).toHaveBeenCalledTimes(1);
+    expect(onPubKeyGenerated.mock.calls[0][0]).toContain('"kty": "EC"');
+  });
+
+  it('generateKeyPair がエラーを投げると keyError がセットされる', async () => {
+    const { generateKeyPair } = await import('@/utils/qr-ticket');
+    vi.mocked(generateKeyPair).mockRejectedValueOnce(new Error('crypto error'));
+
+    const { result } = renderHook(() => useTicketKeyPair());
+
+    await act(async () => {
+      await result.current.generateKeys();
+    });
+
+    expect(result.current.keyError).toBe('鍵の生成に失敗しました');
+    expect(result.current.cryptoKeyPair).toBeNull();
+  });
+});
+
+describe('useTicketKeyPair — importKey', () => {
+  it('正常な秘密鍵 JWK をインポートすると cryptoKeyPair がセットされ showImport が閉じる', async () => {
+    const { result } = renderHook(() => useTicketKeyPair());
+
+    act(() => {
+      result.current.setImportStr(JSON.stringify(mockPrivateJwk));
+    });
+
+    await act(async () => {
+      await result.current.importKey();
+    });
+
+    expect(result.current.cryptoKeyPair).not.toBeNull();
+    expect(result.current.privateKeyJwkStr).toContain('"kty": "EC"');
+    expect(result.current.publicKeyJwkStr).toContain('"kty": "EC"');
+    expect(result.current.showImport).toBe(false);
+    expect(result.current.importStr).toBe('');
+    expect(result.current.keyError).toBe('');
+  });
+
+  it('JSON形式が不正なときに keyError がセットされる', async () => {
+    const { result } = renderHook(() => useTicketKeyPair());
+
+    act(() => {
+      result.current.setImportStr('not-json');
+    });
+
+    await act(async () => {
+      await result.current.importKey();
+    });
+
+    expect(result.current.keyError).toBe('JSON形式が不正です');
+  });
+
+  it('公開鍵 JWK（d フィールドなし）を秘密鍵欄に入力するとエラーになる', async () => {
+    const { result } = renderHook(() => useTicketKeyPair());
+
+    act(() => {
+      result.current.setImportStr(JSON.stringify(mockPublicJwk));
+    });
+
+    await act(async () => {
+      await result.current.importKey();
+    });
+
+    expect(result.current.keyError).toContain('公開鍵です');
+  });
+
+  it('importPrivateKey がエラーを投げると keyError がセットされる', async () => {
+    const { importPrivateKey } = await import('@/utils/qr-ticket');
+    vi.mocked(importPrivateKey).mockRejectedValueOnce(new Error('import error'));
+
+    const { result } = renderHook(() => useTicketKeyPair());
+
+    act(() => {
+      result.current.setImportStr(JSON.stringify(mockPrivateJwk));
+    });
+
+    await act(async () => {
+      await result.current.importKey();
+    });
+
+    expect(result.current.keyError).toContain('インポートに失敗しました');
+  });
+});
+
+describe('useTicketKeyPair — toggleImport', () => {
+  it('toggleImport で showImport が反転する', () => {
+    const { result } = renderHook(() => useTicketKeyPair());
+
+    expect(result.current.showImport).toBe(false);
+    act(() => result.current.toggleImport());
+    expect(result.current.showImport).toBe(true);
+    act(() => result.current.toggleImport());
+    expect(result.current.showImport).toBe(false);
+  });
+});

--- a/src/components/tools/qr-ticket/__tests__/useTicketVerification.test.tsx
+++ b/src/components/tools/qr-ticket/__tests__/useTicketVerification.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTicketVerification } from '../useTicketVerification';
+import type { VerificationResult } from '@/utils/qr-ticket';
+
+// ────────────────────────────────────────────
+// 依存モジュールのモック
+// ────────────────────────────────────────────
+
+const mockPubKey = { type: 'public' } as CryptoKey;
+
+const validResult: VerificationResult = {
+  valid: true,
+  ticket: { e: 'event-test', t: 'T-00001', timestamp: 9999999999 },
+  expired: false,
+};
+
+const invalidResult: VerificationResult = {
+  valid: false,
+  ticket: null,
+  expired: false,
+  error: '署名が無効です',
+};
+
+vi.mock('@/utils/qr-ticket', () => ({
+  importPublicKey: vi.fn(async () => mockPubKey),
+  verifyTicket: vi.fn(async () => validResult),
+}));
+
+vi.mock('@/utils/file-validation', () => ({
+  validateFile: vi.fn(() => ({ ok: true, message: '' })),
+}));
+
+vi.mock('@/utils/qr-reader', () => ({
+  decodeQrFromFile: vi.fn(async () => ({ ok: true, data: 'qr-data' })),
+  DEFAULT_QR_MAX_DIM: 1024,
+}));
+
+// useQrCamera のモック: camera オブジェクトをシンプルに返す
+const mockStartCamera = vi.fn(async () => {});
+const mockStopCamera = vi.fn();
+const mockSetCameraError = vi.fn();
+
+vi.mock('@/hooks/useQrCamera', () => ({
+  useQrCamera: vi.fn(({ onQrDetected }: { onQrDetected: (data: string) => void }) => ({
+    cameraActive: false,
+    cameraError: '',
+    setCameraError: mockSetCameraError,
+    videoRef: { current: null },
+    canvasRef: { current: null },
+    startCamera: mockStartCamera,
+    stopCamera: mockStopCamera,
+    onQrDetected,
+  })),
+}));
+
+const validPubKeyStr = JSON.stringify({ kty: 'EC', crv: 'P-256', x: 'x', y: 'y' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useTicketVerification — 初期状態', () => {
+  it('初期値が正しくセットされている', () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    expect(result.current.verificationResult).toBeNull();
+    expect(result.current.verifying).toBe(false);
+    expect(result.current.scanMode).toBe('camera');
+  });
+});
+
+describe('useTicketVerification — verify', () => {
+  it('正常な公開鍵と有効なQRデータで verificationResult が valid になる', async () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    await act(async () => {
+      await result.current.verify('qr-data');
+    });
+
+    expect(result.current.verificationResult).toEqual(validResult);
+    expect(result.current.verifying).toBe(false);
+  });
+
+  it('公開鍵の JSON が不正なとき verificationResult.valid が false になる', async () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: 'not-json' }));
+
+    await act(async () => {
+      await result.current.verify('qr-data');
+    });
+
+    expect(result.current.verificationResult?.valid).toBe(false);
+    expect(result.current.verificationResult?.error).toContain('公開鍵の形式が不正');
+  });
+
+  it('改竄を検出したとき verificationResult.valid が false になる', async () => {
+    const { verifyTicket } = await import('@/utils/qr-ticket');
+    vi.mocked(verifyTicket).mockResolvedValueOnce(invalidResult);
+
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    await act(async () => {
+      await result.current.verify('tampered-data');
+    });
+
+    expect(result.current.verificationResult?.valid).toBe(false);
+    expect(result.current.verificationResult?.error).toContain('署名が無効');
+  });
+
+  it('signal が abort 済みの場合は状態更新されない', async () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await act(async () => {
+      await result.current.verify('qr-data', controller.signal);
+    });
+
+    // signal が aborted なので verify は先頭で return し状態更新されない
+    expect(result.current.verificationResult).toBeNull();
+  });
+});
+
+describe('useTicketVerification — handleImageUpload', () => {
+  const createFileEvent = (file: File): React.ChangeEvent<HTMLInputElement> => {
+    return {
+      target: { files: [file], value: '' },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+  };
+
+  it('有効な画像でQRを検出すると verificationResult がセットされる', async () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+
+    await act(async () => {
+      await result.current.handleImageUpload(createFileEvent(file));
+    });
+
+    expect(result.current.verificationResult).toEqual(validResult);
+  });
+
+  it('ファイルバリデーション失敗時は setCameraError が呼ばれる', async () => {
+    const { validateFile } = await import('@/utils/file-validation');
+    vi.mocked(validateFile).mockReturnValueOnce({
+      ok: false,
+      code: 'WRONG_TYPE',
+      message: 'ファイルが不正です',
+    });
+
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    const file = new File(['dummy'], 'bad.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await result.current.handleImageUpload(createFileEvent(file));
+    });
+
+    expect(mockSetCameraError).toHaveBeenCalledWith('ファイルが不正です');
+    expect(result.current.verificationResult).toBeNull();
+  });
+
+  it('QRコードが見つからない場合は verificationResult.valid が false になる', async () => {
+    const { decodeQrFromFile } = await import('@/utils/qr-reader');
+    vi.mocked(decodeQrFromFile).mockResolvedValueOnce({ ok: false, reason: 'not-found' });
+
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    const file = new File(['dummy'], 'no-qr.png', { type: 'image/png' });
+
+    await act(async () => {
+      await result.current.handleImageUpload(createFileEvent(file));
+    });
+
+    expect(result.current.verificationResult?.valid).toBe(false);
+    expect(result.current.verificationResult?.error).toContain('QRコードが見つかりませんでした');
+  });
+
+  it('画像読み込みエラーの場合は setCameraError が呼ばれる', async () => {
+    const { decodeQrFromFile } = await import('@/utils/qr-reader');
+    vi.mocked(decodeQrFromFile).mockResolvedValueOnce({ ok: false, reason: 'load-error' });
+
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    const file = new File(['dummy'], 'bad-image.png', { type: 'image/png' });
+
+    await act(async () => {
+      await result.current.handleImageUpload(createFileEvent(file));
+    });
+
+    expect(mockSetCameraError).toHaveBeenCalledWith('画像を読み込めませんでした');
+  });
+});
+
+describe('useTicketVerification — handleRescan', () => {
+  it('handleRescan で verificationResult がリセットされる', async () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    // まず verify を呼んで結果をセット
+    await act(async () => {
+      await result.current.verify('qr-data');
+    });
+    expect(result.current.verificationResult).not.toBeNull();
+
+    // rescan でリセット
+    act(() => result.current.handleRescan());
+
+    expect(result.current.verificationResult).toBeNull();
+    expect(mockSetCameraError).toHaveBeenCalledWith('');
+  });
+
+  it('camera モードのとき handleRescan で startCamera が呼ばれる', async () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    // scanMode はデフォルトで 'camera'
+    act(() => result.current.handleRescan());
+
+    expect(mockStartCamera).toHaveBeenCalledTimes(1);
+  });
+
+  it('upload モードのとき handleRescan で startCamera は呼ばれない', async () => {
+    const { result } = renderHook(() => useTicketVerification({ pubKeyStr: validPubKeyStr }));
+
+    act(() => result.current.setScanMode('upload'));
+    act(() => result.current.handleRescan());
+
+    expect(mockStartCamera).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/tools/qr-ticket/useTicketGeneration.ts
+++ b/src/components/tools/qr-ticket/useTicketGeneration.ts
@@ -1,0 +1,196 @@
+import { useState, useRef } from 'react';
+import {
+  signTicket,
+  generateQrSvg,
+  ticketToQrString,
+  generateTicketId,
+  estimateTicketByteSize,
+  MAX_QR_BYTE_SIZE,
+  type TicketPayload,
+} from '@/utils/qr-ticket';
+import { downloadSvg } from '@/utils/download';
+import { downloadZip } from '@/utils/zip';
+import { sanitizeFilename, isSafeTicketId } from '@/utils/filename';
+import { MAX_TICKETS } from './constants';
+import type { TicketRow, GeneratedQr } from './types';
+
+export interface UseTicketGenerationOptions {
+  cryptoKeyPair: CryptoKeyPair | null;
+}
+
+export interface UseTicketGenerationReturn {
+  eventId: string;
+  expiry: string;
+  tickets: TicketRow[];
+  generating: boolean;
+  generateError: string;
+  generatedQrs: GeneratedQr[];
+  zipping: boolean;
+  zipError: string;
+  setEventId: (v: string) => void;
+  setExpiry: (v: string) => void;
+  addTicket: () => void;
+  removeTicket: (index: number) => void;
+  updateTicket: (index: number, field: keyof TicketRow, value: string) => void;
+  generate: () => Promise<void>;
+  downloadSvgQr: (qr: GeneratedQr) => void;
+  downloadZipQrs: () => Promise<void>;
+}
+
+/**
+ * QRチケット生成・チケット編集・ZIPダウンロード管理フック。
+ */
+export function useTicketGeneration({
+  cryptoKeyPair,
+}: UseTicketGenerationOptions): UseTicketGenerationReturn {
+  const [eventId, setEventId] = useState('');
+  const [expiry, setExpiry] = useState('');
+  const ticketKeyRef = useRef(1);
+  const [tickets, setTickets] = useState<TicketRow[]>([
+    { _key: 1, id: generateTicketId(1), name: '', category: '' },
+  ]);
+  const [generating, setGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState('');
+  const [generatedQrs, setGeneratedQrs] = useState<GeneratedQr[]>([]);
+  const [zipping, setZipping] = useState(false);
+  const [zipError, setZipError] = useState('');
+
+  const addTicket = () => {
+    if (tickets.length >= MAX_TICKETS) return;
+    ticketKeyRef.current += 1;
+    const newKey = ticketKeyRef.current;
+    setTickets((prev) => [
+      ...prev,
+      { _key: newKey, id: generateTicketId(prev.length + 1), name: '', category: '' },
+    ]);
+  };
+
+  const removeTicket = (index: number) => {
+    setTickets((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const updateTicket = (index: number, field: keyof TicketRow, value: string) => {
+    setTickets((prev) => prev.map((t, i) => (i === index ? { ...t, [field]: value } : t)));
+  };
+
+  const generate = async () => {
+    setGenerateError('');
+
+    if (!cryptoKeyPair) {
+      setGenerateError('先に鍵ペアを生成またはインポートしてください');
+      return;
+    }
+    if (!eventId.trim()) {
+      setGenerateError('イベントIDを入力してください');
+      return;
+    }
+    if (!expiry) {
+      setGenerateError('有効期限を設定してください');
+      return;
+    }
+    if (tickets.length === 0) {
+      setGenerateError('チケットを1件以上追加してください');
+      return;
+    }
+    const emptyId = tickets.find((t) => !t.id.trim());
+    if (emptyId) {
+      setGenerateError('チケットIDが空の行があります');
+      return;
+    }
+    const unsafeIdRow = tickets.find((t) => !isSafeTicketId(t.id.trim()));
+    if (unsafeIdRow) {
+      setGenerateError(
+        'チケットIDは英数字・ピリオド・アンダースコア・ハイフンのみ、64 文字以内で入力してください'
+      );
+      return;
+    }
+
+    const longTicket = tickets.find((t) => {
+      const payload: TicketPayload = {
+        e: eventId.trim(),
+        t: t.id.trim(),
+        timestamp: Math.floor(new Date(expiry).getTime() / 1000),
+        n: t.name.trim() || undefined,
+        p: t.category.trim() || undefined,
+      };
+      return estimateTicketByteSize(payload) > MAX_QR_BYTE_SIZE;
+    });
+
+    if (longTicket) {
+      setGenerateError(
+        `データ量が上限（${MAX_QR_BYTE_SIZE}バイト）を超えているチケットがあります。`
+      );
+      return;
+    }
+
+    setGenerating(true);
+    try {
+      const results: GeneratedQr[] = [];
+      for (const row of tickets) {
+        const payload: TicketPayload = {
+          e: eventId.trim(),
+          t: row.id.trim(),
+          timestamp: Math.floor(new Date(expiry).getTime() / 1000),
+          ...(row.name.trim() ? { n: row.name.trim() } : {}),
+          ...(row.category.trim() ? { p: row.category.trim() } : {}),
+        };
+        const signed = await signTicket(payload, cryptoKeyPair.privateKey);
+        const qrString = ticketToQrString(signed);
+        const svg = generateQrSvg(qrString);
+        if (!svg) {
+          setGenerateError(`チケット ${row.id} のQRコード生成に失敗しました（データが長すぎます）`);
+          setGenerating(false);
+          return;
+        }
+        results.push({ _key: row._key, ticket: signed, svg, qrString });
+      }
+      setGeneratedQrs(results);
+    } catch {
+      setGenerateError('QRコードの生成中にエラーが発生しました');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const downloadSvgQr = (qr: GeneratedQr) => {
+    const safeName = sanitizeFilename(`ticket-${qr.ticket.t}.svg`, ['svg']);
+    downloadSvg(qr.svg.replace('<svg ', '<svg width="160" height="160" '), safeName);
+  };
+
+  const downloadZipQrs = async () => {
+    if (generatedQrs.length === 0 || zipping) return;
+    setZipping(true);
+    setZipError('');
+    try {
+      const files = generatedQrs.map(({ ticket, svg }) => ({
+        name: sanitizeFilename(`ticket-${ticket.t}.svg`, ['svg']),
+        content: svg.replace('<svg ', '<svg width="160" height="160" '),
+        folder: 'tickets',
+      }));
+      await downloadZip(files, 'tickets.zip');
+    } catch {
+      setZipError('ZIPの作成に失敗しました');
+    } finally {
+      setZipping(false);
+    }
+  };
+
+  return {
+    eventId,
+    expiry,
+    tickets,
+    generating,
+    generateError,
+    generatedQrs,
+    zipping,
+    zipError,
+    setEventId,
+    setExpiry,
+    addTicket,
+    removeTicket,
+    updateTicket,
+    generate,
+    downloadSvgQr,
+    downloadZipQrs,
+  };
+}

--- a/src/components/tools/qr-ticket/useTicketKeyPair.ts
+++ b/src/components/tools/qr-ticket/useTicketKeyPair.ts
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import {
+  generateKeyPair,
+  exportKeyPair,
+  importPrivateKey,
+  importPublicKey,
+} from '@/utils/qr-ticket';
+
+export interface TicketKeyPairState {
+  cryptoKeyPair: CryptoKeyPair | null;
+  privateKeyJwkStr: string;
+  publicKeyJwkStr: string;
+  keyGenerating: boolean;
+  keyError: string;
+  showImport: boolean;
+  importStr: string;
+}
+
+export interface TicketKeyPairActions {
+  generateKeys: () => Promise<void>;
+  importKey: () => Promise<void>;
+  toggleImport: () => void;
+  setImportStr: (v: string) => void;
+  /** 鍵生成時に検証タブの公開鍵欄へ伝播させるコールバックを渡すと呼ばれる */
+  onPubKeyGenerated?: (pubKeyStr: string) => void;
+}
+
+export type UseTicketKeyPairReturn = TicketKeyPairState & {
+  generateKeys: () => Promise<void>;
+  importKey: () => Promise<void>;
+  toggleImport: () => void;
+  setImportStr: (v: string) => void;
+};
+
+/**
+ * QRチケット鍵ペア管理フック。
+ * 鍵の生成・インポートに関する状態とロジックを一元管理する。
+ */
+export function useTicketKeyPair(options?: {
+  onPubKeyGenerated?: (pubKeyStr: string) => void;
+}): UseTicketKeyPairReturn {
+  const [cryptoKeyPair, setCryptoKeyPair] = useState<CryptoKeyPair | null>(null);
+  const [privateKeyJwkStr, setPrivateKeyJwkStr] = useState('');
+  const [publicKeyJwkStr, setPublicKeyJwkStr] = useState('');
+  const [keyGenerating, setKeyGenerating] = useState(false);
+  const [keyError, setKeyError] = useState('');
+  const [showImport, setShowImport] = useState(false);
+  const [importStr, setImportStr] = useState('');
+
+  const generateKeys = async () => {
+    setKeyGenerating(true);
+    setKeyError('');
+    try {
+      const pair = await generateKeyPair();
+      const exported = await exportKeyPair(pair);
+      const privStr = JSON.stringify(exported.privateKey, null, 2);
+      const pubStr = JSON.stringify(exported.publicKey, null, 2);
+      setCryptoKeyPair(pair);
+      setPrivateKeyJwkStr(privStr);
+      setPublicKeyJwkStr(pubStr);
+      options?.onPubKeyGenerated?.(pubStr);
+    } catch {
+      setKeyError('鍵の生成に失敗しました');
+    } finally {
+      setKeyGenerating(false);
+    }
+  };
+
+  const importKey = async () => {
+    setKeyError('');
+    let jwk: JsonWebKey;
+    try {
+      jwk = JSON.parse(importStr) as JsonWebKey;
+    } catch {
+      setKeyError('JSON形式が不正です');
+      return;
+    }
+    if (!('d' in jwk)) {
+      setKeyError('これは公開鍵です。秘密鍵（"d" フィールドを含むJWK）を入力してください。');
+      return;
+    }
+    try {
+      const privKey = await importPrivateKey(jwk);
+      // ECDSA JWK から公開鍵部分を抽出（d フィールドを除去）
+      const { d: _d, key_ops: _ops, ...pubJwk } = jwk as Record<string, unknown>;
+      const pubKeyJwk = { ...pubJwk, key_ops: ['verify'] } as JsonWebKey;
+      const pubKey = await importPublicKey(pubKeyJwk);
+      const privStr = JSON.stringify(jwk, null, 2);
+      const pubStr = JSON.stringify(pubKeyJwk, null, 2);
+      setCryptoKeyPair({ privateKey: privKey, publicKey: pubKey });
+      setPrivateKeyJwkStr(privStr);
+      setPublicKeyJwkStr(pubStr);
+      options?.onPubKeyGenerated?.(pubStr);
+      setShowImport(false);
+      setImportStr('');
+    } catch {
+      setKeyError('秘密鍵のインポートに失敗しました。有効なECDSA P-256 JWKを入力してください。');
+    }
+  };
+
+  const toggleImport = () => setShowImport((v) => !v);
+
+  return {
+    cryptoKeyPair,
+    privateKeyJwkStr,
+    publicKeyJwkStr,
+    keyGenerating,
+    keyError,
+    showImport,
+    importStr,
+    generateKeys,
+    importKey,
+    toggleImport,
+    setImportStr,
+  };
+}

--- a/src/components/tools/qr-ticket/useTicketVerification.ts
+++ b/src/components/tools/qr-ticket/useTicketVerification.ts
@@ -1,0 +1,125 @@
+import { useState, useRef, useCallback } from 'react';
+import { importPublicKey, verifyTicket, type VerificationResult } from '@/utils/qr-ticket';
+import { validateFile } from '@/utils/file-validation';
+import { decodeQrFromFile, DEFAULT_QR_MAX_DIM } from '@/utils/qr-reader';
+import { useQrCamera } from '@/hooks/useQrCamera';
+
+export interface UseTicketVerificationOptions {
+  pubKeyStr: string;
+}
+
+export interface UseTicketVerificationReturn {
+  verificationResult: VerificationResult | null;
+  verifying: boolean;
+  scanMode: 'camera' | 'upload';
+  camera: ReturnType<typeof useQrCamera>;
+  setScanMode: (v: 'camera' | 'upload') => void;
+  verify: (rawData: string, signal?: AbortSignal) => Promise<void>;
+  handleImageUpload: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+  handleRescan: () => void;
+}
+
+/**
+ * QRチケット検証フック。
+ * カメラ/画像アップロード経由のQR検証ロジックと状態を管理する。
+ */
+export function useTicketVerification({
+  pubKeyStr,
+}: UseTicketVerificationOptions): UseTicketVerificationReturn {
+  const [verificationResult, setVerificationResult] = useState<VerificationResult | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [scanMode, setScanMode] = useState<'camera' | 'upload'>('camera');
+
+  const uploadAbortRef = useRef<AbortController | null>(null);
+
+  const verify = useCallback(
+    async (rawData: string, signal?: AbortSignal) => {
+      if (signal?.aborted) return;
+      setVerifying(true);
+      let pubKey: CryptoKey;
+      try {
+        const jwk = JSON.parse(pubKeyStr) as JsonWebKey;
+        pubKey = await importPublicKey(jwk);
+      } catch {
+        if (signal?.aborted) return;
+        setVerificationResult({
+          valid: false,
+          ticket: null,
+          expired: false,
+          error: '公開鍵の形式が不正です。有効なECDSA P-256 JWKを貼り付けてください。',
+        });
+        setVerifying(false);
+        return;
+      }
+      const result = await verifyTicket(rawData, pubKey);
+      if (signal?.aborted) return;
+      setVerificationResult(result);
+      setVerifying(false);
+    },
+    [pubKeyStr]
+  );
+
+  const camera = useQrCamera({ onQrDetected: verify });
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+
+    const validation = validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
+    if (!validation.ok) {
+      camera.setCameraError(validation.message);
+      return;
+    }
+
+    camera.setCameraError('');
+    setVerificationResult(null);
+
+    uploadAbortRef.current?.abort();
+    const controller = new AbortController();
+    uploadAbortRef.current = controller;
+    let result;
+    try {
+      result = await decodeQrFromFile(file, {
+        maxDim: DEFAULT_QR_MAX_DIM,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      camera.setCameraError('画像を読み込めませんでした');
+      return;
+    }
+
+    if (!result.ok) {
+      if (result.reason === 'load-error') {
+        camera.setCameraError('画像を読み込めませんでした');
+      } else {
+        setVerificationResult({
+          valid: false,
+          ticket: null,
+          expired: false,
+          error: 'QRコードが見つかりませんでした',
+        });
+      }
+      return;
+    }
+    await verify(result.data, controller.signal);
+  };
+
+  const handleRescan = () => {
+    setVerificationResult(null);
+    camera.setCameraError('');
+    if (scanMode === 'camera') camera.startCamera();
+  };
+
+  return {
+    verificationResult,
+    verifying,
+    scanMode,
+    camera,
+    setScanMode,
+    verify,
+    handleImageUpload,
+    handleRescan,
+  };
+}


### PR DESCRIPTION
## 概要

#167 のうち QrTicket の責務分割を対応。EncodingConverter の useMemo 化は #217 で対応済。

## 背景

\`src/components/tools/QrTicket.tsx\` は 398 行に肥大化し、以下の問題があった:

- **19 個の \`useState\`** が同一コンポーネントに並ぶ
- 鍵操作 / チケット編集 / QR 生成 / ZIP / 検証 が同居
- \`GenerateTab\` への props は **22 個** のフラットな bucket relay
- 状態が論理的に「鍵 / 生成 / 検証」3 ドメインにまたがり、不整合状態を作り込みやすい

## 改修内容

### 3 ドメインフックに分離

| 新設 hook | 責務 |
|---|---|
| \`src/components/tools/qr-ticket/useTicketKeyPair.ts\` | 鍵生成・インポート・関連 state |
| \`src/components/tools/qr-ticket/useTicketGeneration.ts\` | チケット編集・QR 生成・ZIP ダウンロード |
| \`src/components/tools/qr-ticket/useTicketVerification.ts\` | QR 検証・カメラ管理 |

### \`QrTicket.tsx\` の縮小

- 398 行 → 上記 3 hook を呼び出して合成するだけのコンテナに
- 19 個の \`useState\` が hook 内に集約され、コンテナ側の state は最小限に

### \`GenerateTab\` props 削減

- **実装前**: 22 個のフラット props（\`cryptoKeyPair\` / \`privateKeyJwkStr\` / ... / \`onDownloadZip\`）
- **実装後**: 2 個のオブジェクト props（\`keyPair\` / \`generation\`）
- 各オブジェクトはドメイン hook の戻り値そのままで、可読性の高いオブジェクトリテラル形式の props 渡しに

### 単体テスト追加

新規 \`src/components/tools/qr-ticket/__tests__/\` 配下:

- \`useTicketKeyPair.test.tsx\`: 9 ケース（鍵生成・インポート）
- \`useTicketGeneration.test.tsx\`: 14 ケース（チケット編集・QR 生成・ZIP）
- \`useTicketVerification.test.tsx\`: 12 ケース（正常検証・改竄検出・画像アップロード経路）
- 計 35 ケース新規追加

## 検証

- \`npm run test\`: 424 → **459** 件、全件緑（+35）
- \`astro check\`: 0 errors / 0 warnings
- \`npm run test:e2e\`: 142 passed / 1 skipped、全件緑（58.9s）
- \`aria-*\` / \`role=\` の削除なし

## フォローアップ

- #225: GenerateTab props の useMemo 安定化 + verify signal の camera 経路への伝播 (本 PR review で指摘された軽微な改善 2 件)
- #224: \`|\` 含有時の専用エラーメッセージ追加 (本 PR merge 後着手、PR #218 review で指摘された UX 改善)

## 関連

- close #167（EncodingConverter は #217 で完了、本 PR で QrTicket 完了）
- ref #216（qrcode-generator 副作用 import 解消、本 PR とは独立）