### PR TITLE
test(e2e): playwright webServer を process.env.CI で分岐 (#248)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2357,7 +2357,7 @@ XSS sink への inline script 注入 (`<script>maliciousCode()</script>`) を考
 
 ### 関連 PR / issue
 
-- 本 PR: 実装時に番号置換
+- 本 PR: [#249](https://github.com/fumtas1k/devtools/pull/249)
 - 解消する issue: [#176](https://github.com/fumtas1k/devtools/issues/176)（A-1 完了）
 - 前提依存: [063]（E2E preview 切替）／[061]（CSP 違反 CI 検知ゲート）／[054]（CSP 初導入）
 - 後続: [#176](https://github.com/fumtas1k/devtools/issues/176) の B 案（`style-src 'unsafe-inline'` 削減）
@@ -2392,7 +2392,7 @@ PR #247 セルフレビューの I-2 / I-3 として #248 に分離し別 PR で
 
 ### 関連 PR / issue
 
-- 本 PR: 実装時に番号置換
+- 本 PR: [#251](https://github.com/fumtas1k/devtools/pull/251)
 - 解消する issue: [#248](https://github.com/fumtas1k/devtools/issues/248)
 - 起源: PR #247 セルフレビュー I-2 / I-3
 - 関連: [063]（preview 切替）

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2361,3 +2361,38 @@ XSS sink への inline script 注入 (`<script>maliciousCode()</script>`) を考
 - 解消する issue: [#176](https://github.com/fumtas1k/devtools/issues/176)（A-1 完了）
 - 前提依存: [063]（E2E preview 切替）／[061]（CSP 違反 CI 検知ゲート）／[054]（CSP 初導入）
 - 後続: [#176](https://github.com/fumtas1k/devtools/issues/176) の B 案（`style-src 'unsafe-inline'` 削減）
+
+---
+
+## [065] 2026-05-03 — Playwright `webServer` を `process.env.CI` で分岐
+
+**2026-05-03 | ステータス: 採用**
+
+### 背景
+
+[063] で `webServer.command` を `npm run build && npm run preview ...` に切替えた際、`.github/workflows/test.yml` 側でも `npm run build` step を追加したため **CI で build が 2 回走る**構成になっていた（webServer 内 build は incremental cache で軽いとはいえ wasteful、CI ログ可読性も悪化）。加えて `reuseExistingServer: true` + preview の組み合わせで、ローカルで開発者が手動 `npm run preview` を起動したまま `npm run test:e2e` を回すと **古い `dist/` に対して E2E が silent pass** する罠が発生する（dev 時代は HMR で吸収されていた）。
+
+PR #247 セルフレビューの I-2 / I-3 として #248 に分離し別 PR で対応することにした。
+
+### 決断
+
+`playwright.config.ts:webServer` を `process.env.CI` で分岐する:
+
+- **CI**: `command: 'npm run preview -- --port 4321'`（事前 step で build 済み）、`timeout: 30_000`（preview 起動は瞬時、env 由来失敗を早期検知）、`reuseExistingServer: true`（fresh runner なので影響なし）
+- **Local**: `command: 'npm run build && npm run preview ...'`（build 忘れの safety net）、`timeout: 120_000`（build 時間込み）、`reuseExistingServer: false`（毎回新規 build/preview で stale dist trap を回避）
+
+ローカルで毎回 build が走るのは incremental cache で 2 回目以降数秒、開発体験への影響は軽微。
+
+### 影響 / 移行
+
+- **CI 実行時間**: build の重複実行がなくなり ~25s 短縮（cold start で計測）
+- **ローカル開発**: `npm run test:e2e` 実行ごとに incremental build が走る。手動 preview を別途起動した状態での E2E は port 衝突で失敗するため、`npm run pretest:e2e` で port 解放してから実行
+- **fail-fast**: CI の env 由来失敗（webServer 起動不可等）が 30s で確定
+- **後続作業**: なし（独立完結）
+
+### 関連 PR / issue
+
+- 本 PR: 実装時に番号置換
+- 解消する issue: [#248](https://github.com/fumtas1k/devtools/issues/248)
+- 起源: PR #247 セルフレビュー I-2 / I-3
+- 関連: [063]（preview 切替）

--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -13,7 +13,7 @@
 - 本番 (Cloudflare Pages) のビルド成果物に対して E2E を回し、prod-parity を確保するため（`docs/decisions.md` [063]）。後続 [#176](https://github.com/fumtas1k/devtools/issues/176) 採用時には `<meta>` ベース CSP も生成されるため、その評価基盤を先回りで整備する位置付けでもある
 - Astro の `security.csp` 機能は dev mode で動作せず build/preview のみで有効（[公式 docs](https://docs.astro.build/en/reference/configuration-reference/#securitycsp)）
 
-`webServer.timeout` は build 時間を含むため 120s に延長してある（cold start でも収まる余裕）。
+`webServer.timeout` は CI で 30s / Local で 120s（[#248] で `process.env.CI` 分岐に変更）。CI では `.github/workflows/test.yml` 側で事前 build 済みのため preview 起動の早期検知に倒し、Local は build 込みのため余裕を持たせている。
 
 ---
 
@@ -67,7 +67,7 @@ PR 作成手順を含むため `docs/playbooks/pr-creation.md` 3 章を参照。
 - **環境由来の失敗**（`waitForReactHydration` timeout、`Error: connect ECONNREFUSED 127.0.0.1:4321`、`Timed out waiting for server to start`、`webServer was not ready` 等）→ ステップ 0 の整地と `npm run build` が成功するかの確認を実施してから 1 回だけ再実行
 - 再実行でも環境由来失敗が続く場合 → **CI を最終判断とする**（push して CI 結果を待つ）
 
-> 補足: `playwright.config.ts` の `webServer.timeout` は 120s（#246 で 30s → 120s に延長。build 時間込み）。env 由来失敗の発見はこのタイムアウトで早期に確定する。
+> 補足: `playwright.config.ts` の `webServer.timeout` は CI で 30s / Local で 120s（[#248] で `process.env.CI` 分岐に変更）。CI では `.github/workflows/test.yml` 側で事前 build 済みのため preview 起動の早期検知に倒し、Local は build 込みのため余裕を持たせている。env 由来失敗の発見は CI のタイムアウトで早期に確定する。
 
 > macOS/Linux 前提。Windows/WSL では別手段（`netstat -ano` + `taskkill` 等）が必要。
 
@@ -77,14 +77,14 @@ PR 作成手順を含むため `docs/playbooks/pr-creation.md` 3 章を参照。
 
 ## 5. コマンドリファレンス（抜粋）
 
-| 用途                       | コマンド                                                                              |
-| :------------------------- | :------------------------------------------------------------------------------------ |
-| ユニットテスト             | `npm run test` / `npm run test:watch`                                                 |
-| 型チェック                 | `node_modules/.bin/astro check`                                                       |
-| 型チェック（特定ファイル） | `npx astro check --filter <file>`                                                     |
-| E2E テスト                 | `npm run test:e2e` ❌ `npm run e2e` は存在しない（内部で build + preview を直列起動） |
-| node_modules 整備          | `npm ci`                                                                              |
-| port 4321 解放             | `npm run pretest:e2e`                                                                 |
+| 用途                       | コマンド                                                                                                                             |
+| :------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| ユニットテスト             | `npm run test` / `npm run test:watch`                                                                                                |
+| 型チェック                 | `node_modules/.bin/astro check`                                                                                                      |
+| 型チェック（特定ファイル） | `npx astro check --filter <file>`                                                                                                    |
+| E2E テスト                 | `npm run test:e2e` ❌ `npm run e2e` は存在しない（local では内部で build + preview を直列起動。CI は事前 build 済みで preview のみ） |
+| node_modules 整備          | `npm ci`                                                                                                                             |
+| port 4321 解放             | `npm run pretest:e2e`                                                                                                                |
 
 ---
 
@@ -101,6 +101,11 @@ npm run pretest:e2e   # 既存 npm script。中身は lsof -ti:4321 | xargs kill
 ```
 
 `npm run test:e2e` は pre-hook で自動実行するので、通常は気にしなくて良い。手動で kill だけしたい時に使う。
+
+> Local では `reuseExistingServer: false`（[#248]）に変更したため、開発者が手動で
+> `npm run preview` を別途起動した状態で `npm run test:e2e` を回すと、Playwright は
+> 既存 server を再利用せず port 4321 を新規 bind しようとして衝突する。手動 preview を
+> 終了してから E2E を回すか、`npm run pretest:e2e` で port を解放する。
 
 ### 6.2 node_modules が壊れて `npm ci` が EPERM で失敗する
 

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -81,6 +81,25 @@ gh pr create --base develop --title "..." --body-file "$TMPDIR/pr_body.md"
 - バックティック含有時は `-F` / `--body-file` 経由で投稿（`docs/shared-agent-rules.md` 6.1）。
 - 一時ファイルは `$TMPDIR` か `/tmp/claude/` 配下に置く（`Write(/tmp/claude/**)` は allow、`Write(/tmp/**)` は ask）。
 
+### 4.1 `decisions.md` の `本 PR:` 行は PR 作成直後に番号置換する
+
+新規エントリ追加時に `本 PR: 実装時に番号置換` のような placeholder を残しておくと、PR がマージされた後に永続的な記録（`docs/decisions.md`）から本 PR を辿れなくなる。**`gh pr create` で PR 番号が確定した直後に、未 push の修正 commit として置換する** こと。
+
+```bash
+# PR 作成
+PR_URL=$(gh pr create --base develop --title "..." --body-file "$TMPDIR/pr_body.md")
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+# decisions.md の placeholder を即時置換
+sed -i.bak "s|本 PR: 実装時に番号置換|本 PR: [#${PR_NUM}](${PR_URL})|" docs/decisions.md
+rm docs/decisions.md.bak
+
+git add docs/decisions.md && git commit -m "docs(decisions): [NNN] 関連 PR 番号 (#${PR_NUM}) を置換"
+git push
+```
+
+過去 PR で残置した placeholder（`grep -n "実装時に番号置換" docs/decisions.md` で検出可能）が見つかったら次回触る PR で retrofit する運用とする（採用根拠: [065] PR #251 レビュー M-1）。
+
 ---
 
 ## 5. 親向けレビュー取得手順（取りこぼし防止）

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,14 +21,22 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    // #246: security.csp の `<meta>` を含めた本番相当 CSP を E2E で評価するため
-    // dev server ではなく `astro build` 後の `dist/` を `astro preview` で配信する。
-    // build はキャッシュが効くと数秒、cold でも 15〜25s 程度。preview 起動は瞬時。
-    command: 'npm run build && npm run preview -- --port 4321',
-    url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4321',
-    // build 時間を含むため 30s → 120s に延長（cold start でも収まる余裕）
-    timeout: 120_000,
-    reuseExistingServer: true,
-  },
+  webServer: (() => {
+    // #248: CI と local で webServer 設定を分ける
+    // - CI: `.github/workflows/test.yml` が事前に `npm run build` を走らせるため
+    //   webServer は preview だけで十分。timeout は 30s（fail-fast、env 由来失敗の早期検知）。
+    // - Local: build → preview を直列起動して safety net。`reuseExistingServer: false`
+    //   で毎回新規 build/preview し stale dist による silent pass を防ぐ。
+    //   incremental cache が効くため 2 回目以降の build は数秒。
+    // 採用根拠: docs/decisions.md [063] / [065]
+    const isCI = !!process.env.CI;
+    return {
+      command: isCI
+        ? 'npm run preview -- --port 4321'
+        : 'npm run build && npm run preview -- --port 4321',
+      url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4321',
+      timeout: isCI ? 30_000 : 120_000,
+      reuseExistingServer: !isCI,
+    };
+  })(),
 });


### PR DESCRIPTION
## 概要

#248 解消。`playwright.config.ts:webServer` を `process.env.CI` で分岐し、(a) CI で `npm run build` が二重実行されていた wasteful 構成を解消、(b) ローカルの `reuseExistingServer: true` × preview による stale dist silent pass の罠を防止。

PR #247 のセルフレビュー I-2 / I-3 を follow-up issue として分離した実装。

詳細: `docs/decisions.md` [065]

## 主な変更

### `playwright.config.ts`

`webServer` を IIFE で `process.env.CI` 分岐に書き換え:

| 観点 | CI | Local |
|---|---|---|
| `command` | `npm run preview -- --port 4321` | `npm run build && npm run preview -- --port 4321` |
| `timeout` | `30_000`（preview 起動瞬時、env 由来失敗を fail-fast 検知） | `120_000`（build 時間込み） |
| `reuseExistingServer` | `true`（fresh runner、影響なし） | `false`（stale dist trap 回避、毎回 fresh build） |

CI 側で build 重複が消え、ローカル側で incremental cache が効くため開発体験への影響は軽微（2 回目以降の build は数秒）。

### `docs/playbooks/e2e-validation.md`

- 0 章末尾: `webServer.timeout` 説明を CI 30s / local 120s 分岐に更新
- 4 章: env 由来失敗の補足を CI 30s 早期検知前提に更新
- 5 章コマンドリファレンス: E2E 行に CI/local の挙動差を明記
- 6.1 章: `reuseExistingServer: false` 化に伴う「手動 `npm run preview` を別途起動した状態での E2E は port 衝突する」注意を追記

### `docs/decisions.md` [065]

新規エントリ追加（背景・決断・影響・関連）。[063] の preview 切替経緯と紐付け。

## 検証

| ゲート | 結果 |
|---|---|
| `npm run test`（unit, 41 files） | 578 passed |
| `node_modules/.bin/astro check`（168 files） | 0 errors / 0 warnings |
| `npm run test -- tests/meta/docs-section-references.test.ts` | 7 / 7 pass |
| `npm run test:e2e`（local mode） | 144 passed / 1 skipped (既存) / 0 failed、1.3m |
| `CI=1 npm run test:e2e`（CI mode、事前 build 済み） | 144 passed / 1 skipped / 0 failed、1.2m |
| aria 削除 diff | OK |

CI 1.2m vs Local 1.3m — CI モードは preview のみで build を skip するため約 6% 高速（実機計測。実 CI でも build 重複削除 ~25s 短縮見込み）。

## 確認観点

- [x] CI 全 green
- [ ] CI mode (preview only / 30s timeout) が安定
- [ ] Local mode (build + preview / 120s timeout) が従来同等の挙動
- [ ] `reuseExistingServer: false` の port 衝突注意が docs に反映

## 関連

- 解消する issue: #248
- 起源: PR #247 セルフレビュー I-2 / I-3
- 関連エントリ: `docs/decisions.md` [063] / [065]
