### PR TITLE
refactor(ui,tools): #176 B 案 PR 3 — JwtDecoder + UuidV7Generator inline style 撤去 + #262 partial

### DIFF
--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -17,16 +17,16 @@
 
 ## 進捗状況
 
-| #        | スコープ                                                                                                                                         | 状態      | PR                                                                     |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ---------------------------------------------------------------------- |
-| **PR 0** | VRT 導入のみ（mock 注入版 spec、別 workflow、required check 外す、CI Linux baseline）                                                            | ✅ merged | [#254 (merged 26f566b)](https://github.com/fumtas1k/devtools/pull/254) |
-| **PR 1** | 基礎工事 + ui/\* simple (11 ファイル) — `@layer components` foundation + migration tracker + ClearButton CSSOM 撤去 + ToggleGroup setProperty 化 | ✅ merged | [#256 (merged eb5e537)](https://github.com/fumtas1k/devtools/pull/256) |
-| PR 1.5   | ui/\* complex (ResultTable + InputField) — API redesign 含む                                                                                     | ✅ merged | [#261 (merged 8e58bd5)](https://github.com/fumtas1k/devtools/pull/261) |
-| PR 2     | qr-ticket/\* — inline style 撤去 + #225 (useMemo/abort) 同梱                                                                                     | ✅ merged | [#272 (merged 37adb60)](https://github.com/fumtas1k/devtools/pull/272) |
-| PR 3     | JwtDecoder + UuidV7Generator                                                                                                                     | 未着手    | -                                                                      |
-| PR 4     | Gs1Databar + EncodingConverter + DummyText                                                                                                       | 未着手    | -                                                                      |
-| PR 5     | QrReader + ConfigConverter + JanCode + QrCode + 残り tools                                                                                       | 未着手    | -                                                                      |
-| PR 6     | flip + cleanup（CSP strict 化）                                                                                                                  | 未着手    | -                                                                      |
+| #        | スコープ                                                                                                                                         | 状態       | PR                                                                     |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ---------------------------------------------------------------------- |
+| **PR 0** | VRT 導入のみ（mock 注入版 spec、別 workflow、required check 外す、CI Linux baseline）                                                            | ✅ merged  | [#254 (merged 26f566b)](https://github.com/fumtas1k/devtools/pull/254) |
+| **PR 1** | 基礎工事 + ui/\* simple (11 ファイル) — `@layer components` foundation + migration tracker + ClearButton CSSOM 撤去 + ToggleGroup setProperty 化 | ✅ merged  | [#256 (merged eb5e537)](https://github.com/fumtas1k/devtools/pull/256) |
+| PR 1.5   | ui/\* complex (ResultTable + InputField) — API redesign 含む                                                                                     | ✅ merged  | [#261 (merged 8e58bd5)](https://github.com/fumtas1k/devtools/pull/261) |
+| PR 2     | qr-ticket/\* — inline style 撤去 + #225 (useMemo/abort) 同梱                                                                                     | ✅ merged  | [#272 (merged 37adb60)](https://github.com/fumtas1k/devtools/pull/272) |
+| PR 3     | JwtDecoder + UuidV7Generator + #262 partial (uuid-v7 CSP gate)                                                                                   | 🔄 PR open | [#275](https://github.com/fumtas1k/devtools/pull/275)                  |
+| PR 4     | Gs1Databar + EncodingConverter + DummyText                                                                                                       | 未着手     | -                                                                      |
+| PR 5     | QrReader + ConfigConverter + JanCode + QrCode + 残り tools                                                                                       | 未着手     | -                                                                      |
+| PR 6     | flip + cleanup（CSP strict 化）                                                                                                                  | 未着手     | -                                                                      |
 
 **重要 — PR 0 の意義**: VRT を ui migration と bundle した PR #253 が architectural 問題で close になったため、VRT を独立 PR で proper sequencing（mock 注入 → CI Linux baseline → required check 外す）で先行導入する。詳細は Claude memory `feedback_vrt_setup_sequencing.md` / `feedback_infra_feature_separation.md` 参照（PC ローカル）。
 
@@ -37,25 +37,31 @@
 - **prerequisite (close 済)**: [#258](https://github.com/fumtas1k/devtools/issues/258) ClearButton / CopyButton に `type="button"` 追加 — PR [#268](https://github.com/fumtas1k/devtools/pull/268) で対応 (✅ merged) / 同種パターン follow-up [#269](https://github.com/fumtas1k/devtools/issues/269) を PR [#270](https://github.com/fumtas1k/devtools/pull/270) で対応 (✅ merged)
 - **PR 内同梱 (close 済)**: [#225](https://github.com/fumtas1k/devtools/issues/225) refactor(QrTicket): GenerateTab props の useMemo 安定化 + verify signal の camera 経路への伝播 — PR `#272` 内で対応
 
-## PR 1 / PR 1.5 / PR 2 follow-up issue 処理タイミング表
+### PR 3 (#275)
 
-各 issue の処理推奨タイミング (2026-05-04 時点):
+- **PR 内同梱 (partial、close は PR 5 で)**: [#262](https://github.com/fumtas1k/devtools/issues/262) test(e2e): generator ページの applyProductionCsp E2E gate を追加（PR 6 前段必須） — PR `#275` で **uuid-v7 部分** に gate を挿入 (`tests/e2e/uuid-v7.spec.ts` の全 test を `browser.newContext()` pattern + `applyProductionCsp(page)` で gate、陽性対照 1 件追加)。**ulid-generator 部分は PR 5 で対応して #262 close 予定**
+- **PR review 由来 follow-up**: [#276](https://github.com/fumtas1k/devtools/issues/276) test(e2e): applyProductionCsp の `browser.newContext` boilerplate を `withProductionCsp` ラッパで集約 — **PR 5 前段の独立 infra PR** で対応推奨（`feedback_infra_feature_separation.md` 準拠）。PR 5 着手前に整備すると PR 5 が薄くなる
 
-| issue                                                   | 内容                                                                      | 処理タイミング                                  | 備考                                                                  |
-| ------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------- |
-| [#257](https://github.com/fumtas1k/devtools/issues/257) | ToggleGroup `--toggle-cols` removeProperty cleanup                        | 独立 (低優先)                                   | ResultTable の ref callback パターンを参照可。実害なし                |
-| [#258](https://github.com/fumtas1k/devtools/issues/258) | ClearButton/CopyButton `type="button"`                                    | ✅ closed                                       | PR `#268` で対応                                                      |
-| [#259](https://github.com/fumtas1k/devtools/issues/259) | ActionButton danger+disabled border                                       | 独立 (デザイン判断後)                           | A 案 vs B 案、blocking なし                                           |
-| [#260](https://github.com/fumtas1k/devtools/issues/260) | className 構築方式 clsx 統一                                              | PR 2-5 で都度 `filter(Boolean)` 採用 or 一括 PR | PR 1.5 で先行採用済                                                   |
-| [#262](https://github.com/fumtas1k/devtools/issues/262) | applyProductionCsp generator gate                                         | **PR 6 前段必須**                               | 下記 PR 6 チェックリスト参照                                          |
-| [#263](https://github.com/fumtas1k/devtools/issues/263) | aria-selected ARIA spec 違反                                              | **#264 と同 PR**                                | 同 `<tr>` 編集、統合修正候補                                          |
-| [#264](https://github.com/fumtas1k/devtools/issues/264) | クリック行キーボード操作 (WCAG)                                           | **#263 と同 PR**                                | 同上                                                                  |
-| [#265](https://github.com/fumtas1k/devtools/issues/265) | useEffect deps anti-pattern                                               | ✅ closed                                       | PR 1.5 (#261) で対応済                                                |
-| [#266](https://github.com/fumtas1k/devtools/issues/266) | width JSDoc origin discipline                                             | ✅ closed                                       | PR 1.5 (#261) で対応済                                                |
-| [#269](https://github.com/fumtas1k/devtools/issues/269) | ToggleGroup / QrReader / Gs1Databar `type="button"` (PR 1 由来漏れ)       | ✅ closed                                       | PR `#270` で対応                                                      |
-| [#271](https://github.com/fumtas1k/devtools/issues/271) | ESLint `react/button-has-type` 導入 + index.astro 残り 2 件               | 独立 (低優先)                                   | PR 6 以降または専用 PR で                                             |
-| [#273](https://github.com/fumtas1k/devtools/issues/273) | `useTicketVerification.verify` の external signal を `AbortSignal.any` 化 | PR 6 cleanup スコープ候補                       | 現 callsite 実害なし                                                  |
-| [#119](https://github.com/fumtas1k/devtools/issues/119) | .text-link-color 命名規則統一                                             | 独立 (低優先)                                   | PR 1.5 で消費パターン定着、改名は all-files rename になる時期まで保留 |
+## PR 1 / PR 1.5 / PR 2 / PR 3 follow-up issue 処理タイミング表
+
+各 issue の処理推奨タイミング (2026-05-07 時点):
+
+| issue                                                   | 内容                                                                                       | 処理タイミング                                  | 備考                                                                                                                       |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [#257](https://github.com/fumtas1k/devtools/issues/257) | ToggleGroup `--toggle-cols` removeProperty cleanup                                         | 独立 (低優先)                                   | ResultTable の ref callback パターンを参照可。実害なし                                                                     |
+| [#258](https://github.com/fumtas1k/devtools/issues/258) | ClearButton/CopyButton `type="button"`                                                     | ✅ closed                                       | PR `#268` で対応                                                                                                           |
+| [#259](https://github.com/fumtas1k/devtools/issues/259) | ActionButton danger+disabled border                                                        | 独立 (デザイン判断後)                           | A 案 vs B 案、blocking なし                                                                                                |
+| [#260](https://github.com/fumtas1k/devtools/issues/260) | className 構築方式 clsx 統一                                                               | PR 2-5 で都度 `filter(Boolean)` 採用 or 一括 PR | PR 1.5 で先行採用済                                                                                                        |
+| [#262](https://github.com/fumtas1k/devtools/issues/262) | applyProductionCsp generator gate                                                          | **PR 5 で close**                               | PR 3 (#275) で uuid-v7 部分対応済 (open のまま)、ulid-generator 部分は PR 5 で対応して close。下記 PR 6 チェックリスト参照 |
+| [#263](https://github.com/fumtas1k/devtools/issues/263) | aria-selected ARIA spec 違反                                                               | **#264 と同 PR**                                | 同 `<tr>` 編集、統合修正候補                                                                                               |
+| [#264](https://github.com/fumtas1k/devtools/issues/264) | クリック行キーボード操作 (WCAG)                                                            | **#263 と同 PR**                                | 同上                                                                                                                       |
+| [#265](https://github.com/fumtas1k/devtools/issues/265) | useEffect deps anti-pattern                                                                | ✅ closed                                       | PR 1.5 (#261) で対応済                                                                                                     |
+| [#266](https://github.com/fumtas1k/devtools/issues/266) | width JSDoc origin discipline                                                              | ✅ closed                                       | PR 1.5 (#261) で対応済                                                                                                     |
+| [#269](https://github.com/fumtas1k/devtools/issues/269) | ToggleGroup / QrReader / Gs1Databar `type="button"` (PR 1 由来漏れ)                        | ✅ closed                                       | PR `#270` で対応                                                                                                           |
+| [#271](https://github.com/fumtas1k/devtools/issues/271) | ESLint `react/button-has-type` 導入 + index.astro 残り 2 件                                | 独立 (低優先)                                   | PR 6 以降または専用 PR で                                                                                                  |
+| [#273](https://github.com/fumtas1k/devtools/issues/273) | `useTicketVerification.verify` の external signal を `AbortSignal.any` 化                  | PR 6 cleanup スコープ候補                       | 現 callsite 実害なし                                                                                                       |
+| [#276](https://github.com/fumtas1k/devtools/issues/276) | applyProductionCsp の `browser.newContext` boilerplate を `withProductionCsp` ラッパで集約 | **PR 5 前段 (infra PR)**                        | `feedback_infra_feature_separation.md` 準拠。PR 5 で 10+ 件規模になる前に整備すると PR 5 が薄くなる                        |
+| [#119](https://github.com/fumtas1k/devtools/issues/119) | .text-link-color 命名規則統一                                                              | 独立 (低優先)                                   | PR 1.5 で消費パターン定着、改名は all-files rename になる時期まで保留                                                      |
 
 ## B 案接近系 issue（独立判断）
 
@@ -83,10 +89,11 @@ PR 6 で以下を **すべて含む** こと。漏れを防ぐため本セクシ
 - [ ] PR description に「`#176` B 案完了」を明記、関連 PR (#249/#254/#256/#261/#272/PR 3-5) を全 link
 - [ ] `grep -c "style={{" src/` = **0** を最終確認
 - [ ] 全 E2E + 全 unit + astro check pass
-- [ ] PR 1 (#256) / PR 1.5 (#261) / PR 2 (#272) の follow-up 系 issue のうち PR 6 で同時対応するものがあれば close、後続するものは PR 6 description で言及。
+- [ ] PR 1 (#256) / PR 1.5 (#261) / PR 2 (#272) / PR 3 (#275) の follow-up 系 issue のうち PR 6 で同時対応するものがあれば close、後続するものは PR 6 description で言及。
   - PR 1 由来: #257-#260
-  - PR 1.5 由来: [#262](https://github.com/fumtas1k/devtools/issues/262) (CSP gate / **PR 6 前段必須**) / [#263](https://github.com/fumtas1k/devtools/issues/263) (aria-selected ARIA spec) / [#264](https://github.com/fumtas1k/devtools/issues/264) (キーボード操作 WCAG 2.1.1) / [#265](https://github.com/fumtas1k/devtools/issues/265) (useEffect deps anti-pattern, ✅ closed) / [#266](https://github.com/fumtas1k/devtools/issues/266) (width JSDoc origin discipline, ✅ closed)
+  - PR 1.5 由来: [#262](https://github.com/fumtas1k/devtools/issues/262) (CSP gate / **PR 5 で close**、PR 3 で uuid-v7 partial 対応済) / [#263](https://github.com/fumtas1k/devtools/issues/263) (aria-selected ARIA spec) / [#264](https://github.com/fumtas1k/devtools/issues/264) (キーボード操作 WCAG 2.1.1) / [#265](https://github.com/fumtas1k/devtools/issues/265) (useEffect deps anti-pattern, ✅ closed) / [#266](https://github.com/fumtas1k/devtools/issues/266) (width JSDoc origin discipline, ✅ closed)
   - PR 2 由来: [#273](https://github.com/fumtas1k/devtools/issues/273) (`AbortSignal.any` 化、`useTicketVerification.verify` external signal link 改善)
+  - PR 3 由来: [#276](https://github.com/fumtas1k/devtools/issues/276) (`withProductionCsp` ラッパ helper、**PR 5 前段 infra PR で対応推奨**)
 - [ ] **`.text-primary` 命名衝突リスクの再評価** — `src/styles/global.css` の `.text-primary` (PR 2 で追加) は `--color-primary` を `@theme` に登録すると Tailwind auto-utility と衝突する可能性。PR 6 で `@theme` 切替するなら `text-brand` 等への rename 候補。`@theme` 切替自体を見送るなら現状維持で OK。決定事項を `docs/decisions.md` [067] に明記すること。
 - [ ] **Tailwind `border` utility と `@layer components` の `border-color` 優先度確認** — PR 2 で導入した `.alert-success` / `.alert-error` は `<div className="rounded-lg p-4 border alert-success">` のように Tailwind `border` (border-color: currentColor 系) と併用。layer 順序によっては期待色にならないリスクが PR 2 review で指摘済（実害は VRT pass で未顕在）。CSP strict 化後の VRT 再撮影で diff が出たら fix。
 

--- a/docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md
+++ b/docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md
@@ -1,0 +1,640 @@
+# #176 B 案 PR 3 実装計画書
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal**: `JwtDecoder.tsx` (21 件) + `UuidV7Generator.tsx` (20 件) の inline style 撤去と #262 partial 対応 (`tests/e2e/uuid-v7.spec.ts` への applyProductionCsp gate 追加) を独立 PR として完了する。
+
+**Architecture**: PR 1 / 1.5 / 2 で確立した「`@layer components` への意味クラス追加 + Tailwind utility」pattern を継承。Phase 0 (親 Opus) で foundation commit、Phase 1 で sonnet subagent 2 並列 (Track A: JwtDecoder / Track B: UuidV7Generator + uuid-v7 E2E)、Phase 2 で親 Opus が MIGRATED_FILES 追加 + 検証 + PR 作成。
+
+**Tech Stack**: TypeScript / React 19 / Astro 5 / Tailwind CSS 4 / Vitest / Playwright
+
+**作成日**: 2026-05-07
+**Spec**: `docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md`
+**ブランチ**: `feature/issue-176-b3-jwt-uuid`
+**Worktree**: `.claude/worktrees/issue-176-b3`
+**Base**: `origin/develop` (26a8c67 — `#274` merged 後)
+
+---
+
+## 進行モデル
+
+`feedback_subagent_model.md` / `feedback_subagent_workflow.md` / `feedback_subagent_verification_trust.md` 準拠。
+
+| Phase | 担当                  | 内容                                                                                  |
+| ----- | --------------------- | ------------------------------------------------------------------------------------- |
+| 0     | 親 Opus               | spec / plan 作成、worktree 作成、global.css foundation commit                         |
+| 1     | sonnet 並列 (2 track) | Track A (JwtDecoder) / Track B (UuidV7Generator + uuid-v7 E2E) の実装                 |
+| 2     | 親 Opus               | `MIGRATED_FILES` 追加、ローカル必須ゲート 3 件直接実行、aria diff 確認、push、PR 作成 |
+| 3     | 親 Opus + reviewer    | review サイクル（review 中は push 控える）                                            |
+
+---
+
+## File Structure
+
+| File                                                 | Phase | 担当    | 変更内容                                                        |
+| ---------------------------------------------------- | ----- | ------- | --------------------------------------------------------------- |
+| `docs/superpowers/specs/2026-05-07-...-design.md`    | 0     | 親 Opus | spec をブランチ最初の commit として配置                         |
+| `docs/superpowers/plans/2026-05-07-...-jwt-uuid.md`  | 0     | 親 Opus | plan を spec と同 commit で配置                                 |
+| `src/styles/global.css`                              | 0     | 親 Opus | `@layer components` に PR 3 用 class 17 件追記                  |
+| `src/components/tools/JwtDecoder.tsx`                | 1     | Track A | inline style 21 件除去 + Section variant 化 + import 整理       |
+| `src/components/tools/UuidV7Generator.tsx`           | 1     | Track B | inline style 20 件除去 + FIELD_CLASSES 化 + import 整理         |
+| `tests/e2e/uuid-v7.spec.ts`                          | 1     | Track B | applyProductionCsp gate 全 test 適用 + 陽性対照 1 件追加 (#262) |
+| `src/utils/__tests__/inline-style-migration.test.ts` | 2     | 親 Opus | `MIGRATED_FILES` array に 2 件追加                              |
+
+**触らない**:
+
+- `src/components/tools/__tests__/JwtDecoder.test.ts` (logic test のみで Section の DOM レンダリング非依存)
+- `src/utils/styles.ts` (PR 6 で削除、本 PR では import 削除のみ)
+- `src/utils/csp.ts` / `public/_headers` (PR 6 でstrict 化)
+
+---
+
+## Phase 0 — 親 Opus 直接実行
+
+### Task 0.1: Worktree 作成
+
+- [ ] **Step 1**: 現在のブランチが `develop` で clean state であることを確認
+
+```bash
+git status
+git branch --show-current
+# Expected: clean / develop
+```
+
+- [ ] **Step 2**: worktree を作成（`origin/develop` ベースを **明示**、memory `feedback_worktree_base_branch.md`）
+
+```bash
+git worktree add .claude/worktrees/issue-176-b3 origin/develop -b feature/issue-176-b3-jwt-uuid
+```
+
+- [ ] **Step 3**: worktree で `npm ci` 実行（subagent の test 実行に必要、SessionStart hook で自動実行されるが念のため確認）
+
+```bash
+cd .claude/worktrees/issue-176-b3 && npm ci
+```
+
+Expected: `node_modules` が worktree に存在し vitest / playwright が解決可能。
+
+### Task 0.2: spec / plan ファイル配置
+
+- [ ] **Step 1**: develop 側で書いた spec / plan を worktree にコピー
+
+```bash
+cp docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md \
+   .claude/worktrees/issue-176-b3/docs/superpowers/specs/
+cp docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md \
+   .claude/worktrees/issue-176-b3/docs/superpowers/plans/
+```
+
+- [ ] **Step 2**: develop 側の untracked spec / plan を削除（worktree のみで保持）
+
+```bash
+rm docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md
+rm docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md
+```
+
+### Task 0.3: global.css に @layer components 追記
+
+worktree で作業（以下すべて `.claude/worktrees/issue-176-b3` 内）。
+
+- [ ] **Step 1**: `src/styles/global.css` の末尾 `@layer components { ... }` ブロックの閉じ `}` の **直前** に下記を追記（spec §4 と完全一致）
+
+```css
+/* === PR 3: JwtDecoder + UuidV7Generator migration helpers === */
+
+/* JwtDecoder: Section accent borders */
+.section-jwt-header {
+  border-left: 4px solid var(--color-error);
+}
+.section-jwt-payload {
+  border-left: 4px solid #9333ea;
+}
+.section-jwt-signature {
+  border-left: 4px solid var(--color-primary);
+}
+
+/* JwtDecoder: JSON syntax colors (not UI tokens, kept local) */
+.jwt-json-key {
+  color: var(--color-link);
+}
+.jwt-json-value {
+  color: #6e4f0e;
+}
+
+/* JwtDecoder: <pre> (decoded JSON) typography */
+.jwt-pre {
+  font-size: 0.75rem;
+  line-height: 1.33;
+  letter-spacing: -0.12px;
+}
+
+/* Checkbox accent (link color) */
+.accent-link {
+  accent-color: var(--color-link);
+}
+
+/* Warning semantic palette (expBadge no-exp 用) */
+.text-warning {
+  color: var(--color-warning);
+}
+.bg-warning-tint {
+  background: var(--color-warning-bg);
+}
+
+/* UuidV7Generator: 5 field colors (UUID hex parts) */
+.uuid-field-ts {
+  color: var(--color-primary);
+}
+.uuid-field-ver {
+  color: #7c3aed;
+}
+.uuid-field-rand-a {
+  color: #059669;
+}
+.uuid-field-var {
+  color: #d97706;
+}
+.uuid-field-rand-b {
+  color: #0891b2;
+}
+
+/* UuidV7Generator: field key label typography (caption の font-size override) */
+.uuid-field-key {
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.7;
+  letter-spacing: 0.02em;
+}
+.uuid-field-bits {
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+```
+
+**重要**: `.uuid-field-key` は `.caption` の **後** に定義すること（CSS source 順位で `.caption` の font-size 0.875rem を 0.75rem に override するため）。同 `@layer components` 内なら specificity 同等のため source 順位が有効。
+
+- [ ] **Step 2**: 既存 commit の class と重複していないか確認
+
+```bash
+grep -n "section-jwt-header\|jwt-json-key\|accent-link\|text-warning\|bg-warning-tint\|uuid-field-" src/styles/global.css | head -20
+# Expected: 各 class が 1 件ずつ（重複なし）
+```
+
+- [ ] **Step 3**: vitest 一部実行で global.css 読み込みが壊れていないか確認
+
+```bash
+npm run test -- src/utils/__tests__/inline-style-migration.test.ts
+# Expected: 既存 16 ファイルの migration test pass
+```
+
+### Task 0.4: Phase 0 commit
+
+- [ ] **Step 1**: stage + commit
+
+```bash
+git add docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md \
+        docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md \
+        src/styles/global.css
+
+git commit -m "$(cat <<'EOF'
+chore(spec): #176 B 案 PR 3 spec / plan / global.css foundation
+
+Phase 0: spec / plan 配置 + global.css @layer components に
+JwtDecoder + UuidV7Generator migration 用 class 17 件を追加。
+
+追加 class:
+- section-jwt-{header,payload,signature}
+- jwt-json-{key,value}
+- jwt-pre / accent-link
+- text-warning / bg-warning-tint
+- uuid-field-{ts,ver,rand-a,var,rand-b}
+- uuid-field-{key,bits}
+
+Phase 1 (sonnet 並列) で JwtDecoder / UuidV7Generator + uuid-v7 E2E
+の migration を進める。
+
+ref: docs/projects/issue-176-b-plan-progress.md
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2**: 確認
+
+```bash
+git log --oneline -1
+git status
+# Expected: 1 件の commit、clean state
+```
+
+---
+
+## Phase 1 — 並列 sonnet subagent dispatch
+
+**重要**: Track A / Track B は **完全に独立** したファイルを触る（cross-file dependency なし）。並列 dispatch して OK。
+
+### Track A: `JwtDecoder.tsx` migration（21 styles）
+
+- [ ] **Step 1**: subagent prompt 作成（下記 §Subagent prompt template 参照）
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領後、親 Opus が `git diff --name-only HEAD~1..HEAD` で変更範囲確認
+
+**Track A 完了基準**:
+
+- [ ] `src/components/tools/JwtDecoder.tsx` の `style={{` ヒット 0、`element.style.X = Y` 形式 0
+- [ ] `import { ... } from '@/utils/styles'` 削除（残 import なし）
+- [ ] `Section` component が `variant: 'header' | 'payload' | 'signature'` prop に変更
+- [ ] `expBadge` / `sigBadge` の `style: CSSProperties` が `badgeClass: string` に変更
+- [ ] commit 1 件: `refactor(tools): #176 B 案 PR 3 — JwtDecoder.tsx inline style 撤去`
+- [ ] subagent 自己検証: `npm run test -- src/components/tools/__tests__/JwtDecoder.test.ts` pass + `npx astro check` 0 errors
+
+### Track B: `UuidV7Generator.tsx` migration（20 styles）+ `tests/e2e/uuid-v7.spec.ts` (#262 partial)
+
+- [ ] **Step 1**: subagent prompt 作成（下記 §Subagent prompt template 参照）
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領後、親 Opus が `git diff --name-only HEAD~2..HEAD` で変更範囲確認
+
+**Track B 完了基準**:
+
+- [ ] `src/components/tools/UuidV7Generator.tsx` の `style={{` ヒット 0、`element.style.X = Y` 形式 0
+- [ ] `import { ... } from '@/utils/styles'` 削除
+- [ ] `FIELD_COLORS` const → `FIELD_CLASSES` const へ refactor
+- [ ] `tests/e2e/uuid-v7.spec.ts` の全 test が `browser.newContext()` pattern で `applyProductionCsp(page)` を使用
+- [ ] 陽性対照 1 件追加 (script-src 違反による gate 動作確認)
+- [ ] commit 2 件:
+  - `refactor(tools): #176 B 案 PR 3 — UuidV7Generator.tsx inline style 撤去`
+  - `test(e2e): #176 B 案 PR 3 — uuid-v7 spec に applyProductionCsp gate 追加 (#262 partial)`
+- [ ] subagent 自己検証: `npm run test -- src/utils/__tests__/uuid-v7.test.ts` pass + `npx astro check` 0 errors
+
+**Track B の順序制約**: UuidV7Generator.tsx の inline style 撤去を **先** に commit してから uuid-v7.spec.ts の gate 追加を commit する（gate を先に入れて migration が後だと CSP 違反で fail する可能性、spec §10 R3）。
+
+---
+
+## Phase 2 — 親 Opus 直接実行（統合 + 検証 + PR）
+
+### Task 2.1: Phase 1 完了確認
+
+- [ ] **Step 1**: subagent 完了報告 2 件を受領
+- [ ] **Step 2**: 想定外ファイル変更が無いことを確認
+
+```bash
+git diff origin/develop --name-only | sort
+# Expected:
+# docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md
+# docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md
+# src/components/tools/JwtDecoder.tsx
+# src/components/tools/UuidV7Generator.tsx
+# src/styles/global.css
+# tests/e2e/uuid-v7.spec.ts
+```
+
+- [ ] **Step 3**: 各対象ファイルの inline style 残存ゼロ確認
+
+```bash
+grep -c "style={{" src/components/tools/JwtDecoder.tsx
+grep -c "style={{" src/components/tools/UuidV7Generator.tsx
+# Expected: 0 / 0
+```
+
+### Task 2.2: MIGRATED_FILES 追加
+
+- [ ] **Step 1**: `src/utils/__tests__/inline-style-migration.test.ts` の `MIGRATED_FILES` array に 2 件追加
+
+`'src/components/tools/qr-ticket/TicketDetail.tsx',` の **後** に下記を追加:
+
+```ts
+  // PR 3 で追加
+  'src/components/tools/JwtDecoder.tsx',
+  'src/components/tools/UuidV7Generator.tsx',
+```
+
+- [ ] **Step 2**: migration test pass 確認
+
+```bash
+npm run test -- src/utils/__tests__/inline-style-migration.test.ts
+# Expected: 18 ファイルの migration test 全 pass + 陽性対照 3 件 pass
+```
+
+- [ ] **Step 3**: commit
+
+```bash
+git add src/utils/__tests__/inline-style-migration.test.ts
+git commit -m "$(cat <<'EOF'
+test(migration): MIGRATED_FILES に PR 3 対象 2 件追加
+
+JwtDecoder.tsx / UuidV7Generator.tsx の inline style 撤去完了に
+伴い progressive migration tracker に追加。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md §5
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.3: ローカル必須ゲート（subagent 報告は信頼せず親が直接実行、`feedback_subagent_verification_trust.md`）
+
+- [ ] **Step 1**: vitest 全 pass
+
+```bash
+npm run test
+# Expected: 全 unit test pass、migration test 18 件 pass、陽性対照 3 件 pass
+```
+
+- [ ] **Step 2**: TypeScript 型チェック
+
+```bash
+npx astro check
+# Expected: 0 errors
+```
+
+- [ ] **Step 3**: E2E 全 pass（`feedback_e2e_before_pr.md`、PR 作成前必須）
+
+```bash
+npm run test:e2e
+# Expected: jwt-decoder.spec.ts / uuid-v7.spec.ts (CSP gate 含む 陽性対照含む) 全 pass
+```
+
+E2E は build + preview を直列起動するため数分かかる。フォアグラウンドで実行して全 pass を確認する。
+
+### Task 2.4: a11y 退化検知（`feedback_commander_checklist.md`）
+
+- [ ] **Step 1**: aria-\* 削除行が無いこと
+
+```bash
+git diff origin/develop -- src/components/tools/JwtDecoder.tsx src/components/tools/UuidV7Generator.tsx \
+  | grep -E '^-.*aria-' | grep -vE '^---|^\+\+\+'
+# Expected: 出力 0 行
+```
+
+- [ ] **Step 2**: role / data-testid 削除行が無いこと
+
+```bash
+git diff origin/develop -- src/components/tools/JwtDecoder.tsx src/components/tools/UuidV7Generator.tsx \
+  | grep -E '^-.*(role=|data-testid=)' | grep -vE '^---|^\+\+\+'
+# Expected: 出力 0 行
+```
+
+- [ ] **Step 3**: `htmlFor` / `<label>` 構造が維持されていること（目視）
+
+```bash
+git diff origin/develop -- src/components/tools/JwtDecoder.tsx src/components/tools/UuidV7Generator.tsx \
+  | grep -E '^[+-].*htmlFor='
+# 削除のみがあれば NG (label 構造の意図しない変更)
+```
+
+### Task 2.5: PR 作成前 final check (`docs/playbooks/pr-creation.md` 4 点)
+
+- [ ] **Step 1**: develop ベース一致確認
+
+```bash
+[ "$(git rev-parse origin/develop)" = "$(git merge-base HEAD origin/develop)" ] && echo OK
+# Expected: OK
+```
+
+- [ ] **Step 2**: `_headers` / `astro.config.mjs` / `src/utils/styles.ts` を **触っていない** こと（PR 6 スコープ）
+
+```bash
+git diff origin/develop --name-only | grep -E "_headers|astro.config|src/utils/styles\.ts"
+# Expected: 出力 0 行
+```
+
+### Task 2.6: push + PR 作成
+
+- [ ] **Step 1**: PR 本文を `/tmp/claude/pr_body_b3.md` に書き出し
+
+```bash
+mkdir -p /tmp/claude
+cat > /tmp/claude/pr_body_b3.md <<'EOF'
+## 概要
+
+`#176` B 案バッチの PR 3。`JwtDecoder.tsx` (21 件) と `UuidV7Generator.tsx` (20 件) の JSX inline style を `@layer components` の意味クラス + Tailwind utility に置換し、同時に `tests/e2e/uuid-v7.spec.ts` に `applyProductionCsp(page)` E2E gate を挿入して issue #262 の uuid-v7 部分を partial 対応する。
+
+- spec: `docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md`
+- plan: `docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md`
+- バッチ進捗: `docs/projects/issue-176-b-plan-progress.md`
+
+## 主要な変更
+
+### `src/styles/global.css` 追加 class (17 件)
+
+- JwtDecoder 用: `.section-jwt-{header,payload,signature}` / `.jwt-json-{key,value}` / `.jwt-pre` / `.accent-link`
+- UuidV7Generator 用: `.uuid-field-{ts,ver,rand-a,var,rand-b}` / `.uuid-field-{key,bits}`
+- 汎用 (PR 4-5 で再利用見込): `.text-warning` / `.bg-warning-tint`
+
+### `JwtDecoder.tsx` (21 件 → 0)
+
+- `Section` component の `accentColor` prop を `variant: 'header' | 'payload' | 'signature'` の discriminated union に変更
+- `expBadge` / `sigBadge` の `style: CSSProperties` を `badgeClass: string` に変更
+- `<pre>` typography (`font-size: 0.75rem; line-height: 1.33; letter-spacing: -0.12px`) を `.jwt-pre` に集約
+- checkbox の `accentColor` を `.accent-link` class に置換
+- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除
+
+### `UuidV7Generator.tsx` (20 件 → 0)
+
+- `FIELD_COLORS` const を `FIELD_CLASSES` const に refactor
+- `ColoredUuid` / `FieldBreakdownPanel` で動的色を class 切替で表現
+- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除
+
+### `tests/e2e/uuid-v7.spec.ts` への applyProductionCsp gate (#262 partial)
+
+- 全 test を `browser.newContext()` pattern に変更し `applyProductionCsp(page)` を `goto` 前に挿入
+- 陽性対照 1 件追加 (script-src 違反で gate 動作確認、`config-converter.spec.ts` 既存 pattern 踏襲)
+- ulid-generator 部分は PR 5 で対応して #262 close 予定
+
+## 検証
+
+- [x] `npm run test` 全 pass (migration test 18 件 + 陽性対照 3 件含む)
+- [x] `npx astro check` 0 errors
+- [x] `npm run test:e2e` 全 pass (uuid-v7 CSP gate + 陽性対照含む)
+- [x] a11y 退化なし (`aria-*` / `role=` / `data-testid=` 削除行 0)
+- [x] inline style 残存ゼロ (`grep -c "style={{"` = 0 for both files)
+
+## VRT
+
+`visual-regression.yml` で baseline 比較 (non-required check)。意図的差分があれば PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger。
+
+## 関連
+
+- 起源 issue: #176 (アプローチ B)
+- 部分対応 issue: #262 (uuid-v7 部分のみ、ulid-generator は PR 5 へ)
+- 前提 PR: #249 (A-1) / #254 (VRT) / #256 (PR 1) / #261 (PR 1.5) / #272 (PR 2)
+- 後続: PR 4 (Gs1Databar + EncodingConverter + DummyText) / PR 5 (QrReader + 残り tools + #262 close) / PR 6 (flip + cleanup)
+EOF
+```
+
+- [ ] **Step 2**: push
+
+```bash
+git push -u origin feature/issue-176-b3-jwt-uuid
+```
+
+- [ ] **Step 3**: PR 作成（`--base develop` を **必ず** 明示、`--body-file` で本文渡し）
+
+```bash
+gh pr create --base develop \
+  --title "refactor(ui,tools): #176 B 案 PR 3 — JwtDecoder + UuidV7Generator inline style 撤去 + #262 partial" \
+  --body-file /tmp/claude/pr_body_b3.md
+```
+
+Expected: PR URL を user に提示。
+
+---
+
+## Phase 3 — review サイクル
+
+- [ ] **Step 1**: PR 作成後は **自発的な修正 push を控える** (memory `feedback_hold_push_during_review.md`)
+- [ ] **Step 2**: CI green + reviewer LGTM 後に user に merge を依頼
+- [ ] **Step 3**: merge 後に `docs/projects/issue-176-b-plan-progress.md` の進捗テーブル更新（PR 3 を ✅ merged に）→ chore PR
+- [ ] **Step 4**: worktree 削除順序（memory `feedback_worktree_merge_order.md`）
+
+```bash
+# 順序: gh pr merge --delete-branch の **前** に worktree remove
+git worktree remove .claude/worktrees/issue-176-b3
+git branch -D feature/issue-176-b3-jwt-uuid  # ローカルにブランチ参照が残れば削除
+```
+
+---
+
+## Subagent prompt template
+
+各 subagent には以下要素を **必ず** 含める:
+
+1. **作業ディレクトリ**: `/Users/fumta/projects/devtools/.claude/worktrees/issue-176-b3`
+2. **担当ファイル list**（変更可能なもの／触ってはいけないもの）
+3. **spec 該当 section の reference** (`docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md` § N.M)
+4. **global.css の新規 class 一覧**（Phase 0 で commit 済、§4 参照）
+5. **自己検証コマンド**: `npm run test -- <該当 test path>` + `npx astro check`
+6. **やってはいけないこと**:
+   - `git push`（親が実行）
+   - `gh pr create`（親が実行）
+   - `npm run test:vrt` 実行（memory `feedback_vrt_ci_only.md`、ローカル baseline 不在）
+   - 他 Track のファイル変更
+   - `src/utils/styles.ts` の削除（PR 6 スコープ）
+   - `src/styles/global.css` の編集（Phase 0 で foundation commit 済、追加 class 不要）
+7. **完了報告フォーマット**:
+   - 変更ファイル list (`git diff --name-only HEAD~N..HEAD`)
+   - commit list (`git log --oneline HEAD~N..HEAD`)
+   - 自己検証結果 (vitest / astro check の出力要約)
+   - 残課題（あれば）
+
+### Track A subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b3
+
+タスク: src/components/tools/JwtDecoder.tsx の inline style を spec §1 に従い撤去する。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md (特に §1.1〜1.7)
+- 既存パターン: src/components/tools/qr-ticket/VerifyTab.tsx (PR 2 で migrate 済、参考)
+- global.css: PR 3 用 class は §4 で commit 済 (HEAD~1)
+
+変更可能なファイル:
+- src/components/tools/JwtDecoder.tsx (本体)
+
+触ってはいけないファイル:
+- src/components/tools/__tests__/JwtDecoder.test.ts (logic test、Section DOM 非依存のため astro check で型互換確認のみ)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済)
+- src/components/tools/UuidV7Generator.tsx (Track B)
+- tests/e2e/* (Track B)
+
+完了基準:
+- grep -c "style={{" src/components/tools/JwtDecoder.tsx → 0
+- import { bodyEmphasis, caption, colors } from '@/utils/styles' を削除
+- Section component が variant: 'header' | 'payload' | 'signature' prop に変更
+- 局所定数 jsonKeyColor / jsonValueColor 削除
+- npm run test -- src/components/tools/__tests__/JwtDecoder.test.ts pass
+- npx astro check 0 errors
+- 1 件の commit を作成 (タイトル: "refactor(tools): #176 B 案 PR 3 — JwtDecoder.tsx inline style 撤去")
+
+やってはいけないこと:
+- git push / gh pr create
+- npm run test:vrt
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加 (Phase 0 で完了済、不足あれば親 Opus に報告)
+
+完了後 報告: 変更ファイル list + commit list + 自己検証結果。
+```
+
+### Track B subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b3
+
+タスク: 2 つの作業を 1 subagent で連続実行 (commit は分ける):
+1. src/components/tools/UuidV7Generator.tsx の inline style 撤去 (spec §2)
+2. tests/e2e/uuid-v7.spec.ts に applyProductionCsp gate を全 test 適用 + 陽性対照 1 件追加 (spec §3)
+
+順序制約: 1 を先に commit してから 2 に進む (gate を先に入れて migration が後だと CSP 違反で fail するため)。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md (§2 と §3)
+- 既存パターン (E2E): tests/e2e/config-converter.spec.ts line 200-275
+- helper API: tests/e2e/helpers.ts (CspGuard interface line 83-87、必須 browser.newContext() 制約 line 40-60)
+- global.css: PR 3 用 class は §4 で commit 済 (HEAD~1)
+
+変更可能なファイル:
+- src/components/tools/UuidV7Generator.tsx (commit 1)
+- tests/e2e/uuid-v7.spec.ts (commit 2)
+
+触ってはいけないファイル:
+- src/utils/__tests__/uuid-v7.test.ts (logic test、変更不要)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済)
+- src/components/tools/JwtDecoder.tsx (Track A)
+- tests/e2e/ulid-generator.spec.ts (PR 5 スコープ、#262 残部分)
+
+完了基準:
+- grep -c "style={{" src/components/tools/UuidV7Generator.tsx → 0
+- FIELD_COLORS const → FIELD_CLASSES const に refactor 済
+- import { bodyEmphasis, caption, colors } from '@/utils/styles' を削除
+- tests/e2e/uuid-v7.spec.ts の全 test が browser.newContext() pattern + applyProductionCsp(page)
+- 陽性対照 1 件追加 (script-src 違反、config-converter.spec.ts line 242-275 と同 pattern)
+- npm run test -- src/utils/__tests__/uuid-v7.test.ts pass
+- npx astro check 0 errors
+- 2 件の commit を作成:
+  - "refactor(tools): #176 B 案 PR 3 — UuidV7Generator.tsx inline style 撤去"
+  - "test(e2e): #176 B 案 PR 3 — uuid-v7 spec に applyProductionCsp gate 追加 (#262 partial)"
+
+やってはいけないこと:
+- git push / gh pr create
+- npm run test:vrt
+- npm run test:e2e (時間かかる、E2E 全 pass は親が Phase 2 で確認)
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加
+- 陽性対照を inline style 違反で起こす (style-src 'unsafe-inline' は PR 6 まで残存のため、必ず script-src 違反で起こす)
+
+完了後 報告: 変更ファイル list + commit list + 自己検証結果。
+```
+
+---
+
+## メモリ参照
+
+- `project_b_plan_progress.md` (pointer; SoT は repo `docs/projects/issue-176-b-plan-progress.md`)
+- `feedback_subagent_model.md` (sonnet 明示)
+- `feedback_subagent_workflow.md` (subagent は allow リスト内 Bash のみ)
+- `feedback_subagent_verification_trust.md` (親が直接検証)
+- `feedback_subagent_testing.md` (E2E は親が実行)
+- `feedback_commander_checklist.md` (PR 作成前チェック)
+- `feedback_e2e_before_pr.md` (E2E は PR 作成前)
+- `feedback_hold_push_during_review.md` (review 中は push 控える)
+- `feedback_branch_workflow.md` (`--base develop` 明示)
+- `feedback_pr_language.md` (PR 日本語)
+- `feedback_heredoc_no_escape.md` (HEREDOC で backtick エスケープしない)
+- `feedback_worktree_base_branch.md` (worktree は origin/develop -b 明示)
+- `feedback_worktree_location.md` (`.claude/worktrees/<name>` または `$TMPDIR/<name>`)
+- `feedback_worktree_merge_order.md` (worktree remove → branch delete の順)
+- `feedback_vrt_ci_only.md` (ローカル test:vrt 走らせない)
+- `feedback_followup_routing.md` (PR 後の離散タスクは issue 化)
+- `feedback_prod_parity_csp.md` (本番 CSP 制約を E2E で再現)
+- `feedback_positive_control_for_gates.md` (gate には陽性対照を併設)
+
+---
+
+## Phase 1 開始判定
+
+Phase 0 commit 完了 + worktree の `npm ci` 完了を確認したら Phase 1 dispatch。両 Track が独立ファイルに閉じるため **同時並列 dispatch** で OK。

--- a/docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md
@@ -1,0 +1,772 @@
+# #176 B 案 PR 3: `JwtDecoder` + `UuidV7Generator` inline style 撤去 設計書
+
+**作成日**: 2026-05-07
+**Issue**: [#176](https://github.com/fumtas1k/devtools/issues/176) アプローチ B / PR 3
+**前提**: A-1 ([#249](https://github.com/fumtas1k/devtools/pull/249)) + VRT 基盤 ([#254](https://github.com/fumtas1k/devtools/pull/254)) + PR 1 ([#256](https://github.com/fumtas1k/devtools/pull/256)) + PR 1.5 ([#261](https://github.com/fumtas1k/devtools/pull/261)) + PR 2 ([#272](https://github.com/fumtas1k/devtools/pull/272)) 完了済み
+**参照**: バッチ計画全体は repo SoT [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md)。PR 1 / 1.5 / 2 spec の命名規約・既存 `@layer components` 定義を継承。
+
+---
+
+## ゴール
+
+`src/components/tools/JwtDecoder.tsx` (21 件の `style={{`) と `src/components/tools/UuidV7Generator.tsx` (20 件) から JSX inline style を完全撤去し、`@layer components` の class + Tailwind utility に置換する。同時に、PR 1.5 由来 follow-up [#262](https://github.com/fumtas1k/devtools/issues/262)（applyProductionCsp E2E gate / **PR 6 前段必須**）の **uuid-v7 部分** を `tests/e2e/uuid-v7.spec.ts` に挿入する。
+
+完了基準:
+
+1. 対象 2 ファイルから `style={{` ヒット数 0、`element.style.X = Y` 形式の inline mutation 0
+2. `src/utils/__tests__/inline-style-migration.test.ts` の `MIGRATED_FILES` array に 2 件を追加（合計 18 件）して migration test pass
+3. `src/styles/global.css` の `@layer components` に **本 PR で必要な class のみ** 追加（YAGNI 厳守、§4 参照）
+4. **同梱 issue [#262](https://github.com/fumtas1k/devtools/issues/262) 部分対応**:
+   - `tests/e2e/uuid-v7.spec.ts` の全 test に `applyProductionCsp(page)` を `goto` 前に挿入
+   - 陽性対照 1 件追加（gate 自体の動作確認）
+   - ulid-generator 部分は **PR 5 で対応して #262 close**。PR 3 description には「#262 partial」明記
+5. **VRT 検証**: `visual-regression.yml` で baseline 比較。意図的差分があれば PR ブランチ上で `update-visual-baseline.yml` を `workflow_dispatch` trigger
+6. ローカル必須ゲート: push 前に `npm run test`（vitest）/ `npx astro check` / `npm run test:e2e` 全 green（親 Opus 直接実行）
+7. `src/utils/styles.ts` 自体は **削除しない**（PR 6 で削除）。本 PR では `caption` / `bodyEmphasis` / `colors` の **import 削除** のみ
+8. `docs/ui-conventions.md` 追加更新は不要（PR 1 で出揃い）
+
+非ゴール:
+
+- `Gs1Databar` / `EncodingConverter` / `DummyText` (PR 4)、`QrReader` / `ConfigConverter` / `JanCode` / `QrCode` / `UlidGenerator` (PR 5)、`flip + cleanup` (PR 6)
+- `ulid-generator.spec.ts` への applyProductionCsp gate 追加（PR 5 スコープ）
+- `src/utils/styles.ts` 削除（PR 6）
+- `_headers` の `style-src 'unsafe-inline'` 撤去（PR 6）
+- `docs/decisions.md` 新規エントリ（PR 6 [067] で B 案完了として一括記録）
+- ハードコード hex (`#9333ea` / `#7c3aed` / `#059669` / `#d97706` / `#0891b2` / `#6e4f0e`) の `--color-*` token 化（D2、PR 6 cleanup 候補）
+
+---
+
+## なぜ独立 PR か
+
+| 観点                      | 説明                                                                                                                                                                                                                                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **PR サイズ規律**         | JwtDecoder + UuidV7Generator で 41 件の inline style + #262 部分対応 + 新規 class 追加。PR 4-5 と bundle すると review unit 肥大化（memory `feedback_pr_size.md`）。                                                                                                                                               |
+| **VRT 影響面の独立性**    | jwt-decoder.astro / uuid-v7.astro は独立 page で baseline に乗る。Gs1Databar (PR 4) や QrReader (PR 5) と差分原因を切り分けやすい。                                                                                                                                                                                |
+| **#262 同梱の自然性**     | UuidV7Generator は PR 1.5 で導入された `setProperty('--var', value)` を踏む ResultTable を経由する数少ない page。PR 3 で migration したタイミングで CSP gate を入れるのが最も自然（PR 6 まで間が空くと記憶コスト増）。                                                                                             |
+| **新規 class の責務範囲** | 本 PR で新規追加するのは `text-warning` / `bg-warning-tint` / `accent-link` の 3 汎用 + `section-jwt-*` (3) / `jwt-json-*` (2) / `jwt-pre` / `uuid-field-*` (5) / `uuid-field-key` / `uuid-field-bits` の固有 12 件。汎用 3 件は PR 4-5 で再利用見込、固有 12 件は本 PR で導入し後続で類似要件があれば再利用する。 |
+
+memory 参照:
+
+- `project_b_plan_progress.md` (pointer; SoT は repo `docs/projects/issue-176-b-plan-progress.md`)
+- `feedback_pr_size.md`
+- `feedback_infra_feature_separation.md`
+- `feedback_subagent_verification_trust.md`
+- `feedback_commander_checklist.md`
+- `feedback_e2e_before_pr.md`
+- `feedback_subagent_model.md`
+- `feedback_prod_parity_csp.md`
+- `feedback_positive_control_for_gates.md`
+
+---
+
+## 採用する設計（ファイル別）
+
+### 1. `JwtDecoder.tsx` (21 件)
+
+#### 1.1 `Section` component の variant 化（line 162-203）
+
+**現状**:
+
+```jsx
+function Section({ title, accentColor, data, renderValue, 'data-testid': testId }: SectionProps) {
+  return (
+    <div
+      className="rounded-lg p-4"
+      style={{ background: colors.bgSubtle, borderLeft: `4px solid ${accentColor}` }}
+      data-testid={testId}
+    >
+      ...
+    </div>
+  );
+}
+```
+
+**移行先**:
+
+```jsx
+type SectionVariant = 'header' | 'payload' | 'signature';
+
+interface SectionProps {
+  title: string;
+  variant: SectionVariant;
+  data: Record<string, unknown>;
+  renderValue?: (k: string, v: unknown) => React.ReactNode;
+  'data-testid'?: string;
+}
+
+function Section({ title, variant, data, renderValue, 'data-testid': testId }: SectionProps) {
+  const json = JSON.stringify(data, null, 2);
+  return (
+    <div className={`rounded-lg p-4 bg-subtle section-jwt-${variant}`} data-testid={testId}>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="body-emphasis text-default">{title}</h3>
+        <CopyButton text={json} label="コピー" />
+      </div>
+      <pre className="overflow-x-auto font-mono text-default jwt-pre">
+        <span className="text-muted">{'{'}</span>
+        {'\n'}
+        {Object.entries(data).map(([k, v]) => (
+          <span key={k} className="block pl-4">
+            {renderValue ? (
+              renderValue(k, v)
+            ) : (
+              <>
+                <span className="jwt-json-key">"{k}"</span>
+                <span className="text-default">: </span>
+                <span className="jwt-json-value">{JSON.stringify(v)}</span>
+              </>
+            )}
+          </span>
+        ))}
+        <span className="text-muted">{'}'}</span>
+      </pre>
+    </div>
+  );
+}
+```
+
+呼出側:
+
+```jsx
+<Section variant="header"  title="Header (JOSE)"     data={parsed.header}  data-testid="jwt-header" />
+<Section variant="payload" title="Payload (Claims)"  data={parsed.payload} renderValue={...} data-testid="jwt-payload" />
+```
+
+Signature ボックス（line 367-383、`Section` 不使用の inline 構造）:
+
+```jsx
+<div className="rounded-lg p-4 bg-subtle section-jwt-signature">
+  <div className="mb-2 flex items-center justify-between">
+    <h3 className="body-emphasis text-default">Signature</h3>
+    <CopyButton text={parsed.signature} label="コピー" />
+  </div>
+  <p className="break-all font-mono caption text-default">{parsed.signature}</p>
+  <p className="mt-2 caption text-muted">
+    {secretKey.trim() ? '上記のキーで署名を検証しています' : 'キーを入力すると署名を検証します'}
+  </p>
+</div>
+```
+
+#### 1.2 `PayloadValue` component（line 139-152）
+
+```jsx
+function PayloadValue({ k, v }: { k: string; v: unknown }) {
+  const isTs = TIMESTAMP_KEYS.includes(k) && typeof v === 'number';
+  return (
+    <span>
+      <span className="jwt-json-key">"{k}"</span>
+      <span className="text-default">: </span>
+      <span className="jwt-json-value">{JSON.stringify(v)}</span>
+      {isTs && (
+        <span className="ml-2 text-xs text-muted">→ {formatTimestamp(v as number)}</span>
+      )}
+    </span>
+  );
+}
+```
+
+#### 1.3 status badges（line 243-265）
+
+`expBadge` / `sigBadge` の `style: CSSProperties` を `badgeClass: string` に変更:
+
+```ts
+const expBadge: Record<ExpStatus, { label: string; badgeClass: string }> = {
+  valid: { label: '有効', badgeClass: 'bg-success-tint text-success' },
+  expired: { label: '期限切れ', badgeClass: 'bg-error-tint text-error-text' },
+  'no-exp': { label: 'exp なし', badgeClass: 'bg-warning-tint text-warning' },
+};
+
+const sigBadge: Record<SigStatus, { label: string; badgeClass: string } | null> = {
+  unchecked: null,
+  verifying: { label: '検証中…', badgeClass: 'bg-subtle text-muted' },
+  valid: { label: '署名: 有効', badgeClass: 'bg-success-tint text-success' },
+  invalid: { label: '署名: 無効', badgeClass: 'bg-error-tint text-error-text' },
+  unsupported: { label: '署名: 未対応アルゴリズム', badgeClass: 'bg-subtle text-muted' },
+  error: {
+    label: '署名: 検証エラー（キー形式を確認）',
+    badgeClass: 'bg-error-tint text-error-text',
+  },
+};
+```
+
+呼出側:
+
+```jsx
+<span className={`rounded-full px-3 py-0.5 caption font-medium ${expBadge[parsed.expStatus].badgeClass}`}>
+  {expBadge[parsed.expStatus].label}
+  {parsed.expStatus === 'valid' && parsed.remainingMs !== undefined && (
+    <span className="ml-1 opacity-75">（{formatRemaining(parsed.remainingMs)}）</span>
+  )}
+</span>
+
+{sigBadge[sigStatus] && (
+  <span className={`rounded-full px-3 py-0.5 caption font-medium ${sigBadge[sigStatus]!.badgeClass}`}>
+    {sigBadge[sigStatus]!.label}
+  </span>
+)}
+```
+
+`fontWeight: 500` → `font-medium`（Tailwind 500 ✓）。
+
+#### 1.4 checkbox accent-color（line 316-321）
+
+```jsx
+<input
+  type="checkbox"
+  checked={verifyExp}
+  onChange={(e) => setVerifyExp(e.target.checked)}
+  className="w-4 h-4 accent-link"
+/>
+```
+
+`w-4 h-4` = 1rem ✓。`.accent-link` は §4 で追加。
+
+#### 1.5 caption / label / hint 系（line 287-324）
+
+```jsx
+// 鍵入力ラベル末尾 caption (line 290-298)
+<>
+  {keyLabel}
+  <span className="caption text-muted ml-2">（任意）</span>
+</>
+
+// 有効期限ラベル (line 311-315)
+<label className="flex items-center gap-2 cursor-pointer caption text-default">
+```
+
+`...caption + fontWeight: 400 + marginLeft: '0.5rem'` → caption は既に fontWeight 400、`ml-2` = 0.5rem ✓。
+
+#### 1.6 import 整理
+
+```ts
+// Before
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
+// After (削除のみ — 残す import なし)
+```
+
+局所定数 `jsonKeyColor` / `jsonValueColor` も削除（class に隠蔽されたため）。
+
+#### 1.7 件数集計
+
+| 移行先                                                                                 | 件数   |
+| -------------------------------------------------------------------------------------- | ------ |
+| 既存 class（text-default / bg-subtle 等）                                              | 約 11  |
+| 新 class（§4: section-jwt-\* / jwt-\* / accent-link / text-warning / bg-warning-tint） | 約 7   |
+| Tailwind 標準 utility のみ（w-4 h-4 等）                                               | 約 3   |
+| **合計**                                                                               | **21** |
+
+---
+
+### 2. `UuidV7Generator.tsx` (20 件)
+
+#### 2.1 `FIELD_COLORS` の named class 化
+
+**現状**:
+
+```ts
+const FIELD_COLORS = {
+  unixTsMs: colors.primary,
+  ver: '#7C3AED',
+  randA: '#059669',
+  varNibble: '#D97706',
+  randB: '#0891B2',
+} as const;
+```
+
+**移行先**:
+
+```ts
+const FIELD_CLASSES = {
+  unixTsMs: 'uuid-field-ts',
+  ver: 'uuid-field-ver',
+  randA: 'uuid-field-rand-a',
+  varNibble: 'uuid-field-var',
+  randB: 'uuid-field-rand-b',
+} as const;
+```
+
+5 class は §4 で `global.css` に定義。
+
+#### 2.2 `ColoredUuid` component（line 36-63）
+
+```jsx
+function ColoredUuid({ uuid, quoteStyle }: { uuid: string; quoteStyle: QuoteStyle }) {
+  const parts = uuid.split('-');
+  const quote = quoteStyle === 'double' ? '"' : quoteStyle === 'single' ? "'" : '';
+  const fullText = `${quote}${uuid}${quote}`;
+
+  return (
+    <span
+      className="font-mono caption whitespace-nowrap"
+      aria-label={fullText}
+      title={fullText}
+    >
+      {quote && <span className="text-muted">{quote}</span>}
+      <span className={FIELD_CLASSES.unixTsMs}>{parts[0]}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.unixTsMs}>{parts[1]}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.ver}>{parts[2][0]}</span>
+      <span className={FIELD_CLASSES.randA}>{parts[2].substring(1)}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.varNibble}>{parts[3][0]}</span>
+      <span className={FIELD_CLASSES.randB}>{parts[3].substring(1)}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.randB}>{parts[4]}</span>
+      {quote && <span className="text-muted">{quote}</span>}
+    </span>
+  );
+}
+```
+
+注意: 元 inline は `{ ...caption, letterSpacing: '0.02em', whiteSpace: 'nowrap' }`。`.caption` が既に `letter-spacing: 0.02em` を持つため redundancy 解消。
+
+#### 2.3 `FieldBreakdownPanel` component（line 66-107）
+
+```jsx
+function FieldBreakdownPanel({ uuid }: { uuid: string }) {
+  const fields = parseUuidV7Fields(uuid);
+
+  const fieldDefs = [
+    { key: 'unix_ts_ms', bits: '48bit', value: fields.unixTsMs,  className: FIELD_CLASSES.unixTsMs },
+    { key: 'ver',        bits: '4bit',  value: fields.ver,       className: FIELD_CLASSES.ver },
+    { key: 'rand_a',     bits: '12bit', value: fields.randA,     className: FIELD_CLASSES.randA },
+    { key: 'var',        bits: '2bit',  value: fields.varNibble, className: FIELD_CLASSES.varNibble },
+    { key: 'rand_b',     bits: '62bit', value: fields.randB,     className: FIELD_CLASSES.randB },
+  ] as const;
+
+  return (
+    <div className="rounded-lg p-3 bg-subtle border border-default">
+      <p className="caption text-muted mb-2">フィールド分解</p>
+      <div className="flex flex-wrap gap-x-4 gap-y-2">
+        {fieldDefs.map((f) => (
+          <div key={f.key} className="flex flex-col gap-0.5">
+            <span className="text-muted uuid-field-key">
+              {f.key} <span className="uuid-field-bits">({f.bits})</span>
+            </span>
+            <code
+              className={`font-mono whitespace-nowrap rounded px-1.5 py-0.5 bg-default border border-default caption ${f.className}`}
+            >
+              {f.value}
+            </code>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+**設計判断**: `<code>` の inline は `{ ...caption, fontFamily: 'monospace', color: f.color, background: colors.bg, border: '1px solid ${colors.border}', whiteSpace: 'nowrap' }`。`caption` + `font-mono` で fontFamily を override する形（caption は font-family 未指定）。`.uuid-field-{name}` で color のみ override。実装中に subagent が `.uuid-field-code` 統合 class が読みやすいと判断したら追加可（D3、subagent 判断）。
+
+#### 2.4 ResultTable header の bodyEmphasis（line 180）
+
+```jsx
+<span className="body-emphasis text-default">{rows.length} 件生成</span>
+```
+
+#### 2.5 import 整理
+
+```ts
+// Before
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
+// After (削除のみ — 残す import なし)
+```
+
+#### 2.6 件数集計
+
+| 移行先                                         | 件数   |
+| ---------------------------------------------- | ------ |
+| FIELD_CLASSES (5 種) を ColoredUuid 内 11 ヶ所 | 11     |
+| FieldBreakdownPanel 内（外枠/p/spans/code）    | 5      |
+| ColoredUuid 外枠 caption + muted quote (3)     | 3      |
+| ResultTable header の bodyEmphasis             | 1      |
+| **合計**                                       | **20** |
+
+---
+
+## 3. `tests/e2e/uuid-v7.spec.ts` への #262 部分対応
+
+### 3.1 採用パターン
+
+`tests/e2e/config-converter.spec.ts` line 206-262 を踏襲。`applyProductionCsp(page)` を `goto` 前に挿入し、test 末尾で `guard.assertNoViolations()` を呼ぶ。
+
+### 3.2 実装テンプレート
+
+**重要な制約** (`tests/e2e/helpers.ts` line 40-60 のドキュメントコメント参照):
+
+- default の `page` fixture では `page.route` 介入が **空回り** する。**必ず `browser.newContext()` で新規 context を作る** こと（config-converter.spec.ts の既存 pattern）
+- guard の API は `assertNoViolations()` / `violations` getter / `dispose()` の 3 種。`getViolations()` メソッドは存在しない
+- 陽性対照は **`script-src` 違反** で起こす（`style-src 'unsafe-inline'` は PR 6 まで残存するため inline style 違反は捕捉できない）。`config-converter.spec.ts` line 242-275 と同じ「外部 origin の `<script src>` を `document.head` に append」pattern を踏襲
+
+```ts
+import { test, expect } from '@playwright/test';
+import { applyProductionCsp, waitForReactHydration } from './helpers';
+
+test.describe('uuid-v7 generator (with production CSP)', () => {
+  test('uuid-v7 を生成できる（CSP 違反なし）', async ({ browser }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      await page.goto('/tools/uuid-v7');
+      await waitForReactHydration(page);
+
+      // 既存 test ロジック...
+
+      guard.assertNoViolations();
+    } finally {
+      await context.close();
+    }
+  });
+
+  // 既存の他 test も同パターンで wrap...
+
+  // 陽性対照（gate 自体の動作確認）
+  test('applyProductionCsp は実際に CSP 違反を捕捉する（ゲート自体の動作確認）', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      const response = await page.goto('/tools/uuid-v7');
+      // 前提検証: route 注入によって本番 CSP がレスポンスヘッダに乗っていること
+      expect(response?.headers()['content-security-policy']).toContain("script-src 'self'");
+      await page.evaluate(() => {
+        const script = document.createElement('script');
+        script.src = 'https://example.com/violates-csp.js';
+        document.head.appendChild(script);
+      });
+      await expect.poll(() => guard.violations.length).toBeGreaterThan(0);
+    } finally {
+      await context.close();
+    }
+  });
+});
+```
+
+実際の挿入位置・assert 形式・既存 test の保持/再構成は subagent が `tests/e2e/config-converter.spec.ts` line 200-275 と既存 `tests/e2e/uuid-v7.spec.ts` の構造を読んで決定。
+
+**migration 工程との整合**: PR 3 では `_headers` の CSP は変更しない（PR 6 まで `style-src 'unsafe-inline'` 残存）。そのため本 PR 時点では gate が「将来的な strict 化に備えた骨組み」として機能する。陽性対照が `script-src` 違反で動作確認できれば gate 自体は機能していることが保証される。
+
+memory `feedback_positive_control_for_gates.md` 準拠（gate には陽性対照を必ず併設）。
+
+### 3.3 #262 close の判定
+
+PR 3 で uuid-v7 部分のみ完了 → **#262 は close せず**、PR 5 (UlidGenerator) で `tests/e2e/ulid-generator.spec.ts` も追加してから close。PR 3 description には「#262 partial」を明記。PR 6 前段必須なので PR 5 で確実に close されれば PR 6 blocking 解消 ✓。
+
+---
+
+## 4. `src/styles/global.css` への追記（PR 3 で**新規追加**する分のみ）
+
+PR 1 / 1.5 / 2 で既に追加済みの class（`.caption` / `.body-emphasis` / `.text-default` / `.text-muted` / `.bg-default` / `.bg-subtle` / `.bg-surface` / `.border-default` / `.border-input` / `.bg-error-tint` / `.bg-success-tint` / `.text-error` / `.text-error-text` / `.text-success` / `.text-primary` / `.alert-success` / `.alert-error` / `.btn-link-plain` 等）は再定義しない。本 PR 追加分:
+
+```css
+@layer components {
+  /* === PR 3: JwtDecoder + UuidV7Generator migration helpers === */
+
+  /* JwtDecoder: Section accent borders */
+  .section-jwt-header {
+    border-left: 4px solid var(--color-error);
+  }
+  .section-jwt-payload {
+    border-left: 4px solid #9333ea;
+  }
+  .section-jwt-signature {
+    border-left: 4px solid var(--color-primary);
+  }
+
+  /* JwtDecoder: JSON syntax colors (not UI tokens, kept local) */
+  .jwt-json-key {
+    color: var(--color-link);
+  }
+  .jwt-json-value {
+    color: #6e4f0e;
+  }
+
+  /* JwtDecoder: <pre> (decoded JSON) typography */
+  .jwt-pre {
+    font-size: 0.75rem;
+    line-height: 1.33;
+    letter-spacing: -0.12px;
+  }
+
+  /* Checkbox accent (link color) */
+  .accent-link {
+    accent-color: var(--color-link);
+  }
+
+  /* Warning semantic palette (expBadge no-exp 用) */
+  .text-warning {
+    color: var(--color-warning);
+  }
+  .bg-warning-tint {
+    background: var(--color-warning-bg);
+  }
+
+  /* UuidV7Generator: 5 field colors (UUID hex parts) */
+  .uuid-field-ts {
+    color: var(--color-primary);
+  }
+  .uuid-field-ver {
+    color: #7c3aed;
+  }
+  .uuid-field-rand-a {
+    color: #059669;
+  }
+  .uuid-field-var {
+    color: #d97706;
+  }
+  .uuid-field-rand-b {
+    color: #0891b2;
+  }
+
+  /* UuidV7Generator: field key label typography (caption の font-size override) */
+  .uuid-field-key {
+    font-size: 0.75rem;
+    font-weight: 400;
+    line-height: 1.7;
+    letter-spacing: 0.02em;
+  }
+  .uuid-field-bits {
+    font-size: 0.7rem;
+    opacity: 0.7;
+  }
+}
+```
+
+**衝突確認**:
+
+- `.section-jwt-*` / `.jwt-*` / `.uuid-field-*` は BEM 風命名で唯一性確保
+- `.accent-link` は Tailwind の `accent-{color}` ファミリと衝突しない（独立 class）
+- `.text-warning` / `.bg-warning-tint` は `--color-warning`（amber-800）/ `--color-warning-bg` の `:root` 既存 token を class 化。Tailwind auto-utility 不在のため衝突なし
+- ハードコード hex（`#9333ea` / `#7c3aed` / `#059669` / `#d97706` / `#0891b2` / `#6e4f0e`）はオリジナル一致を優先（VRT 差分回避）
+
+**新 class の将来性**:
+
+- `.text-warning` / `.bg-warning-tint`: PR 4-5 で再利用見込（中〜高）
+- `.section-jwt-*` / `.jwt-*` / `.accent-link`: JwtDecoder 固有（低）
+- `.uuid-field-*`: UuidV7Generator 固有（低）
+
+PR 6 cleanup でハードコード hex を `--color-*` token 化する選択肢は残せる（`docs/decisions.md` [067] 候補）。本 PR では YAGNI で行わない（D2）。
+
+---
+
+## 5. `inline-style-migration.test.ts` への追加
+
+```ts
+const MIGRATED_FILES: readonly string[] = [
+  // PR 1 で追加済み (11 件、省略)
+  // PR 1.5 で追加済み
+  'src/components/ui/ResultTable.tsx',
+  'src/components/ui/InputField.tsx',
+  // PR 2 で追加 (qr-ticket)
+  'src/components/tools/qr-ticket/GenerateTab.tsx',
+  'src/components/tools/qr-ticket/VerifyTab.tsx',
+  'src/components/tools/qr-ticket/TicketDetail.tsx',
+  // PR 3 で追加
+  'src/components/tools/JwtDecoder.tsx',
+  'src/components/tools/UuidV7Generator.tsx',
+];
+```
+
+陽性対照テストブロックは PR 1 で導入済 → 変更不要。
+
+---
+
+## 6. consumer 変更範囲（**PR 3 で touch するファイル**）
+
+| File                                                 | 変更内容                                                   | 備考                        |
+| ---------------------------------------------------- | ---------------------------------------------------------- | --------------------------- |
+| `src/components/tools/JwtDecoder.tsx`                | inline style 全除去 + Section variant 化 + import 整理     | MIGRATED_FILES 登録         |
+| `src/components/tools/UuidV7Generator.tsx`           | inline style 全除去 + FIELD_CLASSES 化 + import 整理       | MIGRATED_FILES 登録         |
+| `src/styles/global.css`                              | §4 の `@layer components` 追記                             | PR 1/1.5/2 既存ブロック末尾 |
+| `src/utils/__tests__/inline-style-migration.test.ts` | `MIGRATED_FILES` array に 2 件追加                         | -                           |
+| `tests/e2e/uuid-v7.spec.ts`                          | applyProductionCsp gate 全 test に挿入 + 陽性対照 1 件追加 | #262 partial 対応           |
+
+`src/components/tools/__tests__/JwtDecoder.test.ts` は **触らない**（`verifySignature` / `ALG_MAP` のロジック test のみで Section の DOM レンダリングを test していないため、Section variant 化の影響なし。astro check で型互換確認）。
+
+---
+
+## 7. 検証戦略
+
+### 7.1 ローカル必須ゲート（push 前、PR 1 / 1.5 / 2 と同じ）
+
+| 順  | コマンド           | 目的                                                                                                      | 失敗時                                         |
+| --- | ------------------ | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| 1   | `npm run test`     | unit + migration test の MIGRATED_FILES 範囲拡大（16 → 18 件、4 spec 追加） + uuid-v7 関連 unit test pass | 該当ファイルの `style={{` を実コードで除去確認 |
+| 2   | `npx astro check`  | TypeScript 型チェック（Section の `accentColor` → `variant` prop 変更に伴う既存 caller 互換）             | type 修正                                      |
+| 3   | `npm run test:e2e` | functional E2E（JwtDecoder / UuidV7Generator）+ uuid-v7 CSP gate + 陽性対照                               | regression を fix、陽性対照 pass 確認          |
+
+memory `feedback_subagent_verification_trust.md`: **親 Opus が直接実行**（subagent の "pass" 報告は信頼しない）。
+
+### 7.2 CI
+
+| workflow                | 実行内容                           | required?       |
+| ----------------------- | ---------------------------------- | --------------- |
+| `test.yml`              | vitest + e2e                       | ✅ required     |
+| `visual-regression.yml` | `npm run test:vrt` (baseline 比較) | ❌ non-required |
+
+memory `feedback_vrt_ci_only.md`: ローカル `npm run test:vrt` は走らせない。
+
+### 7.3 VRT 差分の判断フロー（PR 1 / 1.5 / 2 と同じ）
+
+PR comment に diff があった場合:
+
+- 意図しない regression（Section border 太さ違い / badge 色違い / UUID 色分け違い等）→ class 定義 / consumer className 修正
+- ピクセル未満の anti-alias 差 → mask か threshold 緩和（事前合意必要）
+- 意図的変化 → PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger → bot が新 baseline を commit back
+
+### 7.4 a11y 退化検知 (memory `feedback_commander_checklist.md` 準拠)
+
+本 PR で特に注意:
+
+- JwtDecoder の `data-testid` 維持（"jwt-header" / "jwt-payload" — 既存 test が依存）
+- JwtDecoder の `role="status"` / `aria-live="polite"`（line 353）維持
+- UuidV7Generator の `role="status"` / `aria-live="polite"`（line 170）維持
+- UuidV7Generator の ColoredUuid の `aria-label` / `title`（screen reader 用 fullText）維持
+- `<input type="checkbox">` の checked / onChange / accent-color 機能維持
+
+親 Opus が PR 作成時に下記を実行:
+
+```bash
+git diff origin/develop -- src/components/tools/JwtDecoder.tsx src/components/tools/UuidV7Generator.tsx | grep -E '^-.*aria-' | grep -vE '^---|^\+\+\+'
+# 出力 0 行であること
+```
+
+---
+
+## 8. バッチ計画における本 PR の位置付け
+
+repo SoT [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md) のテーブル参照。
+
+| #        | スコープ                                                                                | 状態           |
+| -------- | --------------------------------------------------------------------------------------- | -------------- |
+| PR 0     | VRT 導入                                                                                | ✅ #254 merged |
+| PR 1     | 基礎工事 + ui/\* simple 11                                                              | ✅ #256 merged |
+| PR 1.5   | ui/\* complex (ResultTable + InputField)                                                | ✅ #261 merged |
+| PR 2     | qr-ticket/\*                                                                            | ✅ #272 merged |
+| **PR 3** | **JwtDecoder + UuidV7Generator (本 PR)**                                                | **本 PR**      |
+| PR 4     | Gs1Databar + EncodingConverter + DummyText                                              | 未着手         |
+| PR 5     | QrReader + ConfigConverter + JanCode + QrCode + UlidGenerator + 残り tools + #262 close | 未着手         |
+| PR 6     | flip + cleanup                                                                          | 未着手         |
+
+PR は **直列**（前 PR がマージされてから次 PR 着手）。
+
+---
+
+## 9. ブランチ命名 / コミット粒度 / 並列 subagent 分担
+
+### 9.1 ブランチ命名
+
+- `feature/issue-176-b3-jwt-uuid`
+- worktree 経由の場合は memory `feedback_worktree_base_branch.md` に従い `git worktree add ... origin/develop -b feature/issue-176-b3-jwt-uuid` を **明示**
+- worktree の置き場所は memory `feedback_worktree_location.md` に従い `.claude/worktrees/<name>` または `$TMPDIR/<name>`
+
+### 9.2 コミット粒度
+
+```
+1. global.css に PR 3 用 @layer components 追記（section-jwt-*, jwt-json-*, jwt-pre, accent-link, text-warning, bg-warning-tint, uuid-field-*, uuid-field-key, uuid-field-bits）
+2. JwtDecoder.tsx: inline style 撤去 + Section variant 化 + import 整理
+3. UuidV7Generator.tsx: inline style 撤去 + FIELD_CLASSES 化 + import 整理
+4. tests/e2e/uuid-v7.spec.ts: applyProductionCsp gate 全 test 適用 + 陽性対照 1 件 (#262 partial)
+5. inline-style-migration.test.ts: MIGRATED_FILES に 2 件追加
+6. (VRT 差分が出た場合のみ) update-visual-baseline.yml trigger 結果の baseline commit (bot 自動 push)
+```
+
+各 commit で migration test を「追加した範囲だけ pass」する状態に保つ（コミット 5 は最後）。
+
+### 9.3 並列 subagent 分担（sonnet）
+
+memory `feedback_subagent_model.md` に従い `model: "sonnet"` を明示:
+
+| Track | 担当ファイル                                                           | コミット番号 |
+| ----- | ---------------------------------------------------------------------- | ------------ |
+| **A** | `JwtDecoder.tsx` (21 styles)                                           | 2            |
+| **B** | `UuidV7Generator.tsx` (20 styles) + `tests/e2e/uuid-v7.spec.ts` (#262) | 3, 4         |
+
+**順序**:
+
+1. **Phase 0** (親 Opus): worktree 作成 → spec / plan 確定 → コミット 1（global.css foundation）を直接実行
+2. **Phase 1** (sonnet 並列): Track A / Track B を並列 dispatch
+3. **Phase 2** (親 Opus): コミット 5 (`MIGRATED_FILES` 追加) → ローカル必須ゲート 3 件直接実行 → aria diff 確認 → push → develop ベース PR 作成
+
+### 9.4 PR ベース
+
+`gh pr create --base develop` で必ず明示（memory `feedback_branch_workflow.md` / `feedback_pr_language.md` / `CLAUDE.md` 最重要ルール）。タイトル例:
+
+> `refactor(ui,tools): #176 B 案 PR 3 — JwtDecoder + UuidV7Generator inline style 撤去 + #262 partial`
+
+PR 本文は `--body-file /tmp/claude/pr_body.md` 経由（memory `feedback_heredoc_no_escape.md` / `CLAUDE.md` 6.1）。
+
+---
+
+## 10. リスクと緩和
+
+| ID  | リスク                                                                                                                                | 緩和                                                                                                                                                          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | `Section` の `accentColor` prop → `variant` リファクタで `JwtDecoder.test.ts` が壊れる                                                | `JwtDecoder.test.ts` は `verifySignature` / `ALG_MAP` のロジックのみ assert。Section の DOM レンダリングは test していない。astro check で型互換確認のみで OK |
+| R2  | `.uuid-field-key` の `font-size: 0.75rem` が `.caption` の 0.875rem を override しない                                                | `.uuid-field-key` を `.caption` の **後** に定義。同 `@layer components` 内で source 順位が後の方が優先（specificity 同等のため）。実装時に subagent が確認   |
+| R3  | `applyProductionCsp` を全 test に適用すると既存 e2e が CSP 違反で fail する                                                           | UuidV7Generator は PR 3 内で migration → CSP gate 順序を保つ（コミット 3 → 4）。先に gate を入れて後から migration するのは禁止。subagent への指示で明示      |
+| R4  | ハードコード hex（`#9333ea` 等）が将来 design token に統合されるべきか議論                                                            | 本 PR では YAGNI で hex リテラル維持。PR 6 cleanup で `--color-*` token 化検討余地（decisions [067] 候補）                                                    |
+| R5  | `accent-color` の Safari/iOS 互換                                                                                                     | Safari 13.1+ / iOS 13.4+ で対応済（caniuse 確認）。元コードも `accentColor` inline style を使っていたため互換維持                                             |
+| R6  | `<pre>` の `.jwt-pre` で `letter-spacing: -0.12px` が Tailwind 標準 utility に存在しないため新 class 必須                             | 本 PR で `.jwt-pre` を新 class として追加（§4）。原値厳密一致で VRT diff 回避                                                                                 |
+| R7  | UuidV7Generator の ColoredUuid 11 spans が複数ヶ所で同 class を re-use（`unixTsMs` が 2 ヶ所、`randB` が 2 ヶ所）                     | class re-use は CSS 上問題なし。同 class が同じ color を当てる挙動を維持                                                                                      |
+| R8  | `tests/e2e/uuid-v7.spec.ts` で `applyProductionCsp` を全 test に適用する変更が既存 test の race condition / timing 依存を顕在化させる | applyProductionCsp は route 注入で初回ナビゲーションから効く。timing 影響は config-converter で検証済み pattern。陽性対照 1 件で gate 自体の動作確認          |
+
+---
+
+## 11. 議論ポイント（spec 確定前に user 判断を要する項目）
+
+実装着手前に user レビュー推奨。本 spec で既に user 承認済みの項目を再記録:
+
+### D1. `Section` の variant 型
+
+- **採用**: `variant: 'header' | 'payload' | 'signature'` の discriminated string union（Section が JwtDecoder 内部の閉じた component なので閉集合 OK）
+- **代替**: `accentClass: string` 自由文字列（type 安全性低下）
+- **判断**: 採用案（user 承認済 2026-05-07）
+
+### D2. ハードコード hex の token 化タイミング
+
+- **採用**: 本 PR は class 内に hex 直接記述（`#9333ea` / `#7c3aed` / `#059669` / `#d97706` / `#0891b2` / `#6e4f0e` の 6 値）。PR 6 cleanup で `--color-*` token 化を検討
+- **代替**: 本 PR で `:root` に token 追加 (`--color-jwt-payload`, `--color-uuid-field-ver` 等)
+- **判断**: 採用案（user 承認済 2026-05-07、YAGNI + PR スコープ最小化）
+
+### D3. `.uuid-field-code` の追加可否
+
+- **採用**: 追加しない。`<code>` には `caption font-mono whitespace-nowrap rounded ... uuid-field-{name}` の utility 並べで対応
+- **代替**: 統合 class 追加で利用側 className 簡素化
+- **判断**: 採用案（user 承認済 2026-05-07、subagent 判断に委ねる余地あり）
+
+### D4. uuid-v7.spec.ts の gate 範囲
+
+- **採用**: 全 test を gate（config-converter 既存 pattern と整合）+ 陽性対照 1 件
+- **代替**: ResultTable を踏むテスト 1 件のみ gate
+- **判断**: 採用案（user 承認済 2026-05-07、coverage 増 = 同コスト）
+
+### D5. #262 close タイミング
+
+- **採用**: PR 3 では partial 完了、ulid-generator 部分は PR 5 で対応して #262 close
+- **代替**: PR 3 で ulid-generator も同時対応して #262 完全 close（scope 拡大）
+- **判断**: 採用案（user 承認済 2026-05-07、PR スコープ最小化）
+
+### D6. subagent 分担
+
+- **採用**: Track A (JwtDecoder) / Track B (UuidV7Generator + uuid-v7 E2E) の 2 並列、各 sonnet
+- **代替**: 3 並列（E2E 独立 Track）or 1 直列（subagent 1 件で全実装）
+- **判断**: 採用案（user 承認済 2026-05-07、E2E は UuidV7Generator と同 file トリーで context 連続）
+
+---
+
+## 関連
+
+- 起源 issue: [#176](https://github.com/fumtas1k/devtools/issues/176) アプローチ B
+- 同梱 issue: [#262](https://github.com/fumtas1k/devtools/issues/262) (applyProductionCsp E2E gate, partial 対応)
+- 前提 PR: [#249](https://github.com/fumtas1k/devtools/pull/249) (A-1) / [#252](https://github.com/fumtas1k/devtools/pull/252) (meta-csp) / [#254](https://github.com/fumtas1k/devtools/pull/254) (VRT) / [#256](https://github.com/fumtas1k/devtools/pull/256) (PR 1) / [#261](https://github.com/fumtas1k/devtools/pull/261) (PR 1.5) / [#272](https://github.com/fumtas1k/devtools/pull/272) (PR 2)
+- 過去 decisions: [054]（CSP 初導入）/ [064]（A-1 採用）/ [066]（VRT 採用）
+- repo SoT: [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md)
+- memory: `feedback_pr_size.md` / `feedback_infra_feature_separation.md` / `feedback_subagent_model.md` / `feedback_subagent_verification_trust.md` / `feedback_commander_checklist.md` / `feedback_vrt_ci_only.md` / `feedback_e2e_before_pr.md` / `feedback_branch_workflow.md` / `feedback_pr_language.md` / `feedback_heredoc_no_escape.md` / `feedback_worktree_base_branch.md` / `feedback_worktree_location.md` / `feedback_prod_parity_csp.md` / `feedback_positive_control_for_gates.md`
+- PR 1 spec: `docs/superpowers/specs/2026-05-03-issue-176-b1-foundation-and-ui-simple-design.md`
+- PR 1.5 spec: `docs/superpowers/specs/2026-05-04-issue-176-b1-5-ui-complex-design.md`
+- PR 2 spec: `docs/superpowers/specs/2026-05-04-issue-176-b2-qr-ticket-design.md`

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
-import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { InputField } from '@/components/ui/InputField';
 import {
   parseJwt,
@@ -14,10 +13,6 @@ import { bytesToBase64Url } from '@/utils/base64url';
 import { pemBlockToBytes } from '@/utils/base64';
 
 const SAMPLE_SECRET = 'your-256-bit-secret';
-
-// JWT syntax highlight colors (not UI colors — kept local)
-const jsonKeyColor = colors.link;
-const jsonValueColor = '#6e4f0e';
 
 type AlgParams =
   | { name: 'HMAC'; hash: string }
@@ -140,48 +135,34 @@ function PayloadValue({ k, v }: { k: string; v: unknown }) {
   const isTs = TIMESTAMP_KEYS.includes(k) && typeof v === 'number';
   return (
     <span>
-      <span style={{ color: jsonKeyColor }}>"{k}"</span>
-      <span style={{ color: colors.text }}>: </span>
-      <span style={{ color: jsonValueColor }}>{JSON.stringify(v)}</span>
-      {isTs && (
-        <span className="ml-2" style={{ fontSize: '0.75rem', color: colors.muted }}>
-          → {formatTimestamp(v as number)}
-        </span>
-      )}
+      <span className="jwt-json-key">"{k}"</span>
+      <span className="text-default">: </span>
+      <span className="jwt-json-value">{JSON.stringify(v)}</span>
+      {isTs && <span className="ml-2 text-xs text-muted">→ {formatTimestamp(v as number)}</span>}
     </span>
   );
 }
 
+type SectionVariant = 'header' | 'payload' | 'signature';
+
 interface SectionProps {
   title: string;
-  accentColor: string;
+  variant: SectionVariant;
   data: Record<string, unknown>;
   renderValue?: (k: string, v: unknown) => React.ReactNode;
   'data-testid'?: string;
 }
 
-function Section({ title, accentColor, data, renderValue, 'data-testid': testId }: SectionProps) {
+function Section({ title, variant, data, renderValue, 'data-testid': testId }: SectionProps) {
   const json = JSON.stringify(data, null, 2);
   return (
-    <div
-      className="rounded-lg p-4"
-      style={{ background: colors.bgSubtle, borderLeft: `4px solid ${accentColor}` }}
-      data-testid={testId}
-    >
+    <div className={`rounded-lg p-4 bg-subtle section-jwt-${variant}`} data-testid={testId}>
       <div className="mb-2 flex items-center justify-between">
-        <h3 style={{ ...bodyEmphasis, color: colors.text }}>{title}</h3>
+        <h3 className="body-emphasis text-default">{title}</h3>
         <CopyButton text={json} label="コピー" />
       </div>
-      <pre
-        className="overflow-x-auto font-mono"
-        style={{
-          fontSize: '0.75rem',
-          lineHeight: 1.33,
-          letterSpacing: '-0.12px',
-          color: colors.text,
-        }}
-      >
-        <span style={{ color: colors.muted }}>{'{'}</span>
+      <pre className="overflow-x-auto font-mono text-default jwt-pre">
+        <span className="text-muted">{'{'}</span>
         {'\n'}
         {Object.entries(data).map(([k, v]) => (
           <span key={k} className="block pl-4">
@@ -189,14 +170,14 @@ function Section({ title, accentColor, data, renderValue, 'data-testid': testId 
               renderValue(k, v)
             ) : (
               <>
-                <span style={{ color: jsonKeyColor }}>"{k}"</span>
-                <span style={{ color: colors.text }}>: </span>
-                <span style={{ color: jsonValueColor }}>{JSON.stringify(v)}</span>
+                <span className="jwt-json-key">"{k}"</span>
+                <span className="text-default">: </span>
+                <span className="jwt-json-value">{JSON.stringify(v)}</span>
               </>
             )}
           </span>
         ))}
-        <span style={{ color: colors.muted }}>{'}'}</span>
+        <span className="text-muted">{'}'}</span>
       </pre>
     </div>
   );
@@ -240,27 +221,21 @@ export function JwtDecoderTool() {
     ).then(setSigStatus);
   }, [parsed, secretKey]);
 
-  const expBadge: Record<ExpStatus, { label: string; style: React.CSSProperties }> = {
-    valid: { label: '有効', style: { background: colors.successBg, color: colors.success } },
-    expired: { label: '期限切れ', style: { background: colors.errorBg, color: colors.errorText } },
-    'no-exp': { label: 'exp なし', style: { background: colors.warningBg, color: colors.warning } },
+  const expBadge: Record<ExpStatus, { label: string; badgeClass: string }> = {
+    valid: { label: '有効', badgeClass: 'bg-success-tint text-success' },
+    expired: { label: '期限切れ', badgeClass: 'bg-error-tint text-error-text' },
+    'no-exp': { label: 'exp なし', badgeClass: 'bg-warning-tint text-warning' },
   };
 
-  const sigBadge: Record<SigStatus, { label: string; style: React.CSSProperties } | null> = {
+  const sigBadge: Record<SigStatus, { label: string; badgeClass: string } | null> = {
     unchecked: null,
-    verifying: { label: '検証中…', style: { background: colors.bgSubtle, color: colors.muted } },
-    valid: { label: '署名: 有効', style: { background: colors.successBg, color: colors.success } },
-    invalid: {
-      label: '署名: 無効',
-      style: { background: colors.errorBg, color: colors.errorText },
-    },
-    unsupported: {
-      label: '署名: 未対応アルゴリズム',
-      style: { background: colors.bgSubtle, color: colors.muted },
-    },
+    verifying: { label: '検証中…', badgeClass: 'bg-subtle text-muted' },
+    valid: { label: '署名: 有効', badgeClass: 'bg-success-tint text-success' },
+    invalid: { label: '署名: 無効', badgeClass: 'bg-error-tint text-error-text' },
+    unsupported: { label: '署名: 未対応アルゴリズム', badgeClass: 'bg-subtle text-muted' },
     error: {
       label: '署名: 検証エラー（キー形式を確認）',
-      style: { background: colors.errorBg, color: colors.errorText },
+      badgeClass: 'bg-error-tint text-error-text',
     },
   };
 
@@ -290,11 +265,7 @@ export function JwtDecoderTool() {
           label={
             <>
               {keyLabel}
-              <span
-                style={{ ...caption, color: colors.muted, fontWeight: 400, marginLeft: '0.5rem' }}
-              >
-                （任意）
-              </span>
+              <span className="caption text-muted ml-2">（任意）</span>
             </>
           }
           value={secretKey}
@@ -309,15 +280,12 @@ export function JwtDecoderTool() {
 
       {/* 有効期限チェックトグル */}
       {parsed && (
-        <label
-          className="flex items-center gap-2 cursor-pointer"
-          style={{ ...caption, color: colors.text }}
-        >
+        <label className="flex items-center gap-2 cursor-pointer caption text-default">
           <input
             type="checkbox"
             checked={verifyExp}
             onChange={(e) => setVerifyExp(e.target.checked)}
-            style={{ accentColor: colors.link, width: '1rem', height: '1rem' }}
+            className="w-4 h-4 accent-link"
           />
           有効期限（exp）チェックを行う
         </label>
@@ -328,8 +296,7 @@ export function JwtDecoderTool() {
         <div className="flex flex-wrap items-center gap-2">
           {verifyExp && (
             <span
-              className="rounded-full px-3 py-0.5"
-              style={{ ...caption, fontWeight: 500, ...expBadge[parsed.expStatus].style }}
+              className={`rounded-full px-3 py-0.5 caption font-medium ${expBadge[parsed.expStatus].badgeClass}`}
             >
               {expBadge[parsed.expStatus].label}
               {parsed.expStatus === 'valid' && parsed.remainingMs !== undefined && (
@@ -339,8 +306,7 @@ export function JwtDecoderTool() {
           )}
           {sigBadge[sigStatus] && (
             <span
-              className="rounded-full px-3 py-0.5"
-              style={{ ...caption, fontWeight: 500, ...sigBadge[sigStatus]!.style }}
+              className={`rounded-full px-3 py-0.5 caption font-medium ${sigBadge[sigStatus]!.badgeClass}`}
             >
               {sigBadge[sigStatus]!.label}
             </span>
@@ -353,29 +319,24 @@ export function JwtDecoderTool() {
         <div className="space-y-3" role="status" aria-live="polite">
           <Section
             title="Header (JOSE)"
-            accentColor={colors.error}
+            variant="header"
             data={parsed.header}
             data-testid="jwt-header"
           />
           <Section
             title="Payload (Claims)"
-            accentColor="#9333ea"
+            variant="payload"
             data={parsed.payload}
             renderValue={(k, v) => <PayloadValue k={k} v={v} />}
             data-testid="jwt-payload"
           />
-          <div
-            className="rounded-lg p-4"
-            style={{ background: colors.bgSubtle, borderLeft: `4px solid ${colors.primary}` }}
-          >
+          <div className="rounded-lg p-4 bg-subtle section-jwt-signature">
             <div className="mb-2 flex items-center justify-between">
-              <h3 style={{ ...bodyEmphasis, color: colors.text }}>Signature</h3>
+              <h3 className="body-emphasis text-default">Signature</h3>
               <CopyButton text={parsed.signature} label="コピー" />
             </div>
-            <p className="break-all font-mono" style={{ ...caption, color: colors.text }}>
-              {parsed.signature}
-            </p>
-            <p className="mt-2" style={{ ...caption, color: colors.muted }}>
+            <p className="break-all font-mono caption text-default">{parsed.signature}</p>
+            <p className="mt-2 caption text-muted">
               {secretKey.trim()
                 ? '上記のキーで署名を検証しています'
                 : 'キーを入力すると署名を検証します'}

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -145,6 +145,12 @@ function PayloadValue({ k, v }: { k: string; v: unknown }) {
 
 type SectionVariant = 'header' | 'payload' | 'signature';
 
+const SECTION_CLASSES: Record<SectionVariant, string> = {
+  header: 'section-jwt-header',
+  payload: 'section-jwt-payload',
+  signature: 'section-jwt-signature',
+};
+
 interface SectionProps {
   title: string;
   variant: SectionVariant;
@@ -156,7 +162,7 @@ interface SectionProps {
 function Section({ title, variant, data, renderValue, 'data-testid': testId }: SectionProps) {
   const json = JSON.stringify(data, null, 2);
   return (
-    <div className={`rounded-lg p-4 bg-subtle section-jwt-${variant}`} data-testid={testId}>
+    <div className={`rounded-lg p-4 bg-subtle ${SECTION_CLASSES[variant]}`} data-testid={testId}>
       <div className="mb-2 flex items-center justify-between">
         <h3 className="body-emphasis text-default">{title}</h3>
         <CopyButton text={json} label="コピー" />

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -74,7 +74,7 @@ function FieldBreakdownPanel({ uuid }: { uuid: string }) {
       <div className="flex flex-wrap gap-x-4 gap-y-2">
         {fieldDefs.map((f) => (
           <div key={f.key} className="flex flex-col gap-0.5">
-            <span className="text-muted uuid-field-key">
+            <span className="caption text-muted uuid-field-key">
               {f.key} <span className="uuid-field-bits">({f.bits})</span>
             </span>
             <code

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { v7 as uuidv7 } from 'uuid';
 import { CopyButton } from '@/components/ui/CopyButton';
-import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { CountInput } from '@/components/ui/CountInput';
 import { ClearButton } from '@/components/ui/ClearButton';
@@ -14,13 +13,13 @@ interface UuidRow {
   timestamp: string;
 }
 
-/** フィールド分解パネル用の色定義 */
-const FIELD_COLORS = {
-  unixTsMs: colors.primary,
-  ver: '#7C3AED',
-  randA: '#059669',
-  varNibble: '#D97706',
-  randB: '#0891B2',
+/** フィールド分解パネル用の class 定義 */
+const FIELD_CLASSES = {
+  unixTsMs: 'uuid-field-ts',
+  ver: 'uuid-field-ver',
+  randA: 'uuid-field-rand-a',
+  varNibble: 'uuid-field-var',
+  randB: 'uuid-field-rand-b',
 } as const;
 
 function generateRows(count: number): UuidRow[] {
@@ -39,25 +38,20 @@ function ColoredUuid({ uuid, quoteStyle }: { uuid: string; quoteStyle: QuoteStyl
   const fullText = `${quote}${uuid}${quote}`;
 
   return (
-    <span
-      className="font-mono"
-      style={{ ...caption, letterSpacing: '0.02em', whiteSpace: 'nowrap' }}
-      aria-label={fullText}
-      title={fullText}
-    >
-      {quote && <span style={{ color: colors.muted }}>{quote}</span>}
-      <span style={{ color: FIELD_COLORS.unixTsMs }}>{parts[0]}</span>
-      <span style={{ color: colors.muted }}>-</span>
-      <span style={{ color: FIELD_COLORS.unixTsMs }}>{parts[1]}</span>
-      <span style={{ color: colors.muted }}>-</span>
-      <span style={{ color: FIELD_COLORS.ver }}>{parts[2][0]}</span>
-      <span style={{ color: FIELD_COLORS.randA }}>{parts[2].substring(1)}</span>
-      <span style={{ color: colors.muted }}>-</span>
-      <span style={{ color: FIELD_COLORS.varNibble }}>{parts[3][0]}</span>
-      <span style={{ color: FIELD_COLORS.randB }}>{parts[3].substring(1)}</span>
-      <span style={{ color: colors.muted }}>-</span>
-      <span style={{ color: FIELD_COLORS.randB }}>{parts[4]}</span>
-      {quote && <span style={{ color: colors.muted }}>{quote}</span>}
+    <span className="font-mono caption whitespace-nowrap" aria-label={fullText} title={fullText}>
+      {quote && <span className="text-muted">{quote}</span>}
+      <span className={FIELD_CLASSES.unixTsMs}>{parts[0]}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.unixTsMs}>{parts[1]}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.ver}>{parts[2][0]}</span>
+      <span className={FIELD_CLASSES.randA}>{parts[2].substring(1)}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.varNibble}>{parts[3][0]}</span>
+      <span className={FIELD_CLASSES.randB}>{parts[3].substring(1)}</span>
+      <span className="text-muted">-</span>
+      <span className={FIELD_CLASSES.randB}>{parts[4]}</span>
+      {quote && <span className="text-muted">{quote}</span>}
     </span>
   );
 }
@@ -67,35 +61,24 @@ function FieldBreakdownPanel({ uuid }: { uuid: string }) {
   const fields = parseUuidV7Fields(uuid);
 
   const fieldDefs = [
-    { key: 'unix_ts_ms', bits: '48bit', value: fields.unixTsMs, color: FIELD_COLORS.unixTsMs },
-    { key: 'ver', bits: '4bit', value: fields.ver, color: FIELD_COLORS.ver },
-    { key: 'rand_a', bits: '12bit', value: fields.randA, color: FIELD_COLORS.randA },
-    { key: 'var', bits: '2bit', value: fields.varNibble, color: FIELD_COLORS.varNibble },
-    { key: 'rand_b', bits: '62bit', value: fields.randB, color: FIELD_COLORS.randB },
+    { key: 'unix_ts_ms', bits: '48bit', value: fields.unixTsMs, className: FIELD_CLASSES.unixTsMs },
+    { key: 'ver', bits: '4bit', value: fields.ver, className: FIELD_CLASSES.ver },
+    { key: 'rand_a', bits: '12bit', value: fields.randA, className: FIELD_CLASSES.randA },
+    { key: 'var', bits: '2bit', value: fields.varNibble, className: FIELD_CLASSES.varNibble },
+    { key: 'rand_b', bits: '62bit', value: fields.randB, className: FIELD_CLASSES.randB },
   ] as const;
 
   return (
-    <div
-      className="rounded-lg p-3"
-      style={{ background: colors.bgSubtle, border: `1px solid ${colors.border}` }}
-    >
-      <p style={{ ...caption, color: colors.muted, marginBottom: '0.5rem' }}>フィールド分解</p>
+    <div className="rounded-lg p-3 bg-subtle border border-default">
+      <p className="caption text-muted mb-2">フィールド分解</p>
       <div className="flex flex-wrap gap-x-4 gap-y-2">
         {fieldDefs.map((f) => (
           <div key={f.key} className="flex flex-col gap-0.5">
-            <span style={{ ...caption, color: colors.muted, fontSize: '0.75rem' }}>
-              {f.key} <span style={{ fontSize: '0.7rem', opacity: 0.7 }}>({f.bits})</span>
+            <span className="text-muted uuid-field-key">
+              {f.key} <span className="uuid-field-bits">({f.bits})</span>
             </span>
             <code
-              className="rounded px-1.5 py-0.5"
-              style={{
-                ...caption,
-                fontFamily: 'monospace',
-                color: f.color,
-                background: colors.bg,
-                border: `1px solid ${colors.border}`,
-                whiteSpace: 'nowrap',
-              }}
+              className={`font-mono whitespace-nowrap rounded px-1.5 py-0.5 bg-default border border-default caption ${f.className}`}
             >
               {f.value}
             </code>
@@ -177,7 +160,7 @@ export function UuidV7GeneratorTool() {
             onRowClick={setSelectedIndex}
             renderHeader={() => (
               <>
-                <span style={{ ...bodyEmphasis, color: colors.text }}>{rows.length} 件生成</span>
+                <span className="body-emphasis text-default">{rows.length} 件生成</span>
                 <div className="flex flex-wrap items-center gap-2">
                   <div className="shrink-0">
                     <ToggleGroup<QuoteStyle>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -426,4 +426,74 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   }
+
+  /* === PR 3: JwtDecoder + UuidV7Generator migration helpers === */
+
+  /* JwtDecoder: Section accent borders */
+  .section-jwt-header {
+    border-left: 4px solid var(--color-error);
+  }
+  .section-jwt-payload {
+    border-left: 4px solid #9333ea;
+  }
+  .section-jwt-signature {
+    border-left: 4px solid var(--color-primary);
+  }
+
+  /* JwtDecoder: JSON syntax colors (not UI tokens, kept local) */
+  .jwt-json-key {
+    color: var(--color-link);
+  }
+  .jwt-json-value {
+    color: #6e4f0e;
+  }
+
+  /* JwtDecoder: <pre> (decoded JSON) typography */
+  .jwt-pre {
+    font-size: 0.75rem;
+    line-height: 1.33;
+    letter-spacing: -0.12px;
+  }
+
+  /* Checkbox accent (link color) */
+  .accent-link {
+    accent-color: var(--color-link);
+  }
+
+  /* Warning semantic palette (expBadge no-exp 用) */
+  .text-warning {
+    color: var(--color-warning);
+  }
+  .bg-warning-tint {
+    background: var(--color-warning-bg);
+  }
+
+  /* UuidV7Generator: 5 field colors (UUID hex parts) */
+  .uuid-field-ts {
+    color: var(--color-primary);
+  }
+  .uuid-field-ver {
+    color: #7c3aed;
+  }
+  .uuid-field-rand-a {
+    color: #059669;
+  }
+  .uuid-field-var {
+    color: #d97706;
+  }
+  .uuid-field-rand-b {
+    color: #0891b2;
+  }
+
+  /* UuidV7Generator: field key label typography (caption の font-size override) */
+  .uuid-field-key {
+    font-size: 0.75rem;
+    font-weight: 400;
+    line-height: 1.7;
+    letter-spacing: 0.02em;
+  }
+  .uuid-field-bits {
+    font-size: 0.7rem;
+    opacity: 0.7;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -485,12 +485,12 @@
     color: #0891b2;
   }
 
-  /* UuidV7Generator: field key label typography (caption の font-size override) */
+  /* UuidV7Generator: field key label typography
+     `.caption` (font-size 0.875rem) と組み合わせて使い、font-size のみ override する。
+     consumer 側は `caption text-muted uuid-field-key` で適用。
+     `.caption` の後に定義することで source 順位で勝つ (specificity 同等のため)。 */
   .uuid-field-key {
     font-size: 0.75rem;
-    font-weight: 400;
-    line-height: 1.7;
-    letter-spacing: 0.02em;
   }
   .uuid-field-bits {
     font-size: 0.7rem;

--- a/src/utils/__tests__/inline-style-migration.test.ts
+++ b/src/utils/__tests__/inline-style-migration.test.ts
@@ -32,6 +32,9 @@ const MIGRATED_FILES: readonly string[] = [
   'src/components/tools/qr-ticket/GenerateTab.tsx',
   'src/components/tools/qr-ticket/VerifyTab.tsx',
   'src/components/tools/qr-ticket/TicketDetail.tsx',
+  // PR 3 で追加
+  'src/components/tools/JwtDecoder.tsx',
+  'src/components/tools/UuidV7Generator.tsx',
 ];
 
 describe.skipIf(MIGRATED_FILES.length === 0)('#176 B 案 progressive migration tracker', () => {

--- a/tests/e2e/uuid-v7.spec.ts
+++ b/tests/e2e/uuid-v7.spec.ts
@@ -1,108 +1,204 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { applyProductionCsp, waitForReactHydration } from './helpers';
 
-test.describe('UUID v7 生成', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/uuid-v7');
-    await page.getByLabel('生成数').waitFor();
-    await waitForReactHydration(page);
+test.describe('UUID v7 生成（production CSP 適用）', () => {
+  test('UUIDをデフォルト（10件）生成できる（CSP 違反なし）', async ({ browser }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      await page.goto('/tools/uuid-v7');
+      await page.getByLabel('生成数').waitFor();
+      await waitForReactHydration(page);
+
+      await page.getByRole('button', { name: '生成' }).click();
+
+      // 「10 件生成」というテキストが表示される
+      await expect(page.getByText('10 件生成')).toBeVisible();
+
+      // テーブルに行が存在し、UUID形式（8-4-4-4-12）であることを確認
+      const rows = page.locator('table tbody tr');
+      await expect(rows).toHaveCount(10);
+      const uuidCell = rows.first().locator('td').nth(1);
+      const uuidText = await uuidCell.textContent();
+      // UUID v7 の正規表現 (バージョン 7 であることを確認)
+      expect(uuidText).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+
+      guard.assertNoViolations();
+    } finally {
+      await context.close();
+    }
   });
 
-  test('UUIDをデフォルト（10件）生成できる', async ({ page }) => {
-    await page.getByRole('button', { name: '生成' }).click();
+  test('UUIDを複数件一括生成できる（CSP 違反なし）', async ({ browser }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      await page.goto('/tools/uuid-v7');
+      await page.getByLabel('生成数').waitFor();
+      await waitForReactHydration(page);
 
-    // 「10 件生成」というテキストが表示される
-    await expect(page.getByText('10 件生成')).toBeVisible();
+      const countInput = page.getByLabel('生成数');
+      await countInput.fill('5');
+      await page.getByRole('button', { name: '生成' }).click();
 
-    // テーブルに行が存在し、UUID形式（8-4-4-4-12）であることを確認
-    const rows = page.locator('table tbody tr');
-    await expect(rows).toHaveCount(10);
-    const uuidCell = rows.first().locator('td').nth(1);
-    const uuidText = await uuidCell.textContent();
-    // UUID v7 の正規表現 (バージョン 7 であることを確認)
-    expect(uuidText).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-    );
+      await expect(page.getByText('5 件生成')).toBeVisible();
+      const rows = page.locator('table tbody tr');
+      await expect(rows).toHaveCount(5);
+
+      guard.assertNoViolations();
+    } finally {
+      await context.close();
+    }
   });
 
-  test('UUIDを複数件一括生成できる', async ({ page }) => {
-    const countInput = page.getByLabel('生成数');
-    await countInput.fill('5');
-    await page.getByRole('button', { name: '生成' }).click();
+  test('クォートスタイルを切り替えられる（CSP 違反なし）', async ({ browser }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      await page.goto('/tools/uuid-v7');
+      await page.getByLabel('生成数').waitFor();
+      await waitForReactHydration(page);
 
-    await expect(page.getByText('5 件生成')).toBeVisible();
-    const rows = page.locator('table tbody tr');
-    await expect(rows).toHaveCount(5);
+      await page.getByRole('button', { name: '生成' }).click();
+
+      const noneBtn = page.getByRole('button', { name: 'なし' });
+      const doubleBtn = page.getByRole('button', { name: '"..."' });
+      const singleBtn = page.getByRole('button', { name: "'...'" });
+
+      // デフォルトは「なし」が選択されている
+      await expect(noneBtn).toHaveAttribute('aria-pressed', 'true');
+      await expect(doubleBtn).toHaveAttribute('aria-pressed', 'false');
+      await expect(singleBtn).toHaveAttribute('aria-pressed', 'false');
+
+      const uuidCell = page.locator('table tbody tr').first().locator('td').nth(1);
+      const coloredUuid = uuidCell.locator('span[aria-label]');
+
+      // UUID v7 の正規表現
+      const uuidV7Regex = /[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+
+      // なしの状態ではクォートが含まれない
+      await expect(coloredUuid).toHaveAttribute(
+        'aria-label',
+        new RegExp(`^${uuidV7Regex.source}$`, 'i')
+      );
+
+      // ダブルクォートに切り替え
+      await doubleBtn.click();
+      await expect(noneBtn).toHaveAttribute('aria-pressed', 'false');
+      await expect(doubleBtn).toHaveAttribute('aria-pressed', 'true');
+
+      await expect(coloredUuid).toHaveAttribute(
+        'aria-label',
+        new RegExp(`^"${uuidV7Regex.source}"$`, 'i')
+      );
+
+      // シングルクォートに切り替え
+      await singleBtn.click();
+      await expect(singleBtn).toHaveAttribute('aria-pressed', 'true');
+      await expect(doubleBtn).toHaveAttribute('aria-pressed', 'false');
+
+      await expect(coloredUuid).toHaveAttribute(
+        'aria-label',
+        new RegExp(`^'${uuidV7Regex.source}'$`, 'i')
+      );
+
+      guard.assertNoViolations();
+    } finally {
+      await context.close();
+    }
   });
 
-  test('クォートスタイルを切り替えられる', async ({ page }) => {
-    await page.getByRole('button', { name: '生成' }).click();
+  test('行をクリックするとフィールド分解パネルが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      await page.goto('/tools/uuid-v7');
+      await page.getByLabel('生成数').waitFor();
+      await waitForReactHydration(page);
 
-    const noneBtn = page.getByRole('button', { name: 'なし' });
-    const doubleBtn = page.getByRole('button', { name: '"..."' });
-    const singleBtn = page.getByRole('button', { name: "'...'" });
+      await page.getByRole('button', { name: '生成' }).click();
 
-    // デフォルトは「なし」が選択されている
-    await expect(noneBtn).toHaveAttribute('aria-pressed', 'true');
-    await expect(doubleBtn).toHaveAttribute('aria-pressed', 'false');
-    await expect(singleBtn).toHaveAttribute('aria-pressed', 'false');
+      // 最初の行をクリック
+      await page.locator('table tbody tr').first().click();
 
-    const uuidCell = page.locator('table tbody tr').first().locator('td').nth(1);
-    const coloredUuid = uuidCell.locator('span[aria-label]');
+      // フィールド分解パネルが表示されることを確認
+      await expect(page.getByText('フィールド分解', { exact: true })).toBeVisible();
+      await expect(page.getByText('unix_ts_ms', { exact: true })).toBeVisible();
+      await expect(page.getByText('ver', { exact: true })).toBeVisible();
 
-    // UUID v7 の正規表現
-    const uuidV7Regex = /[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
-
-    // なしの状態ではクォートが含まれない
-    await expect(coloredUuid).toHaveAttribute(
-      'aria-label',
-      new RegExp(`^${uuidV7Regex.source}$`, 'i')
-    );
-
-    // ダブルクォートに切り替え
-    await doubleBtn.click();
-    await expect(noneBtn).toHaveAttribute('aria-pressed', 'false');
-    await expect(doubleBtn).toHaveAttribute('aria-pressed', 'true');
-
-    await expect(coloredUuid).toHaveAttribute(
-      'aria-label',
-      new RegExp(`^"${uuidV7Regex.source}"$`, 'i')
-    );
-
-    // シングルクォートに切り替え
-    await singleBtn.click();
-    await expect(singleBtn).toHaveAttribute('aria-pressed', 'true');
-    await expect(doubleBtn).toHaveAttribute('aria-pressed', 'false');
-
-    await expect(coloredUuid).toHaveAttribute(
-      'aria-label',
-      new RegExp(`^'${uuidV7Regex.source}'$`, 'i')
-    );
+      guard.assertNoViolations();
+    } finally {
+      await context.close();
+    }
   });
 
-  test('行をクリックするとフィールド分解パネルが表示される', async ({ page }) => {
-    await page.getByRole('button', { name: '生成' }).click();
+  test('クリアボタンでリストをリセットできる（CSP 違反なし）', async ({ browser }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      await page.goto('/tools/uuid-v7');
+      await page.getByLabel('生成数').waitFor();
+      await waitForReactHydration(page);
 
-    // 最初の行をクリック
-    await page.locator('table tbody tr').first().click();
+      await page.getByRole('button', { name: '生成' }).click();
+      await expect(page.getByText('10 件生成')).toBeVisible();
 
-    // フィールド分解パネルが表示されることを確認
-    await expect(page.getByText('フィールド分解', { exact: true })).toBeVisible();
-    await expect(page.getByText('unix_ts_ms', { exact: true })).toBeVisible();
-    await expect(page.getByText('ver', { exact: true })).toBeVisible();
+      // 最初の行をクリックしてフィールド分解パネルを表示
+      await page.locator('table tbody tr').first().click();
+      await expect(page.getByText('フィールド分解', { exact: true })).toBeVisible();
+
+      await page.getByRole('button', { name: 'クリア' }).click();
+      await expect(page.getByText('0 件生成')).not.toBeVisible();
+      await expect(page.locator('table')).not.toBeVisible();
+      await expect(page.getByText('フィールド分解', { exact: true })).not.toBeVisible();
+
+      guard.assertNoViolations();
+    } finally {
+      await context.close();
+    }
   });
 
-  test('クリアボタンでリストをリセットできる', async ({ page }) => {
-    await page.getByRole('button', { name: '生成' }).click();
-    await expect(page.getByText('10 件生成')).toBeVisible();
-
-    // 最初の行をクリックしてフィールド分解パネルを表示
-    await page.locator('table tbody tr').first().click();
-    await expect(page.getByText('フィールド分解', { exact: true })).toBeVisible();
-
-    await page.getByRole('button', { name: 'クリア' }).click();
-    await expect(page.getByText('0 件生成')).not.toBeVisible();
-    await expect(page.locator('table')).not.toBeVisible();
-    await expect(page.getByText('フィールド分解', { exact: true })).not.toBeVisible();
+  // 陽性対照 — ゲート自体の動作確認
+  test('applyProductionCsp は実際に CSP 違反を捕捉する（ゲート自体の動作確認）', async ({
+    browser,
+  }) => {
+    // helper の組み合わせが将来壊れたとき「ゲートが空回りしているのに green」
+    // になる事故を防ぐメタテスト。意図的に CSP 違反を発生させ guard.violations
+    // が確実に増えることを確認する。
+    //
+    // 設計メモ:
+    // - browser から新規 context + 新規 page を作る。
+    // - page.evaluate(() => eval(...)) は Playwright が CDP Runtime.evaluate
+    //   経由でコードを評価するため CSP `unsafe-eval` を回避してしまう。代わりに
+    //   「外部 origin の <script src>」を DOM に挿入する経路で違反を起こす。
+    //   PRODUCTION_CSP は `script-src 'self' 'unsafe-inline'` のため
+    //   example.com の外部スクリプトは確実に block され Chromium が
+    //   "Refused to load the script ... because it violates the following
+    //    Content Security Policy directive ..." を console error に出す。
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const guard = await applyProductionCsp(page);
+      const response = await page.goto('/tools/uuid-v7');
+      // 前提検証: route 注入によって本番 CSP がレスポンスヘッダに乗っていること
+      expect(response?.headers()['content-security-policy']).toContain("script-src 'self'");
+      await page.evaluate(() => {
+        const script = document.createElement('script');
+        script.src = 'https://example.com/violates-csp.js';
+        document.head.appendChild(script);
+      });
+      await expect.poll(() => guard.violations.length).toBeGreaterThan(0);
+    } finally {
+      await context.close();
+    }
   });
 });


### PR DESCRIPTION
## 概要

`#176` B 案バッチの PR 3。`JwtDecoder.tsx` (21 件) と `UuidV7Generator.tsx` (20 件) の JSX inline style を `@layer components` の意味クラス + Tailwind utility に置換し、同時に `tests/e2e/uuid-v7.spec.ts` に `applyProductionCsp(page)` E2E gate を挿入して issue #262 の uuid-v7 部分を partial 対応する。

- spec: `docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md`
- plan: `docs/superpowers/plans/2026-05-07-issue-176-b3-jwt-uuid.md`
- バッチ進捗: `docs/projects/issue-176-b-plan-progress.md`

## 主要な変更

### `src/styles/global.css` 追加 class (16 件)

- JwtDecoder 用: `.section-jwt-{header,payload,signature}` / `.jwt-json-{key,value}` / `.jwt-pre` / `.accent-link`
- UuidV7Generator 用: `.uuid-field-{ts,ver,rand-a,var,rand-b}` / `.uuid-field-{key,bits}`
- 汎用 (PR 4-5 で再利用見込): `.text-warning` / `.bg-warning-tint`

### `JwtDecoder.tsx` (21 件 → 0)

- `Section` component の `accentColor` prop を `variant: 'header' | 'payload' | 'signature'` の discriminated union に変更
- `expBadge` / `sigBadge` の `style: CSSProperties` を `badgeClass: string` に変更
- `<pre>` typography (`font-size: 0.75rem; line-height: 1.33; letter-spacing: -0.12px`) を `.jwt-pre` に集約
- checkbox の `accentColor` を `.accent-link` class に置換
- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除

### `UuidV7Generator.tsx` (20 件 → 0)

- `FIELD_COLORS` const を `FIELD_CLASSES` const に refactor
- `ColoredUuid` / `FieldBreakdownPanel` で動的色を class 切替で表現
- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除

### `tests/e2e/uuid-v7.spec.ts` への applyProductionCsp gate (#262 partial)

- 全 test を `browser.newContext()` pattern に変更し `applyProductionCsp(page)` を `goto` 前に挿入
- 陽性対照 1 件追加 (script-src 違反で gate 動作確認、`config-converter.spec.ts` 既存 pattern 踏襲)
- ulid-generator 部分は PR 5 で対応して #262 close 予定

## 検証ログ (親 Opus 直接実行)

- [x] `npm run test` → **614 passed, 1 skipped** (migration test 18 件 × 2 + 陽性対照 3 件含む計 39 件 pass)
- [x] `npx astro check` → **0 errors, 0 warnings, 10 hints** (hints は既存)
- [x] `npm run test:e2e` → **145 passed, 1 skipped** (uuid-v7 CSP gate 5 件 + 陽性対照 1 件含む)
- [x] a11y 退化なし
  - `aria-*` / `role=` / `data-testid=` の削除は無し（diff の "削除行" は reformat 時の行移動で、現コードに同 attribute が維持されていることを確認）
  - `htmlFor=` 変更なし
- [x] inline style 残存ゼロ (`grep -c "style={{" src/components/tools/JwtDecoder.tsx src/components/tools/UuidV7Generator.tsx` = 0 / 0)
- [x] PR 6 スコープ未侵害 (`_headers` / `astro.config.mjs` / `src/utils/styles.ts` 未変更)

## VRT

`visual-regression.yml` で baseline 比較 (non-required check)。意図的差分があれば PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger。

## コミット粒度

```
6d188f8 test(migration): MIGRATED_FILES に PR 3 対象 2 件追加
4029e86 test(e2e): #176 B 案 PR 3 — uuid-v7 spec に applyProductionCsp gate 追加 (#262 partial)
b9454df refactor(tools): #176 B 案 PR 3 — UuidV7Generator.tsx inline style 撤去
2093fb7 refactor(tools): #176 B 案 PR 3 — JwtDecoder.tsx inline style 撤去
0c3c0aa chore(spec): #176 B 案 PR 3 spec / plan / global.css foundation
```

(初回 sonnet 並列 dispatch で commit が結合された race を親 Opus が `git reset --soft` で 3 件に正しく split した経緯あり)

## 関連

- 起源 issue: #176 (アプローチ B)
- 部分対応 issue: #262 (uuid-v7 部分のみ、ulid-generator は PR 5 へ)
- 前提 PR: #249 (A-1) / #254 (VRT) / #256 (PR 1) / #261 (PR 1.5) / #272 (PR 2)
- 後続: PR 4 (Gs1Databar + EncodingConverter + DummyText) / PR 5 (QrReader + 残り tools + #262 close) / PR 6 (flip + cleanup)
