### PR TITLE
refactor(tools): #176 B 案 PR 5a — ConfigConverter + QrReader + JanCode inline style 撤去

### DIFF
--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -57,6 +57,7 @@
 - **削除**: QrReader の module-level スタイル定数 4 個（`rescanButtonStyle` / `startCameraButtonStyle` / `stopCameraButtonStyle` / `uploadLabelStyle`）を全削除し className 化。`uploadLabelStyle(false)` 分岐は YAGNI で削除
 - **race 回避運用**: PR 4 で確立した「subagent 非 commit + 親で順次 commit」を 2 回目運用、安定運用確認
 - **CSSOM hover refactor**: JanCode `<summary>` の `onMouseEnter`/`onMouseLeave` 2 件を `.hover-bg-subtle` で CSS 化（memory `feedback_tailwind_v4_layer_variant.md` 準拠）
+- **self-review NIT follow-up**: [#284](https://github.com/fumtas1k/devtools/issues/284) (`min-w-10` 集約検討、`.label-prefix` 専用 class 化) / [#285](https://github.com/fumtas1k/devtools/issues/285) (カメラボタン utility 列挙を `.btn-action--*-fill` variant に集約検討) を起票。**PR 5b / PR 6 で類似 pattern が出てきたら集約検討、出なければ close**
 
 ### infra PR (#278) — PR 5 前段
 
@@ -105,7 +106,7 @@ PR 5 を **PR 5a / PR 5b** に分割する根拠と各 PR のスコープ。新�
 - **#234 への波及**: 19 spec 横展開のチェックリストで該当する ulid-generator + uuid-v7 を消込 (本 PR 5b で対応する範囲)
 - **#281 再確認**: `withProductionCsp` 自体の meta-test。PR 5b 着手前に再確認、必要なら本 PR で同梱 or 別 follow-up PR に分離
 
-## PR 1 / PR 1.5 / PR 2 / PR 3 / PR 4 / PR #278 (infra) follow-up issue 処理タイミング表
+## PR 1 / PR 1.5 / PR 2 / PR 3 / PR 4 / PR #278 (infra) / PR 5a follow-up issue 処理タイミング表
 
 各 issue の処理推奨タイミング (2026-05-07 時点):
 
@@ -127,6 +128,8 @@ PR 5 を **PR 5a / PR 5b** に分割する根拠と各 PR のスコープ。新�
 | [#279](https://github.com/fumtas1k/devtools/issues/279) | `waitForReactHydration` の label-aware 待ちオプション拡張                                  | event 駆動 (低優先)                             | PR #278 由来 (review 提案 #2)。個別 spec で `waitFor(label)` workaround が 2 件以上溜まったら集約。実害なし                                             |
 | [#280](https://github.com/fumtas1k/devtools/issues/280) | `withProductionCsp` の options 引数 (contextOptions / hydrationTimeout) 拡張               | event 駆動 (YAGNI)                              | PR #278 由来 (review 提案 #3)。`locale` / `viewport` / `hydrationTimeout` 等が必要になった最初のテスト着手時に対応                                      |
 | [#281](https://github.com/fumtas1k/devtools/issues/281) | `withProductionCsp` 自体の挙動を検証する meta-test 追加                                    | **PR 5 着手前に再確認**                         | PR #278 由来 (review 提案 #4)。`fn` throw 時の `context.close` 確実呼出 / `assertNoViolations` 自動呼出 を assert。PR 5 完了後 or #280 着手時に併設候補 |
+| [#284](https://github.com/fumtas1k/devtools/issues/284) | ラベル最小幅 `min-w-10` の集約検討 (`.label-prefix` 専用 class 化)                         | **PR 5b / PR 6 で類似 pattern 確認**            | PR 5a (#283) self-review NIT #1。出なければ close、blocking なし                                                                                        |
+| [#285](https://github.com/fumtas1k/devtools/issues/285) | カメラボタン等の utility 列挙を `.btn-action--*-fill` variant に集約検討                   | **PR 5b / PR 6 で類似 pattern 確認**            | PR 5a (#283) self-review NIT #2。`bg-error-tint` 派 danger fill の新 variant 必要、出なければ close                                                     |
 | [#119](https://github.com/fumtas1k/devtools/issues/119) | .text-link-color 命名規則統一                                                              | 独立 (低優先)                                   | PR 1.5 で消費パターン定着、改名は all-files rename になる時期まで保留                                                                                   |
 
 ## B 案接近系 issue（独立判断）
@@ -155,12 +158,13 @@ PR 6 で以下を **すべて含む** こと。漏れを防ぐため本セクシ
 - [ ] PR description に「`#176` B 案完了」を明記、関連 PR (#249/#254/#256/#261/#272/PR 3-5) を全 link
 - [ ] `grep -c "style={{" src/` = **0** を最終確認
 - [ ] 全 E2E + 全 unit + astro check pass
-- [ ] PR 1 (#256) / PR 1.5 (#261) / PR 2 (#272) / PR 3 (#275) / PR 4 (#277) / 前段 infra PR (#278) の follow-up 系 issue のうち PR 6 で同時対応するものがあれば close、後続するものは PR 6 description で言及。
+- [ ] PR 1 (#256) / PR 1.5 (#261) / PR 2 (#272) / PR 3 (#275) / PR 4 (#277) / 前段 infra PR (#278) / PR 5a (#283) の follow-up 系 issue のうち PR 6 で同時対応するものがあれば close、後続するものは PR 6 description で言及。
   - PR 1 由来: #257-#260
   - PR 1.5 由来: [#262](https://github.com/fumtas1k/devtools/issues/262) (CSP gate / **PR 5 で close**、PR 3 で uuid-v7 partial 対応済) / [#263](https://github.com/fumtas1k/devtools/issues/263) (aria-selected ARIA spec) / [#264](https://github.com/fumtas1k/devtools/issues/264) (キーボード操作 WCAG 2.1.1) / [#265](https://github.com/fumtas1k/devtools/issues/265) (useEffect deps anti-pattern, ✅ closed) / [#266](https://github.com/fumtas1k/devtools/issues/266) (width JSDoc origin discipline, ✅ closed)
   - PR 2 由来: [#273](https://github.com/fumtas1k/devtools/issues/273) (`AbortSignal.any` 化、`useTicketVerification.verify` external signal link 改善)
   - PR 3 由来: [#276](https://github.com/fumtas1k/devtools/issues/276) (`withProductionCsp` ラッパ helper、✅ closed PR [#278](https://github.com/fumtas1k/devtools/pull/278))
   - PR #278 由来: [#279](https://github.com/fumtas1k/devtools/issues/279) (waitForReactHydration label-aware 拡張、event 駆動) / [#280](https://github.com/fumtas1k/devtools/issues/280) (withProductionCsp options 拡張、YAGNI) / [#281](https://github.com/fumtas1k/devtools/issues/281) (withProductionCsp 自体の meta-test、**PR 5 着手前に再確認**)
+  - PR 5a (#283) 由来: [#284](https://github.com/fumtas1k/devtools/issues/284) (`min-w-10` 集約検討、`.label-prefix` 専用 class 化、**PR 5b / PR 6 で類似 pattern 確認**) / [#285](https://github.com/fumtas1k/devtools/issues/285) (カメラボタン等の utility 列挙を `.btn-action--*-fill` variant に集約検討、**PR 5b / PR 6 で類似 pattern 確認**)
 - [ ] **`.text-primary` 命名衝突リスクの再評価** — `src/styles/global.css` の `.text-primary` (PR 2 で追加) は `--color-primary` を `@theme` に登録すると Tailwind auto-utility と衝突する可能性。PR 6 で `@theme` 切替するなら `text-brand` 等への rename 候補。`@theme` 切替自体を見送るなら現状維持で OK。決定事項を `docs/decisions.md` [067] に明記すること。
 - [ ] **Tailwind `border` utility と `@layer components` の `border-color` 優先度確認** — PR 2 で導入した `.alert-success` / `.alert-error` は `<div className="rounded-lg p-4 border alert-success">` のように Tailwind `border` (border-color: currentColor 系) と併用。layer 順序によっては期待色にならないリスクが PR 2 review で指摘済（実害は VRT pass で未顕在）。CSP strict 化後の VRT 再撮影で diff が出たら fix。
 

--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -17,18 +17,18 @@
 
 ## 進捗状況
 
-| #                     | スコープ                                                                                                                                                  | 状態      | PR                                                                     |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------- |
-| **PR 0**              | VRT 導入のみ（mock 注入版 spec、別 workflow、required check 外す、CI Linux baseline）                                                                     | ✅ merged | [#254 (merged 26f566b)](https://github.com/fumtas1k/devtools/pull/254) |
-| **PR 1**              | 基礎工事 + ui/\* simple (11 ファイル) — `@layer components` foundation + migration tracker + ClearButton CSSOM 撤去 + ToggleGroup setProperty 化          | ✅ merged | [#256 (merged eb5e537)](https://github.com/fumtas1k/devtools/pull/256) |
-| PR 1.5                | ui/\* complex (ResultTable + InputField) — API redesign 含む                                                                                              | ✅ merged | [#261 (merged 8e58bd5)](https://github.com/fumtas1k/devtools/pull/261) |
-| PR 2                  | qr-ticket/\* — inline style 撤去 + #225 (useMemo/abort) 同梱                                                                                              | ✅ merged | [#272 (merged 37adb60)](https://github.com/fumtas1k/devtools/pull/272) |
-| PR 3                  | JwtDecoder + UuidV7Generator + #262 partial (uuid-v7 CSP gate)                                                                                            | ✅ merged | [#275 (merged 1150883)](https://github.com/fumtas1k/devtools/pull/275) |
-| PR 4                  | Gs1Databar + EncodingConverter + DummyText                                                                                                                | ✅ merged | [#277 (merged 495f60e)](https://github.com/fumtas1k/devtools/pull/277) |
-| **infra (PR 5 前段)** | `withProductionCsp` ラッパ helper 追加 (#276 close)                                                                                                       | ✅ merged | [#278 (merged 73de179)](https://github.com/fumtas1k/devtools/pull/278) |
-| PR 5a                 | ConfigConverter + QrReader + JanCode (大物 3 つ、CSSOM hover 含む) — 31 inline style + 2 CSSOM                                                            | 未着手    | -                                                                      |
-| PR 5b                 | Base64Codec + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 (QrTicket / UrlEncoder) + `tests/e2e/ulid-generator.spec.ts` 新設 (#262 close) | 未着手    | -                                                                      |
-| PR 6                  | flip + cleanup（CSP strict 化）                                                                                                                           | 未着手    | -                                                                      |
+| #                     | スコープ                                                                                                                                                  | 状態       | PR                                                                     |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------- |
+| **PR 0**              | VRT 導入のみ（mock 注入版 spec、別 workflow、required check 外す、CI Linux baseline）                                                                     | ✅ merged  | [#254 (merged 26f566b)](https://github.com/fumtas1k/devtools/pull/254) |
+| **PR 1**              | 基礎工事 + ui/\* simple (11 ファイル) — `@layer components` foundation + migration tracker + ClearButton CSSOM 撤去 + ToggleGroup setProperty 化          | ✅ merged  | [#256 (merged eb5e537)](https://github.com/fumtas1k/devtools/pull/256) |
+| PR 1.5                | ui/\* complex (ResultTable + InputField) — API redesign 含む                                                                                              | ✅ merged  | [#261 (merged 8e58bd5)](https://github.com/fumtas1k/devtools/pull/261) |
+| PR 2                  | qr-ticket/\* — inline style 撤去 + #225 (useMemo/abort) 同梱                                                                                              | ✅ merged  | [#272 (merged 37adb60)](https://github.com/fumtas1k/devtools/pull/272) |
+| PR 3                  | JwtDecoder + UuidV7Generator + #262 partial (uuid-v7 CSP gate)                                                                                            | ✅ merged  | [#275 (merged 1150883)](https://github.com/fumtas1k/devtools/pull/275) |
+| PR 4                  | Gs1Databar + EncodingConverter + DummyText                                                                                                                | ✅ merged  | [#277 (merged 495f60e)](https://github.com/fumtas1k/devtools/pull/277) |
+| **infra (PR 5 前段)** | `withProductionCsp` ラッパ helper 追加 (#276 close)                                                                                                       | ✅ merged  | [#278 (merged 73de179)](https://github.com/fumtas1k/devtools/pull/278) |
+| PR 5a                 | ConfigConverter + QrReader + JanCode (大物 3 つ、CSSOM hover 含む) — 31 inline style + 2 CSSOM                                                            | 🔄 PR open | [#283](https://github.com/fumtas1k/devtools/pull/283)                  |
+| PR 5b                 | Base64Codec + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 (QrTicket / UrlEncoder) + `tests/e2e/ulid-generator.spec.ts` 新設 (#262 close) | 未着手     | -                                                                      |
+| PR 6                  | flip + cleanup（CSP strict 化）                                                                                                                           | 未着手     | -                                                                      |
 
 **重要 — PR 0 の意義**: VRT を ui migration と bundle した PR #253 が architectural 問題で close になったため、VRT を独立 PR で proper sequencing（mock 注入 → CI Linux baseline → required check 外す）で先行導入する。詳細は Claude memory `feedback_vrt_setup_sequencing.md` / `feedback_infra_feature_separation.md` 参照（PC ローカル）。
 
@@ -49,6 +49,14 @@
 - **特殊事項**: Gs1Databar 内で `e.currentTarget.style.X = Y` 形式の CSSOM hover state mutation 9 件を Tailwind `hover:` modifier に refactor。inline style と同等の hover 挙動を CSS で表現
 - **race 回避運用**: PR 3 の commit 結合 race 反省を踏まえ、subagent は commit せず親 Opus が Phase 1.5 で順次 commit する方式を初採用（3 commit が綺麗に分離、prettier 巻き込みも親が制御）
 - **新規 class**: `.summary-no-marker` の 1 件のみ（Gs1Databar `<details>/<summary>` 専用、PR 1〜3 既存 class で 95% 以上カバー）
+
+### PR 5a (#283)
+
+- **新規 class**: `.qr-video-preview` の 1 件のみ（QrReader `<video>` 黒背景専用）
+- **再利用**: PR 4 で導入された `.hover-bg-subtle` を JanCode `<summary>` で再利用（新規不要）。`.summary-no-marker` も再利用
+- **削除**: QrReader の module-level スタイル定数 4 個（`rescanButtonStyle` / `startCameraButtonStyle` / `stopCameraButtonStyle` / `uploadLabelStyle`）を全削除し className 化。`uploadLabelStyle(false)` 分岐は YAGNI で削除
+- **race 回避運用**: PR 4 で確立した「subagent 非 commit + 親で順次 commit」を 2 回目運用、安定運用確認
+- **CSSOM hover refactor**: JanCode `<summary>` の `onMouseEnter`/`onMouseLeave` 2 件を `.hover-bg-subtle` で CSS 化（memory `feedback_tailwind_v4_layer_variant.md` 準拠）
 
 ### infra PR (#278) — PR 5 前段
 

--- a/docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md
+++ b/docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md
@@ -1,0 +1,926 @@
+# #176 B 案 PR 5a 実装計画書
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal**: `ConfigConverter.tsx` (11 件) + `QrReader.tsx` (11 件) + `JanCode.tsx` (9 件) + JanCode 内 `e.currentTarget.style.X = Y` 2 件を撤去し、`@layer components` の意味クラス + Tailwind utility に置換する。
+
+**Architecture**: PR 1〜4 で確立した「`@layer components` への意味クラス追加 + Tailwind utility」pattern を継承。**新規 class は `.qr-video-preview` の 1 件のみ** (95% 以上を既存 class でカバー、JanCode hover は PR 4 既存 `.hover-bg-subtle` を再利用)。Phase 0 (親 Opus) で foundation commit、Phase 1 で sonnet subagent 3 並列、**Phase 1.5 で親 Opus が順次 commit (PR 4 で確立した運用継承)**、Phase 2 で MIGRATED_FILES + 検証 + PR 作成。
+
+**Tech Stack**: TypeScript / React 19 / Astro 5 / Tailwind CSS 4 / Vitest / Playwright
+
+**作成日**: 2026-05-07
+**Spec**: `docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md`
+**ブランチ**: `feature/issue-176-b5a-config-qr-jan`
+**Worktree**: `.claude/worktrees/issue-176-b5a`
+**Base**: `origin/develop` (PR 4 #277 + infra #278 merge 後の最新)
+
+---
+
+## 進行モデル
+
+`feedback_subagent_model.md` / `feedback_subagent_workflow.md` / `feedback_subagent_verification_trust.md` 準拠。
+
+| Phase | 担当                  | 内容                                                                                  |
+| ----- | --------------------- | ------------------------------------------------------------------------------------- |
+| 0     | 親 Opus               | spec / plan 配置、worktree 作成、global.css foundation commit                         |
+| 1     | sonnet 並列 (3 track) | Track A / B / C の **編集 + self-verification のみ** (commit せず)                    |
+| 1.5   | 親 Opus               | Track A / B / C の変更を順次 stage + commit (race 完全回避)                           |
+| 2     | 親 Opus               | `MIGRATED_FILES` 追加、ローカル必須ゲート 3 件直接実行、aria diff 確認、push、PR 作成 |
+| 3     | 親 Opus + reviewer    | review サイクル → merge → SoT 更新 → worktree cleanup                                 |
+
+---
+
+## File Structure
+
+| File                                                     | Phase | 担当    | 変更内容                                                                  |
+| -------------------------------------------------------- | ----- | ------- | ------------------------------------------------------------------------- |
+| `docs/superpowers/specs/2026-05-07-...-design.md`        | 0     | 親 Opus | spec をブランチ最初の commit として配置                                   |
+| `docs/superpowers/plans/2026-05-07-...-config-qr-jan.md` | 0     | 親 Opus | plan を spec と同 commit で配置                                           |
+| `src/styles/global.css`                                  | 0     | 親 Opus | `@layer components` に `.qr-video-preview` 1 件追加                       |
+| `src/components/tools/ConfigConverter.tsx`               | 1     | Track A | inline style 11 件除去 + import 整理                                      |
+| `src/components/tools/QrReader.tsx`                      | 1     | Track B | inline style 11 件除去 + module-level スタイル定数 4 個解体 + import 整理 |
+| `src/components/tools/JanCode.tsx`                       | 1     | Track C | inline style 9 件除去 + CSSOM hover 2 件除去 + import 整理                |
+| `src/utils/__tests__/inline-style-migration.test.ts`     | 2     | 親 Opus | `MIGRATED_FILES` array に 3 件追加 (合計 24 件)                           |
+| `docs/projects/issue-176-b-plan-progress.md`             | 2     | 親 Opus | PR 5a 状態を current 化 (PR 3-4 経験を踏まえ merge 待ち間 SoT 反映)       |
+
+**触らない**:
+
+- `src/components/tools/__tests__/*.test.ts` (logic test、本 PR の class 化は DOM 構造非変更)
+- `src/utils/styles.ts` (PR 6 で削除、本 PR は import 削除のみ)
+- `src/utils/csp.ts` / `public/_headers` (PR 6 で strict 化)
+- `tests/e2e/*.spec.ts` (本 PR で applyProductionCsp gate 追加せず、#262 残部分 = ulid-generator は PR 5b で対応)
+- `src/hooks/useQrCamera.ts` (logic、本 PR スコープ外)
+
+---
+
+## Phase 0 — 親 Opus 直接実行
+
+### Task 0.1: Worktree 作成
+
+- [ ] **Step 1**: 現在のブランチが `develop` で clean state であることを確認
+
+```bash
+git status
+git branch --show-current
+# Expected: clean / develop
+```
+
+- [ ] **Step 2**: origin/develop の最新を fetch (PR 4 #277 + infra #278 merge 済確認)
+
+```bash
+git fetch origin develop
+git rev-parse origin/develop HEAD
+# Expected: 同じ SHA、HEAD が #278 (73de179) 以降
+```
+
+- [ ] **Step 3**: worktree を作成 (`origin/develop` ベースを **明示**)
+
+```bash
+git worktree add .claude/worktrees/issue-176-b5a origin/develop -b feature/issue-176-b5a-config-qr-jan
+```
+
+- [ ] **Step 4**: worktree で `npm ci` 実行
+
+```bash
+cd .claude/worktrees/issue-176-b5a && npm ci
+```
+
+Expected: `node_modules` が worktree に存在し vitest / playwright が解決可能。
+
+### Task 0.2: spec / plan ファイル配置
+
+- [ ] **Step 1**: develop 側で書いた spec / plan を worktree にコピー
+
+```bash
+cp docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md \
+   .claude/worktrees/issue-176-b5a/docs/superpowers/specs/
+cp docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md \
+   .claude/worktrees/issue-176-b5a/docs/superpowers/plans/
+```
+
+- [ ] **Step 2**: develop 側の untracked spec / plan を削除
+
+```bash
+rm docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md
+rm docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md
+```
+
+### Task 0.3: global.css に .qr-video-preview 追記
+
+worktree で作業 (以下すべて `.claude/worktrees/issue-176-b5a` 内)。
+
+- [ ] **Step 1**: `src/styles/global.css` の末尾 `@layer components { ... }` ブロックの閉じ `}` の **直前**、PR 4 の `.hover-bg-active` 定義の **後** に下記を追記
+
+```css
+/* === PR 5a: QrReader video preview background === */
+/* QRリーダーの <video> 要素は `getUserMedia` 開始前 (display:none で隠蔽中) の
+   コントラスト確保 + 起動失敗時のフォールバック (黒画面) として黒背景を維持する。
+   一意の用途のため component-scoped class とする (色 token 化はしない)。 */
+.qr-video-preview {
+  background: #000;
+}
+```
+
+- [ ] **Step 2**: 重複なし確認
+
+```bash
+grep -n "qr-video-preview" src/styles/global.css
+# Expected: 1 行 (.qr-video-preview { ...)
+```
+
+- [ ] **Step 3**: PR 4 既存 `.hover-bg-subtle` / `.summary-no-marker` が削除されていないか確認 (JanCode が再利用するため)
+
+```bash
+grep -n "hover-bg-subtle\|summary-no-marker" src/styles/global.css
+# Expected: 各 1 行以上
+```
+
+- [ ] **Step 4**: vitest 一部実行で global.css 読み込みが壊れていないか確認
+
+```bash
+npm run test -- src/utils/__tests__/inline-style-migration.test.ts
+# Expected: 既存 21 ファイルの migration test pass + 陽性対照 3 件 pass
+```
+
+### Task 0.4: Phase 0 commit
+
+- [ ] **Step 1**: stage + commit
+
+```bash
+git add docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md \
+        docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md \
+        src/styles/global.css
+
+git commit -m "$(cat <<'EOF'
+chore(spec): #176 B 案 PR 5a spec / plan / global.css foundation
+
+Phase 0: spec / plan 配置 + global.css @layer components に
+QrReader <video> 要素用 .qr-video-preview class 1 件を追加。
+
+PR 1〜4 で導入済の class (caption, body-emphasis, text-default, text-muted,
+text-on-primary, text-error, text-error-text, text-primary, text-link-color,
+text-warning, bg-default, bg-subtle, bg-surface, bg-error-tint,
+bg-warning-tint, border-default, border-input, alert-success, alert-error,
+btn-link-plain, summary-no-marker, hover-bg-subtle 等) を再利用するため
+新規 class は最小限 1 件のみ。JanCode の <summary> hover は PR 4 既存の
+.hover-bg-subtle を再利用 (新規不要)。
+
+Phase 1 (sonnet 並列 × 3 Track) で ConfigConverter / QrReader / JanCode
+の migration を進める。Race 回避のため subagent は commit せず、
+Phase 1.5 で親 Opus が順次 commit する運用 (PR 4 で確立)。
+
+ref: docs/projects/issue-176-b-plan-progress.md
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2**: 確認
+
+```bash
+git log --oneline -1
+git status
+# Expected: 1 件の commit、clean state
+```
+
+---
+
+## Phase 1 — 並列 sonnet subagent dispatch (commit せず)
+
+**重要**: 3 Track を **同時並列** dispatch して OK (独立ファイルに閉じる + commit しないので race 不可能)。各 subagent は ファイル編集 + self-verification のみ実施。
+
+### Track A: `ConfigConverter.tsx` migration (11 件)
+
+- [ ] **Step 1**: subagent prompt 作成 (下記 §Subagent prompt template の Track A 参照)
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領 (status / 変更ファイル list / self-verification 結果)
+
+**Track A 完了基準**:
+
+- [ ] `grep -c "style={{" src/components/tools/ConfigConverter.tsx` → **0**
+- [ ] `grep "from '@/utils/styles'" src/components/tools/ConfigConverter.tsx` → 0
+- [ ] subagent が `npm run test -- src/utils/__tests__/config-converter.test.ts` (もしくは関連 test) で pass を確認
+- [ ] subagent が `npx astro check` で 0 errors 確認
+- [ ] **commit していないこと** (`git log --oneline -1` が Phase 0 commit のままであること)
+
+### Track B: `QrReader.tsx` migration (11 件 + module-level スタイル定数 4 個解体)
+
+- [ ] **Step 1**: subagent prompt 作成 (下記 §Subagent prompt template の Track B 参照)
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領
+
+**Track B 完了基準**:
+
+- [ ] `grep -c "style={{" src/components/tools/QrReader.tsx` → **0**
+- [ ] `grep "from '@/utils/styles'" src/components/tools/QrReader.tsx` → 0
+- [ ] `grep -E "^const (rescan|startCamera|stopCamera|uploadLabel)" src/components/tools/QrReader.tsx` → 0 (module-level 定数全削除)
+- [ ] file input が `className="sr-only"` になっていること (D2 採用案)
+- [ ] subagent が astro check / 関連 test の pass 確認
+- [ ] **commit していないこと**
+
+### Track C: `JanCode.tsx` migration (9 件 + CSSOM hover 2 件除去)
+
+- [ ] **Step 1**: subagent prompt 作成 (下記 §Subagent prompt template の Track C 参照)
+- [ ] **Step 2**: Agent dispatch (`model: "sonnet"`)
+- [ ] **Step 3**: 完了報告受領
+
+**Track C 完了基準**:
+
+- [ ] `grep -c "style={{" src/components/tools/JanCode.tsx` → **0**
+- [ ] `grep "from '@/utils/styles'" src/components/tools/JanCode.tsx` → 0
+- [ ] `grep -E "\.style\.[a-zA-Z]+\s*=" src/components/tools/JanCode.tsx | grep -v setProperty` → 0 (CSSOM mutation 全消去)
+- [ ] `onMouseEnter` / `onMouseLeave` attribute は完全削除 (PR 4 Gs1Databar pattern で `.hover-bg-subtle` 化)
+- [ ] subagent が astro check / 関連 test の pass 確認
+- [ ] **commit していないこと**
+
+---
+
+## Phase 1.5 — 親 Opus が順次 commit (race 完全回避)
+
+Phase 1 の 3 Track が全て完了報告を出した後、親 Opus が下記を実行。
+
+### Task 1.5.1: 状態確認
+
+- [ ] **Step 1**: 3 ファイル全てが modified、commit はまだ Phase 0 のままであることを確認
+
+```bash
+git status
+# Expected:
+#   modified: src/components/tools/ConfigConverter.tsx
+#   modified: src/components/tools/QrReader.tsx
+#   modified: src/components/tools/JanCode.tsx
+
+git log --oneline -2
+# Expected: HEAD = Phase 0 chore(spec) commit
+```
+
+- [ ] **Step 2**: 各ファイルの inline style 残存ゼロ確認
+
+```bash
+grep -c "style={{" src/components/tools/ConfigConverter.tsx \
+                   src/components/tools/QrReader.tsx \
+                   src/components/tools/JanCode.tsx
+# Expected: 全て 0
+```
+
+- [ ] **Step 3**: JanCode の CSSOM mutation 残存ゼロ確認
+
+```bash
+grep -E "\.style\.[a-zA-Z]+\s*=" src/components/tools/JanCode.tsx | grep -v setProperty
+# Expected: 出力なし (全消去)
+```
+
+### Task 1.5.2: Track A (ConfigConverter) commit
+
+- [ ] **Step 1**: ConfigConverter.tsx のみ stage
+
+```bash
+git add src/components/tools/ConfigConverter.tsx
+```
+
+- [ ] **Step 2**: 想定通りのファイルのみ staged であることを確認
+
+```bash
+git status --short
+# Expected: M src/components/tools/ConfigConverter.tsx (1 行のみ M)
+#           その他 2 ファイルは M (unstaged) のまま
+```
+
+- [ ] **Step 3**: commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(tools): #176 B 案 PR 5a — ConfigConverter.tsx inline style 撤去
+
+inline style 11 件を @layer components の class + Tailwind utility に置換。
+
+変換元/変換先ラベルを `caption text-muted min-w-10` に集約、警告メッセージ
+カードを `border border-warning bg-warning-tint` で表現、schema toggle
+ボタンを `caption text-link-color btn-link-plain` で構成、arrow rotation
+を `rotate-90` Tailwind 標準で表現、kbd を `caption text-muted font-mono`
+に置換、検証結果カードを既存 .alert-success / .alert-error 利用。
+
+import { caption, colors } from '@/utils/styles' を削除。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md §1
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.5.3: Track B (QrReader) commit
+
+- [ ] **Step 1**: QrReader.tsx のみ stage
+
+```bash
+git add src/components/tools/QrReader.tsx
+git status --short
+# Expected: M src/components/tools/QrReader.tsx + M src/components/tools/JanCode.tsx (unstaged)
+```
+
+- [ ] **Step 2**: commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(tools): #176 B 案 PR 5a — QrReader.tsx inline style 撤去 + module-level スタイル定数解体
+
+inline style 11 件 + module-level スタイル定数 4 個 (rescanButtonStyle /
+startCameraButtonStyle / stopCameraButtonStyle / uploadLabelStyle) を
+全て解体し、@layer components の class + Tailwind utility に置換。
+
+カメラ起動ボタンを bg-primary text-on-primary、停止ボタンを border-error
+bg-error-tint text-error で表現。<video> 要素は新規 .qr-video-preview class
+で黒背景を維持、display 切替は Tailwind hidden クラスで表現。
+
+file input は Tailwind sr-only に置換 (a11y 同等以上)。
+uploadLabelStyle(false) 呼び出しがないことを事前確認の上、
+disabled 分岐は削除 (YAGNI)。
+
+URL 警告カードは border border-warning bg-warning-tint、URL 開くボタンは
+border border-warning bg-default で構成。
+
+import { caption, colors } from '@/utils/styles' を削除。
+React named import (React.ChangeEvent) は維持。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md §2
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.5.4: Track C (JanCode) commit
+
+- [ ] **Step 1**: JanCode.tsx のみ stage
+
+```bash
+git add src/components/tools/JanCode.tsx
+```
+
+- [ ] **Step 2**: commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(tools): #176 B 案 PR 5a — JanCode.tsx inline style 撤去 + summary hover を CSS に移行
+
+inline style 9 件を @layer components の class + Tailwind utility に置換。
+e.currentTarget.style.background mutation (onMouseEnter/onMouseLeave で
+hover bg を直接書き換え) 2 件を削除し、PR 4 既存の .hover-bg-subtle class
+で hover 挙動を CSS で表現。
+
+結果カードを border border-default bg-surface、完成コードの文字間隔を
+tracking-[0.1em] arbitrary value、計算過程 <details> を border border-default
++ <summary> を caption font-bold text-muted summary-no-marker hover-bg-subtle
+で構成。バーコードプレビュー wrapper を border border-default bg-default。
+
+memory feedback_tailwind_v4_layer_variant.md: hover:bg-subtle variant は
+@layer components 手書き class に効かないため、専用 .hover-bg-subtle
+class (PR 4 で導入済) を再利用。
+
+import { bodyEmphasis, caption, colors } from '@/utils/styles' を削除。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md §3
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3**: 3 commit に正しく split されたか確認
+
+```bash
+git log --oneline -5
+# Expected:
+# <SHA> refactor(tools): #176 B 案 PR 5a — JanCode.tsx inline style 撤去 + summary hover を CSS に移行
+# <SHA> refactor(tools): #176 B 案 PR 5a — QrReader.tsx inline style 撤去 + module-level スタイル定数解体
+# <SHA> refactor(tools): #176 B 案 PR 5a — ConfigConverter.tsx inline style 撤去
+# <SHA> chore(spec): #176 B 案 PR 5a spec / plan / global.css foundation
+# 73de179 test(e2e): #276 withProductionCsp ラッパで applyProductionCsp boilerplate を集約 (#278)
+
+git show --stat HEAD HEAD~1 HEAD~2 | head -30
+# Each commit が 1 ファイルのみ変更していることを確認
+```
+
+---
+
+## Phase 2 — 親 Opus 直接実行 (統合 + 検証 + PR)
+
+### Task 2.1: MIGRATED_FILES 追加
+
+- [ ] **Step 1**: `src/utils/__tests__/inline-style-migration.test.ts` の `MIGRATED_FILES` array に 3 件追加
+
+`'src/components/tools/DummyText.tsx',` の **後** に下記を追加:
+
+```ts
+  // PR 5a で追加
+  'src/components/tools/ConfigConverter.tsx',
+  'src/components/tools/QrReader.tsx',
+  'src/components/tools/JanCode.tsx',
+```
+
+- [ ] **Step 2**: migration test pass 確認
+
+```bash
+npm run test -- src/utils/__tests__/inline-style-migration.test.ts
+# Expected: 24 ファイルの migration test 全 pass + 陽性対照 3 件 pass = 計 51 件 pass
+```
+
+- [ ] **Step 3**: commit
+
+```bash
+git add src/utils/__tests__/inline-style-migration.test.ts
+git commit -m "$(cat <<'EOF'
+test(migration): MIGRATED_FILES に PR 5a 対象 3 件追加
+
+ConfigConverter.tsx / QrReader.tsx / JanCode.tsx の
+inline style 撤去完了に伴い progressive migration tracker に追加
+(21 → 24 件)。
+
+ref: docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md §5
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.2: SoT (progress doc) 更新
+
+- [ ] **Step 1**: `docs/projects/issue-176-b-plan-progress.md` を更新 (PR 3-4 と同パターン、merge 待ち間 SoT current 化)
+
+進捗状況テーブルの PR 5a 行を更新:
+
+```markdown
+| PR 5a | ConfigConverter + QrReader + JanCode (大物 3 つ、CSSOM hover 含む) — 31 inline style + 2 CSSOM | 🔄 PR open | [#XXX](https://github.com/fumtas1k/devtools/pull/XXX) |
+```
+
+(`#XXX` は Task 2.6 で取得した PR 番号、後で書き換え)
+
+着手済 PR 履歴に PR 5a section を追加:
+
+```markdown
+### PR 5a (#XXX)
+
+- **新規 class**: `.qr-video-preview` の 1 件のみ (QrReader video 黒背景)
+- **再利用**: PR 4 で導入された `.hover-bg-subtle` を JanCode `<summary>` で再利用 (新規不要)
+- **削除**: QrReader の module-level スタイル定数 4 個 (`rescanButtonStyle` / `startCameraButtonStyle` / `stopCameraButtonStyle` / `uploadLabelStyle`) を全削除し className 化。`uploadLabelStyle(false)` 分岐は YAGNI で削除
+- **race 回避運用**: PR 4 で確立した「subagent 非 commit + 親で順次 commit」を 2 回目運用、安定運用確認
+- **CSSOM hover refactor**: JanCode `<summary>` の `onMouseEnter`/`onMouseLeave` 2 件を `.hover-bg-subtle` で CSS 化
+```
+
+- [ ] **Step 2**: 一旦 PR 番号未確定で commit せず、Phase 2 の最後 (PR 作成後) に PR 番号を確定して 1 commit に集約。本 step は **skip** し、Task 2.7 で実施。
+
+### Task 2.3: ローカル必須ゲート (subagent 報告は信頼せず親が直接実行)
+
+- [ ] **Step 1**: vitest 全 pass
+
+```bash
+npm run test
+# Expected: 全 unit test pass、migration test 24 件 × 2 + 陽性対照 3 件 = 51 件 pass 含む
+```
+
+- [ ] **Step 2**: TypeScript 型チェック
+
+```bash
+npx astro check
+# Expected: 0 errors, 0 warnings
+```
+
+- [ ] **Step 3**: E2E 全 pass (`feedback_e2e_before_pr.md`、PR 作成前必須)
+
+```bash
+npm run test:e2e
+# Expected: 全 spec pass (config-converter / qr-reader / jan-code 含む)
+```
+
+E2E は build + preview を直列起動するため数分かかる。フォアグラウンドで実行して全 pass を確認する。
+
+### Task 2.4: a11y 退化検知
+
+- [ ] **Step 1**: aria-\* / role= / data-testid= / htmlFor= 削除行が無いこと
+
+```bash
+git diff origin/develop -- src/components/tools/ConfigConverter.tsx \
+                           src/components/tools/QrReader.tsx \
+                           src/components/tools/JanCode.tsx \
+  | grep -E '^-.*(aria-|role=|data-testid=|htmlFor=)' | grep -vE '^---|^\+\+\+'
+# Expected: 出力 0 行
+# (reformat による行移動の "削除行" が出る場合は現コードで grep 確認、PR 3-4 と同運用)
+```
+
+- [ ] **Step 2**: 万が一何か "削除" 行が出た場合、現コードで存在を grep 確認
+
+```bash
+grep -n "data-testid\|aria-label\|aria-expanded\|aria-controls\|aria-live\|role=" src/components/tools/ConfigConverter.tsx | head -10
+grep -n "data-testid\|aria-label\|htmlFor=\|aria-hidden" src/components/tools/QrReader.tsx | head -10
+grep -n "data-testid\|aria-label\|aria-live" src/components/tools/JanCode.tsx | head -10
+# Expected: PR 3-4 と同じく diff の "削除行" が現コードに維持されていれば OK
+```
+
+### Task 2.5: PR 作成前 final check
+
+- [ ] **Step 1**: develop ベース一致確認
+
+```bash
+[ "$(git rev-parse origin/develop)" = "$(git merge-base HEAD origin/develop)" ] && echo OK
+# Expected: OK
+```
+
+- [ ] **Step 2**: PR 6 スコープ侵害なし確認
+
+```bash
+git diff origin/develop --name-only | grep -cE "_headers|astro.config|src/utils/styles\.ts" || echo "0 (PR 6 スコープに触れていない = OK)"
+# Expected: 0
+```
+
+- [ ] **Step 3**: 想定外ファイル変更がないこと
+
+```bash
+git diff origin/develop --name-only | sort
+# Expected:
+# docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md
+# docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md
+# src/components/tools/ConfigConverter.tsx
+# src/components/tools/JanCode.tsx
+# src/components/tools/QrReader.tsx
+# src/styles/global.css
+# src/utils/__tests__/inline-style-migration.test.ts
+```
+
+### Task 2.6: push + PR 作成
+
+- [ ] **Step 1**: PR 本文を `/tmp/claude/pr_body_b5a.md` に書き出し (CLAUDE.md 6.1: `--body-file` 必須)
+
+```bash
+mkdir -p /tmp/claude
+cat > /tmp/claude/pr_body_b5a.md <<'EOF'
+## 概要
+
+`#176` B 案バッチの PR 5a。`ConfigConverter.tsx` (11 件) + `QrReader.tsx` (11 件) + `JanCode.tsx` (9 件) の JSX inline style + JanCode 内 `e.currentTarget.style.X = Y` 形式の CSSOM 直接 mutation 2 件 (`<summary>` の `onMouseEnter`/`onMouseLeave` hover state) を `@layer components` の意味クラス + Tailwind utility に置換する。
+
+PR 5 全体 (9 ツール) を 5a (大物 3 つ) と 5b (残り 7 つ + ulid-generator E2E + #262 close) に分割した前半。
+
+- spec: `docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md`
+- plan: `docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md`
+- バッチ進捗: `docs/projects/issue-176-b-plan-progress.md`
+
+## 主要な変更
+
+### `src/styles/global.css` 追加 class (1 件のみ)
+
+- `.qr-video-preview` (QrReader `<video>` 専用、`background: #000`)
+
+JanCode `<summary>` hover は **PR 4 で導入された `.hover-bg-subtle` を再利用** (新規不要)。
+PR 1〜4 で導入済の class (`caption` / `body-emphasis` / `text-default` / `text-muted` / `text-on-primary` / `text-error` / `text-error-text` / `text-primary` / `text-link-color` / `text-warning` / `bg-default` / `bg-subtle` / `bg-surface` / `bg-error-tint` / `bg-warning-tint` / `border-default` / `border-input` / `alert-success` / `alert-error` / `btn-link-plain` / `summary-no-marker` / `hover-bg-subtle`) で 95% 以上をカバー。
+
+### `ConfigConverter.tsx` (11 件 → 0)
+
+- 変換元/変換先ラベルを `caption text-muted min-w-10` で表現
+- 警告メッセージカードを `border border-warning bg-warning-tint` (Tailwind auto-utility 利用)
+- schema toggle ボタンを既存 `.btn-link-plain` (PR 1.5) + `text-link-color` で構成、arrow rotation は `rotate-90` Tailwind 標準
+- 検証結果カードは既存 `.alert-success` / `.alert-error` (PR 2) を利用
+- 新規 class 追加なし
+- `import { caption, colors } from '@/utils/styles'` を削除
+
+### `QrReader.tsx` (11 件 → 0、module-level 定数 4 個解体)
+
+- module-level スタイル定数 4 個 (`rescanButtonStyle` / `startCameraButtonStyle` / `stopCameraButtonStyle` / `uploadLabelStyle`) を全削除し className 化
+- `<video>` 要素を `w-full max-w-[400px] rounded-lg qr-video-preview` で構成、display 切替は Tailwind `hidden`
+- カメラ起動ボタンは Tailwind auto-utility `bg-primary` + `.text-on-primary`、停止ボタンは `border-error bg-error-tint text-error`
+- file input を Tailwind 標準 `sr-only` に置換 (a11y 同等以上)
+- `uploadLabelStyle(false)` 呼び出しがないことを事前確認の上、disabled 分岐削除 (YAGNI)
+- URL 警告カードは `border border-warning bg-warning-tint`、URL 開くリンクは `border border-warning bg-default`
+- `import { caption, colors } from '@/utils/styles'` を削除 (React named import は維持)
+
+### `JanCode.tsx` (9 件 + 2 hover refactor → 0)
+
+- `onMouseEnter`/`onMouseLeave` で `e.currentTarget.style.background = ...` していた 2 件 (計算過程 `<summary>`) を削除し、PR 4 既存の `.hover-bg-subtle` (CSS `:hover` 表現) で代替
+- 完成コード文字間隔は `tracking-[0.1em]` arbitrary value
+- 結果カード / バーコードプレビュー wrapper を `border border-default bg-surface` / `border border-default bg-default` で構成
+- 計算過程 `<details>/<summary>` marker 非表示は PR 4 既存 `.summary-no-marker` を再利用
+- 新規 class 追加なし
+- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除
+
+## Race 回避運用 (PR 4 で確立した運用継承)
+
+PR 3 で sonnet 並列 dispatch 時に commit 結合 race が発生 → PR 4 で「subagent 非 commit」運用を初採用 → 成功。本 PR では 2 回目運用として継承:
+
+- subagent は **ファイル編集 + self-verification (vitest, astro check) のみ** 実施
+- subagent は `git add` / `git commit` を実行しない
+- 親 Opus が Phase 1.5 で 1 ファイルずつ stage + commit (3 commit、各 1 ファイル変更)
+
+結果: commit message と内容が完全一致、prettier 巻き込みも親が制御。
+
+## CSSOM hover refactor (memory `feedback_tailwind_v4_layer_variant.md` 適用)
+
+JanCode の `<summary>` hover を Tailwind `hover:bg-subtle` variant ではなく PR 4 で導入された専用 `.hover-bg-subtle` class で表現。これは Tailwind v4 で `@layer components` 内の手書き class に対して `hover:` variant が CSS rule を生成しない silent regression を回避するため。
+
+## 検証ログ (親 Opus 直接実行)
+
+- [x] `npm run test` 全 pass (migration test 24 件 × 2 + 陽性対照 3 件 = 51 件 pass 含む)
+- [x] `npx astro check` → 0 errors, 0 warnings
+- [x] `npm run test:e2e` 全 pass (config-converter / qr-reader / jan-code 含む)
+- [x] a11y 退化なし (`aria-*` / `role=` / `data-testid=` / `htmlFor=` 削除行 0、reformat の行移動は現コードで存在確認)
+- [x] inline style 残存ゼロ (`grep -c "style={{"` = 0 / 0 / 0)
+- [x] CSSOM mutation 残存ゼロ (`grep -E "\.style\.[a-zA-Z]+\s*="` で setProperty 以外 = 0)
+- [x] PR 6 スコープ未侵害 (`_headers` / `astro.config.mjs` / `src/utils/styles.ts` 未変更)
+
+## VRT
+
+`visual-regression.yml` で baseline 比較 (non-required check)。意図的差分があれば PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger。
+
+特に確認すべき差分点:
+
+- QrReader `<video>` の `display: none` → `hidden` クラス、初期状態で video が描画されないこと
+- QrReader file input: `position: absolute` 視覚消去 → `sr-only` (clip + margin -1) で同等の不可視性
+- JanCode `<summary>` hover 時の bg 変化 (CSSOM mutation 撤去後も `.hover-bg-subtle` で bg 変化が見える)
+- ConfigConverter schema toggle arrow: `rotate-90` で 90 度回転 (transition-duration 200ms)
+
+## コミット粒度
+
+```
+
+<SHA> docs(progress): #176 B 案 PR 5a (#XXX) の状態を反映
+<SHA> test(migration): MIGRATED_FILES に PR 5a 対象 3 件追加
+<SHA> refactor(tools): #176 B 案 PR 5a — JanCode.tsx inline style 撤去 + summary hover を CSS に移行
+<SHA> refactor(tools): #176 B 案 PR 5a — QrReader.tsx inline style 撤去 + module-level スタイル定数解体
+<SHA> refactor(tools): #176 B 案 PR 5a — ConfigConverter.tsx inline style 撤去
+<SHA> chore(spec): #176 B 案 PR 5a spec / plan / global.css foundation
+
+```
+
+## 関連
+
+- 起源 issue: #176 (アプローチ B)
+- 前提 PR: #249 (A-1) / #254 (VRT) / #256 (PR 1) / #261 (PR 1.5) / #272 (PR 2) / #275 (PR 3) / #277 (PR 4) / #278 (前段 infra)
+- 後続: PR 5b (Base64Codec + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 + ulid-generator E2E + #262 close) / PR 6 (flip + cleanup)
+EOF
+```
+
+- [ ] **Step 2**: push
+
+```bash
+git push -u origin feature/issue-176-b5a-config-qr-jan
+```
+
+- [ ] **Step 3**: PR 作成 (`--base develop` を **必ず** 明示、`--body-file` で本文渡し)
+
+```bash
+gh pr create --base develop \
+  --title "refactor(tools): #176 B 案 PR 5a — ConfigConverter + QrReader + JanCode inline style 撤去" \
+  --body-file /tmp/claude/pr_body_b5a.md
+```
+
+Expected: PR URL を取得 → user に提示 + `#XXX` を Task 2.7 に渡す。
+
+### Task 2.7: progress doc 更新 (PR 番号確定後)
+
+- [ ] **Step 1**: PR 番号 (`#XXX`) を反映して `docs/projects/issue-176-b-plan-progress.md` を更新
+  - 進捗状況テーブル: PR 5a 行を `🔄 PR open + #XXX link` に
+  - 着手済 PR 履歴: PR 5a (#XXX) section を追加 (新規 class / 再利用 / race 回避運用 / CSSOM refactor の特記含む)
+
+- [ ] **Step 2**: prettier 自動 fix
+
+```bash
+npx prettier --write docs/projects/issue-176-b-plan-progress.md
+```
+
+- [ ] **Step 3**: commit
+
+```bash
+git add docs/projects/issue-176-b-plan-progress.md
+git commit -m "$(cat <<'EOF'
+docs(progress): #176 B 案 PR 5a (#XXX) の状態と特記事項を反映
+
+PR 3-4 経験を踏まえ merge 待ちの間も SoT を current 化する運用。
+
+更新内容:
+- 進捗状況テーブル: PR 5a を 🔄 PR open + #XXX link に変更
+- 着手済 PR 履歴: PR 5a (#XXX) section を追加
+  - 新規 class .qr-video-preview の 1 件のみ
+  - JanCode hover は PR 4 既存 .hover-bg-subtle 再利用
+  - QrReader module-level スタイル定数 4 個全削除
+  - subagent 非 commit 運用 2 回目、安定運用確認
+
+ref: https://github.com/fumtas1k/devtools/pull/XXX
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4**: push
+
+```bash
+git push
+```
+
+---
+
+## Phase 3 — review サイクル
+
+- [ ] **Step 1**: PR 作成後は **自発的な修正 push を控える** (memory `feedback_hold_push_during_review.md`)
+- [ ] **Step 2**: CI green + reviewer LGTM 後に user に merge を依頼
+- [ ] **Step 3**: review 指摘があればまとめて対応 commit を 1 件 push (PR 3-4 同様)
+- [ ] **Step 4**: merge 後の cleanup (memory `feedback_worktree_merge_order.md` に従う)
+
+```bash
+# 順序: gh pr merge --delete-branch の **前** に worktree remove
+cd /Users/fumta/projects/devtools
+git worktree remove .claude/worktrees/issue-176-b5a
+git branch -D feature/issue-176-b5a-config-qr-jan 2>&1 || true  # 既に消えている場合あり
+gh pr merge XXX --squash --delete-branch
+git checkout develop && git pull origin develop
+```
+
+---
+
+## Subagent prompt template
+
+各 subagent には以下要素を **必ず** 含める:
+
+1. **作業ディレクトリ**: `/Users/fumta/projects/devtools/.claude/worktrees/issue-176-b5a`
+2. **担当ファイル list** (変更可能 / 触ってはいけない)
+3. **spec 該当 section の reference** (`docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md` § N)
+4. **既存 class 一覧** (Phase 0 で `.qr-video-preview` 追加済、他は PR 1〜4 既存)
+5. **自己検証コマンド**: `npm run test -- <該当 test path>` + `npx astro check`
+6. **やってはいけないこと**:
+   - `git add` / `git commit` (親が Phase 1.5 で実施)
+   - `git push` / `gh pr create`
+   - `npm run test:vrt` (memory `feedback_vrt_ci_only.md`)
+   - `npm run test:e2e` (時間かかる、親が Phase 2 で確認)
+   - 他 Track のファイル変更
+   - `src/utils/styles.ts` 削除 (PR 6 スコープ)
+   - `src/styles/global.css` 編集 (Phase 0 で foundation commit 済、追加 class 不要)
+7. **完了報告フォーマット**:
+   - status: DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED
+   - 変更ファイル list (`git diff --name-only`)
+   - 自己検証結果 (vitest / astro check)
+   - 残課題
+
+### Track A subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b5a
+
+タスク: src/components/tools/ConfigConverter.tsx の inline style を spec §1 に従い撤去する。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md (§1.1〜1.7)
+- 既存パターン: src/components/tools/EncodingConverter.tsx (PR 4 の dropzone label / 警告カード class 化)、src/components/tools/JwtDecoder.tsx (PR 3 の details/summary 構造)
+- global.css: PR 5a 用 .qr-video-preview は HEAD~1 (Phase 0 commit) で foundation commit 済。本 Track では使わない (QrReader 専用)
+- 利用可能な既存 class (PR 1〜4 で導入済): caption / body-emphasis / text-default / text-muted / text-link-color / text-error-text / bg-warning-tint / border-default / border-input / btn-link-plain / alert-success / alert-error 等
+
+変更可能なファイル:
+- src/components/tools/ConfigConverter.tsx (本体)
+
+触ってはいけないファイル:
+- src/components/tools/__tests__/* (logic test、変更不要)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済、新 class 追加不要)
+- src/components/tools/QrReader.tsx (Track B)
+- src/components/tools/JanCode.tsx (Track C)
+- tests/e2e/* (本 PR で gate 追加せず)
+
+完了基準:
+- grep -c "style={{" src/components/tools/ConfigConverter.tsx → 0
+- grep "from '@/utils/styles'" src/components/tools/ConfigConverter.tsx → 0
+- npm run test (unit、ConfigConverter 関連) で pass、astro check で 0 errors
+- npx astro check → 0 errors
+
+やってはいけないこと:
+- git add / git commit (親が Phase 1.5 で実施、subagent は commit せず)
+- git push / gh pr create
+- npm run test:vrt
+- npm run test:e2e (親が Phase 2 で実行)
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加 (Phase 0 で完了済、不足あれば親 Opus に報告)
+
+完了後 報告: status + 変更ファイル list + 自己検証結果 (vitest / astro check 出力要約) + 残課題
+```
+
+### Track B subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b5a
+
+タスク: src/components/tools/QrReader.tsx の inline style + module-level スタイル定数 4 個を spec §2 に従い撤去する。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md (§2.1〜2.11)
+- 既存パターン: src/components/tools/qr-ticket/VerifyTab.tsx (PR 2 の sr-only file input + .qr-file-picker-label)、src/components/tools/Gs1Databar.tsx (PR 4 の hover 表現)
+- global.css: 本 PR で Phase 0 commit 済の .qr-video-preview を <video> で利用
+- 利用可能な既存 class: caption / text-default / text-muted / text-on-primary / text-error / bg-default / bg-subtle / bg-warning-tint / bg-error-tint / border-default / border-input + Tailwind auto-utility (border-warning / border-error / bg-primary)
+- D5 採用案: module-level 定数 4 個 (rescanButtonStyle / startCameraButtonStyle / stopCameraButtonStyle / uploadLabelStyle) を全削除して consumer 側 className 化
+- D2 採用案: file input を Tailwind sr-only に置換
+- D6 採用案: uploadLabelStyle(false) 呼び出しなしを事前確認の上、disabled 分岐削除
+
+変更可能なファイル:
+- src/components/tools/QrReader.tsx (本体)
+
+触ってはいけないファイル:
+- src/components/tools/__tests__/* (logic test、変更不要)
+- src/hooks/useQrCamera.ts (logic、本 PR スコープ外)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済)
+- src/components/tools/ConfigConverter.tsx (Track A)
+- src/components/tools/JanCode.tsx (Track C)
+- tests/e2e/* (本 PR で gate 追加せず)
+
+完了基準:
+- grep -c "style={{" src/components/tools/QrReader.tsx → 0
+- grep "from '@/utils/styles'" src/components/tools/QrReader.tsx → 0
+- grep -E "^const (rescan|startCamera|stopCamera|uploadLabel)" src/components/tools/QrReader.tsx → 0 (module-level 定数全削除)
+- file input が className="sr-only" になっていること
+- uploadLabelStyle 関数自体が削除され、label の className が consumer 側で直接構成されていること
+- React named import (React.ChangeEvent 等) は維持
+- npm run test (unit、QrReader 関連) で pass、astro check で 0 errors
+- npx astro check → 0 errors
+
+やってはいけないこと:
+- git add / git commit (親が Phase 1.5 で実施)
+- git push / gh pr create
+- npm run test:vrt
+- npm run test:e2e
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加
+- camera API logic の変更 (useQrCamera 経由のまま)
+
+完了後 報告: status + 変更ファイル list + 自己検証結果 + 残課題
+```
+
+### Track C subagent prompt 骨子
+
+```
+作業ディレクトリ: /Users/fumta/projects/devtools/.claude/worktrees/issue-176-b5a
+
+タスク: src/components/tools/JanCode.tsx の inline style + e.currentTarget.style.X CSSOM mutation を spec §3 に従い撤去する。
+
+参照:
+- spec: docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md (§3.1〜3.6)
+- 既存パターン: src/components/tools/Gs1Databar.tsx (PR 4 の summary-no-marker / hover-bg-subtle 利用、CSSOM mutation 撤去 pattern)
+- global.css: PR 4 で導入済の .summary-no-marker / .hover-bg-subtle を再利用 (新規 class 不要)
+- 利用可能な既存 class: caption / body-emphasis / text-default / text-muted / text-primary / bg-default / bg-surface / border-default / summary-no-marker / hover-bg-subtle
+- D7 採用案: onMouseEnter/onMouseLeave を完全削除し、Tailwind hover: variant ではなく専用 .hover-bg-subtle class (PR 4) で表現 (memory feedback_tailwind_v4_layer_variant.md 参照)
+
+変更可能なファイル:
+- src/components/tools/JanCode.tsx (本体)
+
+触ってはいけないファイル:
+- src/components/tools/__tests__/* (logic test、変更不要)
+- src/utils/styles.ts (PR 6 スコープ)
+- src/styles/global.css (Phase 0 commit 済)
+- src/components/tools/ConfigConverter.tsx (Track A)
+- src/components/tools/QrReader.tsx (Track B)
+- tests/e2e/* (本 PR で gate 追加せず)
+
+完了基準:
+- grep -c "style={{" src/components/tools/JanCode.tsx → 0
+- grep "from '@/utils/styles'" src/components/tools/JanCode.tsx → 0
+- grep -E "\.style\.[a-zA-Z]+\s*=" src/components/tools/JanCode.tsx | grep -v setProperty → 0 (CSSOM mutation 全消去)
+- onMouseEnter / onMouseLeave attribute は完全削除
+- <summary> の className に "summary-no-marker hover-bg-subtle" が含まれていること
+- 完成コード行に tracking-[0.1em] が含まれていること
+- npm run test (unit、JanCode 関連) で pass、astro check で 0 errors
+- npx astro check → 0 errors
+
+やってはいけないこと:
+- git add / git commit (親が Phase 1.5 で実施)
+- git push / gh pr create
+- npm run test:vrt
+- npm run test:e2e
+- 上記の "触ってはいけないファイル" の変更
+- src/styles/global.css への class 追加
+- Tailwind variant `hover:bg-subtle` の使用 (silent regression、memory feedback_tailwind_v4_layer_variant.md 参照)
+
+完了後 報告: status + 変更ファイル list + 自己検証結果 + 残課題
+```
+
+---
+
+## メモリ参照
+
+- `project_b_plan_progress.md` (pointer; SoT は repo `docs/projects/issue-176-b-plan-progress.md`)
+- `feedback_subagent_model.md` (sonnet 明示)
+- `feedback_subagent_workflow.md` (subagent は allow リスト内 Bash のみ)
+- `feedback_subagent_verification_trust.md` (親が直接検証)
+- `feedback_subagent_testing.md` (E2E は親が実行)
+- `feedback_commander_checklist.md` (PR 作成前チェック)
+- `feedback_e2e_before_pr.md` (E2E は PR 作成前)
+- `feedback_hold_push_during_review.md` (review 中は push 控える)
+- `feedback_branch_workflow.md` (`--base develop` 明示)
+- `feedback_pr_language.md` (PR 日本語)
+- `feedback_heredoc_no_escape.md` (HEREDOC で backtick エスケープしない)
+- `feedback_worktree_base_branch.md` (worktree は origin/develop -b 明示)
+- `feedback_worktree_location.md` (`.claude/worktrees/<name>`)
+- `feedback_worktree_merge_order.md` (worktree remove → branch delete の順)
+- `feedback_vrt_ci_only.md` (ローカル test:vrt 走らせない)
+- `feedback_followup_routing.md` (PR 後の離散タスクは issue 化)
+- `feedback_tailwind_v4_layer_variant.md` (Tailwind hover: variant が @layer components 手書き class に効かない件、JanCode で `.hover-bg-subtle` 専用 class を使う根拠)
+
+---
+
+## Phase 1 開始判定
+
+Phase 0 commit 完了 + worktree の `npm ci` 完了を確認したら Phase 1 dispatch。3 Track が独立ファイル + commit せず方針のため **同時並列 dispatch** で OK (race 不可能)。

--- a/docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md
@@ -1,0 +1,936 @@
+# #176 B 案 PR 5a: `ConfigConverter` + `QrReader` + `JanCode` inline style 撤去 設計書
+
+**作成日**: 2026-05-07
+**Issue**: [#176](https://github.com/fumtas1k/devtools/issues/176) アプローチ B / PR 5a
+**前提**: A-1 ([#249](https://github.com/fumtas1k/devtools/pull/249)) + VRT 基盤 ([#254](https://github.com/fumtas1k/devtools/pull/254)) + PR 1 ([#256](https://github.com/fumtas1k/devtools/pull/256)) + PR 1.5 ([#261](https://github.com/fumtas1k/devtools/pull/261)) + PR 2 ([#272](https://github.com/fumtas1k/devtools/pull/272)) + PR 3 ([#275](https://github.com/fumtas1k/devtools/pull/275)) + PR 4 ([#277](https://github.com/fumtas1k/devtools/pull/277)) + 前段 infra ([#278](https://github.com/fumtas1k/devtools/pull/278)) 完了済み
+**参照**: バッチ計画全体は repo SoT [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md)。PR 1 / 1.5 / 2 / 3 / 4 spec の命名規約・既存 `@layer components` 定義を継承。
+
+---
+
+## ゴール
+
+`src/components/tools/ConfigConverter.tsx` (11 件) + `src/components/tools/QrReader.tsx` (11 件) + `src/components/tools/JanCode.tsx` (9 件) から JSX inline style を完全撤去 + JanCode 内の `e.currentTarget.style.X = Y` 形式の CSSOM 直接 mutation 2 件 (`<summary>` の `onMouseEnter`/`onMouseLeave` hover state) を撤去し、`@layer components` の意味クラス + Tailwind utility に置換する。
+
+完了基準:
+
+1. 対象 3 ファイルから `style={{` ヒット数 0、`element.style.X = Y` 形式の inline mutation 0
+2. `src/utils/__tests__/inline-style-migration.test.ts` の `MIGRATED_FILES` array に 3 件追加 (合計 24 件) して migration test pass
+3. `src/styles/global.css` の `@layer components` に **新規 1 class のみ** 追加 (`.qr-video-preview`、§4 参照)。JanCode `<summary>` hover は **PR 4 既存の `.hover-bg-subtle` を再利用** (新規不要)
+4. **Phase 1 race 回避運用**: subagent は **commit せず** ファイル編集 + self-verification (vitest, astro check) のみ実施、親 Opus が Phase 1.5 で順次 commit (PR 4 の運用継承、§9.4 参照)
+5. **VRT 検証**: `visual-regression.yml` で baseline 比較。意図的差分があれば PR ブランチ上で `update-visual-baseline.yml` を `workflow_dispatch` trigger
+6. ローカル必須ゲート: push 前に `npm run test` (vitest) / `npx astro check` / `npm run test:e2e` 全 green (親 Opus 直接実行)
+7. `src/utils/styles.ts` 自体は **削除しない** (PR 6 で削除)。本 PR では `bodyEmphasis` / `caption` / `colors` の **import 削除** のみ
+
+非ゴール:
+
+- `Base64Codec` / `JsonCsv` / `JsonXml` / `QrCode` / `UlidGenerator` / `QrTicket (root)` / `UrlEncoder` (PR 5b)、`flip + cleanup` (PR 6)
+- `applyProductionCsp` E2E gate 追加 (#262 残部分 = ulid-generator は PR 5b で対応、本 PR 対象 3 ツールは setProperty 未使用のため CSP gate 必須性低)
+- `_headers` の `style-src 'unsafe-inline'` 撤去 (PR 6)
+- `docs/decisions.md` 新規エントリ (PR 6 [067] で B 案完了として一括記録)
+- `withProductionCsp` ラッパ自体の meta-test ([#281](https://github.com/fumtas1k/devtools/issues/281)、PR 5b 着手前に再確認、本 PR 5a スコープ外)
+- QrReader の camera API (`getUserMedia()`) 利用に伴う CSP `media-src` directive 追加要否判断 (PR 6 で実機確認、本 PR 5a は flag のみ)
+
+---
+
+## なぜ独立 PR (5a / 5b 分割) か
+
+| 観点                       | 説明                                                                                                                                                                                                        |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PR サイズ規律**          | PR 5 全体は 9 ツール / 44 inline style + 2 CSSOM。PR 4 と同等規模で bundle すると review unit が 75 件超に肥大化 (memory `feedback_pr_size.md`)。5a (大物 3 つ) と 5b (残り + #262 close + ulid E2E) に分割 |
+| **VRT 影響面の独立性**     | config-converter.astro / qr-reader.astro / jan-code.astro は独立 page で baseline に乗る。5b (Base64/JsonCsv/QrCode/UlidGenerator) と差分原因を切り分けやすい                                               |
+| **新 class の責務範囲**    | 本 PR 新規追加は `.qr-video-preview` の 1 件のみ。QrReader の `<video>` 専用命名で他 tool との衝突なし                                                                                                      |
+| **CSSOM hover refactor**   | JanCode の 2 件 hover mutation は PR 4 Gs1Databar 9 件で確立した pattern (`.hover-bg-subtle`) を流用。5a で完結させる                                                                                       |
+| **race 回避運用の安定化**  | PR 4 で初採用した「subagent 非 commit + 親で順次 commit」方式を 2 回目運用。本 PR でも採用                                                                                                                  |
+| **5a 採用基準**            | inline style ≥ 7 OR CSSOM hover あり = 大物中物 (SoT 分割設計メモ参照)。3 ツール並列 sonnet 構成は PR 4 実績がある                                                                                          |
+| **QrReader camera 隔離性** | QrReader は `getUserMedia` / `<video>` / `<canvas>` 等の特殊要素を含み、他 tool より影響が読みづらい。5a で先に検証することで PR 6 (`media-src` 検討) の前提情報を確保                                      |
+
+memory 参照:
+
+- `project_b_plan_progress.md` (pointer; SoT は repo `docs/projects/issue-176-b-plan-progress.md`)
+- `feedback_pr_size.md`
+- `feedback_subagent_verification_trust.md`
+- `feedback_subagent_model.md`
+- `feedback_commander_checklist.md`
+- `feedback_e2e_before_pr.md`
+- `feedback_tailwind_v4_layer_variant.md` (PR 4 review 由来、`hover:` variant が `@layer components` の手書き class に効かない件)
+
+---
+
+## 採用する設計 (ファイル別)
+
+### 1. `ConfigConverter.tsx` (11 件)
+
+新規 class 不要。全箇所が既存 `@layer components` class + Tailwind 標準 utility + Tailwind auto-utility (`@theme` 由来) でカバー。
+
+#### 1.1 変換元 / 変換先ラベル (line 138-158)
+
+```tsx
+// Before
+<span style={{ ...caption, color: colors.muted, minWidth: '2.5rem' }}>変換元</span>
+<span style={{ ...caption, color: colors.muted, minWidth: '2.5rem' }}>変換先</span>
+
+// After
+<span className="caption text-muted min-w-10">変換元</span>
+<span className="caption text-muted min-w-10">変換先</span>
+```
+
+`min-w-10` = 2.5rem ✓ (Tailwind 4 標準: `0.25rem * 10`)。
+
+#### 1.2 InputField/OutputField wrapper alignItems (line 160)
+
+```tsx
+// Before
+<div className="flex flex-col md:flex-row gap-4" style={{ alignItems: 'flex-start' }}>
+
+// After
+<div className="flex flex-col md:flex-row gap-4 items-start">
+```
+
+#### 1.3 警告メッセージカード (line 195-206)
+
+```tsx
+// Before
+<div
+  className="rounded-lg p-3"
+  style={{ background: colors.warningBg, border: `1px solid ${colors.warning}` }}
+>
+  <ul style={{ ...caption, color: colors.text, margin: 0, paddingLeft: '1.25rem' }}>
+    {warnings.map((w, i) => <li key={i}>{w}</li>)}
+  </ul>
+</div>
+
+// After
+<div className="rounded-lg p-3 border border-warning bg-warning-tint">
+  <ul className="caption text-default m-0 pl-5">
+    {warnings.map((w, i) => <li key={i}>{w}</li>)}
+  </ul>
+</div>
+```
+
+`border-warning` は Tailwind auto-utility (`--color-warning` が `@theme` 内定義のため自動生成)。`bg-warning-tint` は PR 3 既存 (`global.css` line 474-476)。`pl-5` = 1.25rem ✓。
+
+#### 1.4 schema toggle ボタン + arrow (line 208-235)
+
+```tsx
+// Before
+<button
+  ...
+  className="flex items-center gap-1"
+  style={{ ...caption, color: colors.link, background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+>
+  <span aria-hidden="true" style={{
+    display: 'inline-block',
+    transform: schemaOpen ? 'rotate(90deg)' : 'none',
+    transition: 'transform 0.2s',
+  }}>▶</span>
+  JSON Schema で検証する
+</button>
+
+// After
+<button
+  type="button"
+  onClick={() => setSchemaOpen((o) => !o)}
+  aria-expanded={schemaOpen}
+  aria-controls="config-converter-schema-panel"
+  className="flex items-center gap-1 caption text-link-color btn-link-plain"
+>
+  <span
+    aria-hidden="true"
+    className={`inline-block transition-transform duration-200 ${schemaOpen ? 'rotate-90' : ''}`}
+  >
+    ▶
+  </span>
+  JSON Schema で検証する
+</button>
+```
+
+- `text-link-color` は PR 1 既存 (`global.css`)
+- `.btn-link-plain` (PR 1.5 既存): `background: transparent; border: 0; padding: 0; cursor: pointer` — まさに今欲しい組み合わせ
+- `rotate-90` / `transition-transform duration-200` は Tailwind 標準
+
+#### 1.5 Cmd/Ctrl+Enter kbd (line 267-272)
+
+```tsx
+// Before
+<kbd style={{ ...caption, color: colors.muted, fontFamily: 'monospace' }} aria-hidden="true">
+  Cmd/Ctrl+Enter
+</kbd>
+
+// After
+<kbd className="caption text-muted font-mono" aria-hidden="true">
+  Cmd/Ctrl+Enter
+</kbd>
+```
+
+`font-mono` は Tailwind 標準 (`global.css` の `--font-mono` を参照)。
+
+#### 1.6 検証結果カード (line 274-304)
+
+```tsx
+// Before
+<div
+  className="rounded-lg p-3"
+  role={validationResult.valid ? 'status' : 'alert'}
+  aria-live={validationResult.valid ? 'polite' : 'assertive'}
+  style={{
+    background: validationResult.valid ? colors.successBg : colors.errorBg,
+    border: `1px solid ${validationResult.valid ? colors.success : colors.error}`,
+  }}
+>
+  {validationResult.valid ? (
+    <p style={{ ...caption, color: colors.text }}>...</p>
+  ) : (
+    <ul style={{ ...caption, color: colors.errorText, margin: 0, paddingLeft: '1.25rem' }}>...</ul>
+  )}
+</div>
+
+// After
+<div
+  className={`rounded-lg p-3 border ${validationResult.valid ? 'alert-success' : 'alert-error'}`}
+  role={validationResult.valid ? 'status' : 'alert'}
+  aria-live={validationResult.valid ? 'polite' : 'assertive'}
+>
+  {validationResult.valid ? (
+    <p className="caption text-default">...</p>
+  ) : (
+    <ul className="caption text-error-text m-0 pl-5">...</ul>
+  )}
+</div>
+```
+
+`.alert-success` / `.alert-error` は PR 2 既存 (`global.css` line 388-395)。`border` (= `1px solid currentColor` Tailwind 標準) + `border-color` (alert-\* で上書き) の組合せ。
+
+#### 1.7 import 整理
+
+```ts
+// Before
+import { caption, colors } from '@/utils/styles';
+// After (削除)
+```
+
+---
+
+### 2. `QrReader.tsx` (11 件)
+
+新規 class 1 件 (`.qr-video-preview`)。他は既存 class + Tailwind utility でカバー。
+
+#### 2.1 module-level スタイル定数の解体 (line 17-70)
+
+```tsx
+// Before (削除)
+const rescanButtonStyle: React.CSSProperties = { ... };
+const startCameraButtonStyle = { ... };
+const stopCameraButtonStyle = { ... };
+const uploadLabelStyle = (enabled: boolean): React.CSSProperties => ({ ... });
+```
+
+すべて consumer 側に className 化して inline。module-level 定数は全削除する。
+
+#### 2.2 startCamera ボタン (line 177)
+
+`startCameraButtonStyle` 解体:
+
+```tsx
+// Before
+<button type="button" onClick={camera.startCamera} style={startCameraButtonStyle}>
+  カメラを起動
+</button>
+
+// After
+<button
+  type="button"
+  onClick={camera.startCamera}
+  className="caption font-semibold inline-flex items-center px-5 py-2 rounded-lg bg-primary text-on-primary border-0 cursor-pointer"
+>
+  カメラを起動
+</button>
+```
+
+- `bg-primary` は Tailwind auto-utility (`--color-primary` @theme 由来)
+- `.text-on-primary` は PR 1 既存 (`--color-text-on-primary` :root 由来、auto-utility 不在)
+- `border-0` は Tailwind 標準
+- `cursor-pointer` は global rule (`:where(button, ...) { cursor: pointer }`) で自動適用されるが、明示でも害なし。consistency のため記述
+
+#### 2.3 video preview (line 182-194) — **新規 class 利用**
+
+```tsx
+// Before
+<video
+  ref={camera.videoRef}
+  playsInline
+  muted
+  style={{
+    width: '100%',
+    maxWidth: '400px',
+    borderRadius: '0.5rem',
+    display: camera.cameraActive ? 'block' : 'none',
+    background: '#000',
+  }}
+  aria-label="カメラプレビュー"
+/>
+
+// After
+<video
+  ref={camera.videoRef}
+  playsInline
+  muted
+  className={`w-full max-w-[400px] rounded-lg qr-video-preview ${camera.cameraActive ? '' : 'hidden'}`}
+  aria-label="カメラプレビュー"
+/>
+```
+
+- `max-w-[400px]` は Tailwind 4 arbitrary value (CSP-safe、build 時静的 CSS)
+- `hidden` は Tailwind 標準 (`display: none`)
+- `.qr-video-preview` は本 PR 新規追加 (§4 参照)、`background: #000` を保持
+
+#### 2.4 stopCamera ボタン (line 196)
+
+```tsx
+// Before
+<button type="button" onClick={stopCamera} style={stopCameraButtonStyle}>
+  カメラを停止
+</button>
+
+// After
+<button
+  type="button"
+  onClick={stopCamera}
+  className="caption font-semibold inline-flex items-center px-5 py-2 rounded-lg border border-error bg-error-tint text-error cursor-pointer"
+>
+  カメラを停止
+</button>
+```
+
+- `border-error` は Tailwind auto-utility (`--color-error` @theme 由来)
+- `.bg-error-tint` は PR 1 既存 (`--color-error-bg` の semantic alias)
+- `.text-error` は PR 2 既存
+
+#### 2.5 canvas (line 200)
+
+```tsx
+// Before
+<canvas ref={camera.canvasRef} style={{ display: 'none' }} aria-hidden="true" />
+
+// After
+<canvas ref={camera.canvasRef} className="hidden" aria-hidden="true" />
+```
+
+#### 2.6 image upload 説明文 (line 204)
+
+```tsx
+// Before
+<p style={{ ...caption, color: colors.muted }}>
+  QRコードが写った画像（PNG・JPG 等）をアップロードしてください
+</p>
+
+// After
+<p className="caption text-muted">
+  QRコードが写った画像（PNG・JPG 等）をアップロードしてください
+</p>
+```
+
+#### 2.7 visible-hidden file input + label (line 208-226)
+
+```tsx
+// Before
+<input
+  id="qr-image-input"
+  type="file"
+  accept="image/*"
+  onChange={handleImageUpload}
+  style={{ position: 'absolute', width: 1, height: 1, opacity: 0, pointerEvents: 'none' }}
+/>
+<label htmlFor="qr-image-input" style={uploadLabelStyle(true)}>
+  画像を選択
+</label>
+<p style={{ fontSize: '0.75rem', color: colors.muted, marginTop: '0.25rem' }}>
+  対応形式: PNG / JPEG / WebP / GIF / SVG・最大 15 MB
+</p>
+
+// After
+<input
+  id="qr-image-input"
+  type="file"
+  accept="image/*"
+  onChange={handleImageUpload}
+  className="sr-only"
+/>
+<label
+  htmlFor="qr-image-input"
+  className="caption font-semibold inline-block px-4 py-2 rounded-lg border border-input bg-subtle text-default cursor-pointer"
+>
+  画像を選択
+</label>
+<p className="text-xs text-muted mt-1">
+  対応形式: PNG / JPEG / WebP / GIF / SVG・最大 15 MB
+</p>
+```
+
+- `.sr-only` は Tailwind 標準 (アクセス可能な visually-hidden)。元 inline style (`position: absolute; width: 1; height: 1; opacity: 0; pointerEvents: none`) と完全等価ではないが、a11y 担保 (label `htmlFor` 経由のクリック / Tab focus) は同等以上 (sr-only は `clip: rect(0,0,0,0)` も含む)
+- 元の `uploadLabelStyle(true)` 引数 `enabled: true` 固定で常時呼び出されている (第 2 引数なし) ため、`enabled === true` 分岐のみ展開して disabled state は **削除** (デッドコード扱い、現コードで使われていない)
+
+`uploadLabelStyle(false)` の呼び出し有無確認は §6 で grep 命令を明記。
+
+#### 2.8 読取結果テキスト表示 (line 240-256)
+
+```tsx
+// Before
+<div className="rounded-lg p-3" style={{ background: colors.bgSubtle, border: `1px solid ${colors.border}` }}>
+  <pre style={{
+    ...caption,
+    color: colors.text,
+    margin: 0,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all',
+    fontFamily: 'monospace',
+  }}>
+    {content.raw}
+  </pre>
+</div>
+
+// After
+<div className="rounded-lg p-3 border border-default bg-subtle">
+  <pre className="caption text-default m-0 whitespace-pre-wrap break-all font-mono">
+    {content.raw}
+  </pre>
+</div>
+```
+
+#### 2.9 再スキャンボタン (line 261)
+
+`rescanButtonStyle` 解体:
+
+```tsx
+// Before
+<button type="button" onClick={handleRescan} style={rescanButtonStyle}>
+  再スキャン
+</button>
+
+// After
+<button
+  type="button"
+  onClick={handleRescan}
+  className="caption font-bold leading-none inline-flex items-center gap-1.5 px-3 py-2 rounded border border-default bg-subtle text-default cursor-pointer whitespace-nowrap"
+>
+  再スキャン
+</button>
+```
+
+- `leading-none` は Tailwind 標準 (`line-height: 1`)
+- `gap-1.5` = 0.375rem ✓
+- `px-3` = 0.75rem ✓ / `py-2` = 0.5rem ✓
+- `rounded` = 0.25rem ✓
+
+#### 2.10 URL 警告カード (line 267-298)
+
+```tsx
+// Before
+<div
+  className="rounded-lg p-4 space-y-2"
+  style={{ background: colors.warningBg, border: `1px solid ${colors.warning}` }}
+>
+  <p style={{ ...caption, color: colors.text }}>
+    <strong style={{ color: colors.text }}>{content.hostname}</strong>{' '}
+    への外部リンクが含まれています。URLをよく確認してから開いてください。
+  </p>
+  <a
+    href={content.raw}
+    target="_blank"
+    rel="noopener noreferrer"
+    style={{
+      ...caption,
+      fontWeight: 600,
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '0.375rem 0.875rem',
+      borderRadius: '0.375rem',
+      border: `1px solid ${colors.warning}`,
+      background: colors.bg,
+      color: colors.text,
+      textDecoration: 'none',
+    }}
+  >
+    URLを開く
+  </a>
+</div>
+
+// After
+<div className="rounded-lg p-4 space-y-2 border border-warning bg-warning-tint">
+  <p className="caption text-default">
+    <strong className="text-default">{content.hostname}</strong>{' '}
+    への外部リンクが含まれています。URLをよく確認してから開いてください。
+  </p>
+  <a
+    href={content.raw}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="caption font-semibold inline-flex items-center px-3.5 py-1.5 rounded-md border border-warning bg-default text-default no-underline"
+  >
+    URLを開く
+  </a>
+</div>
+```
+
+- `px-3.5` = 0.875rem ✓ / `py-1.5` = 0.375rem ✓ / `rounded-md` = 0.375rem ✓
+- `no-underline` は Tailwind 標準
+- `border-warning` (auto-utility) は §1.3 と同じ
+
+#### 2.11 import 整理
+
+```ts
+// Before
+import { caption, colors } from '@/utils/styles';
+// After (削除)
+```
+
+`React` named import (`React.CSSProperties` / `React.ChangeEvent`) は **保持** (line 1)。`React.ChangeEvent<HTMLInputElement>` の参照が `handleImageUpload` 引数に残るため。
+
+---
+
+### 3. `JanCode.tsx` (9 件 + 2 件 hover refactor)
+
+新規 class 不要。`<summary>` の hover bg は **PR 4 既存の `.hover-bg-subtle`** を再利用。
+
+#### 3.1 結果カード wrapper (line 100-104)
+
+```tsx
+// Before
+<div
+  data-testid="jan-code-result"
+  className="rounded-lg p-4 space-y-3"
+  style={{ border: `1px solid ${colors.border}`, background: colors.bgSurface }}
+>
+
+// After
+<div
+  data-testid="jan-code-result"
+  className="rounded-lg p-4 space-y-3 border border-default bg-surface"
+>
+```
+
+#### 3.2 チェックディジット行 (line 106-107)
+
+```tsx
+// Before
+<span style={{ ...caption, color: colors.muted }}>チェックディジット</span>
+<span style={{ ...bodyEmphasis, color: colors.primary }}>{result.checkDigit}</span>
+
+// After
+<span className="caption text-muted">チェックディジット</span>
+<span className="body-emphasis text-primary">{result.checkDigit}</span>
+```
+
+#### 3.3 完成コード行 (line 110-117)
+
+```tsx
+// Before
+<span style={{ ...caption, color: colors.muted }}>完成コード</span>
+<span className="font-mono" style={{ ...bodyEmphasis, color: colors.text, letterSpacing: '0.1em' }}>
+  {result.fullCode}
+</span>
+
+// After
+<span className="caption text-muted">完成コード</span>
+<span className="font-mono body-emphasis text-default tracking-[0.1em]">
+  {result.fullCode}
+</span>
+```
+
+`tracking-[0.1em]` は Tailwind 4 arbitrary value (PR 4 Gs1Databar §1.2 と同じ pattern、CSP-safe)。
+
+#### 3.4 計算過程 details / summary + hover refactor (line 124-141)
+
+**重要: ここで CSSOM mutation 2 件を撤去する**
+
+```tsx
+// Before
+<details className="rounded-lg" style={{ border: `1px solid ${colors.border}` }}>
+  <summary
+    className="cursor-pointer px-4 py-3 font-bold rounded-lg transition-colors"
+    style={{
+      ...caption,
+      fontWeight: 700,
+      color: colors.muted,
+      listStyle: 'none',
+      background: 'transparent',
+    }}
+    onMouseEnter={(e) => (e.currentTarget.style.background = colors.bgSubtle)}
+    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+  >
+    計算過程を見る
+  </summary>
+  <div
+    className="px-4 pb-4 pt-2 space-y-1 font-mono"
+    style={{ ...caption, color: colors.text }}
+  >
+    {/* ... 計算過程 ... */}
+  </div>
+</details>
+
+// After
+<details className="rounded-lg border border-default">
+  <summary className="cursor-pointer px-4 py-3 rounded-lg caption font-bold text-muted bg-transparent summary-no-marker hover-bg-subtle">
+    計算過程を見る
+  </summary>
+  <div className="px-4 pb-4 pt-2 space-y-1 font-mono caption text-default">
+    {/* ... 計算過程 ... */}
+  </div>
+</details>
+```
+
+- `onMouseEnter` / `onMouseLeave` を **削除**
+- `.summary-no-marker` は PR 4 既存 (`global.css` line 508-513) — `list-style: none` + `::-webkit-details-marker { display: none }` で marker 非表示
+- `.hover-bg-subtle` は PR 4 既存 (`global.css` line 532-537) — `transition-colors` 込みで hover bg を CSS で表現
+- 既存の `transition-colors` Tailwind utility は `.hover-bg-subtle` に組み込まれているので削除して OK
+
+memory `feedback_tailwind_v4_layer_variant.md`: `hover:bg-subtle` のような Tailwind variant は `@layer components` の手書き class に効かない (silent regression)。本 PR でも PR 4 と同じ `.hover-bg-subtle` (専用 hover class) を再利用する。
+
+#### 3.5 バーコードプレビュー wrapper (line 182-185)
+
+```tsx
+// Before
+<div
+  className="rounded-lg flex flex-col items-center gap-4 p-4"
+  style={{ border: `1px solid ${colors.border}`, background: colors.bg }}
+>
+
+// After
+<div className="rounded-lg flex flex-col items-center gap-4 p-4 border border-default bg-default">
+```
+
+#### 3.6 import 整理
+
+```ts
+// Before
+import { bodyEmphasis, caption, colors } from '@/utils/styles';
+// After (削除)
+```
+
+---
+
+## 4. `src/styles/global.css` への追記 (PR 5a で **新規追加** する分のみ)
+
+PR 1 / 1.5 / 2 / 3 / 4 で追加済の class はすべて再利用 (`.caption` / `.body-emphasis` / `.text-default` / `.text-muted` / `.text-on-primary` / `.text-error` / `.text-error-text` / `.text-primary` / `.text-link-color` / `.text-warning` / `.bg-default` / `.bg-subtle` / `.bg-surface` / `.bg-error-tint` / `.bg-warning-tint` / `.border-default` / `.border-input` / `.alert-success` / `.alert-error` / `.btn-link-plain` / `.summary-no-marker` / `.hover-bg-subtle`)。
+
+本 PR 追加分:
+
+```css
+@layer components {
+  /* === PR 5a: QrReader video preview background === */
+  /* QRリーダーの <video> 要素は `getUserMedia` 開始前 (display:none で隠蔽中) の
+     コントラスト確保 + 起動失敗時のフォールバック (黒画面) として黒背景を維持する。
+     一意の用途のため component-scoped class とする (色 token 化はしない)。 */
+  .qr-video-preview {
+    background: #000;
+  }
+}
+```
+
+**衝突確認**:
+
+- `.qr-video-preview` は QrReader の `<video>` 専用、他 tool で同名 class 利用なし (grep 確認 §6)
+- `#000` の literal hex 利用は `--color-*` token に該当値がないため許容。`.jwt-json-value { color: #6e4f0e }` (PR 3、`global.css` line 455) と同じ pattern (one-off で意味のある色)
+
+**Tailwind 4 arbitrary value の利用箇所** (build 時に静的 CSS、CSP-safe):
+
+| utility            | 用途                       | 該当            |
+| ------------------ | -------------------------- | --------------- |
+| `max-w-[400px]`    | QrReader video 最大幅      | QrReader 1 箇所 |
+| `tracking-[0.1em]` | JanCode 完成コード文字間隔 | JanCode 1 箇所  |
+
+これらは Tailwind 4 標準機能。新 class 化のコスト>利益のため utility 利用に留める (PR 4 との整合性)。
+
+---
+
+## 5. `inline-style-migration.test.ts` への追加
+
+```ts
+const MIGRATED_FILES: readonly string[] = [
+  // PR 1 で追加済 (11 件、省略)
+  // PR 1.5 で追加済 (2 件)
+  // PR 2 で追加済 (3 件)
+  // PR 3 で追加済 (2 件)
+  // PR 4 で追加済 (3 件)
+  // PR 5a で追加
+  'src/components/tools/ConfigConverter.tsx',
+  'src/components/tools/QrReader.tsx',
+  'src/components/tools/JanCode.tsx',
+];
+```
+
+陽性対照テストブロックは PR 1 で導入済 → 変更不要。合計 24 ファイル。
+
+---
+
+## 6. consumer 変更範囲 (PR 5a で touch するファイル)
+
+| File                                                 | 変更内容                                                                     | 備考                        |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------- |
+| `src/components/tools/ConfigConverter.tsx`           | inline style 11 件除去 + import 整理                                         | MIGRATED_FILES 登録         |
+| `src/components/tools/QrReader.tsx`                  | inline style 11 件除去 + module-level スタイル定数 4 個削除 + import 整理    | MIGRATED_FILES 登録         |
+| `src/components/tools/JanCode.tsx`                   | inline style 9 件除去 + `e.currentTarget.style.X = Y` 2 件除去 + import 整理 | MIGRATED_FILES 登録         |
+| `src/styles/global.css`                              | `@layer components` に `.qr-video-preview` 1 件追加                          | PR 4 既存ブロック末尾       |
+| `src/utils/__tests__/inline-style-migration.test.ts` | `MIGRATED_FILES` array に 3 件追加 (合計 24 件)                              | -                           |
+| `docs/projects/issue-176-b-plan-progress.md`         | PR 5a の状態を current 化 (PR 4 経験を踏まえ merge 待ち間 SoT 反映)          | 進捗 + follow-up table 更新 |
+
+**触らない**:
+
+- `src/components/tools/__tests__/*.test.ts` (logic test、本 PR の class 化は DOM 構造を変えない)
+- `src/utils/styles.ts` (PR 6 で削除、本 PR は import 削除のみ)
+- `src/utils/csp.ts` / `public/_headers` (PR 6 でstrict 化)
+- `tests/e2e/*.spec.ts` (本 PR で applyProductionCsp gate 追加せず、#262 残部分 = ulid-generator は PR 5b で対応)
+- `src/hooks/useQrCamera.ts` (logic、本 PR スコープ外)
+
+**事前 grep 確認**:
+
+```bash
+# uploadLabelStyle(false) 呼び出しがないこと (= disabled 分岐がデッドコード) を確認
+grep -n "uploadLabelStyle" src/components/tools/QrReader.tsx
+# 期待: 関数定義 (line 60) + 呼び出し 1 箇所 (line 221、enabled=true 固定) のみ
+
+# .qr-video-preview class 名衝突がないこと
+grep -rn "qr-video-preview" src/
+
+# .hover-bg-subtle / .summary-no-marker が PR 4 既存定義にあること
+grep -n "hover-bg-subtle\|summary-no-marker" src/styles/global.css
+```
+
+---
+
+## 7. 検証戦略
+
+### 7.1 ローカル必須ゲート (push 前、親 Opus 直接実行)
+
+| 順  | コマンド           | 目的                                                                    |
+| --- | ------------------ | ----------------------------------------------------------------------- |
+| 1   | `npm run test`     | unit + migration test (21 → 24、6 spec 追加 = 3 ファイル × 2 件 / file) |
+| 2   | `npx astro check`  | TypeScript 型チェック (Tailwind utility の型 break 検知)                |
+| 3   | `npm run test:e2e` | config-converter / qr-reader / jan-code の既存 E2E 全 pass              |
+
+memory `feedback_subagent_verification_trust.md`: 親 Opus 直接実行 (subagent の "pass" 報告は信頼しない)。
+
+### 7.2 CI
+
+| workflow                | 内容                               | required?       |
+| ----------------------- | ---------------------------------- | --------------- |
+| `test.yml`              | vitest + e2e                       | ✅ required     |
+| `visual-regression.yml` | `npm run test:vrt` (baseline 比較) | ❌ non-required |
+
+memory `feedback_vrt_ci_only.md`: ローカル `npm run test:vrt` は走らせない。
+
+### 7.3 a11y 退化検知 (memory `feedback_commander_checklist.md`)
+
+PR 作成前に親が下記実行:
+
+```bash
+git diff origin/develop -- src/components/tools/ConfigConverter.tsx src/components/tools/QrReader.tsx src/components/tools/JanCode.tsx \
+  | grep -E '^-.*(aria-|role=|data-testid=|htmlFor=)' | grep -vE '^---|^\+\+\+'
+# 出力 0 行 = OK (reformatted で行移動した削除行が出る場合は現コードで存在を grep 確認、PR 3-4 と同運用)
+```
+
+特に注意:
+
+- ConfigConverter の schema toggle button の `aria-expanded` / `aria-controls` 維持
+- ConfigConverter の `<kbd aria-hidden="true">` 維持
+- ConfigConverter の検証結果 alert の `role` / `aria-live` 維持 (動的に `status` ↔ `alert`)
+- QrReader の `<input id="qr-image-input">` ↔ `<label htmlFor="qr-image-input">` 関連付け維持
+- QrReader の `<video aria-label="カメラプレビュー">` 維持
+- QrReader の `<canvas aria-hidden="true">` 維持 (display:none → hidden に変わるが a11y は同等)
+- JanCode の `data-testid="jan-code-result"` 維持
+- 全 button の `type="button"` 維持 (PR 1 follow-up #258/#269 で追加済)
+- JanCode `<details>/<summary>` semantic 維持 (browser default 構造を class 化で壊さない、PR 4 Gs1Databar と同じ運用)
+
+### 7.4 VRT 差分の判断フロー (PR 1〜4 と同じ)
+
+PR comment に diff があった場合:
+
+- 意図しない regression (ボタン色違い / video bg 抜け / hover bg 効かない) → class 定義 / consumer className 修正
+- ピクセル未満の anti-alias 差 → mask か threshold 緩和 (事前合意必要)
+- 意図的変化 → PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger → bot が新 baseline を commit back
+
+特に確認すべき差分点:
+
+- QrReader video element: `display:none` → `hidden` class、初期状態で video が描画されないこと
+- QrReader file input: `position: absolute` 視覚消去 → `sr-only` (clip + margin -1) で同等の不可視性
+- JanCode summary: hover 時 `bg-subtle` 適用 (CSSOM mutation 撤去後も bg 変化が見える)
+- ConfigConverter schema toggle arrow: `rotate-90` で 90 度回転 (transition-duration 200ms)
+
+### 7.5 functional E2E 観点
+
+| ツール          | 既存 spec ファイル                         | 本 PR で重要な assertion                                       |
+| --------------- | ------------------------------------------ | -------------------------------------------------------------- |
+| ConfigConverter | `tests/e2e/config-converter.spec.ts`       | サンプル投入 → 変換結果 / schema 検証 / clear ボタン           |
+| QrReader        | `tests/e2e/qr-reader.spec.ts` (存在確認要) | mode 切替 (camera / upload) / file upload 動作 / 結果表示      |
+| JanCode         | `tests/e2e/jan-code.spec.ts`               | JAN-13 / JAN-8 サンプル投入 → SVG 描画 / 計算過程 details 開閉 |
+
+**特に**: QrReader の visible-hidden input (`sr-only`) で `htmlFor` クリックが動くこと、video 要素の `hidden` 属性切替が動くこと。E2E で再現できない実機 camera は手動確認 (post-merge、PR 6 前段)。
+
+---
+
+## 8. バッチ計画における本 PR の位置付け
+
+repo SoT [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md) のテーブル参照。
+
+| #         | スコープ                                                                                                | 状態           |
+| --------- | ------------------------------------------------------------------------------------------------------- | -------------- |
+| PR 0      | VRT 導入                                                                                                | ✅ #254 merged |
+| PR 1      | 基礎工事 + ui/\* simple 11                                                                              | ✅ #256 merged |
+| PR 1.5    | ui/\* complex (ResultTable + InputField)                                                                | ✅ #261 merged |
+| PR 2      | qr-ticket/\*                                                                                            | ✅ #272 merged |
+| PR 3      | JwtDecoder + UuidV7Generator + #262 partial                                                             | ✅ #275 merged |
+| PR 4      | Gs1Databar + EncodingConverter + DummyText                                                              | ✅ #277 merged |
+| infra     | `withProductionCsp` ラッパ helper                                                                       | ✅ #278 merged |
+| **PR 5a** | **ConfigConverter + QrReader + JanCode (本 PR)**                                                        | **本 PR**      |
+| PR 5b     | Base64 + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 + ulid-generator E2E + #262 close | 未着手         |
+| PR 6      | flip + cleanup                                                                                          | 未着手         |
+
+PR は **直列** (前 PR がマージされてから次 PR 着手)。
+
+---
+
+## 9. ブランチ命名 / コミット粒度 / 並列 subagent 分担 + race 回避運用
+
+### 9.1 ブランチ命名
+
+- `feature/issue-176-b5a-config-qr-jan`
+- worktree: `git worktree add .claude/worktrees/issue-176-b5a origin/develop -b feature/issue-176-b5a-config-qr-jan` (memory `feedback_worktree_base_branch.md` / `feedback_worktree_location.md`)
+
+### 9.2 コミット粒度
+
+```
+1. (Phase 0) chore(spec): #176 B 案 PR 5a spec / plan / global.css foundation (.qr-video-preview)
+2. (Phase 1.5) refactor(tools): #176 B 案 PR 5a — ConfigConverter.tsx inline style 撤去
+3. (Phase 1.5) refactor(tools): #176 B 案 PR 5a — QrReader.tsx inline style 撤去 + module-level スタイル定数撤去
+4. (Phase 1.5) refactor(tools): #176 B 案 PR 5a — JanCode.tsx inline style 撤去 + summary hover を CSS に移行
+5. (Phase 2) test(migration): MIGRATED_FILES に PR 5a 対象 3 件追加
+6. (Phase 2) docs(progress): PR 5a (#XXX) の状態を反映
+```
+
+### 9.3 並列 subagent 分担 (sonnet × 3 Track)
+
+memory `feedback_subagent_model.md` に従い `model: "sonnet"` 明示:
+
+| Track | 担当ファイル          | inline style 件数 + 特殊事項                                  |
+| ----- | --------------------- | ------------------------------------------------------------- |
+| **A** | `ConfigConverter.tsx` | 11 件                                                         |
+| **B** | `QrReader.tsx`        | 11 件 + module-level スタイル定数 4 個解体 + sr-only への置換 |
+| **C** | `JanCode.tsx`         | 9 件 + 2 件 hover refactor (CSSOM、`.hover-bg-subtle` 再利用) |
+
+### 9.4 **Phase 1 race 回避運用 (PR 4 運用継承)**
+
+PR 3 で並列 dispatch 時に commit が結合される race が発生 → PR 4 で「subagent 非 commit」運用を初採用 → 成功。本 PR でも継承:
+
+#### 採用方針: subagent は commit せず、親が Phase 1.5 で順次 commit
+
+各 subagent への明示指示:
+
+```
+- ファイル編集 + self-verification (vitest, astro check) のみ実施
+- git add / git commit は実行しない (親が後段で実施)
+- 完了報告: 「変更ファイル list (git diff --name-only) + self-verification 結果」のみ
+```
+
+親 Opus が Phase 1 完了後、Phase 1.5 で:
+
+1. Track A の変更を確認 → `git add src/components/tools/ConfigConverter.tsx` → `git commit -m "..."`
+2. Track B の変更を確認 → `git add src/components/tools/QrReader.tsx` → `git commit -m "..."`
+3. Track C の変更を確認 → `git add src/components/tools/JanCode.tsx` → `git commit -m "..."`
+
+#### 利点 (PR 4 で確認済)
+
+- subagent 間の commit race 完全消去
+- prettier hook の巻き込み reformat も親が制御 (1 commit に閉じる、他 Track ファイルが入らない)
+- 各 commit のメッセージと内容が完全一致
+- subagent の self-verification (vitest / astro check) は維持
+
+### 9.5 PR ベース
+
+`gh pr create --base develop` で必ず明示 (memory `feedback_branch_workflow.md` / `feedback_pr_language.md` / `CLAUDE.md` 最重要ルール)。タイトル例:
+
+> `refactor(tools): #176 B 案 PR 5a — ConfigConverter + QrReader + JanCode inline style 撤去`
+
+PR 本文は `--body-file /tmp/claude/pr_body_b5a.md` 経由 (memory `feedback_heredoc_no_escape.md`)。
+
+---
+
+## 10. リスクと緩和
+
+| ID  | リスク                                                                                              | 緩和                                                                                                                                           |
+| --- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | `max-w-[400px]` arbitrary が Tailwind 4 で生成されない                                              | Tailwind 4 標準機能、`tracking-[0.1em]` (PR 4) で実績あり。astro check で型 break しないか確認、E2E で実描画確認                               |
+| R2  | `sr-only` が元 `position: absolute` 等の inline style と挙動同等でない                              | sr-only は label 経由 click + Tab focus を担保、a11y 同等以上 (clip + margin -1 も含む)。E2E で `<label>` クリック → 画像選択ダイアログ確認可  |
+| R3  | `.qr-video-preview` の `#000` literal hex が `--color-*` token と乖離                               | one-off 用途、token 化のコスト>利益。`.jwt-json-value { color: #6e4f0e }` (PR 3) と同じ pattern。`docs/decisions.md` 記録不要                  |
+| R4  | `border-warning` Tailwind auto-utility が生成されない                                               | `--color-warning: #854d0e` は `global.css` line 51 で `@theme` 内定義済、Tailwind 4 が自動 utility 生成。astro check で型 break しないか確認   |
+| R5  | `.alert-success` / `.alert-error` の border 優先度問題 (`border` Tailwind utility との competition) | PR 2 review で実害なし確認済 (memory `progress doc` 末尾 PR 6 checklist 末尾「Tailwind `border` utility と `@layer components` の優先度」参照) |
+| R6  | `.hover-bg-subtle` が JanCode `<summary>` で hover 効かない                                         | PR 4 で動作確認済 (Gs1Databar の AI フィールド削除 button、GS1 文字列 `<summary>`)。JanCode は同 pattern 流用                                  |
+| R7  | Phase 1 で subagent が指示違反して commit してしまう                                                | 親が Phase 1.5 で `git status` / `git log --oneline -1` を確認して回復可能。最悪 reset --soft で再 commit (PR 3 の経験)                        |
+| R8  | QrReader の `<video hidden>` で video element 自体が DOM から消える / videoRef.current が null      | Tailwind `hidden` = `display: none`、要素は DOM に残る (videoRef.current 維持)。元 inline `display: 'none'` と挙動同等。E2E で起動後再表示確認 |
+| R9  | `uploadLabelStyle(false)` 呼び出しが残存していて disabled 分岐削除で regression                     | §6 の grep 命令で事前確認。実際は line 221 のみ呼び出しで `enabled=true` 固定                                                                  |
+| R10 | QrReader の `getUserMedia()` が CSP strict 化 (PR 6) で動かなくなる                                 | 本 PR スコープ外、PR 6 で `media-src` directive 検討時に flag。本 PR は inline style 撤去のみで camera 機能は変えない                          |
+
+---
+
+## 11. 議論ポイント (spec 確定前 user 判断、本 spec に既に user 承認済 2026-05-07)
+
+### D1. `.qr-video-preview` 新規 class の責務範囲
+
+- **採用**: `background: #000` のみ持つ singleton class
+- **代替 1**: `--color-video-bg: #000` を `:root` に追加 + `.bg-video-bg` class
+- **代替 2**: Tailwind 4 arbitrary `bg-[#000]` を className に書く
+- **判断ポイント**: token 化のコスト vs one-off 利用 (PR 3 `.jwt-json-value` と同じ判断)
+- **判断**: 採用案 (user 承認済 2026-05-07、1 class で命名意図が明確、token 化コスト>利益)
+
+### D2. QrReader file input の visible-hidden を `sr-only` に置換
+
+- **採用**: Tailwind 標準 `sr-only` (clip + margin -1 込み、a11y 担保)
+- **代替**: 元 inline style と完全同等な `.qr-file-input-hidden` class (`position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none`)
+- **判断ポイント**: `sr-only` が業界標準で a11y 同等以上。VRT で diff 出る可能性は低 (両方とも視覚的に消える)
+- **判断**: 採用案 (user 承認済 2026-05-07、Tailwind 標準活用、a11y 同等以上)
+
+### D3. JanCode `<summary>` hover を `.hover-bg-subtle` (PR 4) で再利用
+
+- **採用**: PR 4 で確立した `.hover-bg-subtle` 利用、新規 class 不要
+- **代替**: JanCode 専用 class (`.summary-jan-hover` 等)
+- **判断**: 採用案 (user 承認済 2026-05-07、PR 4 で同 pattern 確立、再利用 rational)
+
+### D4. ConfigConverter schema toggle arrow の rotation を Tailwind utility で表現
+
+- **採用**: `rotate-90` (Tailwind 標準) を conditional className で適用
+- **代替**: 専用 class (`.rotate-on-open`) を新設
+- **判断**: 採用案 (user 承認済 2026-05-07、Tailwind utility で完結、新 class 不要)
+
+### D5. QrReader module-level スタイル定数 4 個 (`rescanButtonStyle` / `startCameraButtonStyle` / `stopCameraButtonStyle` / `uploadLabelStyle`) の解体
+
+- **採用**: 全削除して consumer 側 className 化
+- **代替**: 一部を `.btn-camera-start` 等の専用 class として残す
+- **判断ポイント**: 新規 class を最小化する方針 (本 PR `.qr-video-preview` のみ)。className のみで完結する箇所は class 化しない
+- **判断**: 採用案 (user 承認済 2026-05-07、定数全削除、className 化)
+
+### D6. `uploadLabelStyle(enabled)` の `enabled=false` 分岐削除
+
+- **採用**: `enabled=false` 呼び出しがないことを §6 grep で確認後、`enabled=true` 分岐のみ展開して disabled state は削除
+- **代替**: enabled state を保持して将来の disabled 利用に備える
+- **判断ポイント**: YAGNI / 現コードに `uploadLabelStyle(false)` 呼び出しなし
+- **判断**: 採用案 (user 承認済 2026-05-07、YAGNI、現コードで未使用 code path 削除、PR 6 cleanup と同じ精神)
+
+### D7. CSSOM hover refactor pattern (JanCode `<summary>`)
+
+- **採用**: PR 4 Gs1Databar と同じく `onMouseEnter` / `onMouseLeave` を削除して `.hover-bg-subtle` の CSS `:hover` で表現
+- **代替**: Tailwind `hover:bg-subtle` variant (memory `feedback_tailwind_v4_layer_variant.md` で動かないことが判明済)
+- **判断**: 採用案 (user 承認済 2026-05-07、PR 4 で確立、Tailwind variant は @layer components 手書き class に効かない)
+
+---
+
+## 関連
+
+- 起源 issue: [#176](https://github.com/fumtas1k/devtools/issues/176) アプローチ B
+- 前提 PR: [#249](https://github.com/fumtas1k/devtools/pull/249) (A-1) / [#252](https://github.com/fumtas1k/devtools/pull/252) (meta-csp) / [#254](https://github.com/fumtas1k/devtools/pull/254) (VRT) / [#256](https://github.com/fumtas1k/devtools/pull/256) (PR 1) / [#261](https://github.com/fumtas1k/devtools/pull/261) (PR 1.5) / [#272](https://github.com/fumtas1k/devtools/pull/272) (PR 2) / [#275](https://github.com/fumtas1k/devtools/pull/275) (PR 3) / [#277](https://github.com/fumtas1k/devtools/pull/277) (PR 4) / [#278](https://github.com/fumtas1k/devtools/pull/278) (前段 infra)
+- 過去 decisions: [054]（CSP 初導入）/ [064]（A-1 採用）/ [066]（VRT 採用）
+- repo SoT: [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md)
+- memory: `feedback_pr_size.md` / `feedback_subagent_model.md` / `feedback_subagent_verification_trust.md` / `feedback_commander_checklist.md` / `feedback_vrt_ci_only.md` / `feedback_e2e_before_pr.md` / `feedback_branch_workflow.md` / `feedback_pr_language.md` / `feedback_heredoc_no_escape.md` / `feedback_worktree_base_branch.md` / `feedback_worktree_location.md` / `feedback_worktree_merge_order.md` / `feedback_tailwind_v4_layer_variant.md`
+- PR 1 spec: `docs/superpowers/specs/2026-05-03-issue-176-b1-foundation-and-ui-simple-design.md`
+- PR 1.5 spec: `docs/superpowers/specs/2026-05-04-issue-176-b1-5-ui-complex-design.md`
+- PR 2 spec: `docs/superpowers/specs/2026-05-04-issue-176-b2-qr-ticket-design.md`
+- PR 3 spec: `docs/superpowers/specs/2026-05-07-issue-176-b3-jwt-uuid-design.md`
+- PR 4 spec: `docs/superpowers/specs/2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md`
+- 前段 infra spec: `docs/superpowers/specs/2026-05-07-issue-276-with-production-csp-helper-design.md`

--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -10,7 +10,6 @@ import { convert } from '@/utils/config-converter';
 import type { ConfigFormat } from '@/utils/config-converter';
 import type { ValidationResult } from '@/utils/config-converter/schema-validator';
 import { downloadText } from '@/utils/download';
-import { caption, colors } from '@/utils/styles';
 
 const FORMAT_LABELS: Record<ConfigFormat, string> = {
   json: 'JSON',
@@ -138,7 +137,7 @@ export function ConfigConverterTool() {
     <div className="space-y-6">
       <div className="space-y-2">
         <div className="flex items-center gap-3">
-          <span style={{ ...caption, color: colors.muted, minWidth: '2.5rem' }}>変換元</span>
+          <span className="caption text-muted min-w-10">変換元</span>
           <ToggleGroup
             options={FORMAT_OPTIONS}
             value={from}
@@ -147,7 +146,7 @@ export function ConfigConverterTool() {
           />
         </div>
         <div className="flex items-center gap-3">
-          <span style={{ ...caption, color: colors.muted, minWidth: '2.5rem' }}>変換先</span>
+          <span className="caption text-muted min-w-10">変換先</span>
           <ToggleGroup
             options={FORMAT_OPTIONS}
             value={to}
@@ -157,7 +156,7 @@ export function ConfigConverterTool() {
         </div>
       </div>
 
-      <div className="flex flex-col md:flex-row gap-4" style={{ alignItems: 'flex-start' }}>
+      <div className="flex flex-col md:flex-row gap-4 items-start">
         <div className="w-full md:flex-1 min-w-0">
           <InputField
             id="config-converter-input"
@@ -193,11 +192,8 @@ export function ConfigConverterTool() {
       </div>
 
       {warnings.length > 0 && (
-        <div
-          className="rounded-lg p-3"
-          style={{ background: colors.warningBg, border: `1px solid ${colors.warning}` }}
-        >
-          <ul style={{ ...caption, color: colors.text, margin: 0, paddingLeft: '1.25rem' }}>
+        <div className="rounded-lg p-3 border border-warning bg-warning-tint">
+          <ul className="caption text-default m-0 pl-5">
             {warnings.map((w, i) => (
               <li key={i}>{w}</li>
             ))}
@@ -211,23 +207,11 @@ export function ConfigConverterTool() {
           onClick={() => setSchemaOpen((o) => !o)}
           aria-expanded={schemaOpen}
           aria-controls="config-converter-schema-panel"
-          className="flex items-center gap-1"
-          style={{
-            ...caption,
-            color: colors.link,
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            padding: 0,
-          }}
+          className="flex items-center gap-1 caption text-link-color btn-link-plain"
         >
           <span
             aria-hidden="true"
-            style={{
-              display: 'inline-block',
-              transform: schemaOpen ? 'rotate(90deg)' : 'none',
-              transition: 'transform 0.2s',
-            }}
+            className={`inline-block transition-transform duration-200 ${schemaOpen ? 'rotate-90' : ''}`}
           >
             ▶
           </span>
@@ -264,36 +248,22 @@ export function ConfigConverterTool() {
               >
                 {isValidating ? '検証中…' : '検証する'}
               </ActionButton>
-              <kbd
-                style={{ ...caption, color: colors.muted, fontFamily: 'monospace' }}
-                aria-hidden="true"
-              >
+              <kbd className="caption text-muted font-mono" aria-hidden="true">
                 Cmd/Ctrl+Enter
               </kbd>
             </div>
             {validationResult && (
               <div
-                className="rounded-lg p-3"
+                className={`rounded-lg p-3 border ${validationResult.valid ? 'alert-success' : 'alert-error'}`}
                 role={validationResult.valid ? 'status' : 'alert'}
                 aria-live={validationResult.valid ? 'polite' : 'assertive'}
-                style={{
-                  background: validationResult.valid ? colors.successBg : colors.errorBg,
-                  border: `1px solid ${validationResult.valid ? colors.success : colors.error}`,
-                }}
               >
                 {validationResult.valid ? (
-                  <p style={{ ...caption, color: colors.text }}>
+                  <p className="caption text-default">
                     <span aria-hidden="true">✅ </span>スキーマ検証成功
                   </p>
                 ) : (
-                  <ul
-                    style={{
-                      ...caption,
-                      color: colors.errorText,
-                      margin: 0,
-                      paddingLeft: '1.25rem',
-                    }}
-                  >
+                  <ul className="caption text-error-text m-0 pl-5">
                     {validationResult.errors.map((e, i) => (
                       <li key={i}>
                         <strong>{e.path}</strong>: {e.message}

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -6,7 +6,6 @@ import { InputField } from '@/components/ui/InputField';
 import { DownloadButtonGroup } from '@/components/ui/DownloadButtonGroup';
 import { calcJan, validateJanInput, type JanMode } from '@/utils/jan-code';
 import { ClearButton } from '@/components/ui/ClearButton';
-import { bodyEmphasis, caption, colors } from '@/utils/styles';
 import { downloadSvg as downloadSvgFile, downloadPngFromSvgElement } from '@/utils/download';
 
 export function JanCodeTool() {
@@ -99,20 +98,16 @@ export function JanCodeTool() {
           {/* チェックディジット・完成コード */}
           <div
             data-testid="jan-code-result"
-            className="rounded-lg p-4 space-y-3"
-            style={{ border: `1px solid ${colors.border}`, background: colors.bgSurface }}
+            className="rounded-lg p-4 space-y-3 border border-default bg-surface"
           >
             <div className="flex items-center justify-between">
-              <span style={{ ...caption, color: colors.muted }}>チェックディジット</span>
-              <span style={{ ...bodyEmphasis, color: colors.primary }}>{result.checkDigit}</span>
+              <span className="caption text-muted">チェックディジット</span>
+              <span className="body-emphasis text-primary">{result.checkDigit}</span>
             </div>
             <div className="flex items-center justify-between">
-              <span style={{ ...caption, color: colors.muted }}>完成コード</span>
+              <span className="caption text-muted">完成コード</span>
               <div className="flex items-center gap-2">
-                <span
-                  className="font-mono"
-                  style={{ ...bodyEmphasis, color: colors.text, letterSpacing: '0.1em' }}
-                >
+                <span className="font-mono body-emphasis text-default tracking-[0.1em]">
                   {result.fullCode}
                 </span>
                 <CopyButton text={result.fullCode} label="コピー" />
@@ -121,25 +116,11 @@ export function JanCodeTool() {
           </div>
 
           {/* 計算過程 */}
-          <details className="rounded-lg" style={{ border: `1px solid ${colors.border}` }}>
-            <summary
-              className="cursor-pointer px-4 py-3 font-bold rounded-lg transition-colors"
-              style={{
-                ...caption,
-                fontWeight: 700,
-                color: colors.muted,
-                listStyle: 'none',
-                background: 'transparent',
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = colors.bgSubtle)}
-              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
-            >
+          <details className="rounded-lg border border-default">
+            <summary className="cursor-pointer px-4 py-3 rounded-lg caption font-bold text-muted bg-transparent summary-no-marker hover-bg-subtle">
               計算過程を見る
             </summary>
-            <div
-              className="px-4 pb-4 pt-2 space-y-1 font-mono"
-              style={{ ...caption, color: colors.text }}
-            >
+            <div className="px-4 pb-4 pt-2 space-y-1 font-mono caption text-default">
               {mode === 'jan13' ? (
                 <>
                   <p>
@@ -179,10 +160,7 @@ export function JanCodeTool() {
           </details>
 
           {/* バーコードプレビュー */}
-          <div
-            className="rounded-lg flex flex-col items-center gap-4 p-4"
-            style={{ border: `1px solid ${colors.border}`, background: colors.bg }}
-          >
+          <div className="rounded-lg flex flex-col items-center gap-4 p-4 border border-default bg-default">
             <svg ref={svgRef} aria-label={`JANコード ${result.fullCode} のバーコード`} />
             <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />
           </div>

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -6,68 +6,12 @@ import { Section } from '@/components/ui/Section';
 import { useQrCamera } from '@/hooks/useQrCamera';
 import { useAbortableEffect } from '@/hooks/useAbortableEffect';
 import { detectQrContent, decodeQrFromFile, DEFAULT_QR_MAX_DIM } from '@/utils/qr-reader';
-import { caption, colors } from '@/utils/styles';
 import { validateFile } from '@/utils/file-validation';
 
 const SCAN_OPTIONS = [
   { value: 'camera' as const, label: 'カメラ' },
   { value: 'upload' as const, label: '画像アップロード' },
 ];
-
-const rescanButtonStyle: React.CSSProperties = {
-  fontSize: '0.875rem',
-  fontWeight: 700,
-  lineHeight: 1,
-  letterSpacing: '0.02em',
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: '0.375rem',
-  padding: '0.5rem 0.75rem',
-  borderRadius: '0.25rem',
-  border: `1px solid ${colors.border}`,
-  background: colors.bgSubtle,
-  color: colors.text,
-  cursor: 'pointer',
-  whiteSpace: 'nowrap',
-};
-
-const startCameraButtonStyle = {
-  ...caption,
-  fontWeight: 600,
-  display: 'inline-flex' as const,
-  alignItems: 'center' as const,
-  padding: '0.5rem 1.25rem',
-  borderRadius: '0.5rem',
-  border: 'none',
-  background: colors.primary,
-  color: colors.textOnPrimary,
-  cursor: 'pointer' as const,
-};
-
-const stopCameraButtonStyle = {
-  ...caption,
-  fontWeight: 600,
-  display: 'inline-flex' as const,
-  alignItems: 'center' as const,
-  padding: '0.5rem 1.25rem',
-  borderRadius: '0.5rem',
-  border: `1px solid ${colors.error}`,
-  background: colors.errorBg,
-  color: colors.error,
-  cursor: 'pointer' as const,
-};
-
-const uploadLabelStyle = (enabled: boolean): React.CSSProperties => ({
-  ...caption,
-  fontWeight: 600,
-  display: 'inline-block',
-  padding: '0.5rem 1rem',
-  borderRadius: '0.5rem',
-  border: `1px solid ${colors.borderInput}`,
-  background: enabled ? colors.bgSubtle : colors.bgSurface,
-  color: enabled ? colors.text : colors.muted,
-  cursor: enabled ? 'pointer' : 'not-allowed',
-});
 
 export function QrReaderTool() {
   const [scanMode, setScanMode] = useState<'camera' | 'upload'>('camera');
@@ -174,7 +118,11 @@ export function QrReaderTool() {
             <div className="space-y-3">
               {/* カメラ未起動・結果なし時に「起動」ボタンを表示。エラー後もボタンを残すことでリトライを可能にしている */}
               {!camera.cameraActive && !decoded && (
-                <button type="button" onClick={camera.startCamera} style={startCameraButtonStyle}>
+                <button
+                  type="button"
+                  onClick={camera.startCamera}
+                  className="caption font-semibold inline-flex items-center px-5 py-2 rounded-lg bg-primary text-on-primary border-0 cursor-pointer"
+                >
                   カメラを起動
                 </button>
               )}
@@ -183,25 +131,23 @@ export function QrReaderTool() {
                 ref={camera.videoRef}
                 playsInline
                 muted
-                style={{
-                  width: '100%',
-                  maxWidth: '400px',
-                  borderRadius: '0.5rem',
-                  display: camera.cameraActive ? 'block' : 'none',
-                  background: '#000',
-                }}
+                className={`w-full max-w-[400px] rounded-lg qr-video-preview ${camera.cameraActive ? '' : 'hidden'}`}
                 aria-label="カメラプレビュー"
               />
               {camera.cameraActive && (
-                <button type="button" onClick={stopCamera} style={stopCameraButtonStyle}>
+                <button
+                  type="button"
+                  onClick={stopCamera}
+                  className="caption font-semibold inline-flex items-center px-5 py-2 rounded-lg border border-error bg-error-tint text-error cursor-pointer"
+                >
                   カメラを停止
                 </button>
               )}
-              <canvas ref={camera.canvasRef} style={{ display: 'none' }} aria-hidden="true" />
+              <canvas ref={camera.canvasRef} className="hidden" aria-hidden="true" />
             </div>
           ) : (
             <div className="space-y-2">
-              <p style={{ ...caption, color: colors.muted }}>
+              <p className="caption text-muted">
                 QRコードが写った画像（PNG・JPG 等）をアップロードしてください
               </p>
               {/* input を visually-hidden にしてキーボード・スクリーンリーダーからも操作可能にする */}
@@ -210,18 +156,15 @@ export function QrReaderTool() {
                 type="file"
                 accept="image/*"
                 onChange={handleImageUpload}
-                style={{
-                  position: 'absolute',
-                  width: 1,
-                  height: 1,
-                  opacity: 0,
-                  pointerEvents: 'none',
-                }}
+                className="sr-only"
               />
-              <label htmlFor="qr-image-input" style={uploadLabelStyle(true)}>
+              <label
+                htmlFor="qr-image-input"
+                className="caption font-semibold inline-block px-4 py-2 rounded-lg border border-input bg-subtle text-default cursor-pointer"
+              >
                 画像を選択
               </label>
-              <p style={{ fontSize: '0.75rem', color: colors.muted, marginTop: '0.25rem' }}>
+              <p className="text-xs text-muted mt-1">
                 対応形式: PNG / JPEG / WebP / GIF / SVG・最大 15 MB
               </p>
             </div>
@@ -237,20 +180,8 @@ export function QrReaderTool() {
         <Section title="読取結果" role="status" aria-live="polite">
           <div className="space-y-4">
             {/* テキスト表示 */}
-            <div
-              className="rounded-lg p-3"
-              style={{ background: colors.bgSubtle, border: `1px solid ${colors.border}` }}
-            >
-              <pre
-                style={{
-                  ...caption,
-                  color: colors.text,
-                  margin: 0,
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-all',
-                  fontFamily: 'monospace',
-                }}
-              >
+            <div className="rounded-lg p-3 border border-default bg-subtle">
+              <pre className="caption text-default m-0 whitespace-pre-wrap break-all font-mono">
                 {content.raw}
               </pre>
             </div>
@@ -258,40 +189,27 @@ export function QrReaderTool() {
             {/* コピー & 再スキャンボタン */}
             <div className="flex flex-wrap items-center gap-2">
               <CopyButton text={content.raw} />
-              <button type="button" onClick={handleRescan} style={rescanButtonStyle}>
+              <button
+                type="button"
+                onClick={handleRescan}
+                className="caption font-bold leading-none inline-flex items-center gap-1.5 px-3 py-2 rounded border border-default bg-subtle text-default cursor-pointer whitespace-nowrap"
+              >
                 再スキャン
               </button>
             </div>
 
             {/* URLの場合のフィッシング警告 */}
             {content.kind === 'url' && (
-              <div
-                className="rounded-lg p-4 space-y-2"
-                style={{
-                  background: colors.warningBg,
-                  border: `1px solid ${colors.warning}`,
-                }}
-              >
-                <p style={{ ...caption, color: colors.text }}>
-                  <strong style={{ color: colors.text }}>{content.hostname}</strong>{' '}
+              <div className="rounded-lg p-4 space-y-2 border border-warning bg-warning-tint">
+                <p className="caption text-default">
+                  <strong className="text-default">{content.hostname}</strong>{' '}
                   への外部リンクが含まれています。URLをよく確認してから開いてください。
                 </p>
                 <a
                   href={content.raw}
                   target="_blank"
                   rel="noopener noreferrer"
-                  style={{
-                    ...caption,
-                    fontWeight: 600,
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    padding: '0.375rem 0.875rem',
-                    borderRadius: '0.375rem',
-                    border: `1px solid ${colors.warning}`,
-                    background: colors.bg,
-                    color: colors.text,
-                    textDecoration: 'none',
-                  }}
+                  className="caption font-semibold inline-flex items-center px-3.5 py-1.5 rounded-md border border-warning bg-default text-default no-underline"
                 >
                   URLを開く
                 </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -548,4 +548,13 @@
   .hover-bg-active:hover {
     background: var(--color-bg-active);
   }
+
+  /* === PR 5a: QrReader video preview background ===
+     QRリーダーの <video> 要素は getUserMedia 開始前 (display:none で隠蔽中) の
+     コントラスト確保 + 起動失敗時のフォールバック (黒画面) として黒背景を維持する。
+     一意の用途のため component-scoped class とする (色 token 化はしない、
+     PR 3 .jwt-json-value と同じ pattern)。 */
+  .qr-video-preview {
+    background: #000;
+  }
 }

--- a/src/utils/__tests__/inline-style-migration.test.ts
+++ b/src/utils/__tests__/inline-style-migration.test.ts
@@ -39,6 +39,10 @@ const MIGRATED_FILES: readonly string[] = [
   'src/components/tools/Gs1Databar.tsx',
   'src/components/tools/EncodingConverter.tsx',
   'src/components/tools/DummyText.tsx',
+  // PR 5a で追加
+  'src/components/tools/ConfigConverter.tsx',
+  'src/components/tools/QrReader.tsx',
+  'src/components/tools/JanCode.tsx',
 ];
 
 describe.skipIf(MIGRATED_FILES.length === 0)('#176 B 案 progressive migration tracker', () => {


### PR DESCRIPTION
## 概要

`#176` B 案バッチの PR 5a。`ConfigConverter.tsx` (11 件) + `QrReader.tsx` (11 件) + `JanCode.tsx` (9 件) の JSX inline style + JanCode 内 `e.currentTarget.style.X = Y` 形式の CSSOM 直接 mutation 2 件 (`<summary>` の `onMouseEnter`/`onMouseLeave` hover state) を `@layer components` の意味クラス + Tailwind utility に置換する。

PR 5 全体 (9 ツール) を 5a (大物 3 つ) と 5b (残り + ulid-generator E2E + #262 close) に分割した前半。

- spec: `docs/superpowers/specs/2026-05-07-issue-176-b5a-config-qr-jan-design.md`
- plan: `docs/superpowers/plans/2026-05-07-issue-176-b5a-config-qr-jan.md`
- バッチ進捗: `docs/projects/issue-176-b-plan-progress.md`

## 主要な変更

### `src/styles/global.css` 追加 class (1 件のみ)

- `.qr-video-preview` (QrReader `<video>` 専用、`background: #000`)

JanCode `<summary>` hover は **PR 4 で導入された `.hover-bg-subtle` を再利用** (新規不要)。
PR 1〜4 で導入済の class (`caption` / `body-emphasis` / `text-default` / `text-muted` / `text-on-primary` / `text-error` / `text-error-text` / `text-primary` / `text-link-color` / `text-warning` / `bg-default` / `bg-subtle` / `bg-surface` / `bg-error-tint` / `bg-warning-tint` / `border-default` / `border-input` / `alert-success` / `alert-error` / `btn-link-plain` / `summary-no-marker` / `hover-bg-subtle`) で 95% 以上をカバー。

### `ConfigConverter.tsx` (11 件 → 0)

- 変換元/変換先ラベルを `caption text-muted min-w-10` で表現
- 警告メッセージカードを `border border-warning bg-warning-tint` (Tailwind auto-utility 利用)
- schema toggle ボタンを既存 `.btn-link-plain` (PR 1.5) + `text-link-color` で構成、arrow rotation は `rotate-90` Tailwind 標準
- 検証結果カードは既存 `.alert-success` / `.alert-error` (PR 2) を利用
- 新規 class 追加なし
- `import { caption, colors } from '@/utils/styles'` を削除

### `QrReader.tsx` (11 件 → 0、module-level 定数 4 個解体)

- module-level スタイル定数 4 個 (`rescanButtonStyle` / `startCameraButtonStyle` / `stopCameraButtonStyle` / `uploadLabelStyle`) を全削除し className 化
- `<video>` 要素を `w-full max-w-[400px] rounded-lg qr-video-preview` で構成、display 切替は Tailwind `hidden`
- カメラ起動ボタンは Tailwind auto-utility `bg-primary` + `.text-on-primary`、停止ボタンは `border-error bg-error-tint text-error`
- file input を Tailwind 標準 `sr-only` に置換 (a11y 同等以上)
- `uploadLabelStyle(false)` 呼び出しがないことを事前確認の上、disabled 分岐削除 (YAGNI)
- URL 警告カードは `border border-warning bg-warning-tint`、URL 開くリンクは `border border-warning bg-default`
- `import { caption, colors } from '@/utils/styles'` を削除 (React named import は維持)

### `JanCode.tsx` (9 件 + 2 hover refactor → 0)

- `onMouseEnter`/`onMouseLeave` で `e.currentTarget.style.background = ...` していた 2 件 (計算過程 `<summary>`) を削除し、PR 4 既存の `.hover-bg-subtle` (CSS `:hover` 表現) で代替
- 完成コード文字間隔は `tracking-[0.1em]` arbitrary value
- 結果カード / バーコードプレビュー wrapper を `border border-default bg-surface` / `border border-default bg-default` で構成
- 計算過程 `<details>/<summary>` marker 非表示は PR 4 既存 `.summary-no-marker` を再利用
- 新規 class 追加なし
- `import { bodyEmphasis, caption, colors } from '@/utils/styles'` を削除

## Race 回避運用 (PR 4 で確立した運用継承)

PR 3 で sonnet 並列 dispatch 時に commit 結合 race が発生 → PR 4 で「subagent 非 commit」運用を初採用 → 成功。本 PR では 2 回目運用として継承:

- subagent は **ファイル編集 + self-verification (vitest, astro check) のみ** 実施
- subagent は `git add` / `git commit` を実行しない
- 親 Opus が Phase 1.5 で 1 ファイルずつ stage + commit (3 commit、各 1 ファイル変更)

結果: commit message と内容が完全一致、prettier 巻き込みも親が制御。

## CSSOM hover refactor (memory `feedback_tailwind_v4_layer_variant.md` 適用)

JanCode の `<summary>` hover を Tailwind `hover:bg-subtle` variant ではなく PR 4 で導入された専用 `.hover-bg-subtle` class で表現。これは Tailwind v4 で `@layer components` 内の手書き class に対して `hover:` variant が CSS rule を生成しない silent regression を回避するため。

## 検証ログ (親 Opus 直接実行)

- [x] `npm run test` 全 pass (migration test 24 件 × 2 + 陽性対照 3 件 = 51 件 pass 含む、合計 626 passed | 1 skipped)
- [x] `npx astro check` → 0 errors, 0 warnings, 10 hints (本 PR 無関係)
- [x] `npm run test:e2e` 全 pass (config-converter / qr-reader / jan-code 含む)
- [x] a11y 退化なし (`aria-*` / `role=` / `data-testid=` / `htmlFor=` 削除行 = reformat 行移動のみ、現コードで存在確認済)
- [x] inline style 残存ゼロ (`grep -c "style={{"` = 0 / 0 / 0)
- [x] CSSOM mutation 残存ゼロ (`grep -E "\.style\.[a-zA-Z]+\s*="` で setProperty 以外 = 0)
- [x] PR 6 スコープ未侵害 (`_headers` / `astro.config.mjs` / `src/utils/styles.ts` 未変更)

## VRT

`visual-regression.yml` で baseline 比較 (non-required check)。意図的差分があれば PR ブランチで `update-visual-baseline.yml` を `workflow_dispatch` trigger。

特に確認すべき差分点:

- QrReader `<video>` の `display: none` → `hidden` クラス、初期状態で video が描画されないこと
- QrReader file input: `position: absolute` 視覚消去 → `sr-only` (clip + margin -1) で同等の不可視性
- JanCode `<summary>` hover 時の bg 変化 (CSSOM mutation 撤去後も `.hover-bg-subtle` で bg 変化が見える)
- ConfigConverter schema toggle arrow: `rotate-90` で 90 度回転 (transition-duration 200ms)

## コミット粒度

```
<SHA> test(migration): MIGRATED_FILES に PR 5a 対象 3 件追加
<SHA> refactor(tools): #176 B 案 PR 5a — JanCode.tsx inline style 撤去 + summary hover を CSS に移行
<SHA> refactor(tools): #176 B 案 PR 5a — QrReader.tsx inline style 撤去 + module-level スタイル定数解体
<SHA> refactor(tools): #176 B 案 PR 5a — ConfigConverter.tsx inline style 撤去
<SHA> chore(spec): #176 B 案 PR 5a spec / plan / global.css foundation
```

## 関連

- 起源 issue: #176 (アプローチ B)
- 前提 PR: #249 (A-1) / #254 (VRT) / #256 (PR 1) / #261 (PR 1.5) / #272 (PR 2) / #275 (PR 3) / #277 (PR 4) / #278 (前段 infra)
- 後続: PR 5b (Base64Codec + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 + ulid-generator E2E + #262 close) / PR 6 (flip + cleanup)
