### PR TITLE
fix(ui,tools): #269 ToggleGroup / QrReader / Gs1Databar の <button> に type="button" 追加

### DIFF
--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -204,6 +204,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
         </span>
         {canRemove && (
           <button
+            type="button"
             onClick={onRemove}
             className="rounded px-2 py-1 transition-colors"
             style={{ ...caption, color: colors.error, background: 'transparent' }}
@@ -271,6 +272,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
             </span>
             {canAddField && (
               <button
+                type="button"
                 onClick={addAiField}
                 style={{ ...caption, color: colors.link }}
                 className="hover:underline"
@@ -317,6 +319,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                       )}
                     </div>
                     <button
+                      type="button"
                       onClick={() => removeAiField(i)}
                       className="rounded-lg p-2 transition-colors shrink-0"
                       style={{
@@ -480,6 +483,7 @@ export function Gs1DatabarTool() {
       <div className="flex flex-wrap items-center gap-3 pt-2">
         {cards.length < MAX_CARDS && (
           <button
+            type="button"
             onClick={addCard}
             className="rounded px-4 py-2 transition-colors"
             style={{

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -174,7 +174,7 @@ export function QrReaderTool() {
             <div className="space-y-3">
               {/* カメラ未起動・結果なし時に「起動」ボタンを表示。エラー後もボタンを残すことでリトライを可能にしている */}
               {!camera.cameraActive && !decoded && (
-                <button onClick={camera.startCamera} style={startCameraButtonStyle}>
+                <button type="button" onClick={camera.startCamera} style={startCameraButtonStyle}>
                   カメラを起動
                 </button>
               )}
@@ -193,7 +193,7 @@ export function QrReaderTool() {
                 aria-label="カメラプレビュー"
               />
               {camera.cameraActive && (
-                <button onClick={stopCamera} style={stopCameraButtonStyle}>
+                <button type="button" onClick={stopCamera} style={stopCameraButtonStyle}>
                   カメラを停止
                 </button>
               )}
@@ -258,7 +258,7 @@ export function QrReaderTool() {
             {/* コピー & 再スキャンボタン */}
             <div className="flex flex-wrap items-center gap-2">
               <CopyButton text={content.raw} />
-              <button onClick={handleRescan} style={rescanButtonStyle}>
+              <button type="button" onClick={handleRescan} style={rescanButtonStyle}>
                 再スキャン
               </button>
             </div>

--- a/src/components/ui/ToggleGroup.tsx
+++ b/src/components/ui/ToggleGroup.tsx
@@ -52,6 +52,7 @@ export function ToggleGroup<T extends string>({
       {options.map((opt) => (
         <button
           key={opt.value}
+          type="button"
           onClick={() => onChange(opt.value)}
           aria-pressed={value === opt.value}
           className={`caption font-semibold btn-toggle rounded-lg whitespace-nowrap ${buttonSizeClass}`}


### PR DESCRIPTION
## 概要

`#269` で起票した、`#258` (PR `#268`) 同種パターンの未修正 `<button>` 8 ヶ所を閉じる。

## 修正内容

| File | 件数 | 用途 |
| --- | --- | --- |
| `src/components/ui/ToggleGroup.tsx` | 1 | options.map 内のトグルボタン |
| `src/components/tools/QrReader.tsx` | 3 | カメラ起動 / 停止 / 再スキャン |
| `src/components/tools/Gs1Databar.tsx` | 4 | onRemove / addAiField / removeAiField / addCard |

合計 8 ヶ所すべて `type="button"` を追加。挙動変化はない（防御的修正）。

## 背景

HTML 仕様で `type` 属性なしの `<button>` はデフォルト `type="submit"` として扱われる。`<form>` 要素内で使用された場合にクリックで意図せず form submit を発動させるリスクがあるため、`#258` の同 motivation を散らばらせず連続 merge する。

`#258` (`#268`) で対応済の `ClearButton` / `CopyButton` と合わせて、これで `src/components/` 配下の主要 `<button>` の `type` 漏れは解消（`InputField` / `ActionButton` / `ConfigConverter` / `qr-ticket/GenerateTab` / `layout/*.astro` は元から対応済）。

## 関連

- 起源 issue: `#269`
- 親 issue: `#258`
- 親 PR: `#268`
- 後続 PR: `#176` B 案 PR 2 (qr-ticket migration)

## 検証

- [x] `npm run test` (vitest) — 694 / 694 pass
- [x] `npx astro check` — 0 errors / 0 warnings
- [x] `npm run test:e2e` — 144 spec pass / 1 skip（既存 disabled）

## レビュアー向けメモ

- aria-\* 属性削除なし（`git diff origin/develop` 確認済）
- ESLint rule `react/button-has-type` 導入は本 PR スコープ外（必要なら別 issue）
- 差分は 8 行追加のみ
