### PR TITLE
fix(statusline): 色変しきい値を 70% / 90% に変更

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -57,11 +57,11 @@ make_bar() {
   printf "%b%s%b" "$color" "$bar" "$RESET"
 }
 
-# Color threshold: <=50=green, <=80=orange, >80=red
+# Color threshold: <=70=green, <=90=orange, >90=red
 bar_color() {
   local pct=$1
-  if   [ "$pct" -gt 80 ]; then echo "$RED"
-  elif [ "$pct" -gt 50 ]; then echo "$ORANGE"
+  if   [ "$pct" -gt 90 ]; then echo "$RED"
+  elif [ "$pct" -gt 70 ]; then echo "$ORANGE"
   else echo "$GREEN"; fi
 }
 


### PR DESCRIPTION
## 概要

`.claude/statusline-command.sh` の `bar_color` 関数における色変しきい値を更新。

| 色変 | 変更前 | 変更後 |
|---|---|---|
| 緑 → オレンジ | 50% 超 | 70% 超 |
| オレンジ → 赤 | 80% 超 | 90% 超 |

## 変更内容

- `bar_color()` のしきい値を `50` → `70`、`80` → `90` に修正
- コメントも同様に更新

https://claude.ai/code/session_01CeC4PZppvcnqfZxdSV9iAw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeC4PZppvcnqfZxdSV9iAw)_