### PR TITLE
fix(ci): #293 VRT heredoc 中断回避のため grep に || true 追加

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -89,7 +89,8 @@ jobs:
               echo ""
               # 各 ✘ 行の最後の › 区切り（spec 名）と直前の区切り（viewport 記述）を抽出。
               # retry 行は除外して unique 化、最大 30 行に丸める。
-              grep -E '^[[:space:]]+✘' vrt-output.log \
+              # `|| true` で grep no-match (exit 1) でも heredoc 全体が中断しないようにする。
+              (grep -E '^[[:space:]]+✘' vrt-output.log || true) \
                 | grep -v '(retry' \
                 | awk -F'›' '{
                     n = NF

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -89,8 +89,10 @@ jobs:
               echo ""
               # 各 ✘ 行の最後の › 区切り（spec 名）と直前の区切り（viewport 記述）を抽出。
               # retry 行は除外して unique 化、最大 30 行に丸める。
-              # `|| true` で grep no-match (exit 1) でも heredoc 全体が中断しないようにする。
-              (grep -E '^[[:space:]]+✘' vrt-output.log || true) \
+              # pipeline 全体を `( ... ) || true` で包む: 最初の grep だけでなく後段の `grep -v`
+              # も入力 0 行のとき exit 1 を返すため (grep 仕様)、subshell 全体で救わないと
+              # `set -e -o pipefail` で heredoc が中断する。
+              ( grep -E '^[[:space:]]+✘' vrt-output.log \
                 | grep -v '(retry' \
                 | awk -F'›' '{
                     n = NF
@@ -103,7 +105,7 @@ jobs:
                     print "- [" vp "] " spec
                   }' \
                 | sort -u \
-                | head -30
+                | head -30 ) || true
             fi
 
             echo ""


### PR DESCRIPTION
## 概要

#293 修正。`.github/workflows/visual-regression.yml` の「PR comment 本文を組み立て」step で `grep -E '^[[:space:]]+✘' vrt-output.log` が match 0 件のとき exit 1 を返し、`set -e -o pipefail` で heredoc 全体が中断する問題を修正。

## 修正内容

- `(grep ... || true)` で no-match を許容
- 経緯コメントを 1 行追記

## 動作確認

- yaml 構文確認のみ（local では VRT 経路を再現できないため CI が最終ゲート）
- VRT が通常通り fail spec を吐く場合の挙動には影響なし（regression risk なし）

## 関連

- Closes #293
- 起源 PR: #292（review 指摘 🟡 #3）
