### PR TITLE
fix(qr-ticket): generate にフィールド | 含有の事前 validation を追加 (#224)

### DIFF
--- a/src/components/tools/qr-ticket/__tests__/useTicketGeneration.test.tsx
+++ b/src/components/tools/qr-ticket/__tests__/useTicketGeneration.test.tsx
@@ -152,6 +152,92 @@ describe('useTicketGeneration — generate', () => {
     expect(result.current.generatedQrs[0].svg).toBe('<svg>dummy</svg>');
   });
 
+  it('eventId に | が含まれる場合は専用エラーメッセージがセットされる', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event|test');
+      result.current.setExpiry('2099-12-31T23:59');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('イベントIDに | を含めることはできません');
+    expect(result.current.generateError).toContain('別の記号に置き換えてください');
+    expect(result.current.generatedQrs).toHaveLength(0);
+  });
+
+  it('チケットIDに | が含まれる場合は専用エラーメッセージがセットされる', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+      result.current.updateTicket(0, 'id', 'T-00001|x');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('チケットIDに | を含めることはできません');
+    expect(result.current.generatedQrs).toHaveLength(0);
+  });
+
+  it('参加者名に | が含まれる場合は専用エラーメッセージがセットされる', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+      result.current.updateTicket(0, 'name', '山田|太郎');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('参加者名に | を含めることはできません');
+    expect(result.current.generatedQrs).toHaveLength(0);
+  });
+
+  it('料金区分に | が含まれる場合は専用エラーメッセージがセットされる', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+      result.current.updateTicket(0, 'category', '一般|学生');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toContain('料金区分に | を含めることはできません');
+    expect(result.current.generatedQrs).toHaveLength(0);
+  });
+
+  it('| を含まない正常な入力では | 専用エラーは発生しない', async () => {
+    const { result } = renderHook(() => useTicketGeneration({ cryptoKeyPair: mockCryptoKeyPair }));
+
+    act(() => {
+      result.current.setEventId('event-test');
+      result.current.setExpiry('2099-12-31T23:59');
+      result.current.updateTicket(0, 'name', '山田 太郎');
+      result.current.updateTicket(0, 'category', '一般');
+    });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.generateError).toBe('');
+    expect(result.current.generatedQrs).toHaveLength(1);
+  });
+
   it('generateQrSvg が null を返すとエラーメッセージがセットされる', async () => {
     const { generateQrSvg } = await import('@/utils/qr-ticket');
     vi.mocked(generateQrSvg).mockReturnValueOnce(null);

--- a/src/components/tools/qr-ticket/useTicketGeneration.ts
+++ b/src/components/tools/qr-ticket/useTicketGeneration.ts
@@ -92,6 +92,36 @@ export function useTicketGeneration({
       setGenerateError('チケットを1件以上追加してください');
       return;
     }
+
+    // | 含有チェック: eventId
+    if (eventId.includes('|')) {
+      setGenerateError(
+        'イベントIDに | を含めることはできません。半角 | を別の記号に置き換えてください'
+      );
+      return;
+    }
+    // | 含有チェック: 各チケットフィールド
+    for (const row of tickets) {
+      if (row.id.includes('|')) {
+        setGenerateError(
+          'チケットIDに | を含めることはできません。半角 | を別の記号に置き換えてください'
+        );
+        return;
+      }
+      if (row.name.includes('|')) {
+        setGenerateError(
+          '参加者名に | を含めることはできません。半角 | を別の記号に置き換えてください'
+        );
+        return;
+      }
+      if (row.category.includes('|')) {
+        setGenerateError(
+          '料金区分に | を含めることはできません。半角 | を別の記号に置き換えてください'
+        );
+        return;
+      }
+    }
+
     const emptyId = tickets.find((t) => !t.id.trim());
     if (emptyId) {
       setGenerateError('チケットIDが空の行があります');


### PR DESCRIPTION
## 概要

issue #224 (PR #218 review で指摘された UX 改善 (a)) を対応。\`sanitizeField\` の throw 化により発生していた「\`|\` 入力時に汎用エラーで原因が分からない」UX 劣化を解消する。

## 背景

PR #218 で \`src/utils/qr-ticket.ts\` の \`sanitizeField\` を「\`|\` 含有時 throw する validation」に方針変更した。これにより \`|\` を含む値が \`serializeTicket\` 経由で渡された場合、従来は半角スペース silent 置換だったところが throw に変わる。

しかし \`useTicketGeneration\` の \`generate\` 関数は汎用 try/catch で「QRコードの生成中にエラーが発生しました」と表示していたため、\`|\` 入力時の原因がユーザーに伝わらなかった。

PR #221 (\`QrTicket\` 3 hook 分割) merge 済の develop ベースで、新 \`useTicketGeneration\` フック内に事前 validation を追加する。

## 改修内容

\`src/components/tools/qr-ticket/useTicketGeneration.ts\` の \`generate\` 関数冒頭に事前 validation を追加。

- 各 PAYLOAD フィールド (eventId / チケットID / 参加者名 / 料金区分) を走査
- いずれかに \`|\` (U+007C) が含まれていたら、\`signTicket\` / \`buildPayload\` / \`sanitizeField\` に到達する前に **フィールド名付きの専用エラーメッセージ** を \`setGenerateError\` で表示し early return

採用したエラー文言 (フィールド名付き):
- \`イベントIDに | を含めることはできません。半角 | を別の記号に置き換えてください\`
- \`チケットIDに | を含めることはできません。半角 | を別の記号に置き換えてください\`
- \`参加者名に | を含めることはできません。半角 | を別の記号に置き換えてください\`
- \`料金区分に | を含めることはできません。半角 | を別の記号に置き換えてください\`

汎用メッセージではなくフィールド名付きを採用した理由は、ユーザーが問題箇所を即座に特定できるため UX が高い。既存エラーメッセージのスタイル（\`イベントIDを入力してください\`）に合わせて句点なしで統一。

## テスト追加

\`src/components/tools/qr-ticket/__tests__/useTicketGeneration.test.tsx\` に 5 ケース追加:

1. eventId に \`|\` を含む場合の専用メッセージ
2. チケット ID に \`|\` を含む場合の専用メッセージ
3. 参加者名に \`|\` を含む場合の専用メッセージ
4. 料金区分に \`|\` を含む場合の専用メッセージ
5. \`|\` を含まない正常フローが従来通り通ることの確認

## 検証

- \`npm run test\`: 511 → **516** 件、全件緑（+5）
- \`astro check\`: 0 errors / 0 warnings
- \`npm run test:e2e\`: 142 passed / 1 skipped、全件緑
- \`aria-*\` / \`role=\` の削除なし

## 関連 issue

- close #224
- PR #218 (\`sanitizeField\` throw 化、本 PR は UX 改善 (a) の実装)
- PR #221 (QrTicket 3 hook 分割、本 PR は merge 後着手)