### PR TITLE
fix(ui): #258 ClearButton / CopyButton に type="button" 追加

### DIFF
--- a/src/components/ui/ClearButton.tsx
+++ b/src/components/ui/ClearButton.tsx
@@ -12,6 +12,7 @@ interface Props {
 export function ClearButton({ onClick, className = '' }: Props) {
   return (
     <button
+      type="button"
       onClick={onClick}
       className={`caption text-muted btn-clear rounded-lg px-3 py-1.5 whitespace-nowrap border-0 ${className}`.trim()}
     >

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -85,6 +85,7 @@ export function CopyButton({ text, label = 'コピー', className = '', compact 
   if (compact) {
     return (
       <button
+        type="button"
         onClick={handleClick}
         aria-label={label}
         className={`btn-copy is-compact ${stateClass} rounded-md inline-flex items-center justify-center text-xs px-2 py-1 min-w-8 min-h-8 whitespace-nowrap`.trim()}
@@ -97,6 +98,7 @@ export function CopyButton({ text, label = 'コピー', className = '', compact 
 
   return (
     <button
+      type="button"
       onClick={handleClick}
       aria-label={label}
       className={`btn-copy ${stateClass} caption font-bold inline-flex items-center gap-1.5 rounded px-3 py-2 leading-none tracking-wide whitespace-nowrap ${className}`.trim()}


### PR DESCRIPTION
## 概要

`#258` で指摘された `ui/ClearButton.tsx` / `ui/CopyButton.tsx` の `<button>` 要素に `type="button"` 属性が無い問題を修正。

## 背景

HTML 仕様で `type` 属性なしの `<button>` はデフォルト `type="submit"` として扱われる。これらのボタンが将来 `<form>` 要素内で使用された場合、クリックで意図せず form submit を発動させる submit 暴発リスクがある。

`ActionButton.tsx` は既に line 40 で `type="button"` を明示しており、整合性も確保されていなかった。

## 修正内容

3 ヶ所の `<button>` に `type="button"` を追加:

- `src/components/ui/ClearButton.tsx`: 1 ヶ所
- `src/components/ui/CopyButton.tsx`: compact 分岐 + 通常分岐の 2 ヶ所

挙動変化はない（防御的修正）。

## 関連

- 起源 issue: #258
- 親 issue: #176 (B 案 PR 1 #256 final review で発覚した pre-existing 課題)
- 後続 PR: #176 B 案 PR 2 (qr-ticket migration) の prerequisite として先行 merge

## 検証

- [x] `npm run test` (vitest) — 694 / 694 pass
- [x] `npx astro check` — 0 errors / 0 warnings
- [x] `npm run test:e2e` — 144 spec pass

## レビュアー向けメモ

- aria-\* 属性削除なし（`git diff origin/develop` で確認済）
- 差分は 3 行追加のみ
