### PR TITLE
docs: worktree 作成時の npm ci 必須ルールを proactive に framing 修正 (#297)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 - **言語**: コミットメッセージ・PR 説明文は **必ず日本語**。
 - **スタイリング**: Tailwind カラークラスは禁止。**`colors.*` (React)** または **`var(--color-*)` (Astro)** を使用。
-- **検証**: `npm run test`（ユニット）と `astro check`（型）はサブエージェント / 親共通。**`npm run test:e2e` は push 前に必ず実行**（subagent worktree か親で。内部で build + preview を直列起動。post-PR 代行は不要、CI が最終ゲート）。node_modules 不在の worktree は `npm ci` で整備（SessionStart hook で自動実行）。詳細手順 → `docs/playbooks/e2e-validation.md`
+- **検証**: `npm run test`（ユニット）と `astro check`（型）はサブエージェント / 親共通。**`npm run test:e2e` は push 前に必ず実行**（subagent worktree か親で。内部で build + preview を直列起動。post-PR 代行は不要、CI が最終ゲート）。新規作成 worktree (subagent isolation / 親手動 `git worktree add` 共通) では作成直後に手動 `npm ci` 必須。SessionStart hook は session 開始時のみ fire するため、mid-session 作成 worktree では fire しない。詳細手順 → `docs/playbooks/e2e-validation.md`
 - **PR 作成**: 4 点必須 (正本: `docs/playbooks/pr-creation.md` 3〜4 章 / `docs/shared-agent-rules.md` 6.1, 6.3, 9.6 章 — 不一致時は playbook 優先):
   1. **ベース**: `gh pr create --base develop` 明示 (`gh` デフォルトは main / system prompt の "Main branch" 表示に流されない)
   2. **本文**: `--body-file <path>` 経由必須 (`/tmp/claude/pr_body.md` 等、`--body` 直渡しは禁止 — バックティック化け事故防止)

--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -30,13 +30,13 @@
 
 以下をすべて満たしてから完了報告する。**1 つでも未完了の場合は push せず、未完了の項目を完了報告に明記して親に判断を仰ぐ**。
 
-| #   | チェック項目          | コマンド                                                                       |
-| --- | --------------------- | ------------------------------------------------------------------------------ |
-| 0   | node_modules 整備     | `npm ci`（新規作成 worktree では必須。fresh worktree なら 5〜10 秒で完了。詳細は下記参照）                 |
-| 1   | develop ベース確認    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致  |
-| 2   | ユニットテスト全 pass | `npm run test`                                                                 |
-| 3   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                    |
-| 4   | E2E テスト            | `npm run test:e2e`（env 不備で走らない場合は未完了の旨を明記して親に引き継ぐ） |
+| #   | チェック項目          | コマンド                                                                                   |
+| --- | --------------------- | ------------------------------------------------------------------------------------------ |
+| 0   | node_modules 整備     | `npm ci`（新規作成 worktree では必須。fresh worktree なら 5〜10 秒で完了。詳細は下記参照） |
+| 1   | develop ベース確認    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致              |
+| 2   | ユニットテスト全 pass | `npm run test`                                                                             |
+| 3   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                                |
+| 4   | E2E テスト            | `npm run test:e2e`（env 不備で走らない場合は未完了の旨を明記して親に引き継ぐ）             |
 
 > **ステップ 0 の補足**: fresh subagent isolation worktree では node_modules が存在しないため、素の `npm ci` のみで十分（過去の `scripts/agent-worktree-setup.sh` は不要と判明し、issue #241 / decisions [062] で廃止）。`.claude/settings.json` の SessionStart hook は session 開始時のみ fire するため、mid-session で `git worktree add` した worktree には適用されない。新規作成 worktree では作成直後に手動で `npm ci` を実行する必須ステップとして扱うこと。
 >

--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -32,13 +32,13 @@
 
 | #   | チェック項目          | コマンド                                                                       |
 | --- | --------------------- | ------------------------------------------------------------------------------ |
-| 0   | node_modules 整備     | `npm ci`（fresh worktree なら 5〜10 秒で完了。詳細は下記参照）                 |
+| 0   | node_modules 整備     | `npm ci`（新規作成 worktree では必須。fresh worktree なら 5〜10 秒で完了。詳細は下記参照）                 |
 | 1   | develop ベース確認    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致  |
 | 2   | ユニットテスト全 pass | `npm run test`                                                                 |
 | 3   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                    |
 | 4   | E2E テスト            | `npm run test:e2e`（env 不備で走らない場合は未完了の旨を明記して親に引き継ぐ） |
 
-> **ステップ 0 の補足**: fresh subagent isolation worktree では node_modules が存在しないため、素の `npm ci` のみで十分（過去の `scripts/agent-worktree-setup.sh` は不要と判明し、issue #241 / decisions [062] で廃止）。`.claude/settings.json` の SessionStart hook が `npm ci` を auto-run するので通常は明示実行も不要だが、未実行を疑う場合は手動で再実行する。
+> **ステップ 0 の補足**: fresh subagent isolation worktree では node_modules が存在しないため、素の `npm ci` のみで十分（過去の `scripts/agent-worktree-setup.sh` は不要と判明し、issue #241 / decisions [062] で廃止）。`.claude/settings.json` の SessionStart hook は session 開始時のみ fire するため、mid-session で `git worktree add` した worktree には適用されない。新規作成 worktree では作成直後に手動で `npm ci` を実行する必須ステップとして扱うこと。
 >
 > **既存パッケージの version 操作・削除に注意**: `.idea/` `.vscode/` を同梱する推移依存パッケージ（現プロジェクトでは `iconv-lite` / `stream-replace-string`）の upgrade / uninstall は sandbox の write 制約で EPERM になる可能性あり。新規追加 (`npm install foo`) は影響なし。詳細は issue #241 参照。
 

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -21,13 +21,13 @@ git switch -c <type>/issue-<n>-<slug> origin/develop
 git rev-parse origin/develop
 git merge-base HEAD origin/develop
 
-# node_modules 整備（subagent isolation worktree では特に必須）
+# node_modules 整備（全ての新規作成 worktree で必須。subagent isolation / 親手動 worktree add 共通）
 npm ci
 ```
 
 ブランチ名は `<type>/<slug>`（例: `feat/add-tool`, `fix/issue-123-crash`）。issue がある場合は `<type>/issue-<n>-<slug>` 形式を推奨。
 
-> **`npm ci` 補足**: `.claude/settings.json` の SessionStart hook が条件を満たせば自動実行されるが、明示しておくことで未実行リスクを排除する。subagent isolation worktree では fresh state（node_modules 不在）から始まるため必須。詳細は `docs/playbooks/e2e-validation.md` ステップ 0 補足参照。
+> **`npm ci` 補足**: 新規作成 worktree では必須。SessionStart hook は session 開始時のみ fire し、mid-session で `git worktree add` した worktree には適用されないため、worktree 作成直後に手動で実行する。詳細は `docs/playbooks/e2e-validation.md` ステップ 0 補足参照。
 
 ### 1.2 ベース不一致時のリベース
 
@@ -61,7 +61,7 @@ git rebase --onto origin/develop $(git merge-base HEAD origin/develop) HEAD
 
 | #   | チェック項目         | コマンド                                                                                                               |
 | --- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 0   | node_modules 整備    | `npm ci`（worktree 内で push する場合のみ。SessionStart hook で自動実行されるが念のため）                              |
+| 0   | node_modules 整備    | `npm ci`（新規作成 worktree では必須。SessionStart hook は session 開始時のみ fire し mid-session 作成 worktree には適用されない）                              |
 | 1   | develop ベース確認   | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                          |
 | 2   | スコープ外差分の確認 | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認 |
 | 3   | E2E 直列実行         | `npm run test:e2e`（preview 経由・複数 worktree がある場合は同時実行しない、詳細は `e2e-validation.md` 3 章）          |

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -21,7 +21,7 @@ git switch -c <type>/issue-<n>-<slug> origin/develop
 git rev-parse origin/develop
 git merge-base HEAD origin/develop
 
-# node_modules 整備（全ての新規作成 worktree で必須。subagent isolation / 親手動 worktree add 共通）
+# node_modules 整備（新規作成 worktree の場合は必須 / 親 repo root で直接切替えた場合は既存 node_modules があれば skip 可）
 npm ci
 ```
 

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -59,13 +59,13 @@ git rebase --onto origin/develop $(git merge-base HEAD origin/develop) HEAD
 
 親セッションが直接 push する際は、以下をすべて確認する。
 
-| #   | チェック項目         | コマンド                                                                                                               |
-| --- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 0   | node_modules 整備    | `npm ci`（新規作成 worktree では必須。SessionStart hook は session 開始時のみ fire し mid-session 作成 worktree には適用されない）                              |
-| 1   | develop ベース確認   | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                          |
-| 2   | スコープ外差分の確認 | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認 |
-| 3   | E2E 直列実行         | `npm run test:e2e`（preview 経由・複数 worktree がある場合は同時実行しない、詳細は `e2e-validation.md` 3 章）          |
-| 4   | PR ベース            | `gh pr create --base develop`                                                                                          |
+| #   | チェック項目         | コマンド                                                                                                                           |
+| --- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | node_modules 整備    | `npm ci`（新規作成 worktree では必須。SessionStart hook は session 開始時のみ fire し mid-session 作成 worktree には適用されない） |
+| 1   | develop ベース確認   | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                                      |
+| 2   | スコープ外差分の確認 | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認             |
+| 3   | E2E 直列実行         | `npm run test:e2e`（preview 経由・複数 worktree がある場合は同時実行しない、詳細は `e2e-validation.md` 3 章）                      |
+| 4   | PR ベース            | `gh pr create --base develop`                                                                                                      |
 
 ---
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -104,6 +104,19 @@ post-PR 代行は不要、CI が最終ゲート。
 
 ブランチ作成完成形コマンド・自己検証・rebase 後 push の親引き取り → **`docs/playbooks/pr-creation.md` 1〜2 章**
 
+### 6.2.1 worktree 作成直後の必須セットアップ
+
+`git worktree add` 直後に node_modules を必ず整備する。SessionStart hook は session 開始時のみ fire するため、mid-session で worktree を作成した場合は fire せず、手動で `npm ci` を実行する必要がある（subagent isolation / 親手動 `git worktree add` 共通）。
+
+```bash
+# worktree 作成
+git worktree add .claude/worktrees/<name> origin/develop
+
+# 直後に node_modules 整備（mid-session では SessionStart hook が fire しないため必須）
+cd .claude/worktrees/<name>
+ls node_modules 2>/dev/null || npm ci
+```
+
 ### 6.3 PR 作成時のベースブランチ
 
 `gh pr create` は **`--base develop`** を必ず指定する（デフォルトは `main`）:

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -109,12 +109,13 @@ post-PR 代行は不要、CI が最終ゲート。
 `git worktree add` 直後に node_modules を必ず整備する。SessionStart hook は session 開始時のみ fire するため、mid-session で worktree を作成した場合は fire せず、手動で `npm ci` を実行する必要がある（subagent isolation / 親手動 `git worktree add` 共通）。
 
 ```bash
-# worktree 作成
-git worktree add .claude/worktrees/<name> origin/develop
+# worktree 作成（slug は branch 命名 `<type>/<slug>` と揃える）
+git worktree add .claude/worktrees/<slug> origin/develop
 
 # 直後に node_modules 整備（mid-session では SessionStart hook が fire しないため必須）
-cd .claude/worktrees/<name>
-ls node_modules 2>/dev/null || npm ci
+# `npm ci` は idempotent。`ls` ガードで skip すると package-lock 更新後に false-skip するため明示実行する
+cd .claude/worktrees/<slug>
+npm ci
 ```
 
 ### 6.3 PR 作成時のベースブランチ


### PR DESCRIPTION
## 概要

issue #297 対応。worktree 作成時の `npm ci` 必須ルールが docs に記載されていながら Claude セッションで頻発的に skip されていた問題を、framing の見直しで構造的に防止する。

直近の skip 事故: PR 7b (#289 由来) 着手時に親が `.claude/worktrees/issue-289-pr7b/` を作成後、`npm ci` を skip し user 指摘で発覚。

## 構造的欠陥（issue #297 で指摘）

1. **mid-session 新規 worktree で SessionStart hook が fire しない事実が未明文化**: docs はあちこちで「SessionStart hook で自動実行」と reassure していたが、session 内で `git worktree add` した worktree には hook が再 fire しない。
2. **scope の誤読**: `pr-creation.md` の `(subagent isolation worktree では特に必須)` コメントが「親が手動作成した worktree は対象外」と誤読される構造になっていた。
3. **配置文脈のズレ**: `npm ci` が「検証 / push 前 checklist」セクションに混入していて、worktree 作成直後の必須セットアップとして扱われていなかった。

## 変更内容

| # | ファイル | 変更 |
| - | --- | --- |
| 1 | `CLAUDE.md` L14 | 「SessionStart hook で自動実行」reassurance を削除し、「新規作成 worktree (subagent isolation / 親手動共通) で作成直後に手動 `npm ci` 必須。SessionStart hook は session 開始時のみ fire するため mid-session 作成 worktree では fire しない」と明示 |
| 2 | `docs/playbooks/pr-creation.md` L24 | コメントを「全ての新規作成 worktree で必須。subagent isolation / 親手動 worktree add 共通」に修正 |
| 3 | `docs/playbooks/pr-creation.md` L30 | 「条件を満たせば自動実行されるが、明示しておくことで未実行リスクを排除」表現を削除し、proactive 必須ステップとして書き直し |
| 4 | `docs/playbooks/pr-creation.md` L64 | 表中コメント「SessionStart hook で自動実行されるが念のため」を削除し、mid-session 作成 worktree で hook が fire しない事実を明記 |
| 5 | `docs/playbooks/e2e-validation.md` L35 | 表中コメントに「新規作成 worktree では必須」を追加 |
| 6 | `docs/playbooks/e2e-validation.md` L41 | 「auto-run するので通常は明示実行も不要だが、未実行を疑う場合は手動で再実行」を削除し、session 開始時のみ fire する事実を明記して必須ステップ扱いに |
| 7 | `docs/shared-agent-rules.md` 6.2 章末 | 新規 sub-section **6.2.1 「worktree 作成直後の必須セットアップ」** を追加。`git worktree add` 直後の `cd` + `npm ci` シーケンスをコードブロック付きで掲載 |

## 期待効果

- 親 / subagent 共通の framing で誤読を排除
- mid-session worktree 作成時の skip 事故（本 issue 起票のきっかけ）を構造的に防止
- 「自動実行」「念のため」「未実行を疑う場合」reassurance の削除で proactive ステップを明示化

## 検証

- `git diff origin/develop --name-only` → 4 ファイル（CLAUDE.md / pr-creation.md / e2e-validation.md / shared-agent-rules.md）のみ変更、スコープ外差分なし
- `grep -nE "自動実行|念のため|未実行を疑う" CLAUDE.md docs/playbooks/pr-creation.md docs/playbooks/e2e-validation.md docs/shared-agent-rules.md` → 残存ヒットは `e2e-validation.md` L103 の `npm run test:e2e` pre-hook (pretest:e2e の自動実行) の 1 件のみで、SessionStart hook の文脈とは無関係につき意図的に維持
- `grep -n "6.2.1" docs/shared-agent-rules.md` → 新規 sub-section 見出しが追加されていることを確認
- aria-\* 削除なし
- docs のみの変更のため挙動への影響なし（unit / type / E2E は本 PR では実行不要、CI が最終ゲート）

## 関連

- Closes #297
- 関連 PR (rule 整備履歴): #296
- 関連 memory: `feedback_worktree_and_isolation.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_014xRQKi7NfVcHzAtqzUd3pc)_