### PR TITLE
ci: #291 Playwright 公式 Docker image で 3 workflow の install 7 分待ちを撤廃

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,13 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # #291: Playwright 公式 image でブラウザバイナリ + OS deps を preinstalled 化し、
+    # `npx playwright install --with-deps chromium` の 7 分超を撤廃。
+    # tag は package.json の `@playwright/test` バージョンと一致させる
+    # (Playwright アップデート時は `mcr.microsoft.com/playwright:vX.Y.Z-noble` も bump)。
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v6
 
@@ -68,14 +75,14 @@ jobs:
 
       - run: npm ci
 
-      - name: Playwright ブラウザをインストール
-        run: npx playwright install --with-deps chromium
+      # Playwright ブラウザは container image に preinstalled 済 (#291)。
+      # PLAYWRIGHT_BROWSERS_PATH=/ms-playwright が image で設定済みのため install step 不要。
 
       - name: 本番相当アセットを build（E2E は preview 経由で配信するため必要）
         run: npm run build
 
       - name: E2E テストを実行
-        run: npm run test:e2e
+        run: HOME=/root npm run test:e2e
 
       - name: テストレポートをアップロード（失敗時）
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: npm run build
 
       - name: E2E テストを実行
-        run: HOME=/root npm run test:e2e
+        run: npm run test:e2e
 
       - name: テストレポートをアップロード（失敗時）
         uses: actions/upload-artifact@v7

--- a/.github/workflows/update-visual-baseline.yml
+++ b/.github/workflows/update-visual-baseline.yml
@@ -39,7 +39,7 @@ jobs:
       - name: 本番相当アセットを build
         run: npm run build
       - name: Visual regression baseline を再生成
-        run: HOME=/root npx playwright test --project=visual-regression --workers=1 --update-snapshots
+        run: npx playwright test --project=visual-regression --workers=1 --update-snapshots
       - name: 変更があれば commit & push
         run: |
           if [ -n "$(git status --porcelain tests/e2e/visual-regression.spec.ts-snapshots/)" ]; then

--- a/.github/workflows/update-visual-baseline.yml
+++ b/.github/workflows/update-visual-baseline.yml
@@ -17,6 +17,13 @@ jobs:
     # branch protection 違反を回避し、「baseline 更新は必ず PR ブランチで」を workflow レベルで強制。
     if: github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
+    # #291: Playwright 公式 image でブラウザバイナリ + OS deps を preinstalled 化し、
+    # `npx playwright install --with-deps chromium` の 7 分超を撤廃。
+    # tag は package.json の `@playwright/test` バージョンと一致させる
+    # (Playwright アップデート時は `mcr.microsoft.com/playwright:vX.Y.Z-noble` も bump)。
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v6
         with:
@@ -27,12 +34,12 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - name: Playwright ブラウザをインストール
-        run: npx playwright install --with-deps chromium
+      # Playwright ブラウザは container image に preinstalled 済 (#291)。
+      # PLAYWRIGHT_BROWSERS_PATH=/ms-playwright が image で設定済みのため install step 不要。
       - name: 本番相当アセットを build
         run: npm run build
       - name: Visual regression baseline を再生成
-        run: npx playwright test --project=visual-regression --workers=1 --update-snapshots
+        run: HOME=/root npx playwright test --project=visual-regression --workers=1 --update-snapshots
       - name: 変更があれば commit & push
         run: |
           if [ -n "$(git status --porcelain tests/e2e/visual-regression.spec.ts-snapshots/)" ]; then

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -16,6 +16,13 @@ permissions:
 jobs:
   visual-regression:
     runs-on: ubuntu-latest
+    # #291: Playwright 公式 image でブラウザバイナリ + OS deps を preinstalled 化し、
+    # `npx playwright install --with-deps chromium` の 7 分超を撤廃。
+    # tag は package.json の `@playwright/test` バージョンと一致させる
+    # (Playwright アップデート時は `mcr.microsoft.com/playwright:vX.Y.Z-noble` も bump)。
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v6
 
@@ -26,8 +33,8 @@ jobs:
 
       - run: npm ci
 
-      - name: Playwright ブラウザをインストール
-        run: npx playwright install --with-deps chromium
+      # Playwright ブラウザは container image に preinstalled 済 (#291)。
+      # PLAYWRIGHT_BROWSERS_PATH=/ms-playwright が image で設定済みのため install step 不要。
 
       - name: 本番相当アセットを build
         run: npm run build
@@ -40,7 +47,7 @@ jobs:
         # pipefail で playwright の exit code を tee 越しでも保持。
         run: |
           set -o pipefail
-          npm run test:vrt -- --workers=1 2>&1 | tee vrt-output.log
+          HOME=/root npm run test:vrt -- --workers=1 2>&1 | tee vrt-output.log
 
       - name: テストレポートを artifact upload（pass/fail 問わず）
         if: ${{ !cancelled() }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -47,7 +47,7 @@ jobs:
         # pipefail で playwright の exit code を tee 越しでも保持。
         run: |
           set -o pipefail
-          HOME=/root npm run test:vrt -- --workers=1 2>&1 | tee vrt-output.log
+          npm run test:vrt -- --workers=1 2>&1 | tee vrt-output.log
 
       - name: テストレポートを artifact upload（pass/fail 問わず）
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## 概要

[#291](https://github.com/fumtas1k/devtools/issues/291) (Playwright install 7 分待ち解消)。3 workflow を Playwright 公式 Docker image (`mcr.microsoft.com/playwright:v1.59.1-noble`) に切り替え、`npx playwright install --with-deps chromium` step を撲滅する infra 改善。

PR [#290](https://github.com/fumtas1k/devtools/pull/290) で発覚した「VRT job が cold cache で 15 分超かかる」問題の根本対応。`feedback_infra_feature_separation.md` メモリに従い feature work から分離した独立 PR。

## 変更内容

### 共通改修 (3 workflow)

job 定義に Playwright 公式 image の `container:` 設定を追加:

```yaml
container:
  image: mcr.microsoft.com/playwright:v1.59.1-noble
  options: --user 1001
```

`Playwright ブラウザをインストール` step を撤去 (image に preinstalled)。Playwright を呼ぶ step に `HOME=/root` prefix を追加 (Playwright [公式 GitHub Actions docs](https://playwright.dev/docs/ci#github-actions-with-playwright-docker) 準拠)。

### 対象 job

- `.github/workflows/test.yml` の **`e2e` job** (`test` job は vitest のみで Playwright 不要、対象外)
- `.github/workflows/visual-regression.yml` の `visual-regression` job
- `.github/workflows/update-visual-baseline.yml` の `update-baseline` job

### 設計判断

| 項目 | 決定 | 理由 |
|---|---|---|
| image 選定 | `mcr.microsoft.com/playwright:v1.59.1-noble` | Playwright 公式、ブラウザ + OS deps + Node 22 同梱。tag は `package.json` の `@playwright/test` (1.59.1) と一致 |
| user | `--user 1001` | runner user uid に合わせる (公式 docs 推奨) |
| `HOME=/root` prefix | Playwright 呼び出しのみ | 公式 docs の例に従い defensive 適用。`npm ci` 等は default HOME で OK |
| `actions/setup-node@v6` | 残す | image に Node 22 同梱だが `cache: npm` の利益のため残す。setup-node は Node 既存検出でほぼ no-op |
| binary cache (`actions/cache`) | 採用せず | container アプローチで browser binary は image に含まれるためキャッシュ不要 |
| image tag pinning | 完全 pin (`v1.59.1-noble`) | Playwright update 時に意図的に bump、silent drift を防ぐ |

### 期待効果 (実測は CI 結果で確認)

| job | before | after (期待) |
|---|---|---|
| `e2e` | ~3-4 分 (うち install 1-2 分) | ~2 分 (install 削減) |
| `visual-regression` (cold) | 15 分+ | ~1-2 分 |
| `visual-regression` (warm) | ~5 分 | ~1 分 |
| `update-visual-baseline` | 15 分+ | ~2 分 |

## Playwright バージョンアップ時の手順 (runbook)

`@playwright/test` を upgrade する PR では以下も同時に bump:

```bash
# 例: 1.59.1 → 1.60.0
sed -i '' 's|playwright:v1\.59\.1-noble|playwright:v1.60.0-noble|g' .github/workflows/*.yml
```

Image tag が古いままだと local Playwright と CI の API/挙動が乖離するため、必ず一致させる。

## 検証

ローカル workflow 実行は不可 (Docker image / GH Actions context 必須) のため CI 結果が真の検証:

- [x] yaml syntax check (`python3 -c "yaml.safe_load(...)"`) 全 3 file OK
- [x] `git diff origin/develop --name-only` = 3 workflow ファイルのみ (scope OK)
- [ ] CI: `test` (vitest, container 外) ✅ pass 維持
- [ ] CI: `e2e` (container 内) ✅ pass — 想定 ~2 分
- [ ] CI: `visual-regression` (container 内) ✅ pass — 想定 ~1-2 分
- [ ] CI: 実測時間が install 撤廃の効果を示している (job 時間 vs PR #290 比較)

万一 container 内で動かない場合の fallback 計画:

1. `--user 1001` を `--user root` に変更 (権限問題の場合)
2. `HOME=/root` を削除 (環境変数競合の場合)
3. それでもダメなら `npx playwright install` を残しつつ image だけ使う (binary はキャッシュヒットで skip)

## 関連

- 解消する issue: [#291](https://github.com/fumtas1k/devtools/issues/291)
- 発見元 PR: [#290](https://github.com/fumtas1k/devtools/pull/290) (VRT 15 分超 stuck で発覚)
- 公式 docs: https://playwright.dev/docs/ci#github-actions-with-playwright-docker
