### PR TITLE
docs(rules): shared-agent-rules.md の要約セクションに SSOT 明示マーカー追加 (#242 A)

### DIFF
--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -42,6 +42,8 @@
 
 ## 3. 実装後の検証義務（要点）
 
+> **正本**: `docs/playbooks/e2e-validation.md`（このセクションは要約。手順を変更する場合は playbook 側を先に編集すること）
+
 **E2E テストは実装と同時に書く**: バグ修正・UI 挙動の変更時はコミット前に該当ケースの E2E を追加する。後回し禁止。
 
 **push 前に必須**: `npm run test`（ユニット）／ `node_modules/.bin/astro check`（型）／ `npm run test:e2e`（E2E）。
@@ -87,6 +89,8 @@ post-PR 代行は不要、CI が最終ゲート。
 `gh` コマンドで複数行・バックティック（\`）を含む本文を渡すときは、**直接引数に渡さず一時ファイル経由で投稿すること**。具体的には `-F`または`--body-file` オプションを使用する（MCP / API 経由は不要）。失敗時は投稿状況を必ず確認し、重複は削除して整合性を保つ。
 
 ### 6.2 ブランチ運用（要点）
+
+> **正本**: `docs/playbooks/pr-creation.md` 1〜2 章（このセクションは要約。手順を変更する場合は playbook 側を先に編集すること）
 
 - **`develop` には直接コミットしない**: 必ず feature ブランチを切る。誤って始めた場合は `git stash` → ブランチ切替 → `git stash pop`。
 - **新規作業の手順**: `git checkout develop` → `git pull origin develop` → `git checkout -b <type>/<slug>`（例: `feat/add-tool`, `fix/issue-123-crash`）。issue がある場合は `<type>/issue-<n>-<slug>` 形式を推奨。


### PR DESCRIPTION
issue #242 の A 項目（SSOT 明示）対応。

## 背景

PR #240 で `docs/shared-agent-rules.md` の一部章を `docs/playbooks/` に切り出し、shared-agent-rules.md 側には「要点 + 詳細リンク」を残す構成にした。PR #240 のレビューで、この設計には次のドリフトリスクが指摘された:

- `shared-agent-rules.md` 3 章（要点）と `docs/playbooks/e2e-validation.md`
- `shared-agent-rules.md` 6.2 章（要点）と `docs/playbooks/pr-creation.md` 1〜2 章

同じ内容が要約と詳細の二箇所に存在するため、片方だけ更新されてドリフトする可能性。issue #242 で対応方針 (A: SSOT 明示 / B: 参照チェッカ機械化) を整理した。

## 変更内容

`shared-agent-rules.md` の該当 2 セクションの冒頭に reviewer 提案の「正本」マーカー（引用ブロック）を挿入:

```markdown
## 3. 実装後の検証義務（要点）

> **正本**: `docs/playbooks/e2e-validation.md`（このセクションは要約。手順を変更する場合は playbook 側を先に編集すること）
```

これで編集者は「playbook 側を先に編集する」ルールに気付き、ドリフト発生を抑止できる。

## 対象セクション一覧

| セクション | SSOT 明示 | 理由 |
| --- | --- | --- |
| 3 章「実装後の検証義務（要点）」 | **追加** | playbook 側に詳細あり、典型的な要約 / 正本構造 |
| 6.2 章「ブランチ運用（要点）」 | **追加** | 同上 |
| 6.3 章「PR 作成時のベースブランチ」 | **スキップ** | 4 行のルール本体（`--base develop` 必須）が SSOT 自体。playbook は別レイヤの手順詳細で二重管理ではない |
| 7 章末尾「スタイル・UI ルール（基本）」 | **スキップ** | reviewer も「要検討」。Tailwind 禁止 + 目視確認義務はここが SSOT、ui-conventions.md は実装パターン詳細で別レイヤ |

## テスト

ドキュメントのみの変更。pre-commit hook の Prettier / TypeScript 型チェック pass。CI で test + e2e が回る。

## 残タスク

issue #242 の B 項目「参照チェッカ機械化」は別 PR で対応予定（ツール設計が必要なため分離）。

## 関連

- issue #242（本 PR で part 対応）
- PR #240 のレビューコメント（指摘元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
