### PR TITLE
chore(docs): #176 B 案 SoT に PR #313 merge hash 反映 + #309/#308 状態明記

### DIFF
--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -128,7 +128,7 @@
 - **subagent 委譲方針**: Task 1〜7 は subagent (sonnet) 委譲、Task 8〜10 は親 Opus 直接 (overhead vs. ROI 判断、PR 7a / 7b / 8 と同パターンに揃える)
 - **Phase 2 で発覚した PR 10 申し送り事項**: 13 ツール spec を strict CSP local run したところ、Astro 島ランタイムが injection する固定 inline `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>` (sha256-vv9I...) が headers 側 strict CSP で block される現象を確認。PR 9 の React refactor 自体は無問題 (`useDynamicStyleSheet` 経路は violation 起こさず) で、PR 10 で `_headers` strict 化と同時に Astro island style hash を取り込む経路設計が必要 (詳細は `docs/decisions.md [067]` PR 9 outcome section 参照)
 - **後続**: PR 10 ([#305]) で `_headers` / `<meta>` strict 化 + `stripMetaStyleSrc` 撤去 + Astro island style hash 取り込み + test 群 strict 化 (PR 8 rebase で削除した 3 commit 再投入)
-- **PR 9 follow-up (本 PR、`#312` の後続)**: `#309` (FOUC option A) close / `#308` (sheet 再利用 (ii) 実装見送り) open 維持、`docs/decisions.md [067] Follow-up decisions` で記録 + `useDynamicStyleSheet.ts` JSDoc 補強
+- **PR 9 follow-up (PR [#313](https://github.com/fumtas1k/devtools/pull/313), merged `55550ff`、`#312` の後続)**: `#309` (FOUC option A、closed) / `#308` (sheet 再利用 (ii) 実装見送り、open 維持)、`docs/decisions.md [067] Follow-up decisions` で記録 + `useDynamicStyleSheet.ts` JSDoc 補強
 
 ### PR 10 (issue [#305](https://github.com/fumtas1k/devtools/issues/305)、新規) — B 案最終 flip
 


### PR DESCRIPTION
## 概要

PR [#313](https://github.com/fumtas1k/devtools/pull/313) (PR 9 follow-up — `#309` / `#308` decision メモ化、merged `55550ff`) の SoT 反映。`ad698a5` (PR [#312](https://github.com/fumtas1k/devtools/pull/312)、PR 9 merge hash 反映) と同パターンの chore 更新。

## 変更

- `docs/projects/issue-176-b-plan-progress.md` の PR 9 entry 末尾の follow-up 行を更新:
  - 旧: `**PR 9 follow-up (本 PR、#312 の後続)**: ...`
  - 新: `**PR 9 follow-up (PR #313, merged 55550ff、#312 の後続)**: ...`
- `#309` (FOUC option A、**closed**) / `#308` (sheet 再利用 (ii) 実装見送り、**open 維持**) の状態を明記
- 目的: PR 10 ([#305](https://github.com/fumtas1k/devtools/issues/305)) spec 起草時に merge hash 解決済の参照経路を提供する

## 検証

- docs only 変更、behavioral change ゼロ
- prettier + tsc (pre-commit hook) pass

## 関連

- 親プロジェクト: `#176` B 案 (`docs/projects/issue-176-b-plan-progress.md`)
- 反映対象: PR `#313` (PR 9 follow-up、merged `55550ff`)
- 前例: `ad698a5` (PR `#312`、PR 9 merge hash 反映)
- 後段: PR 10 (`#305`)
