### PR TITLE
refactor(ui): #289 PR 7a — Astro layout/ui inline 撤去 (8 ファイル / 23 件 / 新規 7 class)

### DIFF
--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -27,8 +27,11 @@
 | PR 4                  | Gs1Databar + EncodingConverter + DummyText                                                                                                                                     | ✅ merged  | [#277 (merged 495f60e)](https://github.com/fumtas1k/devtools/pull/277) |
 | **infra (PR 5 前段)** | `withProductionCsp` ラッパ helper 追加 (#276 close)                                                                                                                            | ✅ merged  | [#278 (merged 73de179)](https://github.com/fumtas1k/devtools/pull/278) |
 | PR 5a                 | ConfigConverter + QrReader + JanCode (大物 3 つ、CSSOM hover 含む) — 31 inline style + 2 CSSOM                                                                                 | ✅ merged  | [#283 (merged 46abcb5)](https://github.com/fumtas1k/devtools/pull/283) |
-| PR 5b                 | Base64Codec + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 (QrTicket / UrlEncoder) + `tests/e2e/ulid-generator.spec.ts` を `withProductionCsp` 化 (#262 close) | 🔄 PR open | [#286](https://github.com/fumtas1k/devtools/pull/286)                  |
-| PR 6                  | flip + cleanup（CSP strict 化）                                                                                                                                                | 未着手     | -                                                                      |
+| PR 5b                 | Base64Codec + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 (QrTicket / UrlEncoder) + `tests/e2e/ulid-generator.spec.ts` を `withProductionCsp` 化 (#262 close) | ✅ merged  | [#286 (merged d38b956)](https://github.com/fumtas1k/devtools/pull/286) |
+| PR 6                  | scope 縮小: `styles.ts` 削除 + migration tracker glob 化 (Astro inline 65 件残存判明 → #289 へ委譲)                                                                            | ✅ merged  | [#290 (merged 4505bcf)](https://github.com/fumtas1k/devtools/pull/290) |
+| **PR 7a**             | layout/\* 4 + layouts/\* 2 + ui/\*.astro 2 (Astro inline 23 件撤去 + 新規 7 class) — `#289` 由来                                                                               | 🔄 PR open | (PR 番号は PR 作成後に追記)                                            |
+| PR 7b                 | pages/\*.astro 7 ファイル (Astro inline 残 42 件) — `#289` 由来                                                                                                                | 未着手     | -                                                                      |
+| PR 8                  | 最終 flip + cleanup (`_headers` から `style-src 'unsafe-inline'` 削除 + `stripMetaStyleSrc` 撤去 + `decisions.md [067]` + Astro 検出網追加)                                    | 未着手     | -                                                                      |
 
 **重要 — PR 0 の意義**: VRT を ui migration と bundle した PR #253 が architectural 問題で close になったため、VRT を独立 PR で proper sequencing（mock 注入 → CI Linux baseline → required check 外す）で先行導入する。詳細は Claude memory `feedback_vrt_setup_sequencing.md` / `feedback_infra_feature_separation.md` 参照（PC ローカル）。
 
@@ -76,6 +79,22 @@
 - **目的**: PR 3 で導入された `applyProductionCsp` E2E gate の `browser.newContext` boilerplate (9 行) を `withProductionCsp(browser, path, fn)` 1 行に集約。PR 5b で `tests/e2e/ulid-generator.spec.ts` を CSP gate 化する際の boilerplate 増殖を回避
 - **scope**: helpers.ts に `withProductionCsp` 追加 + `uuid-v7.spec.ts` (5 件) / `config-converter.spec.ts` (1 件) の通常テスト書換。陽性対照メタテスト 2 件は `guard.violations.length` polling のため inline 維持
 - **review feedback follow-up**: [#279](https://github.com/fumtas1k/devtools/issues/279) (waitForReactHydration label-aware) / [#280](https://github.com/fumtas1k/devtools/issues/280) (options 拡張) / [#281](https://github.com/fumtas1k/devtools/issues/281) (ラッパ自体の meta-test) を起票。**#281 は PR 5b 着手前に再確認**
+
+### PR 6 (#290)
+
+- **scope 縮小の経緯**: 当初 spec は「`_headers` から `style-src 'unsafe-inline'` 削除 + `stripMetaStyleSrc` 撤去 + `decisions.md [067]`」だったが、`npm run test:e2e` 実行段階で **Astro `<element style="...">` 属性 65 件 / 15 ファイル** が未移行で残存していたことが判明 (PR 1〜5b は React `style={{}}` のみが対象)。本 PR は scope を `styles.ts` 削除 + migration tracker glob 化のみに縮小し、Astro inline migration を `#289` に委譲
+- **post-mortem**: 元 spec [`docs/superpowers/specs/2026-05-07-issue-176-b6-csp-flip-and-cleanup-design.md`](../superpowers/specs/2026-05-07-issue-176-b6-csp-flip-and-cleanup-design.md) の post-mortem section 参照
+- **次の PR**: PR 7a (本 PR、layout/ui Astro 23 件) → PR 7b (pages/ Astro 42 件) → PR 8 (最終 flip + cleanup、`8ae383a` の revert コードを再利用)
+
+### PR 7a (#TBD) — `#289` 由来
+
+- **scope**: `src/components/layout/*.astro` 4 + `src/layouts/*.astro` 2 + `src/components/ui/{CategoryBadge,ToolInfoSection}.astro` 2 = **8 ファイル / 23 inline 撤去**
+- **新規 class**: 7 件 (`.caption-wide` / `.text-icon` / `.text-tertiary` / `.bg-badge` / `.footer-bar` / `.text-footer-meta` / `.drawer-backdrop`) を `src/styles/global.css` に追加
+- **再利用**: `.caption` / `.text-default` / `.text-muted` / `.text-primary` / `.bg-default` / `.bg-surface` / `.border-default` (PR 1〜5b 既存資産で 14 件カバー)
+- **Tailwind arbitrary**: `tracking-[0.02em]` x 5 / `text-[1.625rem] leading-[1.5]` x 1 / `z-[60]` x 1 / `text-sm leading-none` x 1 — 単発 typography は class 化見送り (YAGNI、PR 5b と同 judgement)
+- **scope 外**: `src/pages/*.astro` 7 ファイル / 42 件 (PR 7b)、`style-src 'unsafe-inline'` 削除 (PR 8)、`inline-style-migration.test.ts` の Astro 検出網追加 (PR 7b 完了後 = 全 65 件移行後)
+- **subagent 非委譲**: 親 Opus 直接実装 + 親直接 E2E (PR 6 / 292 と同パターン、memory `feedback_subagent_verification_trust.md`)
+- **既存 Astro `<style>` scoped block との関係**: Footer / MobileDrawer / Sidebar に既存 `.footer-link` / `.drawer-close-btn` 等の scoped block あり (CSP auto-hash で通過する別経路)。本 PR では touch せず維持。新規 7 class は global.css `@layer components` に集約 (brainstorming Q3 で確定、PR 1〜5b パターン継承)
 
 ## PR 5 分割設計メモ (調査日: 2026-05-07)
 

--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -29,7 +29,7 @@
 | PR 5a                 | ConfigConverter + QrReader + JanCode (大物 3 つ、CSSOM hover 含む) — 31 inline style + 2 CSSOM                                                                                 | ✅ merged  | [#283 (merged 46abcb5)](https://github.com/fumtas1k/devtools/pull/283) |
 | PR 5b                 | Base64Codec + JsonCsv + JsonXml + QrCode + UlidGenerator + zero-style 登録 (QrTicket / UrlEncoder) + `tests/e2e/ulid-generator.spec.ts` を `withProductionCsp` 化 (#262 close) | ✅ merged  | [#286 (merged d38b956)](https://github.com/fumtas1k/devtools/pull/286) |
 | PR 6                  | scope 縮小: `styles.ts` 削除 + migration tracker glob 化 (Astro inline 65 件残存判明 → #289 へ委譲)                                                                            | ✅ merged  | [#290 (merged 4505bcf)](https://github.com/fumtas1k/devtools/pull/290) |
-| **PR 7a**             | layout/\* 4 + layouts/\* 2 + ui/\*.astro 2 (Astro inline 23 件撤去 + 新規 7 class) — `#289` 由来                                                                               | 🔄 PR open | (PR 番号は PR 作成後に追記)                                            |
+| **PR 7a**             | layout/\* 4 + layouts/\* 2 + ui/\*.astro 2 (Astro inline 23 件撤去 + 新規 7 class) — `#289` 由来                                                                               | 🔄 PR open | [#294](https://github.com/fumtas1k/devtools/pull/294)                  |
 | PR 7b                 | pages/\*.astro 7 ファイル (Astro inline 残 42 件) — `#289` 由来                                                                                                                | 未着手     | -                                                                      |
 | PR 8                  | 最終 flip + cleanup (`_headers` から `style-src 'unsafe-inline'` 削除 + `stripMetaStyleSrc` 撤去 + `decisions.md [067]` + Astro 検出網追加)                                    | 未着手     | -                                                                      |
 
@@ -86,7 +86,7 @@
 - **post-mortem**: 元 spec [`docs/superpowers/specs/2026-05-07-issue-176-b6-csp-flip-and-cleanup-design.md`](../superpowers/specs/2026-05-07-issue-176-b6-csp-flip-and-cleanup-design.md) の post-mortem section 参照
 - **次の PR**: PR 7a (本 PR、layout/ui Astro 23 件) → PR 7b (pages/ Astro 42 件) → PR 8 (最終 flip + cleanup、`8ae383a` の revert コードを再利用)
 
-### PR 7a (#TBD) — `#289` 由来
+### PR 7a (#294) — `#289` 由来
 
 - **scope**: `src/components/layout/*.astro` 4 + `src/layouts/*.astro` 2 + `src/components/ui/{CategoryBadge,ToolInfoSection}.astro` 2 = **8 ファイル / 23 inline 撤去**
 - **新規 class**: 7 件 (`.caption-wide` / `.text-icon` / `.text-tertiary` / `.bg-badge` / `.footer-bar` / `.text-footer-meta` / `.drawer-backdrop`) を `src/styles/global.css` に追加

--- a/docs/superpowers/plans/2026-05-08-issue-289-pr7a-astro-layout-ui.md
+++ b/docs/superpowers/plans/2026-05-08-issue-289-pr7a-astro-layout-ui.md
@@ -1,0 +1,924 @@
+# #289 PR 7a — Astro layout/ui inline migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **本 PR の例外**: subagent 委譲はしない。spec § 9「subagent 非委譲、親 Opus 直接実装 + 親直接 E2E」に基づき、親 Opus が全 task を直接実行する (規模 = 8 ファイル / 23 件で並列分担コストに見合わず、memory `feedback_subagent_verification_trust.md` で高 stakes 検証は親直接を推奨)。
+
+**Goal:** `src/components/layout/*.astro` 4 + `src/layouts/*.astro` 2 + `src/components/ui/{CategoryBadge,ToolInfoSection}.astro` 2 = **8 ファイル / 23 件**の Astro `<element style="...">` 属性を全廃し、CSS class (Tailwind utility / 既存 `@layer components` 意味クラス / 新規 7 class) に置換する。
+
+**Architecture:** PR 1〜5b で確立した「`@layer components` 集約」パターンを Astro 側に拡張。新規 class 7 個 (`.caption-wide` / `.text-icon` / `.text-tertiary` / `.bg-badge` / `.footer-bar` / `.text-footer-meta` / `.drawer-backdrop`) を `src/styles/global.css` に追加し、各 Astro ファイルの `style="..."` を `class="..."` 化する。Tailwind v4 の auto-utility と `@layer components` の意味クラスを併用、単発 typography は arbitrary value (`text-[1.625rem] leading-[1.5] tracking-[0.02em]` 等) で対応。
+
+**Tech Stack:** Astro 5.x / Tailwind CSS v4 / Vitest (unit) / Playwright (E2E) / Astro check (type)
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-289-pr7a-astro-inline-layout-ui-design.md`
+
+**Branch:** `feature/issue-289-pr7a-astro-layout-ui` (worktree: `.claude/worktrees/issue-289-pr7a/`、base: `origin/develop`)
+
+---
+
+## File Structure
+
+### 編集ファイル (9 ファイル)
+
+| ファイル                                     | 編集内容                                                       | inline 件数 |
+| -------------------------------------------- | -------------------------------------------------------------- | ----------- |
+| `src/styles/global.css`                      | 新規 7 class を `@layer components` 末尾に追加                 | -           |
+| `src/components/layout/Header.astro`         | L7 / L13 / L22 の `style="..."` を class 化                    | 3           |
+| `src/components/layout/Footer.astro`         | L5 / L8 / L15 / L20 の `style="..."` を class 化               | 4           |
+| `src/components/layout/MobileDrawer.astro`   | L16 / L21 / L31 / L39 / L67 / L82 の `style="..."` を class 化 | 6           |
+| `src/components/layout/Sidebar.astro`        | L19 / L37 の `style="..."` を class 化                         | 2           |
+| `src/layouts/BaseLayout.astro`               | L45 の `style="..."` を class 化                               | 1           |
+| `src/layouts/ToolLayout.astro`               | L51 / L57 / L66 / L71 / L77 の `style="..."` を class 化       | 5           |
+| `src/components/ui/CategoryBadge.astro`      | L11 の `style="..."` を class 化                               | 1           |
+| `src/components/ui/ToolInfoSection.astro`    | L7 の `style="..."` を class 化                                | 1           |
+| `docs/projects/issue-176-b-plan-progress.md` | 進捗状況テーブルに PR 7a 行を追加 (Phase 3 で実施)             | -           |
+
+### 新規ファイル
+
+なし。
+
+---
+
+## Phase 0 — 準備 (親 Opus 直接実行)
+
+### Task 0.1: 進行確認 (worktree / branch / spec / plan)
+
+**Files:**
+
+- Read: `.claude/worktrees/issue-289-pr7a/docs/superpowers/specs/2026-05-08-issue-289-pr7a-astro-inline-layout-ui-design.md`
+- Read: `.claude/worktrees/issue-289-pr7a/docs/superpowers/plans/2026-05-08-issue-289-pr7a-astro-layout-ui.md` (本ファイル)
+
+- [ ] **Step 1: worktree path / branch / base 一致確認**
+
+```bash
+pwd
+git branch --show-current
+git rev-parse origin/develop
+git merge-base HEAD origin/develop
+```
+
+Expected:
+
+- pwd = `/Users/fumta/projects/devtools/.claude/worktrees/issue-289-pr7a`
+- branch = `feature/issue-289-pr7a-astro-layout-ui`
+- `git rev-parse origin/develop` == `git merge-base HEAD origin/develop` (= `b3203e0` 系)
+
+- [ ] **Step 2: node_modules 整備済確認**
+
+```bash
+ls -la node_modules/.bin/prettier node_modules/.bin/astro 2>&1 | head -3
+```
+
+Expected: 両方 symlink で存在 (`npm ci` 完了状態)。
+
+- [ ] **Step 3: 既存 spec commit 確認**
+
+```bash
+git log --oneline -5
+```
+
+Expected: 最新 commit `873ca1a` が `docs(spec): #289 PR 7a — Astro layout/ui inline migration spec 起草`。
+
+### Task 0.2: 事前 grep (PR 7a スコープ inline 件数の baseline 取得)
+
+- [ ] **Step 1: PR 7a スコープ全 8 ファイルで grep**
+
+```bash
+grep -rn 'style=' src/components/layout/ src/layouts/ src/components/ui/CategoryBadge.astro src/components/ui/ToolInfoSection.astro --include='*.astro' | tee /tmp/claude/pr7a-baseline-grep.log
+```
+
+Expected: 23 件 (Header 3 + Footer 4 + MobileDrawer 6 + Sidebar 2 + BaseLayout 1 + ToolLayout 5 + CategoryBadge 1 + ToolInfoSection 1 = 23)。
+
+- [ ] **Step 2: PR 7a スコープ outside (pages/) で grep — touch 防止のため baseline のみ**
+
+```bash
+grep -rn 'style=' src/pages/ --include='*.astro' | wc -l
+```
+
+Expected: 37+ 件 (PR 7b スコープ、本 PR では touch しない)。
+
+---
+
+## Phase 1 — 親 Opus 順次実装 (5 commit)
+
+### Task 1.1: `src/styles/global.css` に新規 7 class 追加
+
+**Files:**
+
+- Modify: `src/styles/global.css` (PR 5a 末尾の `.qr-video-preview` の直後に追加)
+
+- [ ] **Step 1: 現在の global.css 末尾を確認**
+
+```bash
+tail -20 src/styles/global.css
+```
+
+Expected: PR 5a の `.qr-video-preview { background: #000; }` で `@layer components` block 内が終わっている (line 559-560 の `}` が `@layer` の閉じ)。
+
+- [ ] **Step 2: `.qr-video-preview` 定義の直後に新規 7 class を挿入**
+
+挿入位置: `.qr-video-preview { background: #000; }` の直後、`@layer components` の閉じ `}` の直前。
+
+挿入する内容 (spec § global.css への追加 と完全一致):
+
+```css
+/* === PR 7a (#289): Astro layout/ui inline migration helpers === */
+
+/* Caption variant: nav カテゴリラベル等 (letter-spacing wider than .caption) */
+.caption-wide {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  letter-spacing: 0.08em;
+}
+
+/* Icon button color (44x44 SVG ボタンの neutral-700) */
+.text-icon {
+  color: var(--color-neutral-700);
+}
+
+/* CategoryBadge: tertiary color text/bg (PR 2 .text-primary 系列に追従) */
+.text-tertiary {
+  color: var(--color-tertiary);
+}
+.bg-badge {
+  background: var(--color-badge-bg);
+}
+
+/* Footer container & meta text (Footer 専用、neutral 系 primitive 色を意味クラス化) */
+.footer-bar {
+  background: var(--color-neutral-900);
+  color: var(--color-neutral-300);
+}
+.text-footer-meta {
+  color: var(--color-neutral-500);
+}
+
+/* MobileDrawer backdrop (modal 背景の半透明 overlay)
+     注意: rgba(17,24,39,0.5) は --color-neutral-900 の 50% alpha と同等。
+     CSS variable 化は B 案完了後の semantic alias 整理 PR で検討 (今 YAGNI)。 */
+.drawer-backdrop {
+  background: rgba(17, 24, 39, 0.5);
+}
+```
+
+- [ ] **Step 3: prettier 整形**
+
+```bash
+node_modules/.bin/prettier --write src/styles/global.css
+```
+
+Expected: `src/styles/global.css ...ms` の output、エラーなし。
+
+- [ ] **Step 4: 構文 sanity check (astro check)**
+
+```bash
+node_modules/.bin/astro check 2>&1 | tail -5
+```
+
+Expected: `Result (X files): - 0 errors` (X = 既存ファイル数)。
+
+- [ ] **Step 5: 新規 class が unit test の正規表現にヒットしないことの確認**
+
+`inline-style-migration.test.ts` は `*.tsx` のみ対象なので global.css 編集は影響しないが、念のため migration tracker pass を確認:
+
+```bash
+npm run test -- inline-style-migration.test.ts 2>&1 | tail -10
+```
+
+Expected: 全 test pass。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/styles/global.css
+git commit -m "$(cat <<'EOF'
+feat(styles): #289 PR 7a — global.css に新規 7 class 追加
+
+Astro layout/ui inline migration の foundation。
+
+- .caption-wide: nav カテゴリラベル (letter-spacing 0.08em variant of .caption)
+- .text-icon: 44x44 アイコンボタン (var(--color-neutral-700))
+- .text-tertiary / .bg-badge: CategoryBadge 専用色 token (PR 2 .text-primary 系列に追従)
+- .footer-bar / .text-footer-meta: Footer 専用 (neutral 系 primitive を意味クラス化)
+- .drawer-backdrop: MobileDrawer modal 背景 (rgba(17,24,39,0.5))
+
+Refs: #289, #176 B 案 PR 7a (spec §global.css への追加)
+EOF
+)"
+```
+
+Expected: pre-commit hook (prettier + astro check) 通過、commit 成立。
+
+### Task 1.2: Header.astro + Footer.astro inline 撤去
+
+**Files:**
+
+- Modify: `src/components/layout/Header.astro:7,13,22`
+- Modify: `src/components/layout/Footer.astro:5,8,15,20`
+
+- [ ] **Step 1: Header.astro の現状を確認**
+
+```bash
+sed -n '1,30p' src/components/layout/Header.astro
+```
+
+Expected: 3 件の inline (L7 / L13 / L22) を確認。
+
+- [ ] **Step 2: Header.astro L7 (header element) を編集**
+
+L7 の `style="height: 64px; background: var(--color-bg); border-color: var(--color-border);"` を削除し、L6 の `class="sticky top-0 z-50 border-b"` に utility / 既存 class を追加して `class="sticky top-0 z-50 border-b h-16 bg-default border-default"` にする。
+
+- [ ] **Step 3: Header.astro L13 (logo a) を編集**
+
+L13 の `style="color: var(--color-primary); letter-spacing: 0.02em;"` を削除し、L12 の `class="text-xl font-bold transition-opacity hover:opacity-80"` に追加して `class="text-xl font-bold transition-opacity hover:opacity-80 text-primary tracking-[0.02em]"` にする。
+
+- [ ] **Step 4: Header.astro L22 (mobile menu button) を編集**
+
+L22 の `style="width: 44px; height: 44px; color: var(--color-neutral-700);"` を削除し、L21 の `class="lg:hidden flex items-center justify-center rounded-md transition-colors"` に追加して `class="lg:hidden flex items-center justify-center rounded-md transition-colors w-11 h-11 text-icon"` にする。
+
+- [ ] **Step 5: Header.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style=' src/components/layout/Header.astro
+```
+
+Expected: 0 件 (出力なし)。
+
+- [ ] **Step 6: Footer.astro の現状を確認**
+
+```bash
+sed -n '1,30p' src/components/layout/Footer.astro
+```
+
+Expected: 4 件の inline (L5 / L8 / L15 / L20)。`.footer-link` の scoped `<style>` block 存在を確認 (本 PR では touch しない、`<element style="...">` 属性のみ撤去)。
+
+- [ ] **Step 7: Footer.astro L5 (footer container) を編集**
+
+L5 の `<footer style="background: var(--color-neutral-900); color: var(--color-neutral-300);">` を `<footer class="footer-bar">` に変更。
+
+- [ ] **Step 8: Footer.astro L8 (paragraph) を編集**
+
+L8 の `<p class="text-sm" style="letter-spacing: 0.02em; color: var(--color-neutral-500);">` を `<p class="text-sm text-footer-meta tracking-[0.02em]">` に変更。
+
+- [ ] **Step 9: Footer.astro L15 / L20 (link) を編集**
+
+L15 の `class="footer-link underline transition-colors"` の閉じ `>` 直前にある `style="letter-spacing: 0.02em;"` を削除し、`class="footer-link underline transition-colors tracking-[0.02em]"` に変更。L20 も同様。
+
+- [ ] **Step 10: Footer.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style=' src/components/layout/Footer.astro
+```
+
+Expected: 既存 `<style>` scoped block (Astro 構文の `<style>...</style>` block) のみ検出される (これは本 PR で touch しない `.footer-link` 定義)。`style="..."` 属性は 0 件。
+
+注意: `grep 'style='` は `<style>` block の開始タグも match するが、内容ではなく行頭タグのみ。`grep 'style="'` (ダブルクォート付) でより厳密に attribute のみ確認する場合:
+
+```bash
+grep -n 'style="' src/components/layout/Footer.astro
+```
+
+Expected: 0 件。
+
+- [ ] **Step 11: prettier + astro check**
+
+```bash
+node_modules/.bin/prettier --write src/components/layout/Header.astro src/components/layout/Footer.astro
+node_modules/.bin/astro check 2>&1 | tail -5
+```
+
+Expected: 0 errors。
+
+- [ ] **Step 12: visual sanity check (build 試行)**
+
+```bash
+npm run build 2>&1 | tail -10
+```
+
+Expected: build success、`dist/` 生成。Tailwind が新規 utility (`tracking-[0.02em]` / `h-16` / `w-11` 等) を生成していることが暗黙確認できる。
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/components/layout/Header.astro src/components/layout/Footer.astro
+git commit -m "$(cat <<'EOF'
+refactor(layout): #289 PR 7a — Header / Footer Astro inline 撤去
+
+- Header.astro: 3 件 (header bar / logo a / mobile menu button)
+- Footer.astro: 4 件 (footer container / paragraph / link x 2)
+- 既存 `<style>` scoped block (.footer-link) は touch せず
+
+Refs: #289, #176 B 案 PR 7a (spec §1, §2)
+EOF
+)"
+```
+
+Expected: pre-commit hook 通過、commit 成立。
+
+### Task 1.3: MobileDrawer.astro + Sidebar.astro inline 撤去
+
+**Files:**
+
+- Modify: `src/components/layout/MobileDrawer.astro:16,21,31,39,67,82`
+- Modify: `src/components/layout/Sidebar.astro:19,37`
+
+- [ ] **Step 1: MobileDrawer.astro の現状を確認**
+
+```bash
+sed -n '1,90p' src/components/layout/MobileDrawer.astro
+```
+
+Expected: 6 件の inline (L16 / L21 / L31 / L39 / L67 / L82) を確認。
+
+- [ ] **Step 2: MobileDrawer.astro L16 (drawer root) を編集**
+
+L16 の `style="z-index: 60;"` を削除し、L15 の `class="lg:hidden fixed inset-0"` に追加して `class="lg:hidden fixed inset-0 z-[60]"` にする。
+
+- [ ] **Step 3: MobileDrawer.astro L21 (backdrop) を編集**
+
+L21 の `<div id="mobile-drawer-backdrop" class="absolute inset-0" style="background: rgba(17,24,39,0.5);">` を `<div id="mobile-drawer-backdrop" class="absolute inset-0 drawer-backdrop">` に変更。
+
+- [ ] **Step 4: MobileDrawer.astro L31 (drawer panel) を編集**
+
+L30〜31 の `class="absolute right-0 top-0 h-full w-64 overflow-y-auto shadow-xl"` + `style="padding: 1rem; background: var(--color-bg);"` を `class="absolute right-0 top-0 h-full w-64 overflow-y-auto shadow-xl p-4 bg-default"` に統合。
+
+- [ ] **Step 5: MobileDrawer.astro L39 (close button) を編集**
+
+L38〜39 の `class="drawer-close-btn flex items-center justify-center rounded-md transition-colors"` + `style="width: 44px; height: 44px; color: var(--color-neutral-700);"` を `class="drawer-close-btn flex items-center justify-center rounded-md transition-colors w-11 h-11 text-icon"` に統合。
+
+- [ ] **Step 6: MobileDrawer.astro L67 (nav category label) を編集**
+
+L66〜67 の `class="mb-2 px-3 font-bold uppercase"` + `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"` を `class="mb-2 px-3 font-bold uppercase caption-wide text-muted"` に統合。
+
+- [ ] **Step 7: MobileDrawer.astro L82 (drawer link) を編集**
+
+L81〜82 の existing `class={...}` (template literal) はそのままで、L82 末尾の `style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"` を削除。同 element の `class={...}` template literal 内に `min-h-11 caption` を末尾追加 (例: 旧 `flex items-center gap-2 rounded px-3 transition-colors drawer-link` → 新 `flex items-center gap-2 rounded px-3 transition-colors drawer-link min-h-11 caption`)。
+
+注意: L81 は template literal を使う conditional class なので、表記:
+
+```astro
+class={
+  `flex items-center gap-2 rounded px-3 transition-colors drawer-link min-h-11 caption ${isActive ? 'font-bold drawer-link--active' : 'drawer-link--inactive'}`
+}
+```
+
+- [ ] **Step 8: MobileDrawer.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style="' src/components/layout/MobileDrawer.astro
+```
+
+Expected: 0 件。`<style>` scoped block (`.drawer-close-btn` / `.drawer-link--active` 等) は touch せず残存。
+
+- [ ] **Step 9: Sidebar.astro の現状を確認**
+
+```bash
+sed -n '1,45p' src/components/layout/Sidebar.astro
+```
+
+Expected: 2 件の inline (L19 / L37)。
+
+- [ ] **Step 10: Sidebar.astro L19 (nav category label) を編集**
+
+MobileDrawer L67 と同パターン。L18〜19 の `class="mb-2 px-3 font-bold uppercase"` + `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"` を `class="mb-2 px-3 font-bold uppercase caption-wide text-muted"` に統合。
+
+- [ ] **Step 11: Sidebar.astro L37 (nav link) を編集**
+
+MobileDrawer L82 と同パターン。L31〜37 の `class={...}` template literal の末尾に `min-h-11 caption` を追加し、L37 の `style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"` を削除。
+
+- [ ] **Step 12: Sidebar.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style="' src/components/layout/Sidebar.astro
+```
+
+Expected: 0 件。
+
+- [ ] **Step 13: prettier + astro check + build**
+
+```bash
+node_modules/.bin/prettier --write src/components/layout/MobileDrawer.astro src/components/layout/Sidebar.astro
+node_modules/.bin/astro check 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+Expected: 0 errors、build success。
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/components/layout/MobileDrawer.astro src/components/layout/Sidebar.astro
+git commit -m "$(cat <<'EOF'
+refactor(layout): #289 PR 7a — MobileDrawer / Sidebar Astro inline 撤去
+
+- MobileDrawer.astro: 6 件 (drawer root z-index / backdrop / panel / close button / nav category label / drawer link)
+- Sidebar.astro: 2 件 (nav category label / nav link)
+- 共通 nav typography (.caption-wide / .caption / min-h-11) を MobileDrawer + Sidebar で再利用
+- 既存 `<style>` scoped block (.drawer-* / .sidebar-*) は touch せず
+
+Refs: #289, #176 B 案 PR 7a (spec §3, §4)
+EOF
+)"
+```
+
+Expected: pre-commit hook 通過、commit 成立。
+
+### Task 1.4: BaseLayout.astro + ToolLayout.astro inline 撤去
+
+**Files:**
+
+- Modify: `src/layouts/BaseLayout.astro:45`
+- Modify: `src/layouts/ToolLayout.astro:51,57,66,71,77`
+
+- [ ] **Step 1: BaseLayout.astro L45 (body) を編集**
+
+L45 の `<body class="min-h-screen" style="background: var(--color-bg-surface); color: var(--color-text);">` を `<body class="min-h-screen bg-surface text-default">` に変更。
+
+- [ ] **Step 2: BaseLayout.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style="' src/layouts/BaseLayout.astro
+```
+
+Expected: 0 件。
+
+- [ ] **Step 3: ToolLayout.astro の現状を確認**
+
+```bash
+sed -n '40,90p' src/layouts/ToolLayout.astro
+```
+
+Expected: 5 件の inline (L51 / L57 / L66 / L71 / L77)。
+
+- [ ] **Step 4: ToolLayout.astro L51 (breadcrumb container) を編集**
+
+L50〜51 の `class="mb-6 flex items-center gap-1.5"` + `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"` を `class="mb-6 flex items-center gap-1.5 caption text-muted"` に統合。
+
+- [ ] **Step 5: ToolLayout.astro L57 (breadcrumb current span) を編集**
+
+L57 の `<span style="color: var(--color-text);">{tool.name}</span>` を `<span class="text-default">{tool.name}</span>` に変更。
+
+- [ ] **Step 6: ToolLayout.astro L66 (tool icon container) を編集**
+
+L65〜66 の `class="shrink-0"` + `style="color: var(--color-primary);"` を `class="shrink-0 text-primary"` に統合。
+
+- [ ] **Step 7: ToolLayout.astro L71 (tool name H1) を編集**
+
+L70〜71 の `class="font-bold"` + `style="font-size: 1.625rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"` を `class="font-bold text-[1.625rem] leading-[1.5] tracking-[0.02em] text-default"` に統合。
+
+- [ ] **Step 8: ToolLayout.astro L77 (tool description) を編集**
+
+L76〜77 の `class="mt-1"` + `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"` を `class="mt-1 caption text-muted"` に統合。
+
+- [ ] **Step 9: ToolLayout.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style="' src/layouts/ToolLayout.astro
+```
+
+Expected: 0 件。
+
+- [ ] **Step 10: prettier + astro check + build**
+
+```bash
+node_modules/.bin/prettier --write src/layouts/BaseLayout.astro src/layouts/ToolLayout.astro
+node_modules/.bin/astro check 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+Expected: 0 errors、build success。
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro src/layouts/ToolLayout.astro
+git commit -m "$(cat <<'EOF'
+refactor(layouts): #289 PR 7a — BaseLayout / ToolLayout Astro inline 撤去
+
+- BaseLayout.astro: 1 件 (body bg + text color)
+- ToolLayout.astro: 5 件 (breadcrumb container / breadcrumb span / icon / H1 / description)
+- 単発 typography (H1 1.625rem) は Tailwind arbitrary 3 連で対応 (YAGNI、新規 class 化見送り)
+
+Refs: #289, #176 B 案 PR 7a (spec §5, §6)
+EOF
+)"
+```
+
+Expected: pre-commit hook 通過、commit 成立。
+
+### Task 1.5: CategoryBadge.astro + ToolInfoSection.astro inline 撤去
+
+**Files:**
+
+- Modify: `src/components/ui/CategoryBadge.astro:11`
+- Modify: `src/components/ui/ToolInfoSection.astro:7`
+
+- [ ] **Step 1: CategoryBadge.astro の現状を確認**
+
+```bash
+sed -n '1,20p' src/components/ui/CategoryBadge.astro
+```
+
+Expected: 1 件の inline (L11)。
+
+- [ ] **Step 2: CategoryBadge.astro L11 を編集**
+
+L10〜11 の既存 class 部分 (上の行) と `style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em; color: var(--color-tertiary); background: var(--color-badge-bg);"` を統合。元 class が無ければ新規付与。
+
+例 (L10〜11 の合体):
+
+```astro
+<span
+  class="text-sm leading-none tracking-[0.02em] text-tertiary bg-badge ...(その他 既存 utility があればそのまま)"
+></span>
+```
+
+注意: `text-sm` (= 0.875rem) + `leading-none` (= 1) は Tailwind 標準 utility。CategoryBadge.astro の既存 class を読んだ上で増分追加する。
+
+- [ ] **Step 3: CategoryBadge.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style="' src/components/ui/CategoryBadge.astro
+```
+
+Expected: 0 件。
+
+- [ ] **Step 4: ToolInfoSection.astro の現状を確認**
+
+```bash
+sed -n '1,15p' src/components/ui/ToolInfoSection.astro
+```
+
+Expected: 1 件の inline (L7)。
+
+- [ ] **Step 5: ToolInfoSection.astro L7 を編集**
+
+L6〜7 の `class="mt-10 rounded-lg p-6"` + `style="background: var(--color-bg); border: 1px solid var(--color-border);"` を `class="mt-10 rounded-lg p-6 bg-default border border-default"` に統合。
+
+- [ ] **Step 6: ToolInfoSection.astro の inline 残存ゼロ確認**
+
+```bash
+grep -n 'style="' src/components/ui/ToolInfoSection.astro
+```
+
+Expected: 0 件。
+
+- [ ] **Step 7: prettier + astro check + build**
+
+```bash
+node_modules/.bin/prettier --write src/components/ui/CategoryBadge.astro src/components/ui/ToolInfoSection.astro
+node_modules/.bin/astro check 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+Expected: 0 errors、build success。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/ui/CategoryBadge.astro src/components/ui/ToolInfoSection.astro
+git commit -m "$(cat <<'EOF'
+refactor(ui): #289 PR 7a — CategoryBadge / ToolInfoSection Astro inline 撤去
+
+- CategoryBadge.astro: 1 件 (font-size + line-height + tracking + 色 token x2 = 5 declaration を text-sm/leading-none/tracking-[0.02em]/.text-tertiary/.bg-badge に分解)
+- ToolInfoSection.astro: 1 件 (bg + border = 既存 .bg-default + Tailwind border + .border-default)
+
+Refs: #289, #176 B 案 PR 7a (spec §7, §8)
+EOF
+)"
+```
+
+Expected: pre-commit hook 通過、commit 成立。
+
+---
+
+## Phase 2 — 検証 (親 Opus 直接実行)
+
+### Task 2.1: PR 7a スコープの inline 全廃確認
+
+- [ ] **Step 1: PR 7a 8 ファイルで grep**
+
+```bash
+grep -rn 'style="' src/components/layout/ src/layouts/ src/components/ui/CategoryBadge.astro src/components/ui/ToolInfoSection.astro --include='*.astro'
+```
+
+Expected: 0 件 (出力なし)。
+
+- [ ] **Step 2: pages/ は touch していないことを再確認**
+
+```bash
+grep -rn 'style="' src/pages/ --include='*.astro' | wc -l
+```
+
+Expected: 37+ 件 (Phase 0 baseline と同数。本 PR で減らない、PR 7b スコープ)。
+
+### Task 2.2: a11y 退化検知 (aria-\* 削除なし)
+
+- [ ] **Step 1: 全 commit の差分で aria-\* 削除行を検索**
+
+```bash
+git diff origin/develop --unified=0 -- '*.astro' | grep -E '^-' | grep -E 'aria-|role=' | grep -v '^---'
+```
+
+Expected: 0 件 (aria-\* 削除なし)。検出されたら **PR 作成前に必ず原因を確認**して修正 (CLAUDE.md 9.6 / shared-agent-rules.md)。
+
+### Task 2.3: unit test + astro check (local 必須ゲート)
+
+- [ ] **Step 1: unit test 全 pass**
+
+```bash
+npm run test 2>&1 | tail -10
+```
+
+Expected: 全 test pass。`inline-style-migration.test.ts` は `*.tsx` のみ対象なので本 PR の Astro 編集は影響しない。
+
+- [ ] **Step 2: astro check 0 errors**
+
+```bash
+node_modules/.bin/astro check 2>&1 | tail -5
+```
+
+Expected: `Result (X files): - 0 errors - 0 warnings`。
+
+### Task 2.4: E2E (親直接実行、subagent 委譲なし — memory feedback_subagent_verification_trust)
+
+- [ ] **Step 1: port 4321 解放**
+
+```bash
+npm run pretest:e2e
+```
+
+Expected: 既存 server が居れば kill、居なければ no-op。
+
+- [ ] **Step 2: E2E 実行**
+
+```bash
+npm run test:e2e 2>&1 | tail -30
+```
+
+Expected: 全 spec pass。`style-src 'unsafe-inline'` 維持下 (PR 7a では削除しない、PR 8 で flip) のため CSP 違反は出ない設計。
+
+- [ ] **Step 3: 失敗時の判定**
+
+env 由来 (`ECONNREFUSED 4321` / `webServer was not ready` / `hydration timeout`) の場合は再実行。テスト本来の失敗 (assertion error / element not found) は実装修正。layout 系の class 化で text 表示や DOM 構造に影響が出ていれば該当 spec で検出される。
+
+### Task 2.5: 手動視認 (browser、可能なら)
+
+> **note**: 親 Opus セッション内で MCP playwright MCP が利用可能なら手動視認を実施。利用不可なら CI VRT に委譲して step skip。
+
+- [ ] **Step 1: preview server 起動 (Step 1 の E2E pretest で port 解放済前提)**
+
+```bash
+npm run preview &
+sleep 3
+```
+
+- [ ] **Step 2: Header / Footer / Sidebar / ToolLayout 表示視認**
+
+`http://localhost:4321/` (Header / Footer / Sidebar が見える) と `http://localhost:4321/tools/jwt-decoder` (ToolLayout の breadcrumb / H1 / カテゴリバッジ) の表示が PR 前後で同等であることを目視確認。
+
+- [ ] **Step 3: mobile viewport (375px) で MobileDrawer 開閉視認**
+
+ハンバーガーボタンクリック → drawer slide in → backdrop 半透明 → close ボタン → drawer slide out。
+
+- [ ] **Step 4: preview server 停止**
+
+```bash
+npm run pretest:e2e
+```
+
+---
+
+## Phase 3 — 進捗 doc 更新 + PR 作成 (親 Opus 直接実行)
+
+### Task 3.1: 進捗 doc 更新
+
+**Files:**
+
+- Modify: `docs/projects/issue-176-b-plan-progress.md`
+
+- [ ] **Step 1: 進捗状況テーブルに PR 7a 行を追加**
+
+「進捗状況」テーブル (PR 5b の次の行) に以下を追加:
+
+```markdown
+| PR 7a | layout/\* 4 + layouts/\* 2 + ui/\*.astro 2 (Header / Footer / MobileDrawer / Sidebar / BaseLayout / ToolLayout / CategoryBadge / ToolInfoSection) — 23 inline 撤去 + 新規 7 class | 🔄 PR open | (PR 番号は PR 作成後に追記) |
+```
+
+PR 6 の状態を `✅ merged ([#290](...) merged 4505bcf)` に更新 (現状「未着手」で残っている可能性、確認の上)。
+
+- [ ] **Step 2: 「着手済 PR の prerequisite / 同梱 issue 履歴」section に PR 7a の subsection を追加**
+
+```markdown
+### PR 7a (#TBD)
+
+- **新規 class**: 7 件 (`.caption-wide` / `.text-icon` / `.text-tertiary` / `.bg-badge` / `.footer-bar` / `.text-footer-meta` / `.drawer-backdrop`) を `src/styles/global.css` に追加
+- **再利用**: `.caption` / `.text-default` / `.text-muted` / `.text-primary` / `.bg-default` / `.bg-surface` / `.border-default` (PR 1〜5b 既存資産で 14 件カバー)
+- **Tailwind arbitrary**: `tracking-[0.02em]` x 5 / `text-[1.625rem] leading-[1.5]` x 1 / `z-[60]` x 1 / `text-sm leading-none` x 1 — 単発 typography は class 化見送り (YAGNI、PR 5b と同 judgement)
+- **scope 外**: `src/pages/*.astro` 7 ファイル / 37 件 (PR 7b)、`style-src 'unsafe-inline'` 削除 (PR 8)、`inline-style-migration.test.ts` の Astro 検出網追加 (PR 7b 完了後)
+- **subagent 非委譲**: 親 Opus 直接実装 + 親直接 E2E (PR 6 / 292 と同パターン、memory `feedback_subagent_verification_trust.md`)
+```
+
+- [ ] **Step 3: prettier**
+
+```bash
+node_modules/.bin/prettier --write docs/projects/issue-176-b-plan-progress.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/projects/issue-176-b-plan-progress.md
+git commit -m "$(cat <<'EOF'
+chore(docs): #289 PR 7a — 進捗 doc に PR 7a 行と prerequisite 履歴を追加
+
+- 進捗状況テーブルに PR 7a 行追加 (8 ファイル / 23 inline / 7 新規 class)
+- 「着手済 PR の prerequisite / 同梱 issue 履歴」に PR 7a subsection 追加 (新規 class / 再利用 class / Tailwind arbitrary / scope 外を明示)
+
+Refs: #289, #176 B 案 PR 7a
+EOF
+)"
+```
+
+Expected: pre-commit hook 通過、commit 成立。
+
+### Task 3.2: PR 作成 pre-check (3 つ必須、CLAUDE.md / shared-agent-rules.md)
+
+- [ ] **Step 1: develop ベース一致**
+
+```bash
+test "$(git rev-parse origin/develop)" = "$(git merge-base HEAD origin/develop)" && echo "✅ base develop 一致" || echo "❌ rebase が必要"
+```
+
+Expected: `✅ base develop 一致`。
+
+- [ ] **Step 2: スコープ確認 (想定外ファイルなし)**
+
+```bash
+git diff origin/develop --name-only
+```
+
+Expected:
+
+```
+docs/projects/issue-176-b-plan-progress.md
+docs/superpowers/plans/2026-05-08-issue-289-pr7a-astro-layout-ui.md
+docs/superpowers/specs/2026-05-08-issue-289-pr7a-astro-inline-layout-ui-design.md
+src/components/layout/Footer.astro
+src/components/layout/Header.astro
+src/components/layout/MobileDrawer.astro
+src/components/layout/Sidebar.astro
+src/components/ui/CategoryBadge.astro
+src/components/ui/ToolInfoSection.astro
+src/layouts/BaseLayout.astro
+src/layouts/ToolLayout.astro
+src/styles/global.css
+```
+
+11 ファイル (spec / plan / progress doc / global.css / Astro 8) のみ。pages/ や `src/utils/` 等の touch がないことを確認。
+
+- [ ] **Step 3: a11y 保護 (aria-\* 削除なし)**
+
+```bash
+git diff origin/develop --unified=0 -- '*.astro' '*.tsx' | grep -E '^-' | grep -E 'aria-|role=' | grep -v '^---' | wc -l
+```
+
+Expected: `0` (削除行ゼロ)。0 でない場合は内容確認、a11y 退化なら修正必須。
+
+### Task 3.3: PR 本文起草 + push + PR 作成
+
+- [ ] **Step 1: PR 本文を `/tmp/claude/pr_body.md` に書き出し**
+
+```bash
+mkdir -p /tmp/claude
+cat > /tmp/claude/pr_body.md <<'EOF'
+## 概要
+
+`#176` B 案 follow-up `#289` のうち、**layout 系 + ui/\*.astro 2 件** の Astro `<element style="...">` 属性 23 件 / 8 ファイル を CSS class に移行。新規 7 class を `src/styles/global.css` `@layer components` に追加し、Tailwind utility / 既存意味クラスと併用して移行完了。
+
+`style-src 'unsafe-inline'` の削除は本 PR では実施せず、後続 PR 7b (pages/\*.astro 7 ファイル) と PR 8 (最終 flip) に委譲。
+
+## 変更内容
+
+### 新規 7 class (`src/styles/global.css`)
+
+| class | 用途 | 件数 |
+| --- | --- | --- |
+| `.caption-wide` | nav カテゴリラベル (letter-spacing 0.08em) | 2 |
+| `.text-icon` | 44x44 アイコンボタン (var(--color-neutral-700)) | 2 |
+| `.text-tertiary` | CategoryBadge text (var(--color-tertiary)) | 1 |
+| `.bg-badge` | CategoryBadge bg (var(--color-badge-bg)) | 1 |
+| `.footer-bar` | Footer container (neutral-900 bg + neutral-300 text) | 1 |
+| `.text-footer-meta` | Footer copyright text (var(--color-neutral-500)) | 1 |
+| `.drawer-backdrop` | MobileDrawer modal 背景 (rgba(17,24,39,0.5)) | 1 |
+
+### 既存 class 再利用 (14 件カバー)
+
+`.caption` / `.text-default` / `.text-muted` / `.text-primary` / `.bg-default` / `.bg-surface` / `.border-default` を活用。
+
+### Tailwind arbitrary value (8 件)
+
+`tracking-[0.02em]` x 5 / `text-[1.625rem] leading-[1.5]` x 1 / `z-[60]` x 1 / `text-sm leading-none` x 1 — 単発 typography は class 化見送り (YAGNI、PR 5b と同 judgement)。
+
+### touch ファイル (8 + 1 = 9 ファイル)
+
+- `src/styles/global.css` (新規 7 class 追加)
+- `src/components/layout/Header.astro` (3 件)
+- `src/components/layout/Footer.astro` (4 件)
+- `src/components/layout/MobileDrawer.astro` (6 件)
+- `src/components/layout/Sidebar.astro` (2 件)
+- `src/layouts/BaseLayout.astro` (1 件)
+- `src/layouts/ToolLayout.astro` (5 件)
+- `src/components/ui/CategoryBadge.astro` (1 件)
+- `src/components/ui/ToolInfoSection.astro` (1 件)
+
+既存 Astro `<style>` scoped block (`Footer.astro` / `MobileDrawer.astro` / `Sidebar.astro` の `.footer-link` / `.drawer-close-btn` 等) は本 PR では touch せず維持。これらは Astro `security.csp` で auto-hash 化されるため CSP gate を通過済 (= 本 issue #289 の対象外)。
+
+## scope 外 (本 PR で実施しないこと)
+
+- `src/pages/*.astro` 7 ファイル / 37 件 (PR 7b)
+- `style-src 'unsafe-inline'` 削除 + `stripMetaStyleSrc` 撤去 (PR 8)
+- `inline-style-migration.test.ts` への `*.astro` 検出網追加 (PR 7b 完了後 = 全 65 件移行後)
+- `decisions.md [067]` (PR 8)
+
+## 検証
+
+- [x] `npm run test` 全 pass
+- [x] `node_modules/.bin/astro check` 0 errors
+- [x] `npm run test:e2e` 全 spec pass (親直接、`style-src 'unsafe-inline'` 維持下のため CSP 違反は本 PR scope では発生しない)
+- [x] PR 7a 8 ファイルで `grep -n 'style="' ...` = 0 件
+- [x] aria-\* / role 属性削除なし (`git diff origin/develop -- '*.astro' | grep '^-' | grep aria-` = 0 件)
+- [ ] VRT (CI Linux runner): post-push の自動実行で確認、意図しない pixel diff があれば fix
+
+## 関連
+
+- 起票 issue: #289
+- 上位 issue: #176 (B 案 = `style-src 'unsafe-inline'` 削減)
+- 直前 PR: #290 (B 案 PR 6 — scope 縮小、`styles.ts` 削除 + tracker glob 化)
+- 後続 PR: PR 7b (pages/\*.astro 7 ファイル) + PR 8 (最終 flip — `_headers` flip + `decisions.md [067]` + Astro 検出網追加)
+- spec: `docs/superpowers/specs/2026-05-08-issue-289-pr7a-astro-inline-layout-ui-design.md`
+- plan: `docs/superpowers/plans/2026-05-08-issue-289-pr7a-astro-layout-ui.md`
+- 進捗 SoT: `docs/projects/issue-176-b-plan-progress.md`
+
+## レビュー時の注目点
+
+- 新規 7 class の命名 (`.caption-wide` / `.text-icon` 等) が PR 1〜5b の既存命名 family と一貫しているか
+- Astro `<style>` scoped block (Footer / MobileDrawer / Sidebar) を意図せず touch していないか (= scoped CSS は CSP auto-hash で通る別経路、本 PR scope 外)
+- visual regression: layout 系のため全ページ波及。VRT で意図しない pixel diff が出ていないか
+EOF
+```
+
+- [ ] **Step 2: push**
+
+```bash
+git push -u origin feature/issue-289-pr7a-astro-layout-ui
+```
+
+Expected: push 成立、CI workflow trigger。
+
+- [ ] **Step 3: PR 作成 (gh pr create、--base develop 必須、--body-file 必須)**
+
+```bash
+gh pr create \
+  --base develop \
+  --title "refactor(ui): #289 PR 7a — Astro layout/ui inline 撤去 (8 ファイル / 23 件 / 新規 7 class)" \
+  --body-file /tmp/claude/pr_body.md
+```
+
+Expected: PR URL を取得、PR 作成成立。
+
+- [ ] **Step 4: PR URL を進捗 doc / plan に追記 (任意 follow-up)**
+
+> 本 PR merged 後の chore PR or PR 7b 着手時に「(PR 番号は PR 作成後に追記)」 placeholder を実 PR 番号に置換。本 PR 内で実施しない (push 済 commit を amend するのは memory `feedback_branch_workflow.md` で議論余地あり、避ける)。
+
+---
+
+## Self-Review Checklist (Plan 起草後の inline check)
+
+### Spec coverage
+
+- [x] Spec § ゴール (8 ファイル / 23 件 / 7 新規 class) → Phase 1 で全 file カバー
+- [x] Spec § non-goal (pages / style-src / Astro 検出網) → Phase 0 Step 2 baseline + plan 全体で touch しない
+- [x] Spec § global.css への追加 → Task 1.1 で 7 class 追加
+- [x] Spec § 採用する設計 (ファイル別) §1〜§8 → Task 1.2〜1.5 で全 file カバー
+- [x] Spec § 検証戦略 (unit / type / E2E / VRT / 手動) → Task 2.1〜2.5 で全項目カバー
+- [x] Spec § ブランチ命名 / コミット粒度 → Phase 1 で 5 commit + Phase 3 で 1 commit = 計 6 commit、spec § コミット粒度と一致
+- [x] Spec § リスクと緩和 → Task 2.2 (a11y 退化検知) / Task 2.4 (E2E) で kept
+
+### placeholder scan
+
+- [x] "TBD" 残存箇所: 進捗 doc 更新 (Task 3.1) と PR 7a subsection (Task 3.1 Step 2) の `(PR 番号は PR 作成後に追記)` 1 箇所のみ。これは PR 作成後にしか確定しないため意図的 placeholder。
+- [x] "TODO" / "implement later" / "fill in details" なし
+- [x] "Add appropriate error handling" / "handle edge cases" なし
+- [x] "Write tests for the above" 等 abstract test 指示なし
+- [x] 全 step に exact code / exact command を記載
+
+### type / class consistency
+
+- [x] 新規 class 名 (`.caption-wide` / `.text-icon` / `.text-tertiary` / `.bg-badge` / `.footer-bar` / `.text-footer-meta` / `.drawer-backdrop`) は spec § global.css への追加 と完全一致
+- [x] Tailwind utility 名 (`h-16` / `w-11` / `h-11` / `min-h-11` / `p-4` / `tracking-[0.02em]` / `z-[60]` / `text-sm` / `leading-none` / `text-[1.625rem]` / `leading-[1.5]`) は plan 内一貫
+- [x] 既存 class (`.caption` / `.text-default` / `.text-muted` / `.text-primary` / `.bg-default` / `.bg-surface` / `.border-default`) は global.css 既存定義と一致
+
+### scope check
+
+本 plan は 1 PR (PR 7a) 範囲。pages/ と CSP flip は別 plan (PR 7b / PR 8) で起草される、本 plan scope 外。

--- a/docs/superpowers/specs/2026-05-08-issue-289-pr7a-astro-inline-layout-ui-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-289-pr7a-astro-inline-layout-ui-design.md
@@ -1,0 +1,335 @@
+# `#176` B 案 follow-up #289 PR 7a — Astro inline `style="..."` 属性 (layout/\* + ui/\*.astro 2) 移行
+
+> **位置付け**: B 案 (style-src 削減) follow-up issue [#289](https://github.com/fumtas1k/devtools/issues/289) の 3 PR 分割のうち **PR 7a** (波及大の layout 系)。
+>
+> - PR 7a (本 spec): `src/components/layout/*.astro` 4 件 + `src/layouts/*.astro` 2 件 + `src/components/ui/{CategoryBadge,ToolInfoSection}.astro` 2 件 = **8 ファイル / 23 件**
+> - PR 7b: `src/pages/*.astro` 7 ファイル (別セッション)
+> - PR 8 最終 flip: `_headers` から `style-src 'unsafe-inline'` 削除 + `stripMetaStyleSrc` 撤去 + `decisions.md [067]` 追加 (PR 6 で revert した `8ae383a` のコードを再利用)
+>
+> **前提となる context**:
+>
+> - 本 spec は B 案 PR 6 ([#290](https://github.com/fumtas1k/devtools/pull/290), `4505bcf`) merged 後の世界。`styles.ts` 削除 + migration tracker glob 化は済。
+> - PR 1〜5b で **React `style={{}}` を CSS class 化**は完了。本 PR は Astro `<element style="...">` 属性側を扱う。
+> - 元 spec [`docs/superpowers/specs/2026-05-07-issue-176-b6-csp-flip-and-cleanup-design.md`](./2026-05-07-issue-176-b6-csp-flip-and-cleanup-design.md) の post-mortem 部分参照: PR 6 で Astro 65 件残存が判明し scope 縮小、本 issue へ委譲。
+
+---
+
+## ゴール
+
+`src/components/layout/*.astro` (4 件) + `src/layouts/*.astro` (2 件) + `src/components/ui/{CategoryBadge,ToolInfoSection}.astro` (2 件) の **8 ファイル / 23 件の Astro `<element style="...">` 属性** を全廃し、CSS class (Tailwind utility / 既存 `@layer components` 意味クラス / 新規 7 class) に置換する。
+
+**non-goal** (本 PR で実施しないこと):
+
+- `src/pages/*.astro` の inline 属性移行 (PR 7b で対応)
+- `style-src 'unsafe-inline'` の削除 (PR 8 最終 flip で実施)
+- `astro.config.mjs` の `stripMetaStyleSrc()` 撤去 (PR 8)
+- `inline-style-migration.test.ts` への `*.astro` 検出網追加 (PR 7b 完了後 = 全 65 件移行後に追加。PR 7a 単独で追加すると pages 側 37 件残存で false positive fail する)
+- `decisions.md [067]` 追加 (PR 8)
+- visual regression baseline の意図的更新 (差分が出たら本 PR レビュー時に都度判断)
+
+---
+
+## なぜ独立 PR (PR 7a / 7b 分割) か
+
+issue [#289](https://github.com/fumtas1k/devtools/issues/289) で user 判断済。本セクションは判断根拠を残しておく。
+
+### 1. PR size discipline (memory `feedback_pr_size.md`)
+
+65 件 / 15 ファイル を 1 PR に bundle すると review 単位として過大。10 commit / 500 行の自然分割閾値を超える。layout 系 (波及大) と pages 系 (個別ページ) は影響範囲・review 観点が異質で、分けることで reviewer の認知負荷が下がる。
+
+### 2. visual regression risk の隔離
+
+layout 系 (Header / Footer / Sidebar / MobileDrawer / BaseLayout / ToolLayout) は **全ページに波及**するため、VRT pixel diff があれば全 spec に影響が広がる。pages 系 (個別ページ) は対象ページのみ影響。先に layout 側を migrate して baseline を安定化させ、後続 pages 側 PR で対象ページ単位の diff を限定するほうが原因切り分けしやすい。
+
+### 3. 失敗時の rollback 単位
+
+万一 layout 系で意図せぬ regression が出た場合、PR 7a 単位で revert すれば pages 系の作業は影響を受けない。
+
+### 4. ui/\*.astro 2 件 を PR 7a に同梱する根拠
+
+`CategoryBadge.astro` と `ToolInfoSection.astro` は各 1 件のみ。PR 7b 単独でも対応可能だが、layout 系で集約した新規 class (`.text-tertiary` / `.bg-badge`) と semantic 系列 (`.text-primary` / `.bg-default` / `.border-default`) の整合をとるため、layout 側に同梱した方が新規 class の合意形成が 1 PR で完結する。pages 系 PR 7b では新規 class 追加なし (PR 7a までで 100% カバー) で進める前提。
+
+---
+
+## 採用する設計 (ファイル別)
+
+### 表記ルール
+
+各表の「置換後」列での `class="... XXX"` 表記は、**元の `class` 属性を維持し、新規 class (XXX) を末尾に追加**することを意味する。`class` 属性を新規付与する場合 (元属性が無いケース) はその旨明記する。
+
+### 既存 Astro `<style>` scoped block との関係
+
+`Footer.astro` / `MobileDrawer.astro` / `Sidebar.astro` は既に Astro `<style>` scoped block を持ち、`.footer-link` / `.drawer-close-btn` / `.drawer-link` / `.sidebar-link` 等 component-scoped class を局所定義している。これら scoped block は Astro `security.csp` で auto-hash 化されるため CSP gate を通過する (= 本 issue #289 の対象外)。
+
+本 PR の新規 7 class を「scoped block に追加するか global.css `@layer components` に追加するか」は brainstorming Q3 で議論し、**user 判断 = global.css 集約** (Q3 で「`Footer 関連を Astro <style> scoped block に変更`」選択肢を見送り)。理由:
+
+- PR 1〜5b で確立した「`@layer components` 集約」パターンとの一貫性
+- `.caption-wide` / `.text-icon` 等は cross-file 利用 (MobileDrawer + Sidebar / Header + MobileDrawer) のため scoped block 化が成立しない (component 跨ぎの依存になる)
+- `.text-tertiary` / `.bg-badge` は PR 2 で確立した「色 token text/bg utility」series の延長
+- Footer/MobileDrawer 専用 class (`.footer-bar` / `.text-footer-meta` / `.drawer-backdrop`) は scoped block 化の正当性が単体で見ればあるが、上 3 つを global に置く以上、命名 prefix で十分隔離できる (= scoped block と global の二重 home を作る不整合を避ける)
+
+**将来の整理 PR (B 案完了後) で scoped block 化を再検討する余地は残す**が、本 PR scope 外。
+
+### 1. `src/components/layout/Header.astro` (3 件)
+
+| 行  | inline                                                                                  | 置換後                                                                   |
+| --- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| L7  | `style="height: 64px; background: var(--color-bg); border-color: var(--color-border);"` | `class="... h-16 bg-default border-default"` (既存 utility + 既存 class) |
+| L13 | `style="color: var(--color-primary); letter-spacing: 0.02em;"`                          | `class="... text-primary tracking-[0.02em]"` (既存 + arbitrary)          |
+| L22 | `style="width: 44px; height: 44px; color: var(--color-neutral-700);"`                   | `class="... w-11 h-11 text-icon"` (Tailwind utility + 新規 `.text-icon`) |
+
+### 2. `src/components/layout/Footer.astro` (4 件)
+
+| 行  | inline                                                                           | 置換後                                                                                      |
+| --- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| L5  | `style="background: var(--color-neutral-900); color: var(--color-neutral-300);"` | `class="footer-bar"` (新規 1 class に集約)                                                  |
+| L8  | `style="letter-spacing: 0.02em; color: var(--color-neutral-500);"`               | `class="text-sm text-footer-meta tracking-[0.02em]"` (新規 `.text-footer-meta` + arbitrary) |
+| L15 | `style="letter-spacing: 0.02em;"` (link)                                         | `class="... tracking-[0.02em]"` (arbitrary)                                                 |
+| L20 | `style="letter-spacing: 0.02em;"` (link)                                         | `class="... tracking-[0.02em]"` (arbitrary)                                                 |
+
+> **note**: Footer container の `color: var(--color-neutral-300)` は `.footer-bar` で `color` 設定済 → 子要素の link は `inherit` で OK (一部 link は `color` を別途指定したい場合 spec で明示)。Footer L8 paragraph は `color: var(--color-neutral-500)` で container と異なるため別 class `.text-footer-meta` に分離。
+
+### 3. `src/components/layout/MobileDrawer.astro` (6 件)
+
+| 行  | inline                                                                                              | 置換後                                                               |
+| --- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| L16 | `style="z-index: 60;"`                                                                              | `class="... z-[60]"` (arbitrary)                                     |
+| L21 | `style="background: rgba(17,24,39,0.5);"` (backdrop)                                                | `class="absolute inset-0 drawer-backdrop"` (新規 `.drawer-backdrop`) |
+| L31 | `style="padding: 1rem; background: var(--color-bg);"`                                               | `class="... p-4 bg-default"` (Tailwind + 既存)                       |
+| L39 | `style="width: 44px; height: 44px; color: var(--color-neutral-700);"`                               | `class="... w-11 h-11 text-icon"` (Header L22 と同パターン)          |
+| L67 | `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"` | `class="caption-wide text-muted"` (新規 `.caption-wide` + 既存)      |
+| L82 | `style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"`          | `class="... min-h-11 caption"` (Tailwind + 既存 `.caption` 再利用)   |
+
+### 4. `src/components/layout/Sidebar.astro` (2 件)
+
+| 行  | inline                                                                                              | 置換後                                                                |
+| --- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| L19 | `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"` | `class="... caption-wide text-muted"` (MobileDrawer L67 と同パターン) |
+| L37 | `style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"`          | `class="... min-h-11 caption"` (MobileDrawer L82 と同パターン)        |
+
+### 5. `src/layouts/BaseLayout.astro` (1 件)
+
+| 行  | inline                                                                          | 置換後                                                           |
+| --- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| L45 | `style="background: var(--color-bg-surface); color: var(--color-text);"` (body) | `class="min-h-screen bg-surface text-default"` (既存 class のみ) |
+
+### 6. `src/layouts/ToolLayout.astro` (5 件)
+
+| 行  | inline                                                                                              | 置換後                                                                                      |
+| --- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| L51 | `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"` | `class="... caption text-muted"` (既存)                                                     |
+| L57 | `style="color: var(--color-text);"`                                                                 | `class="text-default"` (既存)                                                               |
+| L66 | `style="color: var(--color-primary);"`                                                              | `class="... text-primary"` (既存)                                                           |
+| L71 | `style="font-size: 1.625rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"`  | `class="text-[1.625rem] leading-[1.5] tracking-[0.02em] text-default"` (arbitrary 3 + 既存) |
+| L77 | `style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"` | `class="caption text-muted"` (L51 と同パターン)                                             |
+
+> **note**: ToolLayout H1 (L71) は単発の typography pattern (`1.625rem; 1.5; 0.02em`) で、PR 5b の class 追加判断基準 (再利用 OR component-scoped 必須挙動) を満たさない。Tailwind v4 の arbitrary value 3 連 (`text-[1.625rem] leading-[1.5] tracking-[0.02em]`) で表現する。class 化したくなる誘惑はあるが YAGNI 採用 (PR 1〜5b と同じ judgement)。
+
+### 7. `src/components/ui/CategoryBadge.astro` (1 件)
+
+| 行  | inline                                                                                                                                  | 置換後                                                                                                        |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| L11 | `style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em; color: var(--color-tertiary); background: var(--color-badge-bg);"` | `class="... text-sm leading-none tracking-[0.02em] text-tertiary bg-badge"` (新規 2 class + Tailwind utility) |
+
+> **note**: 既存 `.badge-category` (PR 2 の qr-ticket pill 専用、`color: primary; border: primary;`) とは色 token も用途も異なるため再利用しない。`.text-tertiary` / `.bg-badge` は PR 2 で確立した「色 token text/bg utility」series (`.text-primary` / `.bg-default` 等) に追従する命名。
+
+### 8. `src/components/ui/ToolInfoSection.astro` (1 件)
+
+| 行  | inline                                                                        | 置換後                                                |
+| --- | ----------------------------------------------------------------------------- | ----------------------------------------------------- |
+| L7  | `style="background: var(--color-bg); border: 1px solid var(--color-border);"` | `class="... bg-default border border-default"` (既存) |
+
+---
+
+## `src/styles/global.css` への追加 (新規 7 class)
+
+```css
+@layer components {
+  /* === PR 7a: Astro inline migration helpers === */
+
+  /* Caption variant: nav カテゴリラベル等 (letter-spacing wider than .caption) */
+  .caption-wide {
+    font-size: 0.875rem;
+    line-height: 1.7;
+    letter-spacing: 0.08em;
+  }
+
+  /* Icon button color (44x44 SVG ボタンの neutral-700) */
+  .text-icon {
+    color: var(--color-neutral-700);
+  }
+
+  /* CategoryBadge: tertiary color text/bg (PR 2 .text-primary 系列に追従) */
+  .text-tertiary {
+    color: var(--color-tertiary);
+  }
+  .bg-badge {
+    background: var(--color-badge-bg);
+  }
+
+  /* Footer container & meta text (Footer 専用、neutral 系 primitive 色を意味クラス化) */
+  .footer-bar {
+    background: var(--color-neutral-900);
+    color: var(--color-neutral-300);
+  }
+  .text-footer-meta {
+    color: var(--color-neutral-500);
+  }
+
+  /* MobileDrawer backdrop (modal 背景の半透明 overlay)
+     注意: rgba(17,24,39,0.5) は --color-neutral-900 の 50% alpha と同等。
+     CSS variable 化は B 案完了後の semantic alias 整理 PR で検討 (今 YAGNI)。 */
+  .drawer-backdrop {
+    background: rgba(17, 24, 39, 0.5);
+  }
+}
+```
+
+> **設計上の判断**:
+>
+> - **letter-spacing 0.02em は class 化せず Tailwind arbitrary** で対応 (4 件出現するが、`tracking-[0.02em]` は Tailwind v4 で auto-utility 化されるため class 追加は YAGNI)。`.caption` family と区別しやすくするためにも arbitrary 維持が望ましい。
+> - **`.drawer-backdrop` は rgba 直書きで OK** (`color-mix(in srgb, var(--color-neutral-900) 50%, transparent)` でも書けるが、PR 1〜5 の前例で rgba 直書きあり (`.qr-video-preview` の `#000` 等)。color-mix 化は B 案完了後の整理 PR スコープ)。
+> - **`.text-icon` の命名理由**: `text-neutral-700` は Tailwind 標準 auto-utility と衝突するため避ける。`var(--color-neutral-700)` は「アイコン色」が唯一の用途のため意味クラス化が成立する。
+
+---
+
+## `inline-style-migration.test.ts` への扱い
+
+**本 PR では拡張しない**。理由:
+
+- 現状 tracker は `src/components/**/*.tsx` のみ glob 対象 (PR 6 で確立)。
+- PR 7a 完了時点では `src/pages/*.astro` 7 ファイル / 37 件 が未移行で残存しているため、Astro 検出網 (`src/**/*.astro` + `style="` regex) を本 PR で追加すると **PR 7b までの間 fail し続ける** (red CI ban)。
+- Astro 検出網の追加は **PR 7b 内 (= 全 65 件移行完了時)** または **PR 8 (最終 flip)** で対応。PR 7b spec で再判断する。
+
+---
+
+## consumer 変更範囲 (PR 7a で touch するファイル)
+
+```
+src/components/layout/Header.astro
+src/components/layout/Footer.astro
+src/components/layout/MobileDrawer.astro
+src/components/layout/Sidebar.astro
+src/components/ui/CategoryBadge.astro
+src/components/ui/ToolInfoSection.astro
+src/layouts/BaseLayout.astro
+src/layouts/ToolLayout.astro
+src/styles/global.css                  # 新規 7 class 追加
+```
+
+合計 9 ファイル。
+
+---
+
+## 検証戦略
+
+### unit / type check
+
+- `npm run test` (Vitest) — global.css に直接依存する unit test は無いため、影響は migration tracker のみ。本 PR では tracker 拡張なしのため pass 維持を確認。
+- `astro check` — typing 影響なし、pass 維持を確認。
+
+### E2E (親直接実行、subagent 委譲なし)
+
+memory `feedback_subagent_verification_trust.md` 準拠で **親 Opus が直接実行** (PR 6 / #292 と同パターン)。
+
+```
+npm run test:e2e
+```
+
+- layout 系の class 化は全 spec 横断 (Header / Footer / Sidebar) のため、**全 E2E pass** が最低条件。
+- `applyProductionCsp` を効かせる spec (uuid-v7 / ulid-generator / config-converter 等) は `style-src 'unsafe-inline'` 維持下で動作するため、本 PR scope では新たな違反は発生しない (PR 8 で `'unsafe-inline'` 削除時に Astro inline 撤去の意義が CSP 側で実証される設計)。
+
+### VRT (Visual Regression Test)
+
+- CI Linux runner で `npm run test:vrt` (memory `feedback_vrt_ci_only.md`)。
+- layout 系の class 化は **理論上 pixel-perfect** (Tailwind utility / 既存 class / 新規 class が inline と同等 CSS を生成するため)。差分が出たら spec / browser 検証で意図確認。
+- 意図的差分があれば `update-visual-baseline.yml` workflow で baseline 更新。
+
+### 手動検証 (browser)
+
+- `/` (index) で Header / Footer / Sidebar の見た目が PR 前後で同一であることを確認。
+- mobile viewport (375px 等) で MobileDrawer 開閉、backdrop 半透明 / hamburger ボタン色が同一であることを確認。
+- ツールページ (例: `/tools/jwt-decoder`) で ToolLayout の breadcrumb / H1 / カテゴリバッジ表示が同一であることを確認。
+
+---
+
+## バッチ計画における本 PR の位置付け
+
+| #              | スコープ                                                                             | 状態           |
+| -------------- | ------------------------------------------------------------------------------------ | -------------- |
+| PR 1〜5b       | React `style={{}}` 全廃 (B 案 PR 1〜5b)                                              | ✅ merged      |
+| PR 6 (#290)    | `styles.ts` 削除 + migration tracker glob 化                                         | ✅ merged      |
+| **PR 7a**      | **本 spec — Astro layout/ui inline 移行**                                            | 🔄 spec 起草中 |
+| PR 7b          | Astro pages/ inline 移行 (37 件 / 7 ファイル)                                        | 未着手         |
+| PR 8 最終 flip | `_headers` flip + `stripMetaStyleSrc` 撤去 + `decisions.md [067]` + Astro 検出網追加 | 未着手         |
+
+---
+
+## ブランチ命名 / コミット粒度 / 並列分担
+
+### ブランチ
+
+`feature/issue-289-pr7a-astro-layout-ui` (worktree path: `.claude/worktrees/issue-289-pr7a/`、base: `origin/develop` 必須 — memory `feedback_worktree_base_branch.md`)。
+
+### 並列分担
+
+**subagent 委譲なし、親 Opus 直接実装**。PR 6 / 292 と同パターン (memory `feedback_subagent_verification_trust.md`)。
+
+理由:
+
+- 8 ファイルで 23 件、規模が小さい (PR 5a の 31 件 / 3 ツール、PR 5b の 9 件 / 5 ツールと同等以下)。
+- layout 系の class 化は VRT 影響評価が必要で、検証主体が親なら commit-and-verify-and-iterate が tight loop で回せる。
+- subagent の「pass」報告 false positive を避ける (memory 同上)。
+
+### コミット粒度
+
+ファイル単位で意味的に commit を分け、4〜6 commit 程度を想定:
+
+1. `feat(styles): #289 PR 7a — global.css に新規 7 class 追加 (caption-wide / text-icon / text-tertiary / bg-badge / footer-bar / text-footer-meta / drawer-backdrop)`
+2. `refactor(layout): #289 PR 7a — Header / Footer Astro inline 撤去`
+3. `refactor(layout): #289 PR 7a — Sidebar / MobileDrawer Astro inline 撤去`
+4. `refactor(layouts): #289 PR 7a — BaseLayout / ToolLayout Astro inline 撤去`
+5. `refactor(ui): #289 PR 7a — CategoryBadge / ToolInfoSection Astro inline 撤去`
+6. `chore(docs): #289 PR 7a — 進捗 doc 更新` — `docs/projects/issue-176-b-plan-progress.md` に PR 7a 行を追加
+
+> 進捗 doc 更新は本 PR 内に同梱 (議論ポイント §5 と整合)。merged 後 chore PR にする選択肢もあるが、PR 7b で次の更新が来るためまとめる方が doc lag が少ない。
+
+---
+
+## リスクと緩和
+
+| リスク                                                                                                  | 程度 | 緩和策                                                                                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| layout 系 (全ページ波及) で意図せぬ visual regression                                                   | 中   | VRT pixel diff で検出 → spec 横断確認 → 意図的差分なら baseline 更新。PR 7a を独立 PR にして rollback を容易化 (本 spec § なぜ独立 PR §1〜§3)                                                           |
+| Tailwind v4 の arbitrary value (`tracking-[0.02em]`) が `@layer components` の class より特異性で負ける | 低   | Tailwind utility は CSS 生成順で `@layer utilities` に入る。`@layer components` (PR 1 で導入) は utilities より前 layer のため、両者併用しても期待どおりの優先順位 (utility 勝ち、これは Tailwind 標準) |
+| `.text-icon` の命名衝突 (将来 Tailwind 標準で `.text-icon` 等が auto-utility 化)                        | 低   | Tailwind v4 標準名 (`text-{size}` / `text-{color}` 系) と直接衝突しない。PR 6 完了時点で `--color-neutral-700` は `@theme` 未登録のため Tailwind が `text-neutral-700` を auto-utility 化する経路もない |
+| `.footer-bar` 等 Footer 専用 class の hardcoded neutral 色 (dark mode 不可)                             | 低   | 現状 dark mode 未サポート (global.css L13 `@variant dark (&:where(.dark, .dark *));` は宣言のみで使われていない)。dark mode 対応時に semantic alias (`--color-bg-footer` 等) 化する想定                 |
+| `.drawer-backdrop` の `rgba(17,24,39,0.5)` が `--color-neutral-900` 変更時に同期しない                  | 低   | dark mode 対応時にあわせて整理 (リスク行と同根)。本 PR scope では rgba 直書き許容、将来の `color-mix(in srgb, ...)` 化は YAGNI                                                                          |
+| Astro inline 撤去で a11y semantic マーカー (aria-\*) を意図せず削除                                     | 低   | 本 PR は `style="..."` 属性のみ touch、`class="..."` 属性は merge 拡張、aria-\* / role / label 系は touch しない。CLAUDE.md 9.6 の "aria 削除検出" pre-create check も親が PR 作成前に実施              |
+| user 確認した方針外で勝手に新規 class を増やす                                                          | 低   | 本 spec で **新規 7 class に限定**を明記。実装中に「もう 1 個欲しい」が出た場合は user に確認後追加                                                                                                     |
+
+---
+
+## 議論ポイント (本 spec 起草時 default 採用案を提示)
+
+> brainstorming session で確認済の主要決定。再変更したい場合は本セクションの代替案を採用。
+
+1. **`.caption-wide` 命名**: ✅ user 採用。代替案 (`.nav-category-label` / `.tracking-wide-caption`) は本 spec で採用しない。
+2. **単発 typography (ToolLayout H1 / CategoryBadge text)**: ✅ user 判断 = Tailwind arbitrary value 採用。class 化は YAGNI で見送り。
+3. **新規 7 class draft**: ✅ user 承認。Footer scoped CSS / `.drawer-backdrop` arbitrary 化等の代替案は採用しない。
+
+### spec 起草時に default 採用とした追加判断
+
+4. **`letter-spacing: 0.02em` 単独 (4 件) を class 化しない**: Tailwind arbitrary `tracking-[0.02em]` で対応。class 化すると `.caption` family との区別がつきにくくなり可読性低下、auto-utility のため CSS bundle にも 1 ルールしか出力されず DRY 観点でも arbitrary が劣らない。
+5. **進捗 doc 更新の commit**: 本 PR 内に同梱する想定 (#6 commit)。merged 後 chore PR にする選択肢もあるが、PR 7b で次の更新が来るためまとめる方が doc lag が少ない。
+
+---
+
+## 関連
+
+- 上位 issue: [#176](https://github.com/fumtas1k/devtools/issues/176) (B 案 = `style-src 'unsafe-inline'` 削減)
+- 起票 issue: [#289](https://github.com/fumtas1k/devtools/issues/289) (Astro inline 65 件 follow-up)
+- 直前 PR: [#290](https://github.com/fumtas1k/devtools/pull/290) (B 案 PR 6 — scope 縮小、`styles.ts` 削除 + tracker glob 化)
+- B 案 series spec: [PR 1](./2026-05-03-issue-176-b1-foundation-and-ui-simple-design.md) / [PR 1.5](./2026-05-04-issue-176-b1-5-ui-complex-design.md) / [PR 2](./2026-05-04-issue-176-b2-qr-ticket-design.md) / [PR 3](./2026-05-07-issue-176-b3-jwt-uuid-design.md) / [PR 4](./2026-05-07-issue-176-b4-gs1-encoding-dummy-design.md) / [PR 5a](./2026-05-07-issue-176-b5a-config-qr-jan-design.md) / [PR 5b](./2026-05-07-issue-176-b5b-rest-tools-and-ulid-e2e-design.md) / [PR 6 (post-mortem)](./2026-05-07-issue-176-b6-csp-flip-and-cleanup-design.md)
+- 進捗 SoT: [`docs/projects/issue-176-b-plan-progress.md`](../../projects/issue-176-b-plan-progress.md)
+- Phase A revert commit (PR 8 で再利用): `8ae383a` (PR 6 で revert)

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -2,22 +2,16 @@
 
 ---
 
-<footer style="background: var(--color-neutral-900); color: var(--color-neutral-300);">
+<footer class="footer-bar">
   <div class="mx-auto max-w-280 px-4 sm:px-6 py-12">
     <div class="flex flex-col gap-3 sm:flex-row sm:justify-between">
-      <p class="text-sm" style="letter-spacing: 0.02em; color: var(--color-neutral-500);">
+      <p class="text-sm text-footer-meta tracking-[0.02em]">
         © 2026 DevTools — すべての処理はブラウザ内で完結します
       </p>
       <nav class="flex gap-6 text-sm" aria-label="フッターナビゲーション">
-        <a
-          href="/about"
-          class="footer-link underline transition-colors"
-          style="letter-spacing: 0.02em;">About</a
-        >
-        <a
-          href="/privacy"
-          class="footer-link underline transition-colors"
-          style="letter-spacing: 0.02em;">プライバシーポリシー</a
+        <a href="/about" class="footer-link underline transition-colors tracking-[0.02em]">About</a>
+        <a href="/privacy" class="footer-link underline transition-colors tracking-[0.02em]"
+          >プライバシーポリシー</a
         >
       </nav>
     </div>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -2,15 +2,11 @@
 import PageContainer from '@/components/ui/PageContainer.astro';
 ---
 
-<header
-  class="sticky top-0 z-50 border-b"
-  style="height: 64px; background: var(--color-bg); border-color: var(--color-border);"
->
+<header class="sticky top-0 z-50 border-b h-16 bg-default border-default">
   <PageContainer class="flex h-full items-center justify-between">
     <a
       href="/"
-      class="text-xl font-bold transition-opacity hover:opacity-80"
-      style="color: var(--color-primary); letter-spacing: 0.02em;"
+      class="text-xl font-bold transition-opacity hover:opacity-80 text-primary tracking-[0.02em]"
     >
       DevTools
     </a>
@@ -18,8 +14,7 @@ import PageContainer from '@/components/ui/PageContainer.astro';
     <button
       id="mobile-menu-toggle"
       type="button"
-      class="lg:hidden flex items-center justify-center rounded-md transition-colors"
-      style="width: 44px; height: 44px; color: var(--color-neutral-700);"
+      class="lg:hidden flex items-center justify-center rounded-md transition-colors w-11 h-11 text-icon"
       aria-label="メニューを開く"
       aria-expanded="false"
       aria-controls="mobile-drawer"

--- a/src/components/layout/MobileDrawer.astro
+++ b/src/components/layout/MobileDrawer.astro
@@ -10,16 +10,9 @@ const { currentSlug } = Astro.props;
 ---
 
 <!-- モバイルドロワー (lg未満のみ表示) -->
-<div
-  id="mobile-drawer-overlay"
-  class="lg:hidden fixed inset-0"
-  style="z-index: 60;"
-  aria-hidden="true"
-  hidden
->
+<div id="mobile-drawer-overlay" class="lg:hidden fixed inset-0 z-[60]" aria-hidden="true" hidden>
   <!-- 背景 -->
-  <div id="mobile-drawer-backdrop" class="absolute inset-0" style="background: rgba(17,24,39,0.5);">
-  </div>
+  <div id="mobile-drawer-backdrop" class="absolute inset-0 drawer-backdrop"></div>
 
   <!-- ドロワーパネル -->
   <div
@@ -27,16 +20,14 @@ const { currentSlug } = Astro.props;
     role="dialog"
     aria-label="ナビゲーション"
     aria-modal="true"
-    class="absolute right-0 top-0 h-full w-64 overflow-y-auto shadow-xl"
-    style="padding: 1rem; background: var(--color-bg);"
+    class="absolute right-0 top-0 h-full w-64 overflow-y-auto shadow-xl p-4 bg-default"
   >
     <!-- 閉じるボタン -->
     <div class="flex justify-start mb-2">
       <button
         id="mobile-drawer-close"
         type="button"
-        class="drawer-close-btn flex items-center justify-center rounded-md transition-colors"
-        style="width: 44px; height: 44px; color: var(--color-neutral-700);"
+        class="drawer-close-btn flex items-center justify-center rounded-md transition-colors w-11 h-11 text-icon"
         aria-label="メニューを閉じる"
       >
         <svg
@@ -62,10 +53,7 @@ const { currentSlug } = Astro.props;
       {
         categories.map((cat) => (
           <div class="mb-6">
-            <h2
-              class="mb-2 px-3 font-bold uppercase"
-              style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"
-            >
+            <h2 class="mb-2 px-3 font-bold uppercase caption-wide text-muted">
               {categoryLabel[cat]}
             </h2>
             <ul>
@@ -78,8 +66,7 @@ const { currentSlug } = Astro.props;
                       <a
                         href={`/tools/${tool.slug}`}
                         aria-current={isActive ? 'page' : undefined}
-                        class={`flex items-center gap-2 rounded px-3 transition-colors drawer-link ${isActive ? 'font-bold drawer-link--active' : 'drawer-link--inactive'}`}
-                        style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
+                        class={`flex items-center gap-2 rounded px-3 transition-colors drawer-link min-h-11 caption ${isActive ? 'font-bold drawer-link--active' : 'drawer-link--inactive'}`}
                       >
                         <ToolIcon slug={tool.slug} size={16} class="shrink-0" />
                         <span>{tool.name}</span>

--- a/src/components/layout/Sidebar.astro
+++ b/src/components/layout/Sidebar.astro
@@ -14,10 +14,7 @@ const { currentSlug } = Astro.props;
     {
       categories.map((cat) => (
         <div class="mb-6">
-          <h2
-            class="mb-2 px-3 font-bold uppercase"
-            style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.08em; color: var(--color-muted);"
-          >
+          <h2 class="mb-2 px-3 font-bold uppercase caption-wide text-muted">
             {categoryLabel[cat]}
           </h2>
           <ul>
@@ -28,13 +25,12 @@ const { currentSlug } = Astro.props;
                   <a
                     href={`/tools/${tool.slug}`}
                     aria-current={currentSlug === tool.slug ? 'page' : undefined}
-                    class={`flex items-center gap-2 rounded px-3 transition-colors sidebar-link
+                    class={`flex items-center gap-2 rounded px-3 transition-colors sidebar-link min-h-11 caption
                   ${
                     currentSlug === tool.slug
                       ? 'font-bold sidebar-link--active'
                       : 'sidebar-link--inactive'
                   }`}
-                    style="min-height: 44px; font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em;"
                   >
                     <ToolIcon slug={tool.slug} size={16} class="shrink-0" />
                     <span>{tool.name}</span>

--- a/src/components/ui/CategoryBadge.astro
+++ b/src/components/ui/CategoryBadge.astro
@@ -7,8 +7,10 @@ const { label, class: extraClass = '' } = Astro.props;
 ---
 
 <span
-  class:list={['rounded-full px-3 font-bold', extraClass]}
-  style="font-size: 0.875rem; line-height: 1; letter-spacing: 0.02em; color: var(--color-tertiary); background: var(--color-badge-bg);"
+  class:list={[
+    'rounded-full px-3 font-bold text-sm leading-none tracking-[0.02em] text-tertiary bg-badge',
+    extraClass,
+  ]}
 >
   {label}
 </span>

--- a/src/components/ui/ToolInfoSection.astro
+++ b/src/components/ui/ToolInfoSection.astro
@@ -2,10 +2,7 @@
 
 ---
 
-<section
-  class="mt-10 rounded-lg p-6"
-  style="background: var(--color-bg); border: 1px solid var(--color-border);"
->
+<section class="mt-10 rounded-lg p-6 bg-default border border-default">
   <h2 class="mb-3 tool-info-heading">このツールについて</h2>
   <slot />
 </section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).href;
     <meta name="theme-color" content="#1A56DB" />
     {jsonLd && <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
   </head>
-  <body class="min-h-screen" style="background: var(--color-bg-surface); color: var(--color-text);">
+  <body class="min-h-screen bg-surface text-default">
     <a href="#main-content" class="skip-link">本文へスキップ</a>
     <Header />
     <MobileDrawer currentSlug={currentSlug} />

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -45,37 +45,22 @@ const jsonLd = {
     <!-- メインコンテンツ -->
     <main class="min-w-0 flex-1" id="main-content">
       <!-- パンくずリスト -->
-      <nav
-        aria-label="パンくずリスト"
-        class="mb-6 flex items-center gap-1.5"
-        style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"
-      >
+      <nav aria-label="パンくずリスト" class="mb-6 flex items-center gap-1.5 caption text-muted">
         <a href="/" class="text-link">ホーム</a>
         <span aria-hidden="true">›</span>
         <span>{categoryLabel[tool.category]}</span>
         <span aria-hidden="true">›</span>
-        <span style="color: var(--color-text);">{tool.name}</span>
+        <span class="text-default">{tool.name}</span>
       </nav>
 
       <!-- ツールヘッダー -->
       <div class="mb-8 flex items-center gap-4">
-        <ToolIcon
-          slug={tool.slug}
-          size={32}
-          class="shrink-0"
-          style="color: var(--color-primary);"
-        />
+        <ToolIcon slug={tool.slug} size={32} class="shrink-0 text-primary" />
         <div class="min-w-0 flex-1">
-          <h1
-            class="font-bold"
-            style="font-size: 1.625rem; line-height: 1.5; letter-spacing: 0.02em; color: var(--color-text);"
-          >
+          <h1 class="font-bold text-[1.625rem] leading-[1.5] tracking-[0.02em] text-default">
             {tool.name}
           </h1>
-          <p
-            class="mt-1"
-            style="font-size: 0.875rem; line-height: 1.7; letter-spacing: 0.02em; color: var(--color-muted);"
-          >
+          <p class="mt-1 caption text-muted">
             {tool.description}
           </p>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -190,6 +190,10 @@
     line-height: 1.7;
     letter-spacing: 0.02em;
   }
+  /* `font-weight: 400` を明示的に指定。bold 親要素の文脈で使う場合に
+     継承を断ち切る (Sidebar/MobileDrawer の link が bold 親に置かれた際の
+     意図せぬ太字化を防ぐ)。bold が必要な場合は consumer 側で
+     Tailwind `font-bold` を併用 (cascade layer 順で utilities が勝つ)。 */
   .caption {
     font-size: 0.875rem;
     font-weight: 400;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -557,4 +557,42 @@
   .qr-video-preview {
     background: #000;
   }
+
+  /* === PR 7a (#289): Astro layout/ui inline migration helpers === */
+
+  /* Caption variant: nav カテゴリラベル等 (letter-spacing wider than .caption) */
+  .caption-wide {
+    font-size: 0.875rem;
+    line-height: 1.7;
+    letter-spacing: 0.08em;
+  }
+
+  /* Icon button color (44x44 SVG ボタンの neutral-700) */
+  .text-icon {
+    color: var(--color-neutral-700);
+  }
+
+  /* CategoryBadge: tertiary color text/bg (PR 2 .text-primary 系列に追従) */
+  .text-tertiary {
+    color: var(--color-tertiary);
+  }
+  .bg-badge {
+    background: var(--color-badge-bg);
+  }
+
+  /* Footer container & meta text (Footer 専用、neutral 系 primitive 色を意味クラス化) */
+  .footer-bar {
+    background: var(--color-neutral-900);
+    color: var(--color-neutral-300);
+  }
+  .text-footer-meta {
+    color: var(--color-neutral-500);
+  }
+
+  /* MobileDrawer backdrop (modal 背景の半透明 overlay)
+     注意: rgba(17,24,39,0.5) は --color-neutral-900 の 50% alpha と同等。
+     CSS variable 化は B 案完了後の semantic alias 整理 PR で検討 (今 YAGNI)。 */
+  .drawer-backdrop {
+    background: rgba(17, 24, 39, 0.5);
+  }
 }


### PR DESCRIPTION
## 概要

`#176` B 案 follow-up `#289` のうち、**layout 系 + ui/\*.astro 2 件** の Astro `<element style="...">` 属性 23 件 / 8 ファイル を CSS class に移行。新規 7 class を `src/styles/global.css` `@layer components` に追加し、Tailwind utility / 既存意味クラスと併用して移行完了。

`style-src 'unsafe-inline'` の削除は本 PR では実施せず、後続 PR 7b (pages/\*.astro 7 ファイル) と PR 8 (最終 flip) に委譲。

## 変更内容

### 新規 7 class (`src/styles/global.css`)

| class               | 用途                                                  | 件数 |
| ------------------- | ----------------------------------------------------- | ---- |
| `.caption-wide`     | nav カテゴリラベル (letter-spacing 0.08em)            | 2    |
| `.text-icon`        | 44x44 アイコンボタン (var(--color-neutral-700))       | 2    |
| `.text-tertiary`    | CategoryBadge text (var(--color-tertiary))            | 1    |
| `.bg-badge`         | CategoryBadge bg (var(--color-badge-bg))              | 1    |
| `.footer-bar`       | Footer container (neutral-900 bg + neutral-300 text)  | 1    |
| `.text-footer-meta` | Footer copyright text (var(--color-neutral-500))      | 1    |
| `.drawer-backdrop`  | MobileDrawer modal 背景 (rgba(17,24,39,0.5))          | 1    |

### 既存 class 再利用 (14 件カバー)

`.caption` / `.text-default` / `.text-muted` / `.text-primary` / `.bg-default` / `.bg-surface` / `.border-default` を活用。

### Tailwind arbitrary value (8 件)

`tracking-[0.02em]` x 5 / `text-[1.625rem] leading-[1.5]` x 1 / `z-[60]` x 1 / `text-sm leading-none` x 1 — 単発 typography は class 化見送り (YAGNI、PR 5b と同 judgement)。

### `px → rem` 挙動差 (a11y 観点で改善方向)

`64px → h-16 (4rem)` (Header) / `44px → w-11/h-11 (2.75rem)` (44x44 アイコンボタン) は、ユーザがブラウザのルートフォントサイズを変更した場合に **rem 系がスケールする** 挙動差を持ちます。WCAG 2.5.5 (Target Size) は CSS px で 44px 基準のため、デフォルト 16px 環境では同等、ユーザがフォントサイズを上げる環境ではむしろ touch target が拡大される方向で **a11y 的にはむしろ改善**。意図的な選択ではないが望ましい副作用として記録。

### touch ファイル (8 + 1 = 9 ファイル)

- `src/styles/global.css` (新規 7 class 追加)
- `src/components/layout/Header.astro` (3 件)
- `src/components/layout/Footer.astro` (4 件)
- `src/components/layout/MobileDrawer.astro` (6 件)
- `src/components/layout/Sidebar.astro` (2 件)
- `src/layouts/BaseLayout.astro` (1 件)
- `src/layouts/ToolLayout.astro` (5 件)
- `src/components/ui/CategoryBadge.astro` (1 件)
- `src/components/ui/ToolInfoSection.astro` (1 件)

既存 Astro `<style>` scoped block (`Footer.astro` / `MobileDrawer.astro` / `Sidebar.astro` の `.footer-link` / `.drawer-close-btn` 等) は本 PR では touch せず維持。これらは Astro `security.csp` で auto-hash 化されるため CSP gate を通過済 (= 本 issue #289 の対象外)。

## scope 外 (本 PR で実施しないこと)

- `src/pages/*.astro` 7 ファイル / 42 件 (PR 7b)
- `style-src 'unsafe-inline'` 削除 + `stripMetaStyleSrc` 撤去 (PR 8)
- `inline-style-migration.test.ts` への `*.astro` 検出網追加 (PR 7b 完了後 = 全 65 件移行後)
- `decisions.md [067]` (PR 8)

## 検証

- [x] `npm run test` 全 750 件 pass (43 ファイル)
- [x] `node_modules/.bin/astro check` 0 errors / 0 warnings
- [x] `npm run test:e2e` 全 146 件 pass + 1 skipped (既存) — 親直接、`style-src 'unsafe-inline'` 維持下のため CSP 違反は本 PR scope では発生しない
- [x] `npm run build` 18 page(s) built 成功
- [x] PR 7a 8 ファイルで `grep -n 'style="' ...` = 0 件
- [x] aria-\* / role= 総数 before/after 同一 (prettier multi-line→1-line 整形による diff `-` 行は false positive、`+` 行で同 attribute 保持を確認済)
- [x] VRT (CI Linux runner): post-push の自動実行で pixel diff なし pass

## 関連

- 起票 issue: #289
- 上位 issue: #176 (B 案 = `style-src 'unsafe-inline'` 削減)
- 直前 PR: #290 (B 案 PR 6 — scope 縮小、`styles.ts` 削除 + tracker glob 化)
- 後続 PR: PR 7b (pages/\*.astro 7 ファイル) + PR 8 (最終 flip — `_headers` flip + `decisions.md [067]` + Astro 検出網追加)
- spec: `docs/superpowers/specs/2026-05-08-issue-289-pr7a-astro-inline-layout-ui-design.md`
- plan: `docs/superpowers/plans/2026-05-08-issue-289-pr7a-astro-layout-ui.md`
- 進捗 SoT: `docs/projects/issue-176-b-plan-progress.md`

## レビュー時の注目点

- 新規 7 class の命名 (`.caption-wide` / `.text-icon` 等) が PR 1〜5b の既存命名 family と一貫しているか
- Astro `<style>` scoped block (Footer / MobileDrawer / Sidebar) を意図せず touch していないか (= scoped CSS は CSP auto-hash で通る別経路、本 PR scope 外)
- visual regression: layout 系のため全ページ波及。VRT で意図しない pixel diff が出ていないか
