### PR TITLE
refactor(tools): #176 B 案 PR 4 — Gs1Databar + EncodingConverter + DummyText inline style 撤去

### DIFF
--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -9,6 +9,73 @@
 
 ---
 
+## [2026-05-07] Tailwind v4 で `@layer components` 内手書き class は `hover:` / `focus:` 等の variant に対応しない（規約昇格候補）
+
+### 現象
+
+PR #277 (#176 B 案 PR 4) で `Gs1Databar.tsx` の hover state を `hover:bg-error-tint` / `hover:bg-subtle` の Tailwind hover utility で表現したが、build 出力 (`dist/_astro/BaseLayout.*.css`) に該当 CSS rule (`.hover\:bg-error-tint:hover { ... }` / `.hover\:bg-subtle:hover { ... }`) が **0 件** しか生成されず、UI 上 hover フィードバックが完全に消失する silent regression が発生した。
+
+`hover:bg-blue-50` などの Tailwind primitive カラー utility (= `@theme` の `--color-blue-50` から auto-generate された utility) は variant 対応するが、`.bg-subtle` / `.bg-error-tint` / `.text-primary` 等の `global.css` の `@layer components` 内で **手書き定義** した class は variant 非対応 (Tailwind v4 の仕様)。
+
+### 根本原因
+
+Tailwind v4 の variant 生成ルール:
+
+- `@theme` トークンから auto-generate される utility → variant 対応 ✓ (`hover:bg-blue-50`, `hover:text-primary` 等が生成される)
+- `@layer components` 内で手書き定義した class → variant **対応外** ✗ (`hover:bg-subtle` は CSS rule が生成されない)
+
+DOM には `class="...hover:bg-subtle..."` の文字列が乗るが、対応する `.hover\:bg-subtle:hover { ... }` の CSS rule が出力されないため hover 時に何も起きない。
+
+### 対処
+
+専用の hover 用 class を `@layer components` 内に `:hover` 擬似クラスごと定義する。`.btn-clear` (PR 1) / `.btn-copy.is-copied` (PR 1) と同じ pattern:
+
+```css
+@layer components {
+  .btn-remove-card {
+    color: var(--color-error);
+    background: transparent;
+    transition: background-color 0.15s;
+  }
+  .btn-remove-card:hover {
+    background: var(--color-error-bg);
+  }
+
+  .hover-bg-subtle {
+    transition: background-color 0.15s;
+  }
+  .hover-bg-subtle:hover {
+    background: var(--color-bg-subtle);
+  }
+}
+```
+
+JSX 側は `className="caption btn-remove-card"` のように適用 (variant prefix を使わない)。
+
+### 検証手順 (今後の PR で)
+
+`@layer components` 内手書き class に `hover:` / `focus:` / `aria-pressed:` 等の variant を新規追加した場合、必ず build 出力で CSS rule が生成されているか確認する:
+
+```bash
+npm run build
+CSS=$(find dist -name "BaseLayout*.css" | head -1)
+grep -oE '\.hover\\\\:bg-[a-z0-9-]+:hover\{[^}]*\}' "$CSS"
+# 期待: 該当 class の :hover rule が出力されていること
+```
+
+VRT は pixel diff のみのため hover state までは検出できない。E2E で `hover()` → `getComputedStyle().backgroundColor` の差分 assert を加えると更に堅牢 (#234 の applyProductionCsp 全ツール展開と同種の能動検出 gate)。
+
+### 関連修正
+
+- `docs/ui-conventions.md` の line 30-31 (旧記述「同じ理由で `hover:bg-subtle` のような『Tailwind hover utility + 意味クラス』も許容」) を本 lesson の発見に基づき修正済 (variant 非対応の警告に書き換え)
+- PR #277 の commit `58ebf04` で対応 class 追加 (`.btn-remove-card` / `.hover-bg-subtle` / `.hover-bg-active`)
+
+### 規約昇格候補
+
+`shared-agent-rules.md` 7 章 (Tailwind カラー使用制限) または UI スタイリング章への追加候補。本教訓は反復的に発生する種類のもの (B 案 PR 5 / PR 6 でも同 pattern を踏む可能性あり) なので、次回 agent-lessons.md 整理タイミングで昇格判断推奨。
+
+---
+
 ## [2026-04-28] QRチケット 160px 表示と等倍デコードによる読み取り失敗リスク
 
 ### 現象

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -70,6 +70,14 @@ VRT は pixel diff のみのため hover state までは検出できない。E2E
 - `docs/ui-conventions.md` の line 30-31 (旧記述「同じ理由で `hover:bg-subtle` のような『Tailwind hover utility + 意味クラス』も許容」) を本 lesson の発見に基づき修正済 (variant 非対応の警告に書き換え)
 - PR #277 の commit `58ebf04` で対応 class 追加 (`.btn-remove-card` / `.hover-bg-subtle` / `.hover-bg-active`)
 
+### 副次発見: markdown content scan による unused utility 混入
+
+PR #277 の re-review で reviewer が「build CSS に `hover:bg-blue-50:hover` が unused で残っている」観察を報告。原因調査の結果、Tailwind v4 vite plugin の auto content scan は `docs/` 配下の markdown も対象としており、spec / plan / agent-lessons / decisions の md ファイル中で説明用に書いた `hover:bg-blue-50` 等の utility 名リテラル文字列を拾って unused utility が build CSS に混入していた。
+
+対処は `src/styles/global.css` 冒頭に `@source not "../../docs";` ディレクティブを追加して docs/ を scan 範囲外にする (PR #277 で実施済)。docs/ は実装コードを含まないため scan する意味がなく、副作用なし。
+
+なお `src/` 配下の `.css` / `.tsx` 等のコメント内に utility 名リテラルを書くと scan されるため、説明する場合は `hover-prefix + bg + blue-50` のように分割して記述する必要がある (PR #277 commit `58ebf04` の global.css コメントが実例)。
+
 ### 規約昇格候補
 
 `shared-agent-rules.md` 7 章 (Tailwind カラー使用制限) または UI スタイリング章への追加候補。本教訓は反復的に発生する種類のもの (B 案 PR 5 / PR 6 でも同 pattern を踏む可能性あり) なので、次回 agent-lessons.md 整理タイミングで昇格判断推奨。

--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -23,8 +23,8 @@
 | **PR 1** | 基礎工事 + ui/\* simple (11 ファイル) — `@layer components` foundation + migration tracker + ClearButton CSSOM 撤去 + ToggleGroup setProperty 化 | ✅ merged  | [#256 (merged eb5e537)](https://github.com/fumtas1k/devtools/pull/256) |
 | PR 1.5   | ui/\* complex (ResultTable + InputField) — API redesign 含む                                                                                     | ✅ merged  | [#261 (merged 8e58bd5)](https://github.com/fumtas1k/devtools/pull/261) |
 | PR 2     | qr-ticket/\* — inline style 撤去 + #225 (useMemo/abort) 同梱                                                                                     | ✅ merged  | [#272 (merged 37adb60)](https://github.com/fumtas1k/devtools/pull/272) |
-| PR 3     | JwtDecoder + UuidV7Generator + #262 partial (uuid-v7 CSP gate)                                                                                   | 🔄 PR open | [#275](https://github.com/fumtas1k/devtools/pull/275)                  |
-| PR 4     | Gs1Databar + EncodingConverter + DummyText                                                                                                       | 未着手     | -                                                                      |
+| PR 3     | JwtDecoder + UuidV7Generator + #262 partial (uuid-v7 CSP gate)                                                                                   | ✅ merged  | [#275 (merged 1150883)](https://github.com/fumtas1k/devtools/pull/275) |
+| PR 4     | Gs1Databar + EncodingConverter + DummyText                                                                                                       | 🔄 PR open | [#277](https://github.com/fumtas1k/devtools/pull/277)                  |
 | PR 5     | QrReader + ConfigConverter + JanCode + QrCode + 残り tools                                                                                       | 未着手     | -                                                                      |
 | PR 6     | flip + cleanup（CSP strict 化）                                                                                                                  | 未着手     | -                                                                      |
 
@@ -42,7 +42,13 @@
 - **PR 内同梱 (partial、close は PR 5 で)**: [#262](https://github.com/fumtas1k/devtools/issues/262) test(e2e): generator ページの applyProductionCsp E2E gate を追加（PR 6 前段必須） — PR `#275` で **uuid-v7 部分** に gate を挿入 (`tests/e2e/uuid-v7.spec.ts` の全 test を `browser.newContext()` pattern + `applyProductionCsp(page)` で gate、陽性対照 1 件追加)。**ulid-generator 部分は PR 5 で対応して #262 close 予定**
 - **PR review 由来 follow-up**: [#276](https://github.com/fumtas1k/devtools/issues/276) test(e2e): applyProductionCsp の `browser.newContext` boilerplate を `withProductionCsp` ラッパで集約 — **PR 5 前段の独立 infra PR** で対応推奨（`feedback_infra_feature_separation.md` 準拠）。PR 5 着手前に整備すると PR 5 が薄くなる
 
-## PR 1 / PR 1.5 / PR 2 / PR 3 follow-up issue 処理タイミング表
+### PR 4 (#277)
+
+- **特殊事項**: Gs1Databar 内で `e.currentTarget.style.X = Y` 形式の CSSOM hover state mutation 9 件を Tailwind `hover:` modifier に refactor。inline style と同等の hover 挙動を CSS で表現
+- **race 回避運用**: PR 3 の commit 結合 race 反省を踏まえ、subagent は commit せず親 Opus が Phase 1.5 で順次 commit する方式を初採用（3 commit が綺麗に分離、prettier 巻き込みも親が制御）
+- **新規 class**: `.summary-no-marker` の 1 件のみ（Gs1Databar `<details>/<summary>` 専用、PR 1〜3 既存 class で 95% 以上カバー）
+
+## PR 1 / PR 1.5 / PR 2 / PR 3 / PR 4 follow-up issue 処理タイミング表
 
 各 issue の処理推奨タイミング (2026-05-07 時点):
 
@@ -89,7 +95,7 @@ PR 6 で以下を **すべて含む** こと。漏れを防ぐため本セクシ
 - [ ] PR description に「`#176` B 案完了」を明記、関連 PR (#249/#254/#256/#261/#272/PR 3-5) を全 link
 - [ ] `grep -c "style={{" src/` = **0** を最終確認
 - [ ] 全 E2E + 全 unit + astro check pass
-- [ ] PR 1 (#256) / PR 1.5 (#261) / PR 2 (#272) / PR 3 (#275) の follow-up 系 issue のうち PR 6 で同時対応するものがあれば close、後続するものは PR 6 description で言及。
+- [ ] PR 1 (#256) / PR 1.5 (#261) / PR 2 (#272) / PR 3 (#275) / PR 4 (#277) の follow-up 系 issue のうち PR 6 で同時対応するものがあれば close、後続するものは PR 6 description で言及。
   - PR 1 由来: #257-#260
   - PR 1.5 由来: [#262](https://github.com/fumtas1k/devtools/issues/262) (CSP gate / **PR 5 で close**、PR 3 で uuid-v7 partial 対応済) / [#263](https://github.com/fumtas1k/devtools/issues/263) (aria-selected ARIA spec) / [#264](https://github.com/fumtas1k/devtools/issues/264) (キーボード操作 WCAG 2.1.1) / [#265](https://github.com/fumtas1k/devtools/issues/265) (useEffect deps anti-pattern, ✅ closed) / [#266](https://github.com/fumtas1k/devtools/issues/266) (width JSDoc origin discipline, ✅ closed)
   - PR 2 由来: [#273](https://github.com/fumtas1k/devtools/issues/273) (`AbortSignal.any` 化、`useTicketVerification.verify` external signal link 改善)

--- a/docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md
+++ b/docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md
@@ -1,0 +1,851 @@
+# #176 B 案 PR 4 実装計画書
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal**: `Gs1Databar.tsx` (20 件) + `EncodingConverter.tsx` (20 件) + `DummyText.tsx` (13 件) + Gs1Databar 内 `e.currentTarget.style.X = Y` 9 件を撤去し、`@layer components` の意味クラス + Tailwind utility (`hover:` modifier 含む) に置換する。
+
+**Architecture**: PR 1〜3 で確立した「`@layer components` への意味クラス追加 + Tailwind utility」pattern を継承。**新規 class は `.summary-no-marker` の 1 件のみ** (95% 以上を既存 class でカバー)。Phase 0 (親 Opus) で foundation commit、Phase 1 で sonnet subagent 3 並列、**Phase 1.5 で親 Opus が順次 commit (PR 3 の race 反省)**、Phase 2 で MIGRATED_FILES + 検証 + PR 作成。
+
+**Tech Stack**: TypeScript / React 19 / Astro 5 / Tailwind CSS 4 / Vitest / Playwright
+
+**作成日**: 2026-05-07
+**Spec**: `docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md`
+**ブランチ**: `feature/issue-176-b4-gs1-encoding-dummy`
+**Worktree**: `.claude/worktrees/issue-176-b4`
+**Base**: `origin/develop` (PR 3 #275 merge 後の最新)
+
+---
+
+## 進行モデル
+
+`feedback_subagent_model.md` / `feedback_subagent_workflow.md` / `feedback_subagent_verification_trust.md` 準拠。
+
+| Phase | 担当                  | 内容                                                                                  |
+| ----- | --------------------- | ------------------------------------------------------------------------------------- |
+| 0     | 親 Opus               | spec / plan 配置、worktree 作成、global.css foundation commit                         |
+| 1     | sonnet 並列 (3 track) | Track A / B / C の **編集 + self-verification のみ** (commit せず)                    |
+| 1.5   | 親 Opus               | Track A / B / C の変更を順次 stage + commit (race 完全回避)                           |
+| 2     | 親 Opus               | `MIGRATED_FILES` 追加、ローカル必須ゲート 3 件直接実行、aria diff 確認、push、PR 作成 |
+| 3     | 親 Opus + reviewer    | review サイクル → merge → SoT 更新 → worktree cleanup                                 |
+
+---
+
+## File Structure
+
+| File                                                          | Phase | 担当    | 変更内容                                                         |
+| ------------------------------------------------------------- | ----- | ------- | ---------------------------------------------------------------- |
+| `docs/superpowers/specs/2026-05-07-...-design.md`             | 0     | 親 Opus | spec をブランチ最初の commit として配置                          |
+| `docs/superpowers/plans/2026-05-07-...-gs1-encoding-dummy.md` | 0     | 親 Opus | plan を spec と同 commit で配置                                  |
+| `src/styles/global.css`                                       | 0     | 親 Opus | `@layer components` に `.summary-no-marker` 1 件追加             |
+| `src/components/tools/Gs1Databar.tsx`                         | 1     | Track A | inline style 20 件除去 + CSSOM hover 9 件除去 + import 整理      |
+| `src/components/tools/EncodingConverter.tsx`                  | 1     | Track B | inline style 20 件除去 + import 整理                             |
+| `src/components/tools/DummyText.tsx`                          | 1     | Track C | inline style 13 件除去 + import 整理                             |
+| `src/utils/__tests__/inline-style-migration.test.ts`          | 2     | 親 Opus | `MIGRATED_FILES` array に 3 件追加 (合計 21 件)                  |
+| `docs/projects/issue-176-b-plan-progress.md`                  | 2     | 親 Opus | PR 4 状態を current 化 (PR 3 経験を踏まえ merge 待ち間 SoT 反映) |
+
+**触らない**:
+
+- `src/components/tools/__tests__/*.test.ts` (logic test、本 PR の class 化は DOM 構造非変更)
+- `src/utils/styles.ts` (PR 6 で削除、本 PR は import 削除のみ)
+- `src/utils/csp.ts` / `public/_headers` (PR 6 で strict 化)
+- `tests/e2e/*.spec.ts` (本 PR で applyProductionCsp gate 追加せず)
+
+---
+
+## Phase 0 — 親 Opus 直接実行
+
+### Task 0.1: Worktree 作成
+
+- [ ] **Step 1**: 現在のブランチが `develop` で clean state であることを確認
+
+```bash
+git status
+git branch --show-current
+# Expected: clean / develop
+```
+
+- [ ] **Step 2**: origin/develop の最新を fetch
+
+```bash
+git fetch origin develop
+git rev-parse origin/develop HEAD
+# Expected: 同じ SHA (PR 3 merge 後)
+```
+
+- [ ] **Step 3**: worktree を作成 (`origin/develop` ベースを **明示**)
+
+```bash
+git worktree add .claude/worktrees/issue-176-b4 origin/develop -b feature/issue-176-b4-gs1-encoding-dummy
+```
+
+- [ ] **Step 4**: worktree で `npm ci` 実行
+
+```bash
+cd .claude/worktrees/issue-176-b4 && npm ci
+```
+
+Expected: `node_modules` が worktree に存在し vitest / playwright が解決可能。
+
+### Task 0.2: spec / plan ファイル配置
+
+- [ ] **Step 1**: develop 側で書いた spec / plan を worktree にコピー
+
+```bash
+cp docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md \
+   .claude/worktrees/issue-176-b4/docs/superpowers/specs/
+cp docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md \
+   .claude/worktrees/issue-176-b4/docs/superpowers/plans/
+```
+
+- [ ] **Step 2**: develop 側の untracked spec / plan を削除
+
+```bash
+rm docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md
+rm docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md
+```
+
+### Task 0.3: global.css に .summary-no-marker 追記
+
+worktree で作業 (以下すべて `.claude/worktrees/issue-176-b4` 内)。
+
+- [ ] **Step 1**: `src/styles/global.css` の末尾 `@layer components { ... }` ブロックの閉じ `}` の **直前** に下記を追記
+
+```css
+/* === PR 4: Gs1Databar <details>/<summary> marker hide === */
+.summary-no-marker {
+  list-style: none;
+}
+.summary-no-marker::-webkit-details-marker {
+  display: none;
+}
+```
+
+- [ ] **Step 2**: 重複なし確認
+
+```bash
+grep -n "summary-no-marker" src/styles/global.css
+# Expected: 2 行 (.summary-no-marker { と .summary-no-marker::-webkit-details-marker {)
+```
+
+- [ ] **Step 3**: vitest 一部実行で global.css 読み込みが壊れていないか確認
+
+```bash
+npm run test -- src/utils/__tests__/inline-style-migration.test.ts
+# Expected: 既存 18 ファイルの migration test pass + 陽性対照 3 件 pass
+```
+
+### Task 0.4: Phase 0 commit
+
+- [ ] **Step 1**: stage + commit
+
+```bash
+git add docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md \
+        docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md \
+        src/styles/global.css
+
+git commit -m "$(cat <<'EOF'
+chore(spec): #176 B 案 PR 4 spec / plan / global.css foundation
+
+Phase 0: spec / plan 配置 + global.css @layer components に
+Gs1Databar <details>/<summary> 用 .summary-no-marker class 1 件を追加。
+
+PR 1〜3 で導入済の class (caption, body-emphasis, text-default, text-muted,
+bg-default, bg-subtle, bg-surface, border-default, border-input,
+bg-error-tint, bg-success-tint, text-error, text-error-text, text-success,
+text-primary, text-link-color 等) を再利用するため新規 class は最小限 1 件のみ。
+
+Phase 1 (sonnet 並列 × 3 Track) で Gs1Databar / EncodingConverter / DummyText
+の migration を進める。Race 回避のため subagent は commit せず、
+Phase 1.5 で親 Opus が順次 commit する運用 (PR 3 の race 反省)。
+
+ref: docs/projects/issue-176-b-plan-progress.md
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2**: 確認
+
+```bash
+git log --oneline -1
+git status
+# Expected: 1 件の commit、clean state
+```
+
+---
+
+## Phase 1 — 並列 sonnet subagent dispatch (commit せず)
+
+**重要**: 3 Track を **同時並列** dispatch して OK (独立ファイルに閉じる + commit しないので race 不可能)。各 subagent は ファイル編集 + self-verification のみ実施。
+
+### Track A: `Gs1Databar.tsx` migration (20 件 + 9 hover refactor)
+
+- [ ] **Step 1**: subagent prompt 作成 (下記 §Subagent prompt template の Track A 参照)
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領 (status / 変更ファイル list / self-verification 結果)
+
+**Track A 完了基準**:
+
+- [ ] `grep -c "style={{" src/components/tools/Gs1Databar.tsx` → **0**
+- [ ] `grep "from '@/utils/styles'" src/components/tools/Gs1Databar.tsx` → 0
+- [ ] `grep -E "\.style\.[a-zA-Z]+\s*=" src/components/tools/Gs1Databar.tsx | grep -v setProperty` → 0 (CSSOM mutation 全消去)
+- [ ] subagent が `npm run test -- src/components/tools/__tests__/` で関連 test pass を確認
+- [ ] subagent が `npx astro check` で 0 errors 確認
+- [ ] **commit していないこと** (`git log --oneline -1` が Phase 0 commit のままであること)
+
+### Track B: `EncodingConverter.tsx` migration (20 件)
+
+- [ ] **Step 1**: subagent prompt 作成 (下記 §Subagent prompt template の Track B 参照)
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領
+
+**Track B 完了基準**:
+
+- [ ] `grep -c "style={{" src/components/tools/EncodingConverter.tsx` → **0**
+- [ ] `grep "from '@/utils/styles'" src/components/tools/EncodingConverter.tsx` → 0
+- [ ] subagent が astro check / 関連 test の pass 確認
+- [ ] **commit していないこと**
+
+### Track C: `DummyText.tsx` migration (13 件)
+
+- [ ] **Step 1**: subagent prompt 作成 (下記 §Subagent prompt template の Track C 参照)
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領
+
+**Track C 完了基準**:
+
+- [ ] `grep -c "style={{" src/components/tools/DummyText.tsx` → **0**
+- [ ] `grep "from '@/utils/styles'" src/components/tools/DummyText.tsx` → 0
+- [ ] subagent が astro check / 関連 test の pass 確認
+- [ ] **commit していないこと**
+
+---
+
+## Phase 1.5 — 親 Opus が順次 commit (race 完全回避)
+
+Phase 1 の 3 Track が全て完了報告を出した後、親 Opus が下記を実行。
+
+### Task 1.5.1: 状態確認
+
+- [ ] **Step 1**: 3 ファイル全てが modified、commit はまだ Phase 0 のままであることを確認
+
+```bash
+git status
+# Expected:
+#   modified: src/components/tools/Gs1Databar.tsx
+#   modified: src/components/tools/EncodingConverter.tsx
+#   modified: src/components/tools/DummyText.tsx
+
+git log --oneline -2
+# Expected: HEAD = Phase 0 chore(spec) commit
+```
+
+- [ ] **Step 2**: 各ファイルの inline style 残存ゼロ確認
+
+```bash
+grep -c "style={{" src/components/tools/Gs1Databar.tsx \
+                   src/components/tools/EncodingConverter.tsx \
+                   src/components/tools/DummyText.tsx
+# Expected: 全て 0
+```
+
+### Task 1.5.2: Track A (Gs1Databar) commit
+
+- [ ] **Step 1**: Gs1Databar.tsx のみ stage
+
+```bash
+git add src/components/tools/Gs1Databar.tsx
+```
+
+- [ ] **Step 2**: 想定通りのファイルのみ staged であることを確認
+
+```bash
+git status --short
+# Expected: M src/components/tools/Gs1Databar.tsx (1 行のみ M)
+#           その他は ??? や M (unstaged) のまま
+```
+
+- [ ] **Step 3**: commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(tools): #176 B 案 PR 4 — Gs1Databar.tsx inline style 撤去 + hover を CSS に移行
+
+inline style 20 件を @layer components の class + Tailwind utility に置換。
+e.currentTarget.style.background mutation (onMouseEnter/onMouseLeave で
+hover bg を直接書き換え) 9 件を全て削除し、Tailwind hover: modifier
+(hover:bg-error-tint / hover:bg-subtle / hover:bg-blue-50) で表現。
+
+GTIN-14 文字間隔は tracking-[0.1em] arbitrary value、
+<details>/<summary> marker は .summary-no-marker class、
+カード追加ボタンの hover bg は hover:bg-blue-50 (--color-blue-50 token).
+
+import { bodyEmphasis, caption, colors } from '@/utils/styles' を削除。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md §1
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.5.3: Track B (EncodingConverter) commit
+
+- [ ] **Step 1**: EncodingConverter.tsx のみ stage
+
+```bash
+git add src/components/tools/EncodingConverter.tsx
+git status --short
+# Expected: M src/components/tools/EncodingConverter.tsx + M src/components/tools/DummyText.tsx (unstaged)
+```
+
+- [ ] **Step 2**: commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(tools): #176 B 案 PR 4 — EncodingConverter.tsx inline style 撤去
+
+inline style 20 件を @layer components の class + Tailwind utility に置換。
+ファイル選択 dropzone (border-dashed)、判定結果カード、変換設定 / 出力
+hex preview の全ての style 属性を class 化。
+
+import { caption, colors } from '@/utils/styles' を削除。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md §2
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.5.4: Track C (DummyText) commit
+
+- [ ] **Step 1**: DummyText.tsx のみ stage
+
+```bash
+git add src/components/tools/DummyText.tsx
+```
+
+- [ ] **Step 2**: commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(tools): #176 B 案 PR 4 — DummyText.tsx inline style 撤去
+
+inline style 13 件を @layer components の class + Tailwind utility に置換。
+<input type="number"> 2 箇所の border-input / outline-none / bg-default
+構造、結果テキストの leading-[1.8] arbitrary value で行間維持。
+
+outline-none は global の :focus-visible rule で focus ring が復活する
+ため a11y 退化なし。
+
+import { bodyEmphasis, caption, colors } from '@/utils/styles' を削除。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md §3
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3**: 3 commit に正しく split されたか確認
+
+```bash
+git log --oneline -5
+# Expected:
+# <SHA> refactor(tools): #176 B 案 PR 4 — DummyText.tsx inline style 撤去
+# <SHA> refactor(tools): #176 B 案 PR 4 — EncodingConverter.tsx inline style 撤去
+# <SHA> refactor(tools): #176 B 案 PR 4 — Gs1Databar.tsx inline style 撤去 + hover を CSS に移行
+# <SHA> chore(spec): #176 B 案 PR 4 spec / plan / global.css foundation
+# 26a8c67 chore(docs): #176 B 案 progress tracker を Claude memory から repo に移行 (#274) <- これは違うかも
+```
+
+(注: `26a8c67` は PR 3 merge 前のもの。PR 3 #275 merge 後の develop は `1150883`。HEAD~5 が `1150883` 想定)
+
+```bash
+git show --stat HEAD HEAD~1 HEAD~2 | head -30
+# Each commit が 1 ファイルのみ変更していることを確認
+```
+
+---
+
+## Phase 2 — 親 Opus 直接実行 (統合 + 検証 + PR)
+
+### Task 2.1: MIGRATED_FILES 追加
+
+- [ ] **Step 1**: `src/utils/__tests__/inline-style-migration.test.ts` の `MIGRATED_FILES` array に 3 件追加
+
+`'src/components/tools/UuidV7Generator.tsx',` の **後** に下記を追加:
+
+```ts
+  // PR 4 で追加
+  'src/components/tools/Gs1Databar.tsx',
+  'src/components/tools/EncodingConverter.tsx',
+  'src/components/tools/DummyText.tsx',
+```
+
+- [ ] **Step 2**: migration test pass 確認
+
+```bash
+npm run test -- src/utils/__tests__/inline-style-migration.test.ts
+# Expected: 21 ファイルの migration test 全 pass + 陽性対照 3 件 pass = 計 45 件 pass
+```
+
+- [ ] **Step 3**: commit
+
+```bash
+git add src/utils/__tests__/inline-style-migration.test.ts
+git commit -m "$(cat <<'EOF'
+test(migration): MIGRATED_FILES に PR 4 対象 3 件追加
+
+Gs1Databar.tsx / EncodingConverter.tsx / DummyText.tsx の
+inline style 撤去完了に伴い progressive migration tracker に追加
+(18 → 21 件)。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md §5
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.2: SoT (progress doc) 更新
+
+- [ ] **Step 1**: `docs/projects/issue-176-b-plan-progress.md` を更新 (PR 3 と同パターン、merge 待ち間 SoT current 化)
+
+進捗状況テーブルの PR 4 行を更新:
+
+```markdown
+| PR 4 | Gs1Databar + EncodingConverter + DummyText | 🔄 PR open | [#XXX](https://github.com/fumtas1k/devtools/pull/XXX) |
+```
+
+(`#XXX` は Task 2.6 で取得した PR 番号、後で書き換え)
+
+着手済 PR 履歴に PR 4 section を追加:
+
+```markdown
+### PR 4 (#XXX)
+
+- **特殊事項**: Gs1Databar 内で `e.currentTarget.style.X = Y` 形式の CSSOM hover state mutation 9 件を Tailwind `hover:` modifier に refactor。inline style と同等の hover 挙動を CSS で表現
+- **race 回避運用**: PR 3 の commit 結合 race 反省を踏まえ、subagent は commit せず親 Opus が Phase 1.5 で順次 commit する方式を初採用 (memory `feedback_subagent_workflow.md` に追記候補)
+```
+
+- [ ] **Step 2**: 一旦 PR 番号未確定で commit せず、Phase 2 の最後 (PR 作成後) に PR 番号を確定して 1 commit に集約。本 step は **skip** し、Task 2.7 で実施。
+
+### Task 2.3: ローカル必須ゲート (subagent 報告は信頼せず親が直接実行)
+
+- [ ] **Step 1**: vitest 全 pass
+
+```bash
+npm run test
+# Expected: 全 unit test pass、migration test 21 件 × 2 + 陽性対照 3 件 = 45 件 pass 含む
+```
+
+- [ ] **Step 2**: TypeScript 型チェック
+
+```bash
+npx astro check
+# Expected: 0 errors, 0 warnings
+```
+
+- [ ] **Step 3**: E2E 全 pass (`feedback_e2e_before_pr.md`、PR 作成前必須)
+
+```bash
+npm run test:e2e
+# Expected: 全 spec pass (gs1-databar / encoding-converter / dummy-text 含む)
+```
+
+E2E は build + preview を直列起動するため数分かかる。フォアグラウンドで実行して全 pass を確認する。
+
+### Task 2.4: a11y 退化検知
+
+- [ ] **Step 1**: aria-\* / role= / data-testid= / htmlFor= 削除行が無いこと
+
+```bash
+git diff origin/develop -- src/components/tools/Gs1Databar.tsx \
+                           src/components/tools/EncodingConverter.tsx \
+                           src/components/tools/DummyText.tsx \
+  | grep -E '^-.*(aria-|role=|data-testid=|htmlFor=)' | grep -vE '^---|^\+\+\+'
+# Expected: 出力 0 行
+# (reformat による行移動の "削除行" が出る場合は現コードで grep 確認、PR 3 と同運用)
+```
+
+- [ ] **Step 2**: 万が一何か "削除" 行が出た場合、現コードで存在を grep 確認
+
+```bash
+grep -n "data-testid\|aria-label\|aria-live\|role=" src/components/tools/Gs1Databar.tsx | head -10
+grep -n "data-testid\|aria-label\|htmlFor=" src/components/tools/EncodingConverter.tsx | head -10
+grep -n "htmlFor=\|aria-label" src/components/tools/DummyText.tsx | head -10
+# Expected: PR 3 と同じく diff の "削除行" が現コードに維持されていれば OK
+```
+
+### Task 2.5: PR 作成前 final check
+
+- [ ] **Step 1**: develop ベース一致確認
+
+```bash
+[ "$(git rev-parse origin/develop)" = "$(git merge-base HEAD origin/develop)" ] && echo OK
+# Expected: OK
+```
+
+- [ ] **Step 2**: PR 6 スコープ侵害なし確認
+
+```bash
+git diff origin/develop --name-only | grep -cE "_headers|astro.config|src/utils/styles\.ts" || echo "0 (PR 6 スコープに触れていない = OK)"
+# Expected: 0
+```
+
+- [ ] **Step 3**: 想定外ファイル変更がないこと
+
+```bash
+git diff origin/develop --name-only | sort
+# Expected:
+# docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md
+# docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md
+# src/components/tools/DummyText.tsx
+# src/components/tools/EncodingConverter.tsx
+# src/components/tools/Gs1Databar.tsx
+# src/styles/global.css
+# src/utils/__tests__/inline-style-migration.test.ts
+```
+
+### Task 2.6: push + PR 作成
+
+- [ ] **Step 1**: PR 本文を `/tmp/claude/pr_body_b4.md` に書き出し (CLAUDE.md 6.1: `--body-file` 必須)
+
+```bash
+mkdir -p /tmp/claude
+cat > /tmp/claude/pr_body_b4.md <<'EOF'
+## 概要
+
+`#176` B 案バッチの PR 4。`Gs1Databar.tsx` (20 件) + `EncodingConverter.tsx` (20 件) + `DummyText.tsx` (13 件) の JSX inline style + Gs1Databar 内 `e.currentTarget.style.X = Y` 形式の CSSOM 直接 mutation 9 件 (`onMouseEnter`/`onMouseLeave` hover state) を `@layer components` の意味クラス + Tailwind utility (`hover:` modifier 含む) に置換する。
+
+- spec: `docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md`
+- plan: `docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md`
+- バッチ進捗: `docs/projects/issue-176-b-plan-progress.md`
+
+## 主要な変更
+
+### `src/styles/global.css` 追加 class (1 件のみ)
+
+- `.summary-no-marker` (Gs1Databar `<details>/<summary>` の marker 非表示、`list-style: none` + `::-webkit-details-marker { display: none }`)
+
+PR 1〜3 で導入済の class (`caption` / `body-emphasis` / `text-default` / `text-muted` / `bg-default` / `bg-subtle` / `bg-surface` / `border-default` / `border-input` / `bg-error-tint` / `text-error` / `text-primary` / `text-link-color` 等) で 95% 以上をカバー。
+
+### `Gs1Databar.tsx` (20 件 + 9 件 hover refactor → 0)
+
+- `<details>/<summary>` marker 非表示を `.summary-no-marker` class に集約
+- GTIN-14 文字間隔は `tracking-[0.1em]` arbitrary value
+- `onMouseEnter`/`onMouseLeave` で `e.currentTarget.style.background = ...` していた 9 件 (4 button + 1 summary) を全て削除し、Tailwind `hover:bg-error-tint` / `hover:bg-subtle` / `hover:bg-blue-50` の `hover:` modifier で表現
+- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除
+
+### `EncodingConverter.tsx` (20 件 → 0)
+
+- ファイル選択 dropzone を `border border-dashed border-default bg-subtle` で表現
+- 判定結果カード / 変換設定 / hex preview を全て既存 class + Tailwind 標準 utility に置換
+- 新規 class 追加なし
+- `import { caption, colors } from '@/utils/styles'` を削除
+
+### `DummyText.tsx` (13 件 → 0)
+
+- `<input type="number">` 2 箇所を `border border-input outline-none bg-default text-default` に置換 (global の `:focus-visible` rule が a11y 担保)
+- 結果テキストの行間は `leading-[1.8]` arbitrary value
+- 新規 class 追加なし
+- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除
+
+## Race 回避運用 (PR 3 反省)
+
+PR 3 で sonnet 並列 dispatch 時に commit が結合される race が発生 (Track A の prettier hook が Track B のファイルを巻き込み、commit message と内容が不一致になった事案)。本 PR では下記方針で **race 自体を防いだ**:
+
+- subagent は **ファイル編集 + self-verification (vitest, astro check) のみ** 実施
+- subagent は `git add` / `git commit` を実行しない
+- 親 Opus が Phase 1.5 で 1 ファイルずつ stage + commit (3 commit、各 1 ファイル変更)
+
+結果: commit message と内容が完全一致、prettier 巻き込みも親が制御。
+
+## 検証ログ (親 Opus 直接実行)
+
+- [x] `npm run test` 全 pass (migration test 21 件 × 2 + 陽性対照 3 件 = 45 件 pass 含む)
+- [x] `npx astro check` → 0 errors, 0 warnings
+- [x] `npm run test:e2e` 全 pass (gs1-databar / encoding-converter / dummy-text 含む)
+- [x] a11y 退化なし (`aria-*` / `role=` / `data-testid=` / `htmlFor=` 削除行 0、reformat の行移動は現コードで存在確認)
+- [x] inline style 残存ゼロ (`grep -c "style={{"` = 0 / 0 / 0)
+- [x] CSSOM mutation 残存ゼロ (`grep -E "\.style\.[a-zA-Z]+\s*="` で setProperty 以外 = 0)
+- [x] PR 6 スコープ未侵害 (`_headers` / `astro.config.mjs` / `src/utils/styles.ts` 未変更)
+
+## VRT
+
+`visual-regression.yml` で baseline 比較 (non-required check)。意図的差分があれば PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger。
+
+## コミット粒度
+
+```
+
+<SHA> docs(progress): #176 B 案 PR 4 (#XXX) の状態を反映
+<SHA> test(migration): MIGRATED_FILES に PR 4 対象 3 件追加
+<SHA> refactor(tools): #176 B 案 PR 4 — DummyText.tsx inline style 撤去
+<SHA> refactor(tools): #176 B 案 PR 4 — EncodingConverter.tsx inline style 撤去
+<SHA> refactor(tools): #176 B 案 PR 4 — Gs1Databar.tsx inline style 撤去 + hover を CSS に移行
+<SHA> chore(spec): #176 B 案 PR 4 spec / plan / global.css foundation
+
+```
+
+## 関連
+
+- 起源 issue: #176 (アプローチ B)
+- 前提 PR: #249 (A-1) / #254 (VRT) / #256 (PR 1) / #261 (PR 1.5) / #272 (PR 2) / #275 (PR 3)
+- 後続: PR 5 (QrReader + 残り tools + #262 close + #276 前段 infra) / PR 6 (flip + cleanup)
+EOF
+```
+
+- [ ] **Step 2**: push
+
+```bash
+git push -u origin feature/issue-176-b4-gs1-encoding-dummy
+```
+
+- [ ] **Step 3**: PR 作成 (`--base develop` を **必ず** 明示、`--body-file` で本文渡し)
+
+```bash
+gh pr create --base develop \
+  --title "refactor(tools): #176 B 案 PR 4 — Gs1Databar + EncodingConverter + DummyText inline style 撤去" \
+  --body-file /tmp/claude/pr_body_b4.md
+```
+
+Expected: PR URL を取得 → user に提示 + `#XXX` を Task 2.7 に渡す。
+
+### Task 2.7: progress doc 更新 (PR 番号確定後)
+
+- [ ] **Step 1**: PR 番号 (`#XXX`) を反映して `docs/projects/issue-176-b-plan-progress.md` を更新
+  - 進捗状況テーブル: PR 4 行を `🔄 PR open + #XXX link` に
+  - 着手済 PR 履歴: PR 4 (#XXX) section を追加 (race 回避運用の特記含む)
+
+- [ ] **Step 2**: prettier 自動 fix
+
+```bash
+npx prettier --write docs/projects/issue-176-b-plan-progress.md
+```
+
+- [ ] **Step 3**: commit
+
+```bash
+git add docs/projects/issue-176-b-plan-progress.md
+git commit -m "$(cat <<'EOF'
+docs(progress): #176 B 案 PR 4 (#XXX) の状態と特記事項を反映
+
+PR 3 経験を踏まえ merge 待ちの間も SoT を current 化する運用。
+
+更新内容:
+- 進捗状況テーブル: PR 4 を 🔄 PR open + #XXX link に変更
+- 着手済 PR 履歴: PR 4 (#XXX) section を追加
+  - Gs1Databar の e.currentTarget.style.X CSSOM mutation を Tailwind hover: 化
+  - subagent 非 commit 方式の race 回避運用を初採用 (PR 3 の race 反省)
+
+ref: https://github.com/fumtas1k/devtools/pull/XXX
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4**: push
+
+```bash
+git push
+```
+
+---
+
+## Phase 3 — review サイクル
+
+- [ ] **Step 1**: PR 作成後は **自発的な修正 push を控える** (memory `feedback_hold_push_during_review.md`)
+- [ ] **Step 2**: CI green + reviewer LGTM 後に user に merge を依頼
+- [ ] **Step 3**: review 指摘があればまとめて対応 commit を 1 件 push (PR 3 同様)
+- [ ] **Step 4**: merge 後の cleanup (memory `feedback_worktree_merge_order.md` に従う)
+
+```bash
+# 順序: gh pr merge --delete-branch の **前** に worktree remove
+cd /Users/fumta/projects/devtools
+git worktree remove .claude/worktrees/issue-176-b4
+git branch -D feature/issue-176-b4-gs1-encoding-dummy 2>&1 || true  # 既に消えている場合あり
+gh pr merge XXX --squash --delete-branch
+git checkout develop && git pull origin develop
+```
+
+---
+
+## Subagent prompt template
+
+各 subagent には以下要素を **必ず** 含める:
+
+1. **作業ディレクトリ**: `/Users/fumta/projects/devtools/.claude/worktrees/issue-176-b4`
+2. **担当ファイル list** (変更可能 / 触ってはいけない)
+3. **spec 該当 section の reference** (`docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md` § N)
+4. **既存 class 一覧** (Phase 0 で `.summary-no-marker` 追加済、他は PR 1〜3 既存)
+5. **自己検証コマンド**: `npm run test -- <該当 test path>` + `npx astro check`
+6. **やってはいけないこと**:
+   - `git add` / `git commit` (親が Phase 1.5 で実施)
+   - `git push` / `gh pr create`
+   - `npm run test:vrt` (memory `feedback_vrt_ci_only.md`)
+   - `npm run test:e2e` (時間かかる、親が Phase 2 で確認)
+   - 他 Track のファイル変更
+   - `src/utils/styles.ts` 削除 (PR 6 スコープ)
+   - `src/styles/global.css` 編集 (Phase 0 で foundation commit 済、追加 class 不要)
+7. **完了報告フォーマット**:
+   - status: DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED
+   - 変更ファイル list (`git diff --name-only`)
+   - 自己検証結果 (vitest / astro check)
+   - 残課題
+
+### Track A subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b4
+
+タスク: src/components/tools/Gs1Databar.tsx の inline style + e.currentTarget.style.X CSSOM mutation を spec §1 に従い撤去する。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md (§1.1〜1.7)
+- 既存パターン: src/components/tools/qr-ticket/VerifyTab.tsx (PR 2 の hidden / data- 属性 / class 化)、src/components/tools/JwtDecoder.tsx (PR 3 の variant 化 / badge class 化)
+- global.css: PR 4 用 .summary-no-marker は HEAD~1 (Phase 0 commit) で foundation commit 済
+
+変更可能なファイル:
+- src/components/tools/Gs1Databar.tsx (本体)
+
+触ってはいけないファイル:
+- src/components/tools/__tests__/Gs1Databar.test.* (logic test、変更不要)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済)
+- src/components/tools/EncodingConverter.tsx (Track B)
+- src/components/tools/DummyText.tsx (Track C)
+- tests/e2e/* (本 PR で gate 追加せず)
+
+完了基準:
+- grep -c "style={{" src/components/tools/Gs1Databar.tsx → 0
+- grep "from '@/utils/styles'" src/components/tools/Gs1Databar.tsx → 0
+- grep -E "\.style\.[a-zA-Z]+\s*=" src/components/tools/Gs1Databar.tsx | grep -v setProperty → 0 (CSSOM mutation 全消去)
+- onMouseEnter / onMouseLeave attribute は完全削除 (Tailwind hover: で表現)
+- npm run test -- src/components/tools/__tests__/ で関連 test pass
+- npx astro check → 0 errors
+
+やってはいけないこと:
+- git add / git commit (親が Phase 1.5 で実施、subagent は commit せず)
+- git push / gh pr create
+- npm run test:vrt
+- npm run test:e2e (親が Phase 2 で実行)
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加 (Phase 0 で完了済、不足あれば親 Opus に報告)
+
+完了後 報告: status + 変更ファイル list + 自己検証結果 (vitest / astro check 出力要約) + 残課題
+```
+
+### Track B subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b4
+
+タスク: src/components/tools/EncodingConverter.tsx の inline style を spec §2 に従い撤去する。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md (§2.1〜2.4)
+- 既存パターン: src/components/tools/UuidV7Generator.tsx (PR 3 で class 化済)、src/components/tools/qr-ticket/VerifyTab.tsx (PR 2 の sr-only file input)
+- global.css: PR 1〜3 で導入済の class (caption, body-emphasis, text-default, text-muted, bg-default, bg-subtle, bg-surface, border-default, border-input, text-error 等)
+
+変更可能なファイル:
+- src/components/tools/EncodingConverter.tsx (本体)
+
+触ってはいけないファイル:
+- src/components/tools/__tests__/EncodingConverter.test.* (logic test、変更不要)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済)
+- src/components/tools/Gs1Databar.tsx (Track A)
+- src/components/tools/DummyText.tsx (Track C)
+- tests/e2e/* (本 PR で gate 追加せず)
+
+完了基準:
+- grep -c "style={{" src/components/tools/EncodingConverter.tsx → 0
+- grep "from '@/utils/styles'" src/components/tools/EncodingConverter.tsx → 0
+- import 行は `import { caption, colors } from '@/utils/styles';` を削除 (bodyEmphasis は EncodingConverter で未 import、確認の上)
+- npm run test -- src/utils/__tests__/encoding.test.ts (もしあれば) で関連 test pass、なければ astro check のみ
+- npx astro check → 0 errors
+
+やってはいけないこと:
+- git add / git commit (親が Phase 1.5 で実施)
+- git push / gh pr create
+- npm run test:vrt
+- npm run test:e2e
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加
+
+完了後 報告: status + 変更ファイル list + 自己検証結果 + 残課題
+```
+
+### Track C subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b4
+
+タスク: src/components/tools/DummyText.tsx の inline style を spec §3 に従い撤去する。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md (§3.1〜3.2)
+- 既存パターン: src/components/tools/UuidV7Generator.tsx (PR 3)、src/components/ui/InputField.tsx (PR 1.5 の input styling)
+- global.css: PR 1〜3 既存 class (caption, body-emphasis, text-default, text-muted, bg-default, bg-subtle, border-default, border-input)
+
+変更可能なファイル:
+- src/components/tools/DummyText.tsx (本体)
+
+触ってはいけないファイル:
+- src/components/tools/__tests__/DummyText.test.* (logic test、変更不要)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済)
+- src/components/tools/Gs1Databar.tsx (Track A)
+- src/components/tools/EncodingConverter.tsx (Track B)
+- tests/e2e/* (本 PR で gate 追加せず)
+
+完了基準:
+- grep -c "style={{" src/components/tools/DummyText.tsx → 0
+- grep "from '@/utils/styles'" src/components/tools/DummyText.tsx → 0
+- <input type="number"> 2 箇所が caption + w-32 (or w-20) + border + border-input + outline-none + bg-default + text-default の class 構成
+- 結果テキスト <p> が caption + text-default + leading-[1.8] + break-all + whitespace-pre-wrap + m-0 構成
+- npm run test -- src/utils/__tests__/dummy-text.test.ts (もしあれば) で関連 test pass、なければ astro check のみ
+- npx astro check → 0 errors
+
+やってはいけないこと:
+- git add / git commit (親が Phase 1.5 で実施)
+- git push / gh pr create
+- npm run test:vrt
+- npm run test:e2e
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加
+
+完了後 報告: status + 変更ファイル list + 自己検証結果 + 残課題
+```
+
+---
+
+## メモリ参照
+
+- `project_b_plan_progress.md` (pointer; SoT は repo `docs/projects/issue-176-b-plan-progress.md`)
+- `feedback_subagent_model.md` (sonnet 明示)
+- `feedback_subagent_workflow.md` (subagent は allow リスト内 Bash のみ)
+- `feedback_subagent_verification_trust.md` (親が直接検証)
+- `feedback_subagent_testing.md` (E2E は親が実行)
+- `feedback_commander_checklist.md` (PR 作成前チェック)
+- `feedback_e2e_before_pr.md` (E2E は PR 作成前)
+- `feedback_hold_push_during_review.md` (review 中は push 控える)
+- `feedback_branch_workflow.md` (`--base develop` 明示)
+- `feedback_pr_language.md` (PR 日本語)
+- `feedback_heredoc_no_escape.md` (HEREDOC で backtick エスケープしない)
+- `feedback_worktree_base_branch.md` (worktree は origin/develop -b 明示)
+- `feedback_worktree_location.md` (`.claude/worktrees/<name>`)
+- `feedback_worktree_merge_order.md` (worktree remove → branch delete の順)
+- `feedback_vrt_ci_only.md` (ローカル test:vrt 走らせない)
+- `feedback_followup_routing.md` (PR 後の離散タスクは issue 化)
+
+---
+
+## Phase 1 開始判定
+
+Phase 0 commit 完了 + worktree の `npm ci` 完了を確認したら Phase 1 dispatch。3 Track が独立ファイル + commit せず方針のため **同時並列 dispatch** で OK (race 不可能)。

--- a/docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md
@@ -1,0 +1,718 @@
+# #176 B 案 PR 4: `Gs1Databar` + `EncodingConverter` + `DummyText` inline style 撤去 設計書
+
+**作成日**: 2026-05-07
+**Issue**: [#176](https://github.com/fumtas1k/devtools/issues/176) アプローチ B / PR 4
+**前提**: A-1 ([#249](https://github.com/fumtas1k/devtools/pull/249)) + VRT 基盤 ([#254](https://github.com/fumtas1k/devtools/pull/254)) + PR 1 ([#256](https://github.com/fumtas1k/devtools/pull/256)) + PR 1.5 ([#261](https://github.com/fumtas1k/devtools/pull/261)) + PR 2 ([#272](https://github.com/fumtas1k/devtools/pull/272)) + PR 3 ([#275](https://github.com/fumtas1k/devtools/pull/275)) 完了済み
+**参照**: バッチ計画全体は repo SoT [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md)。PR 1 / 1.5 / 2 / 3 spec の命名規約・既存 `@layer components` 定義を継承。
+
+---
+
+## ゴール
+
+`src/components/tools/Gs1Databar.tsx` (20 件) + `src/components/tools/EncodingConverter.tsx` (20 件) + `src/components/tools/DummyText.tsx` (13 件) から JSX inline style を完全撤去 + Gs1Databar 内の `e.currentTarget.style.X = Y` 形式の CSSOM 直接 mutation 9 件 (`onMouseEnter`/`onMouseLeave` hover state) を撤去し、`@layer components` の意味クラス + Tailwind utility (`hover:` modifier 含む) に置換する。
+
+完了基準:
+
+1. 対象 3 ファイルから `style={{` ヒット数 0、`element.style.X = Y` 形式の inline mutation 0
+2. `src/utils/__tests__/inline-style-migration.test.ts` の `MIGRATED_FILES` array に 3 件追加 (合計 21 件) して migration test pass
+3. `src/styles/global.css` の `@layer components` に **新規 1 class のみ** 追加 (`.summary-no-marker`、§4 参照)
+4. **Phase 1 race 回避運用**: subagent は **commit せず** ファイル編集 + self-verification (vitest, astro check) のみ実施、親 Opus が Phase 1.5 で順次 commit (PR 3 の commit 結合 race の反省、§9.4 参照)
+5. **VRT 検証**: `visual-regression.yml` で baseline 比較。意図的差分があれば PR ブランチ上で `update-visual-baseline.yml` を `workflow_dispatch` trigger
+6. ローカル必須ゲート: push 前に `npm run test` (vitest) / `npx astro check` / `npm run test:e2e` 全 green (親 Opus 直接実行)
+7. `src/utils/styles.ts` 自体は **削除しない** (PR 6 で削除)。本 PR では `bodyEmphasis` / `caption` / `colors` の **import 削除** のみ
+
+非ゴール:
+
+- `QrReader` / `ConfigConverter` / `JanCode` / `QrCode` / `UlidGenerator` (PR 5)、`flip + cleanup` (PR 6)
+- `applyProductionCsp` E2E gate 追加 (#234 / #262 残部分は PR 5 で対応、本 PR 対象 3 ツールは setProperty 未使用のため CSP gate 必須性低)
+- `_headers` の `style-src 'unsafe-inline'` 撤去 (PR 6)
+- `docs/decisions.md` 新規エントリ (PR 6 [067] で B 案完了として一括記録)
+- ハードコード hex の token 化 (本 PR 新規 hex なし、`hover:bg-blue-50` は既存 `--color-blue-50` token を Tailwind auto-utility 経由で参照)
+
+---
+
+## なぜ独立 PR か
+
+| 観点                    | 説明                                                                                                                                                                       |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PR サイズ規律**       | 3 ファイル合計 53 件の inline style + 9 件の CSSOM hover refactor + 新規 class 追加。PR 5 と bundle すると review unit が 90 件超に肥大化 (memory `feedback_pr_size.md`)。 |
+| **VRT 影響面の独立性**  | gs1-databar.astro / encoding-converter.astro / dummy-text.astro は独立 page で baseline に乗る。PR 5 (QrReader 等) と差分原因を切り分けやすい。                            |
+| **新 class の責務範囲** | 本 PR 新規追加は `.summary-no-marker` の 1 件のみ。Gs1Databar `<details>` 固有命名で他 tool との衝突なし。                                                                 |
+| **race 回避運用の検証** | PR 3 で並列 dispatch 時 commit 結合 race が発生。本 PR は subagent 非 commit 方式を初採用、運用検証も兼ねる (§9.4)。                                                       |
+
+memory 参照:
+
+- `project_b_plan_progress.md` (pointer; SoT は repo `docs/projects/issue-176-b-plan-progress.md`)
+- `feedback_pr_size.md`
+- `feedback_subagent_verification_trust.md`
+- `feedback_commander_checklist.md`
+- `feedback_e2e_before_pr.md`
+- `feedback_subagent_model.md`
+
+---
+
+## 採用する設計 (ファイル別)
+
+### 1. `Gs1Databar.tsx` (20 件 + 9 件 hover refactor)
+
+#### 1.1 カード wrapper / ヘッダー (line 184-218)
+
+```tsx
+// Before
+<div className="rounded-lg" style={{ border: `1px solid ${colors.borderInput}`, background: colors.bg }}>
+  <div className="flex items-center justify-between px-4 py-3 rounded-t-lg"
+       style={{ background: colors.bgSubtle, borderBottom: `1px solid ${colors.border}` }}>
+    <span style={{ ...caption, fontWeight: 700, color: colors.text }}>
+      バーコード {index + 1}
+      {gtinResult && (
+        <span className="font-mono ml-2" style={{ ...caption, color: colors.muted, fontWeight: 400 }}>
+          — {gtinResult.fullGtin}
+        </span>
+      )}
+    </span>
+    {canRemove && (
+      <button type="button" onClick={onRemove}
+              className="rounded px-2 py-1 transition-colors"
+              style={{ ...caption, color: colors.error, background: 'transparent' }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = colors.errorBg)}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+              aria-label={`バーコード ${index + 1} を削除`}>削除</button>
+    )}
+  </div>
+
+// After
+<div className="rounded-lg border border-input bg-default">
+  <div className="flex items-center justify-between px-4 py-3 rounded-t-lg bg-subtle border-b border-default">
+    <span className="caption font-bold text-default">
+      バーコード {index + 1}
+      {gtinResult && (
+        <span className="font-mono ml-2 caption text-muted">— {gtinResult.fullGtin}</span>
+      )}
+    </span>
+    {canRemove && (
+      <button type="button" onClick={onRemove}
+              className="rounded px-2 py-1 transition-colors caption text-error bg-transparent hover:bg-error-tint"
+              aria-label={`バーコード ${index + 1} を削除`}>削除</button>
+    )}
+  </div>
+```
+
+`onMouseEnter`/`onMouseLeave` を **削除**。Tailwind `hover:bg-error-tint` で hover bg 表現 (`bg-error-tint` は PR 1 既存 class)。
+
+#### 1.2 GTIN 計算結果ボックス (line 238-265)
+
+```tsx
+<div className="rounded-lg p-3 flex flex-wrap items-center gap-x-6 gap-y-2 border border-default bg-surface">
+  <div className="flex items-center gap-2">
+    <span className="caption text-muted">チェックディジット</span>
+    <span className="body-emphasis text-primary">{gtinResult.checkDigit}</span>
+  </div>
+  <div className="flex items-center gap-2">
+    <span className="caption text-muted">GTIN-14</span>
+    <span className="font-mono body-emphasis text-default tracking-[0.1em]">
+      {gtinResult.fullGtin}
+    </span>
+    <span className="hidden sm:inline-flex">
+      <CopyButton text={gtinResult.fullGtin} label="コピー" />
+    </span>
+    <span className="sm:hidden inline-flex">
+      <CopyButton text={gtinResult.fullGtin} compact />
+    </span>
+  </div>
+</div>
+```
+
+`tracking-[0.1em]` は Tailwind 4 arbitrary value (CSP-safe、build 時に静的 CSS 生成)。
+
+#### 1.3 AI フィールド label / 追加ボタン / エラー / 削除 ✕ ボタン (line 268-340)
+
+```tsx
+<div>
+  <div className="mb-2 flex items-center justify-between">
+    <span className="caption text-default font-semibold">合成シンボル（任意）</span>
+    {canAddField && (
+      <button
+        type="button"
+        onClick={addAiField}
+        className="caption text-link-color hover:underline"
+      >
+        + フィールド追加
+      </button>
+    )}
+  </div>
+  <div className="space-y-3">
+    {aiFields.map((field, i) => {
+      // ...
+      return (
+        <div key={i} className="flex flex-col sm:flex-row gap-2 items-start">
+          {/* Select / BareInput 部省略 */}
+          {field.error && (
+            <p role="alert" className="caption text-error mt-1">
+              {field.error}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={() => removeAiField(i)}
+            className="rounded-lg p-2 transition-colors shrink-0 caption text-muted bg-transparent hover:bg-subtle mt-[2px]"
+            aria-label="フィールドを削除"
+          >
+            ✕
+          </button>
+        </div>
+      );
+    })}
+  </div>
+</div>
+```
+
+#### 1.4 バーコードプレビュー / GS1 文字列 details (line 344-393)
+
+```tsx
+{
+  /* バーコードプレビュー */
+}
+{
+  svgContent && (
+    <div
+      className="rounded-lg flex flex-col items-center gap-4 p-5 border border-default bg-surface"
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        aria-label={`GS1 DataBar ${gtinResult?.fullGtin} のバーコード`}
+        dangerouslySetInnerHTML={{ __html: svgContent }}
+      />
+      <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />
+    </div>
+  );
+}
+
+{
+  /* GS1 文字列 details */
+}
+{
+  gtinResult && (
+    <details className="rounded-lg border border-default">
+      <summary className="cursor-pointer px-4 py-3 rounded-lg transition-colors caption font-bold text-default bg-transparent hover:bg-subtle summary-no-marker">
+        GS1文字列を見る
+      </summary>
+      <div className="px-4 pb-4 pt-2">
+        <div className="flex items-center gap-2">
+          <code className="flex-1 rounded px-3 py-2 font-mono break-all caption bg-subtle text-default">
+            {gs1String}
+          </code>
+          <CopyButton text={gs1String} label="コピー" />
+        </div>
+      </div>
+    </details>
+  );
+}
+```
+
+`.summary-no-marker` (新規 class、§4 で定義):
+
+```css
+.summary-no-marker {
+  list-style: none;
+}
+.summary-no-marker::-webkit-details-marker {
+  display: none;
+}
+```
+
+`onMouseEnter`/`onMouseLeave` 削除。`hover:bg-subtle` で表現。
+
+#### 1.5 カード追加ボタン (line 484-500)
+
+```tsx
+<button
+  type="button"
+  onClick={addCard}
+  className="rounded px-4 py-2 transition-colors caption font-bold border border-primary bg-transparent text-primary hover:bg-blue-50"
+>
+  + バーコードを追加
+</button>
+```
+
+`bg-blue-50` は Tailwind auto-utility (`--color-blue-50` = `#eff6ff` = `colors.bgPrimary`)。`hover:bg-blue-50` で hover bg 表現。
+
+#### 1.6 MAX 件数メッセージ (line 503)
+
+```tsx
+<span className="caption text-muted">最大 {MAX_CARDS} 件まで追加できます</span>
+```
+
+#### 1.7 import 整理
+
+```ts
+// Before
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
+// After (削除)
+```
+
+---
+
+### 2. `EncodingConverter.tsx` (20 件)
+
+新規 class 不要。全箇所が既存 class + Tailwind 標準 utility でカバー。
+
+#### 2.1 入力ラベル + dropzone label (line 240-329)
+
+```tsx
+{/* 入力方式 */}
+<div className="flex items-center gap-3">
+  <span className="caption text-muted">入力:</span>
+  <ToggleGroup ... />
+</div>
+
+{/* ファイル入力 dropzone */}
+{inputMethod === 'file' && (
+  <div>
+    <div className="caption text-default font-bold mb-3">ファイルを選択</div>
+    <label className="flex items-center gap-3 rounded-lg px-4 py-3 cursor-pointer transition-colors caption border border-dashed border-default bg-subtle text-muted">
+      <svg ... />
+      <span>{fileName || 'クリックしてファイルを選択'}</span>
+      <input ref={fileInputRef} type="file" className="sr-only" ... />
+    </label>
+    <p className="text-xs text-muted mt-1">
+      対応形式: テキストファイル（.txt / .csv / .json / .xml / .yaml / .toml 等）・最大 10 MB
+    </p>
+    {fileBytes && (
+      <div className="mt-2 rounded-lg px-3 py-2 font-mono caption text-muted bg-subtle border border-default break-all">
+        <span className="text-default">{formatBytes(fileBytes.length)}</span>
+        {'　'}
+        {hexPreview(fileBytes)}
+      </div>
+    )}
+  </div>
+)}
+```
+
+`border-dashed` は Tailwind 標準。`break-all` は Tailwind 標準 (`word-break: break-all`)。
+
+#### 2.2 判定結果カード (line 336-373)
+
+```tsx
+{
+  detection && (
+    <div
+      data-testid="detection-result"
+      className="rounded-lg px-4 py-3 space-y-1 border border-default bg-subtle"
+    >
+      <div className="flex flex-wrap gap-x-6 gap-y-1">
+        <span data-testid="detection-encoding" className="caption text-muted">
+          文字コード:{' '}
+          <strong className="text-default">{ENCODING_LABELS[detection.encoding]}</strong>
+        </span>
+        <span data-testid="detection-bom" className="caption text-muted">
+          BOM: <strong className="text-default">{detection.hasBom ? 'あり' : 'なし'}</strong>
+        </span>
+        <span className="caption text-muted">
+          サイズ: <strong className="text-default">{formatBytes(detection.byteLength)}</strong>
+        </span>
+      </div>
+      {decodedPreview && (
+        <div className="mt-2 font-mono rounded px-2 py-1.5 overflow-auto caption text-default bg-default border border-default max-h-24 whitespace-pre-wrap break-all">
+          {decodedPreview}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+`max-h-24` = 6rem ✓、`whitespace-pre-wrap` / `break-all` は Tailwind 標準。
+
+#### 2.3 変換設定 / 出力 (line 376-471)
+
+```tsx
+{mode === 'convert' && (
+  <div className="space-y-3">
+    <div>
+      <label htmlFor="enc-source" className="caption text-muted mb-2 block">元の文字コード:</label>
+      <Select id="enc-source" ... />
+    </div>
+    <div>
+      <label htmlFor="enc-target" className="caption text-muted mb-2 block">変換後の文字コード:</label>
+      <Select id="enc-target" ... />
+    </div>
+    {UTF16_ENCODINGS.has(targetEnc) ? (
+      <div className="caption text-muted">改行コード: UTF-16 では改行コード正規化は適用されません</div>
+    ) : (
+      <div>
+        <div className="caption text-muted mb-2">改行コード:</div>
+        <ToggleGroup ... />
+      </div>
+    )}
+    {bomActive && (
+      <label className="flex items-center gap-2 cursor-pointer caption text-default">
+        <input type="checkbox" checked={withBom} onChange={...} aria-label="BOM を付与する" />
+        BOM を付与する
+      </label>
+    )}
+  </div>
+)}
+
+{mode === 'convert' && outputBytes && (
+  <div data-testid="output-hex-preview" className="caption text-muted mt-1">
+    {formatBytes(outputBytes.length)}　先頭: {hexPreview(outputBytes, 16)}
+  </div>
+)}
+```
+
+#### 2.4 import 整理
+
+```ts
+// Before
+import { caption, colors } from '@/utils/styles';
+// After (削除 — EncodingConverter は bodyEmphasis を import していない、現状確認済)
+```
+
+---
+
+### 3. `DummyText.tsx` (13 件)
+
+新規 class 不要。
+
+#### 3.1 文字種 / 文字数 / 改行 / 結果 表示 (line 96-217)
+
+```tsx
+return (
+  <div className="space-y-6">
+    {/* 文字種 */}
+    <div>
+      <p className="body-emphasis text-default mb-3">文字種</p>
+      <ToggleGroup ... />
+    </div>
+
+    {/* 文字数 */}
+    <div>
+      <label htmlFor="dummy-length" className="body-emphasis text-default block mb-1">文字数</label>
+      <input id="dummy-length" type="number" min={1} max={5000}
+             value={lengthInput} onChange={...} onBlur={...} onKeyDown={...}
+             className="rounded-lg px-3 py-2 caption w-32 border border-input outline-none bg-default text-default" />
+      <p className="caption text-muted mt-1">1〜5000文字</p>
+    </div>
+
+    {/* 改行 */}
+    <div>
+      <p className="body-emphasis text-default mb-1">改行</p>
+      <div className="flex items-center gap-3 flex-wrap">
+        <ToggleGroup ... />
+        {lineBreak && (
+          <div className="flex items-center gap-2">
+            <label htmlFor="chunk-size" className="caption text-muted">間隔</label>
+            <input id="chunk-size" type="number" min={1} max={1000}
+                   value={chunkInput} onChange={...} onBlur={...}
+                   className="rounded-lg px-3 py-2 caption w-20 border border-input outline-none bg-default text-default" />
+            <span className="caption text-muted">文字ごと（1〜1000）</span>
+          </div>
+        )}
+      </div>
+    </div>
+
+    {/* 結果 */}
+    {result && (
+      <div className="rounded-lg border border-default overflow-hidden">
+        <div className="flex items-center justify-between gap-2 px-4 py-3 bg-subtle border-b border-default">
+          <span className="body-emphasis text-default">{result.length} 文字</span>
+          <div className="flex items-center gap-2">
+            <CopyButton text={result} label="コピー" />
+            <ClearButton onClick={() => setResult('')} />
+          </div>
+        </div>
+        <div className="px-4 py-4 bg-default">
+          <p className="caption text-default leading-[1.8] break-all whitespace-pre-wrap m-0">
+            {result}
+          </p>
+        </div>
+      </div>
+    )}
+  </div>
+);
+```
+
+`outline-none` の維持理由: global の `:where(input, ...):focus-visible { outline: var(--focus-ring); outline-offset: 2px }` rule が a11y 担保 (キーボード focus 時 focus ring 復活)。
+
+`leading-[1.8]` arbitrary (`leading-7` = 1.75 だと厳密一致せず VRT diff リスク)。
+
+`w-32` = 8rem / `w-20` = 5rem、`m-0` は Tailwind 標準。
+
+#### 3.2 import 整理
+
+```ts
+// Before
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
+// After (削除)
+```
+
+---
+
+## 4. `src/styles/global.css` への追記 (PR 4 で **新規追加** する分のみ)
+
+PR 1 / 1.5 / 2 / 3 で追加済の class はすべて再利用 (`.caption` / `.body-emphasis` / `.text-default` / `.text-muted` / `.bg-default` / `.bg-subtle` / `.bg-surface` / `.border-default` / `.border-input` / `.bg-error-tint` / `.bg-success-tint` / `.text-error` / `.text-error-text` / `.text-success` / `.text-primary` / `.text-link-color` 等)。本 PR 追加分:
+
+```css
+@layer components {
+  /* === PR 4: Gs1Databar <details>/<summary> marker hide === */
+  .summary-no-marker {
+    list-style: none;
+  }
+  .summary-no-marker::-webkit-details-marker {
+    display: none;
+  }
+}
+```
+
+**衝突確認**:
+
+- `.summary-no-marker` は BEM 風命名で唯一性確保
+- `::-webkit-details-marker` は WebKit/Blink、`list-style: none` は Firefox の marker を消すため、両方カバー
+- 他 tool で `<details>` が再利用される場合は同 class を流用可
+
+**Tailwind 4 arbitrary value の利用箇所** (build 時に静的 CSS、CSP-safe):
+
+| utility            | 用途                            | 該当              |
+| ------------------ | ------------------------------- | ----------------- |
+| `tracking-[0.1em]` | GTIN-14 文字間隔                | Gs1Databar 1 箇所 |
+| `mt-[2px]`         | AI フィールド削除ボタンの微調整 | Gs1Databar 1 箇所 |
+| `leading-[1.8]`    | DummyText 結果テキスト行間      | DummyText 1 箇所  |
+
+これらは Tailwind 4 標準機能。新 class 化のコスト>利益のため utility 利用に留める。
+
+---
+
+## 5. `inline-style-migration.test.ts` への追加
+
+```ts
+const MIGRATED_FILES: readonly string[] = [
+  // PR 1 で追加済 (11 件、省略)
+  // PR 1.5 で追加済 (2 件)
+  // PR 2 で追加済 (3 件)
+  // PR 3 で追加済 (2 件)
+  // PR 4 で追加
+  'src/components/tools/Gs1Databar.tsx',
+  'src/components/tools/EncodingConverter.tsx',
+  'src/components/tools/DummyText.tsx',
+];
+```
+
+陽性対照テストブロックは PR 1 で導入済 → 変更不要。合計 21 ファイル。
+
+---
+
+## 6. consumer 変更範囲 (PR 4 で touch するファイル)
+
+| File                                                 | 変更内容                                                                      | 備考                          |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------- |
+| `src/components/tools/Gs1Databar.tsx`                | inline style 20 件除去 + `e.currentTarget.style.X = Y` 9 件除去 + import 整理 | MIGRATED_FILES 登録           |
+| `src/components/tools/EncodingConverter.tsx`         | inline style 20 件除去 + import 整理                                          | MIGRATED_FILES 登録           |
+| `src/components/tools/DummyText.tsx`                 | inline style 13 件除去 + import 整理                                          | MIGRATED_FILES 登録           |
+| `src/styles/global.css`                              | `@layer components` に `.summary-no-marker` 1 件追加                          | PR 1/1.5/2/3 既存ブロック末尾 |
+| `src/utils/__tests__/inline-style-migration.test.ts` | `MIGRATED_FILES` array に 3 件追加 (合計 21 件)                               | -                             |
+| `docs/projects/issue-176-b-plan-progress.md`         | PR 4 の状態を current 化 (PR 3 経験を踏まえ merge 待ち間 SoT 反映)            | 進捗 + follow-up table 更新   |
+
+**触らない**:
+
+- `src/components/tools/__tests__/*.test.ts` (logic test、本 PR の class 化は DOM 構造を変えない)
+- `src/utils/styles.ts` (PR 6 で削除、本 PR は import 削除のみ)
+- `src/utils/csp.ts` / `public/_headers` (PR 6 でstrict 化)
+- `tests/e2e/*.spec.ts` (本 PR で applyProductionCsp gate 追加せず、#234 は PR 5 / 6 で対応)
+
+---
+
+## 7. 検証戦略
+
+### 7.1 ローカル必須ゲート (push 前、親 Opus 直接実行)
+
+| 順  | コマンド           | 目的                                                                    |
+| --- | ------------------ | ----------------------------------------------------------------------- |
+| 1   | `npm run test`     | unit + migration test (18 → 21、6 spec 追加 = 3 ファイル × 2 件 / file) |
+| 2   | `npx astro check`  | TypeScript 型チェック                                                   |
+| 3   | `npm run test:e2e` | gs1-databar / encoding-converter / dummy-text の既存 E2E 全 pass        |
+
+memory `feedback_subagent_verification_trust.md`: 親 Opus 直接実行 (subagent の "pass" 報告は信頼しない)。
+
+### 7.2 CI
+
+| workflow                | 内容                               | required?       |
+| ----------------------- | ---------------------------------- | --------------- |
+| `test.yml`              | vitest + e2e                       | ✅ required     |
+| `visual-regression.yml` | `npm run test:vrt` (baseline 比較) | ❌ non-required |
+
+memory `feedback_vrt_ci_only.md`: ローカル `npm run test:vrt` は走らせない。
+
+### 7.3 a11y 退化検知 (memory `feedback_commander_checklist.md`)
+
+PR 作成前に親が下記実行:
+
+```bash
+git diff origin/develop -- src/components/tools/Gs1Databar.tsx src/components/tools/EncodingConverter.tsx src/components/tools/DummyText.tsx \
+  | grep -E '^-.*(aria-|role=|data-testid=|htmlFor=)' | grep -vE '^---|^\+\+\+'
+# 出力 0 行 = OK (reformatted で行移動した削除行が出る場合は現コードで存在を grep 確認、PR 3 と同運用)
+```
+
+特に注意:
+
+- Gs1Databar の各 button の `aria-label` 維持 (削除/追加/AI削除)
+- Gs1Databar `<details>/<summary>` の `<details>` semantic 維持 (browser default 構造を class 化で壊さない)
+- Gs1Databar `data-testid="gs1-databar-tool"` 等の維持
+- EncodingConverter の `data-testid` 維持 (`detection-result` / `detection-encoding` / `detection-bom` / `output-hex-preview`)
+- DummyText の `htmlFor` / `<label>` 構造維持
+- `<button type="button">` 属性維持 (PR 1 follow-up #258/#269 で追加済)
+
+### 7.4 VRT 差分の判断フロー (PR 1 / 1.5 / 2 / 3 と同じ)
+
+PR comment に diff があった場合:
+
+- 意図しない regression (button hover 色違い / dashed border 太さ違い等) → class 定義 / consumer className 修正
+- ピクセル未満の anti-alias 差 → mask か threshold 緩和 (事前合意必要)
+- 意図的変化 → PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger → bot が新 baseline を commit back
+
+---
+
+## 8. バッチ計画における本 PR の位置付け
+
+repo SoT [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md) のテーブル参照。
+
+| #        | スコープ                                                                                                       | 状態           |
+| -------- | -------------------------------------------------------------------------------------------------------------- | -------------- |
+| PR 0     | VRT 導入                                                                                                       | ✅ #254 merged |
+| PR 1     | 基礎工事 + ui/\* simple 11                                                                                     | ✅ #256 merged |
+| PR 1.5   | ui/\* complex (ResultTable + InputField)                                                                       | ✅ #261 merged |
+| PR 2     | qr-ticket/\*                                                                                                   | ✅ #272 merged |
+| PR 3     | JwtDecoder + UuidV7Generator + #262 partial                                                                    | ✅ #275 merged |
+| **PR 4** | **Gs1Databar + EncodingConverter + DummyText (本 PR)**                                                         | **本 PR**      |
+| PR 5     | QrReader + ConfigConverter + JanCode + QrCode + UlidGenerator + 残り tools + #262 close + #276 (前段 infra PR) | 未着手         |
+| PR 6     | flip + cleanup                                                                                                 | 未着手         |
+
+PR は **直列** (前 PR がマージされてから次 PR 着手)。
+
+---
+
+## 9. ブランチ命名 / コミット粒度 / 並列 subagent 分担 + race 回避運用
+
+### 9.1 ブランチ命名
+
+- `feature/issue-176-b4-gs1-encoding-dummy`
+- worktree: `git worktree add .claude/worktrees/issue-176-b4 origin/develop -b feature/issue-176-b4-gs1-encoding-dummy` (memory `feedback_worktree_base_branch.md` / `feedback_worktree_location.md`)
+
+### 9.2 コミット粒度
+
+```
+1. (Phase 0) chore(spec): #176 B 案 PR 4 spec / plan / global.css foundation (.summary-no-marker)
+2. (Phase 1.5) refactor(tools): #176 B 案 PR 4 — Gs1Databar.tsx inline style 撤去 + hover を CSS に移行
+3. (Phase 1.5) refactor(tools): #176 B 案 PR 4 — EncodingConverter.tsx inline style 撤去
+4. (Phase 1.5) refactor(tools): #176 B 案 PR 4 — DummyText.tsx inline style 撤去
+5. (Phase 2) test(migration): MIGRATED_FILES に PR 4 対象 3 件追加
+6. (Phase 2) docs(progress): PR 4 (#XXX) の状態を反映
+```
+
+### 9.3 並列 subagent 分担 (sonnet × 3 Track)
+
+memory `feedback_subagent_model.md` に従い `model: "sonnet"` 明示:
+
+| Track | 担当ファイル            | inline style 件数 + 特殊事項        |
+| ----- | ----------------------- | ----------------------------------- |
+| **A** | `Gs1Databar.tsx`        | 20 件 + 9 件 hover refactor (CSSOM) |
+| **B** | `EncodingConverter.tsx` | 20 件                               |
+| **C** | `DummyText.tsx`         | 13 件                               |
+
+### 9.4 **Phase 1 race 回避運用 (PR 3 反省)**
+
+PR 3 で並列 dispatch 時に commit が結合される race が発生 (Track A の prettier hook が Track B のファイルを巻き込み、commit message と内容が不一致になった事案)。本 PR では下記方針で **race 自体を防ぐ**:
+
+#### 採用方針: subagent は commit せず、親が Phase 1.5 で順次 commit
+
+各 subagent への明示指示:
+
+```
+- ファイル編集 + self-verification (vitest, astro check) のみ実施
+- git add / git commit は実行しない (親が後段で実施)
+- 完了報告: 「変更ファイル list (git diff --name-only) + self-verification 結果」のみ
+```
+
+親 Opus が Phase 1 完了後、Phase 1.5 で:
+
+1. Track A の変更を確認 → `git add src/components/tools/Gs1Databar.tsx` → `git commit -m "..."`
+2. Track B の変更を確認 → `git add src/components/tools/EncodingConverter.tsx` → `git commit -m "..."`
+3. Track C の変更を確認 → `git add src/components/tools/DummyText.tsx` → `git commit -m "..."`
+
+#### 利点
+
+- subagent 間の commit race 完全消去
+- prettier hook の巻き込み reformat も親が制御 (1 commit に閉じる、他 Track ファイルが入らない)
+- 各 commit のメッセージと内容が完全一致
+- subagent の self-verification (vitest / astro check) は維持
+
+### 9.5 PR ベース
+
+`gh pr create --base develop` で必ず明示 (memory `feedback_branch_workflow.md` / `feedback_pr_language.md` / `CLAUDE.md` 最重要ルール)。タイトル例:
+
+> `refactor(tools): #176 B 案 PR 4 — Gs1Databar + EncodingConverter + DummyText inline style 撤去`
+
+PR 本文は `--body-file /tmp/claude/pr_body_b4.md` 経由 (memory `feedback_heredoc_no_escape.md`)。
+
+---
+
+## 10. リスクと緩和
+
+| ID  | リスク                                                                      | 緩和                                                                                                                                 |
+| --- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| R1  | `tracking-[0.1em]` / `leading-[1.8]` arbitrary が Tailwind 4 で生成されない | Tailwind 4 標準機能、`config-converter` 等で実績あり。astro check で型 break しないか確認、E2E で実描画確認                          |
+| R2  | `outline-none` が a11y 退化を起こす                                         | global の `:focus-visible { outline: var(--focus-ring); outline-offset: 2px }` rule で focus ring 復活。E2E で keyboard focus 確認可 |
+| R3  | `.summary-no-marker` が Firefox で marker 残存                              | `list-style: none` が Firefox の marker を消す。`::-webkit-details-marker` は Chromium 用 fallback。両対応                           |
+| R4  | `hover:bg-blue-50` が Tailwind auto-utility として未生成                    | `--color-blue-50` は global.css line 22 で `@theme` 内定義済、Tailwind 4 が自動 utility 生成。astro check で型 break しないか確認    |
+| R5  | カードヘッダー `caption font-bold` の優先度問題                             | Tailwind utility (`@layer utilities`) は components より後に解決。`font-bold` (700) が caption の fontWeight 400 を override         |
+| R6  | Phase 1 で subagent が指示違反して commit してしまう                        | 親が Phase 1.5 で `git status` / `git log --oneline -1` を確認して回復可能。最悪 reset --soft で再 commit (PR 3 の経験)              |
+| R7  | `<summary>` の hover bg が summary タグ全体に効いて子要素も影響             | `<summary>` の背景は通常 expand/collapse トリガ全体に効くのが期待挙動。原 inline style と挙動同等                                    |
+| R8  | EncodingConverter の dropzone `border-dashed` が Tailwind 標準で生成不可    | Tailwind 4 標準、`border-style: dashed` 生成。astro check で型 break しないか確認                                                    |
+
+---
+
+## 11. 議論ポイント (spec 確定前 user 判断、本 spec に既に user 承認済)
+
+### D1. `<summary>` marker 非表示の方法
+
+- **採用**: 新 class `.summary-no-marker` (`list-style: none` + `::-webkit-details-marker { display: none }`)
+- **代替**: Tailwind arbitrary `[&::-webkit-details-marker]:hidden marker:hidden` 利用
+- **判断**: 採用案 (user 承認済 2026-05-07、PR 2/3 reviewer が named class を好む傾向、可読性向上)
+
+### D2. `tracking-[0.1em]` / `leading-[1.8]` の arbitrary value 利用
+
+- **採用**: Tailwind 4 arbitrary value をそのまま利用 (`.gtin-14-display` / `.dummy-result-text` 等の class 化はしない)
+- **代替**: 専用 class を新設
+- **判断**: 採用案 (user 承認済 2026-05-07、1 箇所のみの利用、class 増やすコスト>利益)
+
+### D3. Phase 1 race 回避運用 (subagent commit せず、親が一括 commit)
+
+- **採用**: 上記 §9.4 の手法 (PR 3 の race 反省)
+- **代替**: PR 3 同様 subagent commit + 親が事後 reset --soft で split
+- **判断**: 採用案 (user 承認済 2026-05-07、race 自体を防ぐ方が確実)
+
+### D4. `<input type="number">` の outline-none 維持
+
+- **採用**: `outline-none` を維持 (global の `:focus-visible` rule が a11y 担保)
+- **代替**: `outline-none` を撤去 (browser default outline 復活)
+- **判断**: 採用案 (user 承認済 2026-05-07、元 inline style と挙動同等、global rule で a11y 担保)
+
+### D5. カード追加ボタンの `hover:bg-blue-50` 利用
+
+- **採用**: Tailwind auto-utility `bg-blue-50` (`--color-blue-50` 経由) を hover に適用
+- **代替**: 新 class `.btn-card-add` 作成 + その中で `:hover` 定義
+- **判断**: 採用案 (user 承認済 2026-05-07、utility 1 件で完結、新 class 不要)
+
+---
+
+## 関連
+
+- 起源 issue: [#176](https://github.com/fumtas1k/devtools/issues/176) アプローチ B
+- 前提 PR: [#249](https://github.com/fumtas1k/devtools/pull/249) (A-1) / [#252](https://github.com/fumtas1k/devtools/pull/252) (meta-csp) / [#254](https://github.com/fumtas1k/devtools/pull/254) (VRT) / [#256](https://github.com/fumtas1k/devtools/pull/256) (PR 1) / [#261](https://github.com/fumtas1k/devtools/pull/261) (PR 1.5) / [#272](https://github.com/fumtas1k/devtools/pull/272) (PR 2) / [#275](https://github.com/fumtas1k/devtools/pull/275) (PR 3)
+- 過去 decisions: [054]（CSP 初導入）/ [064]（A-1 採用）/ [066]（VRT 採用）
+- repo SoT: [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md)
+- memory: `feedback_pr_size.md` / `feedback_subagent_model.md` / `feedback_subagent_verification_trust.md` / `feedback_commander_checklist.md` / `feedback_vrt_ci_only.md` / `feedback_e2e_before_pr.md` / `feedback_branch_workflow.md` / `feedback_pr_language.md` / `feedback_heredoc_no_escape.md` / `feedback_worktree_base_branch.md` / `feedback_worktree_location.md` / `feedback_worktree_merge_order.md`
+- PR 1 spec: `docs/superpowers/specs/2026-05-03-issue-176-b1-foundation-and-ui-simple-design.md`
+- PR 1.5 spec: `docs/superpowers/specs/2026-05-04-issue-176-b1-5-ui-complex-design.md`
+- PR 2 spec: `docs/superpowers/specs/2026-05-04-issue-176-b2-qr-ticket-design.md`
+- PR 3 spec: `docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md`

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -27,8 +27,8 @@
 CSP `style-src 'unsafe-inline'` 撤去（issue #176 B 案）に伴い、JSX の `style={{}}` および `e.currentTarget.style.X = Y` 形式の DOM mutation は使用禁止。ホバー / 状態色は `src/styles/global.css` の `@layer components` に semantic class として定義し、`:hover` / `[aria-pressed="true"]` / 条件 `className` 切替で表現する。
 
 - Tailwind の **色値直書き** utility（`text-blue-500`, `bg-red-200` 等）は引き続き禁止
-- ただし `@theme` 経由で auto-generate される **意味トークン** utility（`text-primary` / `bg-error` / `text-link` 等は `--color-primary` / `--color-error` / `--color-link` を参照）は使用可。色値直書きではなく既存 SoT を経由するため、カラー使用制限の趣旨と整合
-- 同じ理由で `hover:bg-subtle` のような「Tailwind hover utility + 意味クラス」も許容
+- ただし `@theme` 経由で auto-generate される **意味トークン** utility（`text-primary` / `bg-error` 等は `--color-primary` / `--color-error` を参照）は使用可。色値直書きではなく既存 SoT を経由するため、カラー使用制限の趣旨と整合
+- ⚠️ **重要 — Tailwind v4 の variant 制約**: `@layer components` 内で **手書き定義** した class（`.bg-subtle` / `.bg-error-tint` / `.text-primary` 等、`global.css` の `@layer components` ブロックに記述したもの）は **`hover:` / `focus:` 等の variant に対応しない**（CSS rule が build 出力に含まれず silent regression する）。`@theme` の token から auto-generate される utility のみ variant 対応する。**`hover:bg-subtle` のような書き方は使えない**。代わりに専用の hover 用 class を `@layer components` 内に定義する pattern (下記 `.btn-clear` 例のように `:hover` 擬似クラスごと書く) を用いること
 
 ```tsx
 // before (PR #176 B 案 移行前の旧パターン、現在は禁止)

--- a/src/components/tools/DummyText.tsx
+++ b/src/components/tools/DummyText.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { useClampedInput } from '@/hooks/useClampedInput';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
-import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 
 type CharType = 'hiragana' | 'katakana' | 'japanese' | 'alphanumeric' | 'lorem';
@@ -97,7 +96,7 @@ export function DummyTextTool() {
     <div className="space-y-6">
       {/* 文字種 */}
       <div>
-        <p style={{ ...bodyEmphasis, color: colors.text, marginBottom: '0.75rem' }}>文字種</p>
+        <p className="body-emphasis text-default mb-3">文字種</p>
         <ToggleGroup
           options={CHAR_TYPES}
           value={charType}
@@ -109,10 +108,7 @@ export function DummyTextTool() {
 
       {/* 文字数 */}
       <div>
-        <label
-          htmlFor="dummy-length"
-          style={{ ...bodyEmphasis, color: colors.text, display: 'block', marginBottom: '0.25rem' }}
-        >
+        <label htmlFor="dummy-length" className="body-emphasis text-default block mb-1">
           文字数
         </label>
         <input
@@ -128,22 +124,14 @@ export function DummyTextTool() {
               handleLengthBlur();
             }
           }}
-          className="rounded-lg px-3 py-2"
-          style={{
-            ...caption,
-            width: '8rem',
-            border: `1px solid ${colors.borderInput}`,
-            outline: 'none',
-            background: colors.bg,
-            color: colors.text,
-          }}
+          className="rounded-lg px-3 py-2 caption w-32 border border-input outline-none bg-default text-default"
         />
-        <p style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}>1〜5000文字</p>
+        <p className="caption text-muted mt-1">1〜5000文字</p>
       </div>
 
       {/* 改行 */}
       <div>
-        <p style={{ ...bodyEmphasis, color: colors.text, marginBottom: '0.25rem' }}>改行</p>
+        <p className="body-emphasis text-default mb-1">改行</p>
         <div className="flex items-center gap-3 flex-wrap">
           <ToggleGroup<'false' | 'true'>
             options={[
@@ -156,7 +144,7 @@ export function DummyTextTool() {
           />
           {lineBreak && (
             <div className="flex items-center gap-2">
-              <label htmlFor="chunk-size" style={{ ...caption, color: colors.muted }}>
+              <label htmlFor="chunk-size" className="caption text-muted">
                 間隔
               </label>
               <input
@@ -167,17 +155,9 @@ export function DummyTextTool() {
                 value={chunkInput}
                 onChange={(e) => handleChunkChange(e.target.value)}
                 onBlur={handleChunkBlur}
-                className="rounded-lg px-3 py-2"
-                style={{
-                  ...caption,
-                  width: '5rem',
-                  border: `1px solid ${colors.borderInput}`,
-                  outline: 'none',
-                  background: colors.bg,
-                  color: colors.text,
-                }}
+                className="rounded-lg px-3 py-2 caption w-20 border border-input outline-none bg-default text-default"
               />
-              <span style={{ ...caption, color: colors.muted }}>文字ごと（1〜1000）</span>
+              <span className="caption text-muted">文字ごと（1〜1000）</span>
             </div>
           )}
         </div>
@@ -185,31 +165,16 @@ export function DummyTextTool() {
 
       {/* 結果 */}
       {result && (
-        <div
-          className="rounded-lg"
-          style={{ border: `1px solid ${colors.border}`, overflow: 'hidden' }}
-        >
-          <div
-            className="flex items-center justify-between gap-2 px-4 py-3"
-            style={{ background: colors.bgSubtle, borderBottom: `1px solid ${colors.border}` }}
-          >
-            <span style={{ ...bodyEmphasis, color: colors.text }}>{result.length} 文字</span>
+        <div className="rounded-lg border border-default overflow-hidden">
+          <div className="flex items-center justify-between gap-2 px-4 py-3 bg-subtle border-b border-default">
+            <span className="body-emphasis text-default">{result.length} 文字</span>
             <div className="flex items-center gap-2">
               <CopyButton text={result} label="コピー" />
               <ClearButton onClick={() => setResult('')} />
             </div>
           </div>
-          <div className="px-4 py-4" style={{ background: colors.bg }}>
-            <p
-              style={{
-                ...caption,
-                color: colors.text,
-                lineHeight: 1.8,
-                wordBreak: 'break-all',
-                whiteSpace: 'pre-wrap',
-                margin: 0,
-              }}
-            >
+          <div className="px-4 py-4 bg-default">
+            <p className="caption text-default leading-[1.8] break-all whitespace-pre-wrap m-0">
               {result}
             </p>
           </div>

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -6,7 +6,6 @@ import { OutputField } from '@/components/ui/OutputField';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { DownloadButton } from '@/components/ui/DownloadButton';
-import { caption, colors } from '@/utils/styles';
 import { getErrorMessage } from '@/utils/errors';
 import { downloadBytes } from '@/utils/download';
 import { validateFile } from '@/utils/file-validation';
@@ -240,7 +239,7 @@ export function EncodingConverterTool() {
 
       {/* 入力方式 */}
       <div className="flex items-center gap-3">
-        <span style={{ ...caption, color: colors.muted }}>入力:</span>
+        <span className="caption text-muted">入力:</span>
         <ToggleGroup
           options={[
             { value: 'text', label: 'テキスト' },
@@ -271,18 +270,8 @@ export function EncodingConverterTool() {
       {/* ファイル入力 */}
       {inputMethod === 'file' && (
         <div>
-          <div style={{ ...caption, color: colors.text, fontWeight: 700, marginBottom: '0.75rem' }}>
-            ファイルを選択
-          </div>
-          <label
-            className="flex items-center gap-3 rounded-lg px-4 py-3 cursor-pointer transition-colors"
-            style={{
-              border: `1px dashed ${colors.border}`,
-              background: colors.bgSubtle,
-              color: colors.muted,
-              ...caption,
-            }}
-          >
+          <div className="caption text-default font-bold mb-3">ファイルを選択</div>
+          <label className="flex items-center gap-3 rounded-lg px-4 py-3 cursor-pointer transition-colors caption border border-dashed border-default bg-subtle text-muted">
             <svg
               width="20"
               height="20"
@@ -308,21 +297,12 @@ export function EncodingConverterTool() {
               accept={ACCEPT_ATTR}
             />
           </label>
-          <p style={{ fontSize: '0.75rem', color: colors.muted, marginTop: '0.25rem' }}>
+          <p className="text-xs text-muted mt-1">
             対応形式: テキストファイル（.txt / .csv / .json / .xml / .yaml / .toml 等）・最大 10 MB
           </p>
           {fileBytes && (
-            <div
-              className="mt-2 rounded-lg px-3 py-2 font-mono"
-              style={{
-                ...caption,
-                color: colors.muted,
-                background: colors.bgSubtle,
-                border: `1px solid ${colors.border}`,
-                wordBreak: 'break-all',
-              }}
-            >
-              <span style={{ color: colors.text }}>{formatBytes(fileBytes.length)}</span>
+            <div className="mt-2 rounded-lg px-3 py-2 font-mono caption text-muted bg-subtle border border-default break-all">
+              <span className="text-default">{formatBytes(fileBytes.length)}</span>
               {'　'}
               {hexPreview(fileBytes)}
             </div>
@@ -337,36 +317,22 @@ export function EncodingConverterTool() {
       {detection && (
         <div
           data-testid="detection-result"
-          className="rounded-lg px-4 py-3 space-y-1"
-          style={{ border: `1px solid ${colors.border}`, background: colors.bgSubtle }}
+          className="rounded-lg px-4 py-3 space-y-1 border border-default bg-subtle"
         >
           <div className="flex flex-wrap gap-x-6 gap-y-1">
-            <span data-testid="detection-encoding" style={{ ...caption, color: colors.muted }}>
+            <span data-testid="detection-encoding" className="caption text-muted">
               文字コード:{' '}
-              <strong style={{ color: colors.text }}>{ENCODING_LABELS[detection.encoding]}</strong>
+              <strong className="text-default">{ENCODING_LABELS[detection.encoding]}</strong>
             </span>
-            <span data-testid="detection-bom" style={{ ...caption, color: colors.muted }}>
-              BOM:{' '}
-              <strong style={{ color: colors.text }}>{detection.hasBom ? 'あり' : 'なし'}</strong>
+            <span data-testid="detection-bom" className="caption text-muted">
+              BOM: <strong className="text-default">{detection.hasBom ? 'あり' : 'なし'}</strong>
             </span>
-            <span style={{ ...caption, color: colors.muted }}>
-              サイズ:{' '}
-              <strong style={{ color: colors.text }}>{formatBytes(detection.byteLength)}</strong>
+            <span className="caption text-muted">
+              サイズ: <strong className="text-default">{formatBytes(detection.byteLength)}</strong>
             </span>
           </div>
           {decodedPreview && (
-            <div
-              className="mt-2 font-mono rounded px-2 py-1.5 overflow-auto"
-              style={{
-                ...caption,
-                color: colors.text,
-                background: colors.bg,
-                border: `1px solid ${colors.border}`,
-                maxHeight: '6rem',
-                whiteSpace: 'pre-wrap',
-                wordBreak: 'break-all',
-              }}
-            >
+            <div className="mt-2 font-mono rounded px-2 py-1.5 overflow-auto caption text-default bg-default border border-default max-h-24 whitespace-pre-wrap break-all">
               {decodedPreview}
             </div>
           )}
@@ -377,10 +343,7 @@ export function EncodingConverterTool() {
       {mode === 'convert' && (
         <div className="space-y-3">
           <div>
-            <label
-              htmlFor="enc-source"
-              style={{ ...caption, color: colors.muted, marginBottom: '0.5rem', display: 'block' }}
-            >
+            <label htmlFor="enc-source" className="caption text-muted mb-2 block">
               元の文字コード:
             </label>
             <Select
@@ -392,10 +355,7 @@ export function EncodingConverterTool() {
           </div>
 
           <div>
-            <label
-              htmlFor="enc-target"
-              style={{ ...caption, color: colors.muted, marginBottom: '0.5rem', display: 'block' }}
-            >
+            <label htmlFor="enc-target" className="caption text-muted mb-2 block">
               変換後の文字コード:
             </label>
             <Select
@@ -407,14 +367,12 @@ export function EncodingConverterTool() {
           </div>
 
           {UTF16_ENCODINGS.has(targetEnc) ? (
-            <div style={{ ...caption, color: colors.muted }}>
+            <div className="caption text-muted">
               改行コード: UTF-16 では改行コード正規化は適用されません
             </div>
           ) : (
             <div>
-              <div style={{ ...caption, color: colors.muted, marginBottom: '0.5rem' }}>
-                改行コード:
-              </div>
+              <div className="caption text-muted mb-2">改行コード:</div>
               <ToggleGroup
                 options={NEWLINE_OPTIONS}
                 value={newlineMode}
@@ -425,10 +383,7 @@ export function EncodingConverterTool() {
           )}
 
           {bomActive && (
-            <label
-              className="flex items-center gap-2 cursor-pointer"
-              style={{ ...caption, color: colors.text }}
-            >
+            <label className="flex items-center gap-2 cursor-pointer caption text-default">
               <input
                 type="checkbox"
                 checked={withBom}
@@ -461,10 +416,7 @@ export function EncodingConverterTool() {
             }
           />
           {outputBytes && (
-            <div
-              data-testid="output-hex-preview"
-              style={{ ...caption, color: colors.muted, marginTop: '0.25rem' }}
-            >
+            <div data-testid="output-hex-preview" className="caption text-muted mt-1">
               {formatBytes(outputBytes.length)}　先頭: {hexPreview(outputBytes, 16)}
             </div>
           )}

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -10,7 +10,6 @@ import {
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
-import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { InputField } from '@/components/ui/InputField';
 import { BareInput } from '@/components/ui/BareInput';
 import { Select } from '@/components/ui/Select';
@@ -182,34 +181,20 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
   );
 
   return (
-    <div
-      className="rounded-lg"
-      style={{ border: `1px solid ${colors.borderInput}`, background: colors.bg }}
-    >
+    <div className="rounded-lg border border-input bg-default">
       {/* カードヘッダー */}
-      <div
-        className="flex items-center justify-between px-4 py-3 rounded-t-lg"
-        style={{ background: colors.bgSubtle, borderBottom: `1px solid ${colors.border}` }}
-      >
-        <span style={{ ...caption, fontWeight: 700, color: colors.text }}>
+      <div className="flex items-center justify-between px-4 py-3 rounded-t-lg bg-subtle border-b border-default">
+        <span className="caption font-bold text-default">
           バーコード {index + 1}
           {gtinResult && (
-            <span
-              className="font-mono ml-2"
-              style={{ ...caption, color: colors.muted, fontWeight: 400 }}
-            >
-              — {gtinResult.fullGtin}
-            </span>
+            <span className="font-mono ml-2 caption text-muted">— {gtinResult.fullGtin}</span>
           )}
         </span>
         {canRemove && (
           <button
             type="button"
             onClick={onRemove}
-            className="rounded px-2 py-1 transition-colors"
-            style={{ ...caption, color: colors.error, background: 'transparent' }}
-            onMouseEnter={(e) => (e.currentTarget.style.background = colors.errorBg)}
-            onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            className="rounded px-2 py-1 transition-colors caption text-error bg-transparent hover:bg-error-tint"
             aria-label={`バーコード ${index + 1} を削除`}
           >
             削除
@@ -236,22 +221,14 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
 
         {/* GTIN計算結果 */}
         {gtinResult && (
-          <div
-            className="rounded-lg p-3 flex flex-wrap items-center gap-x-6 gap-y-2"
-            style={{ border: `1px solid ${colors.border}`, background: colors.bgSurface }}
-          >
+          <div className="rounded-lg p-3 flex flex-wrap items-center gap-x-6 gap-y-2 border border-default bg-surface">
             <div className="flex items-center gap-2">
-              <span style={{ ...caption, color: colors.muted }}>チェックディジット</span>
-              <span style={{ ...bodyEmphasis, color: colors.primary }}>
-                {gtinResult.checkDigit}
-              </span>
+              <span className="caption text-muted">チェックディジット</span>
+              <span className="body-emphasis text-primary">{gtinResult.checkDigit}</span>
             </div>
             <div className="flex items-center gap-2">
-              <span style={{ ...caption, color: colors.muted }}>GTIN-14</span>
-              <span
-                className="font-mono"
-                style={{ ...bodyEmphasis, color: colors.text, letterSpacing: '0.1em' }}
-              >
+              <span className="caption text-muted">GTIN-14</span>
+              <span className="font-mono body-emphasis text-default tracking-[0.1em]">
                 {gtinResult.fullGtin}
               </span>
               <span className="hidden sm:inline-flex">
@@ -267,15 +244,12 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
         {/* AIフィールド */}
         <div>
           <div className="mb-2 flex items-center justify-between">
-            <span style={{ ...caption, color: colors.text, fontWeight: 600 }}>
-              合成シンボル（任意）
-            </span>
+            <span className="caption text-default font-semibold">合成シンボル（任意）</span>
             {canAddField && (
               <button
                 type="button"
                 onClick={addAiField}
-                style={{ ...caption, color: colors.link }}
-                className="hover:underline"
+                className="caption text-link-color hover:underline"
               >
                 + フィールド追加
               </button>
@@ -310,10 +284,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                         aria-label={`AI フィールド値 ${i + 1}`}
                       />
                       {field.error && (
-                        <p
-                          role="alert"
-                          style={{ ...caption, color: colors.error, marginTop: '0.25rem' }}
-                        >
+                        <p role="alert" className="caption text-error mt-1">
                           {field.error}
                         </p>
                       )}
@@ -321,15 +292,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                     <button
                       type="button"
                       onClick={() => removeAiField(i)}
-                      className="rounded-lg p-2 transition-colors shrink-0"
-                      style={{
-                        ...caption,
-                        color: colors.muted,
-                        marginTop: '2px',
-                        background: 'transparent',
-                      }}
-                      onMouseEnter={(e) => (e.currentTarget.style.background = colors.bgSubtle)}
-                      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                      className="rounded-lg p-2 transition-colors shrink-0 caption text-muted bg-transparent hover:bg-subtle mt-[2px]"
                       aria-label="フィールドを削除"
                     >
                       ✕
@@ -344,8 +307,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
         {/* バーコードプレビュー */}
         {svgContent && (
           <div
-            className="rounded-lg flex flex-col items-center gap-4 p-5"
-            style={{ border: `1px solid ${colors.border}`, background: colors.bgSurface }}
+            className="rounded-lg flex flex-col items-center gap-4 p-5 border border-default bg-surface"
             role="status"
             aria-live="polite"
           >
@@ -363,27 +325,13 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
 
         {/* GS1文字列プレビュー */}
         {gtinResult && (
-          <details className="rounded-lg" style={{ border: `1px solid ${colors.border}` }}>
-            <summary
-              className="cursor-pointer px-4 py-3 rounded-lg transition-colors"
-              style={{
-                ...caption,
-                fontWeight: 700,
-                color: colors.text,
-                listStyle: 'none',
-                background: 'transparent',
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = colors.bgSubtle)}
-              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
-            >
+          <details className="rounded-lg border border-default">
+            <summary className="cursor-pointer px-4 py-3 rounded-lg transition-colors caption font-bold text-default bg-transparent hover:bg-subtle summary-no-marker">
               GS1文字列を見る
             </summary>
             <div className="px-4 pb-4 pt-2">
               <div className="flex items-center gap-2">
-                <code
-                  className="flex-1 rounded px-3 py-2 font-mono break-all"
-                  style={{ ...caption, background: colors.bgSubtle, color: colors.text }}
-                >
+                <code className="flex-1 rounded px-3 py-2 font-mono break-all caption bg-subtle text-default">
                   {gs1String}
                 </code>
                 <CopyButton text={gs1String} label="コピー" />
@@ -485,24 +433,13 @@ export function Gs1DatabarTool() {
           <button
             type="button"
             onClick={addCard}
-            className="rounded px-4 py-2 transition-colors"
-            style={{
-              ...caption,
-              fontWeight: 700,
-              border: `1px solid ${colors.primary}`,
-              color: colors.primary,
-              background: 'transparent',
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.background = colors.bgPrimary)}
-            onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            className="rounded px-4 py-2 transition-colors caption font-bold border border-primary bg-transparent text-primary hover:bg-blue-50"
           >
             + バーコードを追加
           </button>
         )}
         {cards.length >= MAX_CARDS && (
-          <span style={{ ...caption, color: colors.muted }}>
-            最大 {MAX_CARDS} 件まで追加できます
-          </span>
+          <span className="caption text-muted">最大 {MAX_CARDS} 件まで追加できます</span>
         )}
 
         {canDownloadAll && (

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -194,7 +194,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
           <button
             type="button"
             onClick={onRemove}
-            className="rounded px-2 py-1 transition-colors caption text-error bg-transparent hover:bg-error-tint"
+            className="rounded px-2 py-1 caption btn-remove-card"
             aria-label={`バーコード ${index + 1} を削除`}
           >
             削除
@@ -228,7 +228,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
             </div>
             <div className="flex items-center gap-2">
               <span className="caption text-muted">GTIN-14</span>
-              <span className="font-mono body-emphasis text-default tracking-[0.1em]">
+              <span className="font-mono body-emphasis text-default tracking-widest">
                 {gtinResult.fullGtin}
               </span>
               <span className="hidden sm:inline-flex">
@@ -292,7 +292,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                     <button
                       type="button"
                       onClick={() => removeAiField(i)}
-                      className="rounded-lg p-2 transition-colors shrink-0 caption text-muted bg-transparent hover:bg-subtle mt-[2px]"
+                      className="rounded-lg p-2 shrink-0 caption text-muted bg-transparent hover-bg-subtle mt-0.5"
                       aria-label="フィールドを削除"
                     >
                       ✕
@@ -326,7 +326,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
         {/* GS1文字列プレビュー */}
         {gtinResult && (
           <details className="rounded-lg border border-default">
-            <summary className="cursor-pointer px-4 py-3 rounded-lg transition-colors caption font-bold text-default bg-transparent hover:bg-subtle summary-no-marker">
+            <summary className="cursor-pointer px-4 py-3 rounded-lg caption font-bold text-default bg-transparent hover-bg-subtle summary-no-marker">
               GS1文字列を見る
             </summary>
             <div className="px-4 pb-4 pt-2">
@@ -433,7 +433,7 @@ export function Gs1DatabarTool() {
           <button
             type="button"
             onClick={addCard}
-            className="rounded px-4 py-2 transition-colors caption font-bold border border-primary bg-transparent text-primary hover:bg-blue-50"
+            className="rounded px-4 py-2 caption font-bold border border-primary bg-transparent text-primary hover-bg-active"
           >
             + バーコードを追加
           </button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -496,4 +496,12 @@
     font-size: 0.7rem;
     opacity: 0.7;
   }
+
+  /* === PR 4: Gs1Databar <details>/<summary> marker hide === */
+  .summary-no-marker {
+    list-style: none;
+  }
+  .summary-no-marker::-webkit-details-marker {
+    display: none;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -504,4 +504,37 @@
   .summary-no-marker::-webkit-details-marker {
     display: none;
   }
+
+  /* === PR 4 review fix: hover state classes ===
+     Tailwind v4 で `@layer components` 内で手書き定義した class は
+     variant (`hover:`, `focus:` 等) に **対応しない** ため、
+     `hover:bg-{custom}` は CSS rule が生成されず silent regression する。
+     `.btn-clear` (PR 1) と同じパターンで専用 hover class を定義する。 */
+
+  /* Gs1Databar: BarcodeCard 削除ボタン (caption + text-error + hover で error-bg) */
+  .btn-remove-card {
+    color: var(--color-error);
+    background: transparent;
+    transition: background-color 0.15s;
+  }
+  .btn-remove-card:hover {
+    background: var(--color-error-bg);
+  }
+
+  /* Gs1Databar: AI フィールド ✕ ボタン / GS1 文字列 <summary> 共通 (hover で bg-subtle) */
+  .hover-bg-subtle {
+    transition: background-color 0.15s;
+  }
+  .hover-bg-subtle:hover {
+    background: var(--color-bg-subtle);
+  }
+
+  /* Gs1Databar: カード追加ボタン (hover で --color-bg-active = blue-50 semantic alias)
+     project rule "Tailwind カラークラス禁止" 遵守のため hover:bg-blue-50 を本 class に置換。 */
+  .hover-bg-active {
+    transition: background-color 0.15s;
+  }
+  .hover-bg-active:hover {
+    background: var(--color-bg-active);
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,13 @@
 @import '@fontsource/noto-sans-jp/700.css';
 @import '@fontsource/jetbrains-mono/400.css';
 
+/* docs/ 配下の md は Tailwind の auto content scan 対象外にする。
+   spec / plan / decisions / agent-lessons 等で `hover:bg-blue-50` 等の
+   Tailwind utility 名をリテラル文字列として説明する箇所が多いため、
+   scan されると build CSS に unused utility が混入する。
+   docs/ は実装コードを含まないので scan する意味がない。 */
+@source not "../../docs";
+
 /* ダークモード未サポート: dark: クラスはメディアクエリではなく .dark クラス指定時のみ適用 */
 @variant dark (&:where(.dark, .dark *));
 
@@ -530,7 +537,11 @@
   }
 
   /* Gs1Databar: カード追加ボタン (hover で --color-bg-active = blue-50 semantic alias)
-     project rule "Tailwind カラークラス禁止" 遵守のため hover:bg-blue-50 を本 class に置換。 */
+     project rule "Tailwind カラークラス禁止" 遵守のため Tailwind primitive
+     カラー hover utility (hover-prefix + bg + blue-50) を本 class に置換。
+     注意: コメント中に Tailwind utility 名のリテラル文字列を書くと
+     v4 の content scanner に拾われて unused utility が build CSS に
+     混入するため、この種の説明は分割して記述する。 */
   .hover-bg-active {
     transition: background-color 0.15s;
   }

--- a/src/utils/__tests__/inline-style-migration.test.ts
+++ b/src/utils/__tests__/inline-style-migration.test.ts
@@ -35,6 +35,10 @@ const MIGRATED_FILES: readonly string[] = [
   // PR 3 で追加
   'src/components/tools/JwtDecoder.tsx',
   'src/components/tools/UuidV7Generator.tsx',
+  // PR 4 で追加
+  'src/components/tools/Gs1Databar.tsx',
+  'src/components/tools/EncodingConverter.tsx',
+  'src/components/tools/DummyText.tsx',
 ];
 
 describe.skipIf(MIGRATED_FILES.length === 0)('#176 B 案 progressive migration tracker', () => {


### PR DESCRIPTION
## 概要

`#176` B 案バッチの PR 4。`Gs1Databar.tsx` (20 件) + `EncodingConverter.tsx` (20 件) + `DummyText.tsx` (13 件) の JSX inline style + Gs1Databar 内 `e.currentTarget.style.X = Y` 形式の CSSOM 直接 mutation 9 件 (`onMouseEnter`/`onMouseLeave` hover state) を `@layer components` の意味クラス + Tailwind utility (`hover:` modifier 含む) に置換する。

- spec: `docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md`
- plan: `docs/superpowers/plans/2026-05-07-issue-176-b4-gs1-encoding-dummy.md`
- バッチ進捗: `docs/projects/issue-176-b-plan-progress.md`

## 主要な変更

### `src/styles/global.css` 追加 class (1 件のみ)

- `.summary-no-marker` (Gs1Databar `<details>/<summary>` の marker 非表示、`list-style: none` + `::-webkit-details-marker { display: none }`)

PR 1〜3 で導入済の class (`caption` / `body-emphasis` / `text-default` / `text-muted` / `bg-default` / `bg-subtle` / `bg-surface` / `border-default` / `border-input` / `bg-error-tint` / `text-error` / `text-primary` / `text-link-color` 等) で 95% 以上をカバー。

### `Gs1Databar.tsx` (20 件 + 9 件 hover refactor → 0)

- `<details>/<summary>` marker 非表示を `.summary-no-marker` class に集約
- GTIN-14 文字間隔は `tracking-[0.1em]` arbitrary value
- `onMouseEnter`/`onMouseLeave` で `e.currentTarget.style.background = ...` していた 9 件 (4 button + 1 summary) を全て削除し、Tailwind `hover:bg-error-tint` / `hover:bg-subtle` / `hover:bg-blue-50` の `hover:` modifier で表現
- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除

### `EncodingConverter.tsx` (20 件 → 0)

- ファイル選択 dropzone を `border border-dashed border-default bg-subtle` で表現
- 判定結果カード / 変換設定 / hex preview を全て既存 class + Tailwind 標準 utility に置換
- 新規 class 追加なし
- `import { caption, colors } from '@/utils/styles'` を削除

### `DummyText.tsx` (13 件 → 0)

- `<input type="number">` 2 箇所を `border border-input outline-none bg-default text-default` に置換 (global の `:focus-visible` rule が a11y 担保)
- 結果テキストの行間は `leading-[1.8]` arbitrary value
- 新規 class 追加なし
- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除

## Race 回避運用 (PR 3 反省)

PR 3 で sonnet 並列 dispatch 時に commit が結合される race が発生 (Track A の prettier hook が Track B のファイルを巻き込み、commit message と内容が不一致になった事案)。本 PR では下記方針で **race 自体を防いだ**:

- subagent は **ファイル編集 + self-verification (vitest, astro check) のみ** 実施
- subagent は `git add` / `git commit` を実行しない
- 親 Opus が Phase 1.5 で 1 ファイルずつ stage + commit (3 commit、各 1 ファイル変更)

結果: commit message と内容が完全一致、prettier 巻き込みも親が制御。

## 検証ログ (親 Opus 直接実行)

- [x] `npm run test` 全 pass (migration test 21 件 × 2 + 陽性対照 3 件 = 45 件 pass 含む計 620 passed, 1 skipped)
- [x] `npx astro check` → 0 errors, 0 warnings, 10 hints (hints は既存)
- [x] `npm run test:e2e` 全 pass (gs1-databar / encoding-converter / dummy-text 含む計 145 passed, 1 skipped)
- [x] a11y 退化なし (`aria-*` / `role=` / `data-testid=` / `htmlFor=` 削除行 8 件は全て reformat の行移動、現コードで維持されていることを grep 確認済)
- [x] inline style 残存ゼロ (`grep -c "style={{"` = 0 / 0 / 0)
- [x] CSSOM mutation 残存ゼロ (`grep -E "\.style\.[a-zA-Z]+\s*="` で setProperty 以外 = 0、Gs1Databar の onMouseEnter/onMouseLeave 全削除)
- [x] PR 6 スコープ未侵害 (`_headers` / `astro.config.mjs` / `src/utils/styles.ts` 未変更)

## VRT

`visual-regression.yml` で baseline 比較 (non-required check)。意図的差分があれば PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger。

## コミット粒度

```
0a211f8 test(migration): MIGRATED_FILES に PR 4 対象 3 件追加
55febb0 refactor(tools): #176 B 案 PR 4 — DummyText.tsx inline style 撤去
5078949 refactor(tools): #176 B 案 PR 4 — EncodingConverter.tsx inline style 撤去
88a2e17 refactor(tools): #176 B 案 PR 4 — Gs1Databar.tsx inline style 撤去 + hover を CSS に移行
bfa402e chore(spec): #176 B 案 PR 4 spec / plan / global.css foundation
```

## 関連

- 起源 issue: #176 (アプローチ B)
- 前提 PR: #249 (A-1) / #254 (VRT) / #256 (PR 1) / #261 (PR 1.5) / #272 (PR 2) / #275 (PR 3)
- 後続: PR 5 (QrReader + 残り tools + #262 close + #276 前段 infra) / PR 6 (flip + cleanup)
