### PR TITLE
test(security): meta-csp 全ページ glob + astro.config 陽性対照 + defensive replace 維持テスト (#250)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: フォーマットチェックを実行
         run: npm run format:check
 
+      - name: 本番相当アセットを build（meta-csp.test.ts が dist/ を入力とするため必要 / #250）
+        run: npm run build
+
       - name: テストとカバレッジ測定を実行
         run: npm test -- --coverage
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -52,7 +52,11 @@ function stripMetaStyleSrc() {
               .replace(/\s+/g, ' ');
             // 元の attributes 文字列内で content="..." だけを書き換える
             const newAttrs = attrs.replace(/\bcontent\s*=\s*"[^"]*"/i, `content="${stripped}"`);
-            return full.replace(attrs, newAttrs);
+            // #250: String.prototype.replace(string, string) の semantics で
+            // newAttrs 内の $& / $1 / $$ などが特殊置換パターンとして解釈される
+            // のを避けるため callback 形式で渡す。CSP 値に $ が含まれる可能性は
+            // 実質ゼロだが防御的に対処（PR #249 レビュー補足）。
+            return full.replace(attrs, () => newAttrs);
           });
           if (modified !== content) {
             try {

--- a/src/utils/__tests__/astro-config-csp.test.ts
+++ b/src/utils/__tests__/astro-config-csp.test.ts
@@ -50,6 +50,8 @@ describe('astro.config.mjs の CSP 関連設定（#176 A-1 / [064] 陽性対照 
     // String.prototype.replace(string, string) の semantics で第二引数が string だと
     // $&/$1/$$ などが特殊解釈される。CSP 値に $ が混入した場合の安全網として
     // callback 形式 (() => newAttrs) で渡す実装を維持する。
-    expect(ASTRO_CONFIG_CONTENT).toMatch(/full\.replace\(attrs,\s*\(\)\s*=>\s*newAttrs\)/);
+    // 変数名 (attrs / newAttrs 等) には bind せず、`X.replace(Y, () => Z)` の callback パターンが使われていることだけを assert。
+    // 将来 stripMetaStyleSrc 内で変数 rename されてもテストは追従する。
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/\.replace\([^,]+,\s*\(\)\s*=>\s*\w+\)/);
   });
 });

--- a/src/utils/__tests__/astro-config-csp.test.ts
+++ b/src/utils/__tests__/astro-config-csp.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * `astro.config.mjs` から `security.csp` 設定が削除されると `<meta>` CSP が
+ * 出力されず、`<meta>` strict layer + `_headers` permissive layer の AND 評価
+ * 設計（[064]）の前提が崩れる。
+ *
+ * 本テストは `astro.config.mjs` を文字列として読み込み、必須要素の存在を
+ * 直接 assert することで設定削除を CI で即時検知する陽性対照ゲート。
+ *
+ * 同種の検知は `meta-csp.test.ts` でも `<meta>` 不在として間接的に検出されるが、
+ * 本テストは「config レベルで何が壊れたか」を明示するために併設する。
+ *
+ * 参照: docs/decisions.md [064]、メモリ feedback_positive_control_for_gates.md
+ *
+ * #250 I-3 / PR #249 レビュー M (defensive replace callback 形式) 対応。
+ */
+
+const ASTRO_CONFIG_PATH = path.resolve(process.cwd(), 'astro.config.mjs');
+const ASTRO_CONFIG_CONTENT = readFileSync(ASTRO_CONFIG_PATH, 'utf-8');
+
+describe('astro.config.mjs の CSP 関連設定（#176 A-1 / [064] 陽性対照 / #250 I-3）', () => {
+  it('`security` ブロックが存在する', () => {
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/security\s*:\s*\{/);
+  });
+
+  it('`security.csp` ブロックが存在する', () => {
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/csp\s*:\s*\{/);
+  });
+
+  it("`security.csp.algorithm` が 'SHA-256' に設定されている", () => {
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/algorithm\s*:\s*['"]SHA-256['"]/);
+  });
+
+  it('`stripMetaStyleSrc()` integration が integrations 配列に含まれる', () => {
+    // <meta> CSP の style-src は CSP3 の hash + unsafe-inline 共存制約により
+    // strip integration で削除する設計。integration 関数自体の定義と
+    // integrations 配列での呼び出しの両方を確認。
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/function\s+stripMetaStyleSrc\s*\(/);
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/stripMetaStyleSrc\s*\(\s*\)/);
+  });
+
+  it('`vite.build.assetsInlineLimit` が 0 に設定されている (data:font CSP 違反防止 / [063])', () => {
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/assetsInlineLimit\s*:\s*0/);
+  });
+
+  it('stripMetaStyleSrc の full.replace は callback 形式で $ 特殊解釈を回避している (PR #249 review M / #250)', () => {
+    // String.prototype.replace(string, string) の semantics で第二引数が string だと
+    // $&/$1/$$ などが特殊解釈される。CSP 値に $ が混入した場合の安全網として
+    // callback 形式 (() => newAttrs) で渡す実装を維持する。
+    expect(ASTRO_CONFIG_CONTENT).toMatch(/full\.replace\(attrs,\s*\(\)\s*=>\s*newAttrs\)/);
+  });
+});

--- a/src/utils/__tests__/meta-csp.test.ts
+++ b/src/utils/__tests__/meta-csp.test.ts
@@ -16,7 +16,8 @@ import path from 'node:path';
  * と合わせて行う）。本テストでは style-src の不在も検証する。
  *
  * 本テストは built dist/ を入力とするため、`npm run build` 後でないと走らない。
- * CI の e2e job では既に build step があるためその前後に走らせれば pass する。
+ * CI の test job では `npm run build` step を先に走らせる構成（`.github/workflows/test.yml` / #250 で追加）。
+ * dist 不在時は `it.skip` で safe-fail するが、CI で skip 化が起きた場合は test job の build step 抜けを疑うこと。
  *
  * #250: DIST_PAGES を 2 ページ固定から dist/**\/*.html 全件の glob に拡張。
  * 将来ページ固有の inline script が追加された場合も自動で検出網に含まれる。

--- a/src/utils/__tests__/meta-csp.test.ts
+++ b/src/utils/__tests__/meta-csp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
+import { glob } from 'node:fs/promises';
 import path from 'node:path';
 
 /**
@@ -16,27 +17,38 @@ import path from 'node:path';
  *
  * 本テストは built dist/ を入力とするため、`npm run build` 後でないと走らない。
  * CI の e2e job では既に build step があるためその前後に走らせれば pass する。
+ *
+ * #250: DIST_PAGES を 2 ページ固定から dist/**\/*.html 全件の glob に拡張。
+ * 将来ページ固有の inline script が追加された場合も自動で検出網に含まれる。
  */
 
-const DIST_PAGES = [
-  path.resolve(process.cwd(), 'dist', 'index.html'),
-  path.resolve(process.cwd(), 'dist', 'tools', 'qr-code', 'index.html'),
-];
-
+const DIST_DIR = path.resolve(process.cwd(), 'dist');
 const META_CSP_REGEX = /<meta[^>]*http-equiv="content-security-policy"[^>]*content="([^"]+)"/i;
 
-describe('dist/*.html の <meta> CSP（Astro security.csp 由来 / #176 A-1）', () => {
-  for (const distPage of DIST_PAGES) {
+// top-level await: vitest は vite-node 経由で ESM として実行されるため利用可能。
+// dist が無い場合 (build 前) は空配列のまま skip フローに進む。
+const distPages: string[] = [];
+if (existsSync(DIST_DIR)) {
+  for await (const f of glob('**/*.html', { cwd: DIST_DIR })) {
+    distPages.push(`${DIST_DIR}/${f}`);
+  }
+  distPages.sort();
+}
+
+describe('dist/*.html の <meta> CSP（Astro security.csp 由来 / #176 A-1 / #250 全ページ拡張）', () => {
+  if (distPages.length === 0) {
+    it.skip("dist/*.html が無い → 'npm run build' 後に再実行", () => {});
+    return;
+  }
+
+  it(`build 出力の HTML 全ページ (${distPages.length} 件) を検査対象とする`, () => {
+    expect(distPages.length).toBeGreaterThan(0);
+  });
+
+  for (const distPage of distPages) {
     const pageRel = path.relative(process.cwd(), distPage);
 
     describe(pageRel, () => {
-      if (!existsSync(distPage)) {
-        it.skip(`${pageRel} が無い → 'npm run build' 後に再実行`, () => {
-          // dist が無い時は skip 表示。CI は build → vitest の順で走るため必ずある。
-        });
-        return;
-      }
-
       const html = readFileSync(distPage, 'utf-8');
       const match = html.match(META_CSP_REGEX);
 


### PR DESCRIPTION
## 概要

#250 解消。PR #249 セルフレビューの I-1 / I-3 + 補足コメント（defensive replace）に対応する 3 件をまとめて反映。

## 主な変更

### I-1: `meta-csp.test.ts` を全 dist HTML glob に展開

固定 2 ページから `dist/**/*.html` 全件動的取得に置き換え。`for await (const f of glob(...))` を top-level で使い vitest (vite-node) が ESM として実行する利点を活かす。

- 検査対象: 2 ページ → **18 ページ**
- 検証件数: 11 → **91 tests**（1 header + 18 pages × 5 assertions）
- `dist/` 不在時は `it.skip` 経由で安全弁

将来ページ固有 inline script が追加された場合の検出網が緩い問題を解消。

### I-3: `astro.config.mjs` 設定欠落の陽性対照テスト新設

`src/utils/__tests__/astro-config-csp.test.ts` を新規作成。`astro.config.mjs` を文字列として読み込み、`security.csp` 関連の必須要素の存在を直接 assert する。

検証項目（6 件）:

- `security` ブロック存在
- `security.csp` ブロック存在
- `algorithm: 'SHA-256'` 設定
- `stripMetaStyleSrc()` 関数定義 + integrations 配列での呼び出し
- `vite.build.assetsInlineLimit: 0` 設定（[063] data:font 違反防止）
- `full.replace(attrs, () => newAttrs)` callback 形式（後述 defensive replace の維持テスト）

`<meta>` 不在の検知は `meta-csp.test.ts` でも間接的に可能だが、**config レベルで何が壊れたか** を明示する陽性対照として併設（メモリ「Positive Control for Gates」遵守）。

### Defensive replace（PR #249 reviewer 補足）

`astro.config.mjs:57` の `full.replace(attrs, newAttrs)` を `full.replace(attrs, () => newAttrs)` に変更。`String.prototype.replace(string, string)` の semantics で `newAttrs` 内の `$&`/`$1`/`$$` 等が特殊置換解釈される潜在問題への防御策。CSP 値に `$` が混入する可能性は実質ゼロだが、callback 形式で完全に回避。

regression test は astro-config-csp.test.ts の第 6 アサートで callback パターンの維持を文字列レベルで保証。

## 検証

| ゲート | 結果 |
|---|---|
| `npm run test`（unit, 42 files） | **665 passed**（前 PR から +87、内訳: meta-csp +80、astro-config-csp +6、新ファイル含むその他 +1） |
| 該当 3 ファイル単独 | headers + meta-csp + astro-config-csp = **116 passed** |
| `node_modules/.bin/astro check` | 0 errors / 0 warnings |
| `npm run test -- tests/meta/docs-section-references.test.ts` | 7 / 7 pass |
| `npm run test:e2e`（local mode） | 144 passed / 1 skipped (既存) / 0 failed、1.4m |
| aria 削除 diff | OK |
| `astro.config.mjs:59` callback 形式 | OK（`full.replace(attrs, () => newAttrs)` 確認） |

## 確認観点

- [ ] CI 全 green
- [ ] 91 件の meta-csp テストが過剰なく必要 coverage を提供しているか
- [ ] astro-config-csp の文字列 assert アプローチが将来の Prettier フォーマット変更で不安定化しないか
- [ ] callback 形式維持テストが PR #249 reviewer 補足の意図と整合

## 関連

- 解消する issue: #250
- 起源: PR #249 セルフレビュー I-1 / I-3 + reviewer 補足（defensive replace）
- 関連エントリ: `docs/decisions.md` [063] / [064]
