### PR TITLE
fix(ui): #288 DownloadButton の高さを CopyButton と揃える (ActionButton size prop 追加)

### DIFF
--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -1,6 +1,7 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 type Variant = 'default' | 'primary' | 'secondary' | 'danger';
+type Size = 'default' | 'compact';
 
 interface Props extends Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
@@ -11,11 +12,23 @@ interface Props extends Omit<
   children: ReactNode;
   variant?: Variant;
   loading?: boolean;
+  /**
+   * 高さプリセット。
+   * - 'default'（既定）: `font-semibold px-4 py-2`、`caption` の line-height 1.7 を継承
+   * - 'compact': `font-bold px-3 py-2 leading-none`、CopyButton (default) と同じ高さ
+   */
+  size?: Size;
 }
+
+const SIZE_CLASS: Record<Size, string> = {
+  default: 'font-semibold px-4 py-2',
+  compact: 'font-bold px-3 py-2 leading-none',
+};
 
 /**
  * 汎用アクションボタン。
  * - `variant`: 'default' | 'primary' | 'secondary' | 'danger'
+ * - `size`: 'default' | 'compact'（'compact' は CopyButton と同じ高さに揃える）
  * - `loading`: true のとき `aria-busy="true"` を付与し、disabled 状態にする
  * - ローディング中の子要素はそのまま表示するため、呼び出し元でローディング文言に切り替えること
  *   （例: `{loading ? '生成中…' : '生成'}`）
@@ -31,6 +44,7 @@ export function ActionButton({
   children,
   variant = 'default',
   loading = false,
+  size = 'default',
   ...rest
 }: Props) {
   const isDisabled = disabled || loading;
@@ -41,7 +55,7 @@ export function ActionButton({
       onClick={onClick}
       disabled={isDisabled}
       aria-busy={loading ? 'true' : undefined}
-      className={`caption font-semibold inline-flex items-center px-4 py-2 rounded-lg whitespace-nowrap btn-action btn-action--${variant}`}
+      className={`caption inline-flex items-center rounded-lg whitespace-nowrap btn-action btn-action--${variant} ${SIZE_CLASS[size]}`}
       {...rest}
     >
       {children}

--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -31,7 +31,8 @@ function DownloadIcon() {
 
 /**
  * ダウンロードアイコン付きのアクションボタン。
- * `ActionButton` を内部で使用する薄いラッパー。
+ * `ActionButton` を `size="compact"` で内部使用する薄いラッパー。
+ * - 高さは CopyButton (default) と pixel-perfect に揃う（横並び崩れ回避、#288）
  * - `variant="primary"`: primary 色背景 + 白文字 (デフォルト)
  * - `variant="secondary"`: 透過背景 + primary 文字色 + primary ボーダー
  * - `loading=true`: ActionButton 経由で `aria-busy="true"` と disabled 状態を付与
@@ -47,6 +48,7 @@ export function DownloadButton({
   return (
     <ActionButton
       variant={variant}
+      size="compact"
       onClick={onClick}
       disabled={disabled}
       loading={loading}

--- a/src/components/ui/__tests__/ActionButton.test.tsx
+++ b/src/components/ui/__tests__/ActionButton.test.tsx
@@ -148,4 +148,28 @@ describe('ActionButton', () => {
     const btn = screen.getByRole('button') as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
   });
+
+  it('size 未指定（default）は font-semibold + px-4 py-2 を持ち leading-none を持たない', () => {
+    render(<ActionButton onClick={() => {}}>標準</ActionButton>);
+    const btn = screen.getByRole('button') as HTMLButtonElement;
+    expect(btn.className).toContain('font-semibold');
+    expect(btn.className).toContain('px-4');
+    expect(btn.className).toContain('py-2');
+    expect(btn.className).not.toContain('leading-none');
+  });
+
+  it('size="compact" は font-bold + px-3 py-2 leading-none を持つ', () => {
+    render(
+      <ActionButton onClick={() => {}} size="compact">
+        コンパクト
+      </ActionButton>
+    );
+    const btn = screen.getByRole('button') as HTMLButtonElement;
+    expect(btn.className).toContain('font-bold');
+    expect(btn.className).toContain('px-3');
+    expect(btn.className).toContain('py-2');
+    expect(btn.className).toContain('leading-none');
+    expect(btn.className).not.toContain('font-semibold');
+    expect(btn.className).not.toContain('px-4');
+  });
 });

--- a/src/components/ui/__tests__/DownloadButton.test.tsx
+++ b/src/components/ui/__tests__/DownloadButton.test.tsx
@@ -88,4 +88,16 @@ describe('DownloadButton', () => {
     expect(btn.disabled).toBe(true);
     expect(btn.className).toContain('btn-action--secondary');
   });
+
+  // #288: CopyButton と並ぶときに高さが揃うよう、ActionButton の size="compact" を必ず使う
+  it('CopyButton と同高に揃える compact サイズ class（font-bold / px-3 py-2 / leading-none）を持つ', () => {
+    render(<DownloadButton onClick={() => {}} label="DL" />);
+    const btn = screen.getByRole('button') as HTMLButtonElement;
+    expect(btn.className).toContain('font-bold');
+    expect(btn.className).toContain('px-3');
+    expect(btn.className).toContain('py-2');
+    expect(btn.className).toContain('leading-none');
+    expect(btn.className).not.toContain('font-semibold');
+    expect(btn.className).not.toContain('px-4');
+  });
 });


### PR DESCRIPTION
## 概要

`#288` 修正。`DownloadButton` の高さを `CopyButton` と pixel-perfect に揃え、横並び箇所のレイアウト崩れを解消。同時に過去回帰した「単独配置の `DownloadButton` も以前は細かった」状態にも戻す。

## 背景（回帰経緯）

| 時系列 | commit | 変更内容 |
| --- | --- | --- |
| 2026-04-27 | `35bc1ca` "fix: DownloadButton のサイズを CopyButton と完全に統一" | `DownloadButton` 単独で `lineHeight: 1` + `padding: 0.5rem 0.75rem` + `fontWeight: 700` を直接指定 |
| その後 | `ead079d` (`#236`) "DownloadButton を ActionButton の特殊化として再構成" | refactor で `ActionButton` 既定値（`font-semibold` / `px-4 py-2` / line-height 未指定 → `caption` の 1.7 継承）に**回帰** |
| その後 | `eb5e537` (`#256`, `#176` B 案 PR 1) inline style → CSS class 化 | className 確定するも `leading-none` は復活せず、現状の太い高さで固定 |

`caption` クラスが `line-height: 1.7` を持つため、`leading-none` を打ち消している `CopyButton` (default) は ≈ 32px、`leading-none` のない `DownloadButton` (= `ActionButton`) は ≈ 42px となり、`OutputField` の rightSlot で並ぶ 3 画面 + 単独配置 `DownloadButtonGroup` 全体で「以前より大きい」状態になっていた。

## 変更内容

- `src/components/ui/ActionButton.tsx`
  - `size?: 'default' | 'compact'` prop を追加
  - `compact`: `font-bold px-3 py-2 leading-none`（CopyButton と pixel-perfect に揃う）
  - `default`: 現状維持（`font-semibold px-4 py-2`、line-height は `caption` の 1.7 を継承）
  - 「生成」「実行」「削除」など他の `ActionButton` 利用箇所（primary CTA）は `size` 未指定 = `default` のままで**影響なし**
- `src/components/ui/DownloadButton.tsx`
  - 内部で常に `<ActionButton size="compact">` を使用（呼び出し側 API は変更なし）

## 影響範囲

`DownloadButton` 利用 13 箇所すべてが「以前の細い高さ」に戻る:

- `OutputField` rightSlot で並ぶ 3 画面（`#288` 報告 2 画面 + 同種の `EncodingConverter`）: `JsonCsv.tsx` / `ConfigConverter.tsx` / `EncodingConverter.tsx`
- 単独配置: `QrCode.tsx` / `JanCode.tsx` / `Gs1Databar.tsx` / `qr-ticket/GenerateTab.tsx` / `DownloadButtonGroup.tsx`

`ActionButton` を直接使う他コンポーネント（`CountInput` の生成系、各 tools の primary CTA 等）は `size` 未指定 = `default` で**外観変化なし**。

## 検証

- `npx astro check`: 0 errors / 0 warnings
- `npm run test -- --run`: 825 / 825 PASS
  - `ActionButton.test.tsx` に size prop 2 ケース追加
  - `DownloadButton.test.tsx` に compact class 検証 1 ケース追加
- `npm run test:e2e`: 149 PASS / 0 fail / 1 既存 skip
- VRT: `DownloadButton` は VRT スナップショット範囲外のため baseline 更新は不要（CI で fail しない見込み）
- aria-\* 削除: なし（`aria-busy` / `aria-label` を維持）

## Close

Close #288
