### PR TITLE
chore(test): qr-ticket.test.ts の未使用 import (MAX_QR_BYTE_SIZE) を削除

### DIFF
--- a/src/utils/__tests__/qr-ticket.test.ts
+++ b/src/utils/__tests__/qr-ticket.test.ts
@@ -13,7 +13,6 @@ import {
   generateQrSvg,
   generateTicketId,
   estimateTicketByteSize,
-  MAX_QR_BYTE_SIZE,
   PAYLOAD_FIELD_COUNT,
   type TicketPayload,
   type SignedTicket,


### PR DESCRIPTION
## 概要

`src/utils/__tests__/qr-ticket.test.ts` で import されている `MAX_QR_BYTE_SIZE` がテスト本文で参照されていない dead import だったため削除。

## 背景

`#288` 修正中に `npx astro check` を実行した際、以下の warning が hint として残っていることを発見:

```
src/utils/__tests__/qr-ticket.test.ts:16:3 - warning ts(6133):
  'MAX_QR_BYTE_SIZE' is declared but its value is never read.
```

`grep` で確認したところ:

- export 元: `src/utils/qr-ticket.ts:17` `export const MAX_QR_BYTE_SIZE = 250;` — 他で利用されている可能性があるため**保持**
- import 先: `src/utils/__tests__/qr-ticket.test.ts:16` のみ、本文で**参照ゼロ**

`#288` の scope 外のため別 PR で対応 (memory `feedback_pr_size.md` / `feedback_infra_feature_separation.md` 準拠)。

## 変更内容

- `src/utils/__tests__/qr-ticket.test.ts`: import の `MAX_QR_BYTE_SIZE,` 1 行のみ削除

## 検証

- `npx astro check`: 0 errors / 0 warnings（当該 hint が消失）
- `npm run test -- --run src/utils/__tests__/qr-ticket.test.ts`: 33 / 33 PASS
- 動作影響: なし（テスト本文で未使用のため）
