### PR TITLE
docs(agent-lessons): VRT baseline 更新前の DOM / computed style diff 確認手順

### DIFF
--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -176,3 +176,57 @@ PR #267 内では実施しない（settings 巻き戻しが必要 + 検証のた
 - PR #267 (#267 review コメントで reviewer から提示された観察)
 - 上記前エントリ「Claude memory dir は Bash `rm` で削除できない（Claude Code 既知 bug）」と関連 — sandbox.filesystem.allowWrite が Bash に効かない bug と「sandbox profile mirror」仮説は **両立する**（mirror があっても Bash には適用されない実装、というシナリオ）
 - 規約昇格: 不要（仮説段階、harness 挙動のため本ファイルが正所）
+
+---
+
+## [2026-05-08] VRT baseline 更新前に DOM / computed style diff を確認する手順
+
+### 現象 / きっかけ
+
+PR #299 (#289 PR 7b、Astro inline `style="..."` 撤去) で VRT が `/` のみ desktop / mobile 両方 fail。page height が 1px 短縮 (1632 → 1631、diff ratio 0.02% / 23925 px)。inline → CSS class refactor で fractional pixel rendering が tool card 14 枚で累積し合計 1px 差に到達。
+
+### 根本原因
+
+inline `style="..."` と CSS class (例: `bg-[var(...)]` / `.section-heading`) は CSS としては完全等価だが、cascade resolution / fractional pixel rendering で 0.003〜0.005px 単位の微小な差分が出る場合がある。視覚的には等価でも pixel 比較 VRT は失敗する。
+
+### 対処方針 (新規ルール)
+
+VRT が **任意の visual diff で fail** した場合、**baseline 更新する前に必ず以下 2 段階の検証を行う**:
+
+#### 1. DOM 構造 diff
+
+`gh run download <run-id> --name visual-regression-report-pr-<n>` で playwright report を取得し、`expected` と `actual` の HTML スナップショット (Astro が生成する HTML) を比較。次の点に regression がないことを確認:
+
+- `aria-*` / `role=` 属性削除なし (`shared-agent-rules.md` 9.6 章 a11y 保護にも該当)
+- DOM 階層・要素数の差分なし
+- `<img>` `alt` / `<a>` `href` 等の semantic 属性が同一
+
+#### 2. Computed style diff (Playwright MCP)
+
+local preview server で問題ページを開き、**疑わしい element の computed style** を `getComputedStyle()` で取得。`fontSize` / `lineHeight` / `borderBottomWidth` / `backgroundColor` 等の semantic property が baseline と一致することを確認:
+
+```js
+// Playwright MCP 経由の例
+const cs = getComputedStyle(document.querySelector('section'));
+return {
+  borderBottomWidth: cs.borderBottomWidth, // "1px"
+  borderBottomColor: cs.borderBottomColor, // "rgb(219, 234, 254)"
+  backgroundColor: cs.backgroundColor, // "rgb(239, 246, 255)"
+};
+```
+
+両方が baseline と一致 (= rendering nondeterminism のみ) → baseline 更新が妥当。
+どちらかが不一致 (= 真の semantic regression) → baseline 更新前に root cause を fix。
+
+### なぜこの手順が必要か
+
+baseline 更新は「意図した変更」を承認する操作であり、**真の regression を silent に baseline に焼き込んでしまうリスク** がある。本 PR #299 のような pure CSS class refactor では baseline 更新が正解だが、PR 8 (CSP `style-src 'unsafe-inline'` 削除) 等で発生し得る real regression と区別する **判別 gate** を agent ワークフローに組み込む必要がある。
+
+「rendering nondeterminism は baseline 更新で吸収」が pattern 化すると、judgment が機械的になり regression 見逃しが起きる。
+
+### 関連 PR / 観点
+
+- PR #299 (本ルール起票のきっかけ): 1px 累積差で baseline 更新成功、commit `d5c5841` (`Update Visual Regression Baseline` workflow による自動 commit)
+- PR 7a spec § VRT (Visual Regression Test): 「意図的差分があれば `update-visual-baseline.yml` workflow で baseline 更新」 (本ルールはこの判断基準を **明示化**)
+- 関連個人 memory (PC ローカル、本 repo 未収録): `feedback_vrt_ci_only.md` (VRT は CI Linux のみで検証)
+- （規約昇格候補）`docs/shared-agent-rules.md` の VRT 関連 sub-section として昇格検討。本 PR review (`#299` 軽微指摘 #3) で reviewer から「次 PR では VRT 差分が出た場合 baseline 更新前に必ず DOM diff / computed style diff を確認する手順を agent-lessons に明記する価値あり」と提案を受けて記録


### PR DESCRIPTION
## 概要

PR #299 (#289 PR 7b、Astro pages inline 撤去) のレビューで reviewer (軽微指摘 #3) から提案を受けた **VRT baseline 更新前の判別 gate** を `docs/agent-lessons.md` バッファへ追加する docs only PR。

## 追加内容

`[2026-05-08] VRT baseline 更新前に DOM / computed style diff を確認する手順`

### きっかけ (PR #299 で実証)

inline `style="..."` → CSS class への refactor で `/` (index) 1px 短縮 (1632 → 1631)。fractional pixel rendering が tool card 14 枚で累積、合計 1px 差 = rendering nondeterminism。CSS としては完全等価 (Playwright MCP の computed style 検証で確認済) のため baseline 更新で吸収した。

### 新ルール

VRT が visual diff で fail した場合、**baseline 更新前に 2 段階の検証**:

1. **DOM 構造 diff**: `aria-*` / `role=` 削除なし、DOM 階層・semantic 属性が baseline と同一
2. **Computed style diff** (Playwright MCP 経由): `fontSize` / `lineHeight` / `borderBottomWidth` / `backgroundColor` 等の semantic property が baseline と一致

両方一致 → rendering nondeterminism → baseline 更新が妥当。
どちらかが不一致 → 真の semantic regression → baseline 更新前に root cause を fix。

### なぜ必要か

baseline 更新は「意図した変更」を承認する操作。**「nondeterminism は更新で吸収」が pattern 化すると judgment が機械的になり、PR 8 (CSP `style-src 'unsafe-inline'` flip) 等で発生し得る real regression を silent に焼き込むリスクがある**。判別 gate を agent ワークフローに組み込んで予防する。

## 変更ファイル

- `docs/agent-lessons.md` (1 entry / +54 行)

## 検証

- [x] `npx prettier --write docs/agent-lessons.md` OK
- [x] base develop 一致 (`git merge-base HEAD origin/develop`)
- [x] スコープ単一 (`docs/agent-lessons.md` のみ touch)
- [x] aria-\* / role 属性削除なし (docs only commit)
- [ ] CI: docs only のため test / e2e は実行されるが規模影響なし

## 関連

- 起票元レビュー: [PR #299 軽微指摘 #3](https://github.com/fumtas1k/devtools/pull/299) (reviewer 提案)
- 上位 issue: #176 (B 案 = `style-src 'unsafe-inline'` 削減) / #289 (Astro inline 65 件全廃)
- PR #299: 本ルール起票のきっかけ、commit `d5c5841` (Update Visual Regression Baseline workflow 自動 commit) を実例として参照
- 関連 doc: `docs/shared-agent-rules.md` 11 章「教訓の運用」 — agent-lessons はバッファ、再発防止に値する内容は shared-agent-rules.md へ昇格
- 規約昇格候補: 本 entry は将来 shared-agent-rules.md の VRT 関連 sub-section として昇格検討

## scope 外

- shared-agent-rules.md への規約昇格 (本 entry がバッファに 1 度蓄積された後、必要なら別 PR で昇格)
- VRT baseline 更新の自動化 (現状の `Update Visual Regression Baseline` workflow が `workflow_dispatch` 手動 trigger 前提、自動化は別議論)
- agent-lessons.md の既存 6 entry の整理 (本 PR は追加のみ)

## レビュー時の注目点

- 新規ルールの「2 段階検証」の手順が、既存の VRT 運用 (PR 7a / PR 7b で実証された flow) と整合しているか
- `feedback_vrt_ci_only` (memory、PC ローカル) と矛盾しないか — 本 entry は repo doc、複数 PC / 協業者 / CI から参照可能。memory との整合は本 entry が prevailing
- 規約昇格 (shared-agent-rules.md) のタイミング判断 — 本 entry の使用実績が 1 件 (PR #299) のみのため、もう 1 件 PR で適用された後 (PR 8 想定) に昇格でも遅くない
