### PR TITLE
test(e2e): #234 PR 1/5 — 単純変換系 6 spec を applyProductionCsp 配下に移行

### DIFF
--- a/tests/e2e/base64.spec.ts
+++ b/tests/e2e/base64.spec.ts
@@ -1,63 +1,71 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('Base64 エンコード/デコード', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/base64');
-    await page.getByLabel('入力').waitFor();
-    await waitForReactHydration(page);
+test.describe('Base64 エンコード/デコード（production CSP 適用）', () => {
+  test('標準形式でエンコードできる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      await page.getByLabel('入力').fill('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
+    });
   });
 
-  test('標準形式でエンコードできる', async ({ page }) => {
-    await page.getByLabel('入力').fill('Hello');
-    await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
+  test('標準形式でデコードできる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      await page.getByRole('button', { name: 'デコード' }).click();
+      await page.getByLabel('入力').fill('SGVsbG8=');
+      await expect(page.getByLabel('変換結果')).toHaveValue('Hello');
+    });
   });
 
-  test('標準形式でデコードできる', async ({ page }) => {
-    await page.getByRole('button', { name: 'デコード' }).click();
-    await page.getByLabel('入力').fill('SGVsbG8=');
-    await expect(page.getByLabel('変換結果')).toHaveValue('Hello');
+  test('URL-safe 形式でエンコードできる（パディングなし、CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      await page.getByRole('button', { name: 'URL-safe' }).click();
+      await page.getByLabel('入力').fill('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8');
+    });
   });
 
-  test('URL-safe 形式でエンコードできる（パディングなし）', async ({ page }) => {
-    await page.getByRole('button', { name: 'URL-safe' }).click();
-    await page.getByLabel('入力').fill('Hello');
-    await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8');
+  test('モード切替時に入力・出力がリセットされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      await page.getByLabel('入力').fill('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
+
+      await page.getByRole('button', { name: 'デコード' }).click();
+
+      await expect(page.getByLabel('入力')).toHaveValue('');
+      await expect(page.getByLabel('変換結果')).toHaveValue('');
+    });
   });
 
-  test('モード切替時に入力・出力がリセットされる', async ({ page }) => {
-    await page.getByLabel('入力').fill('Hello');
-    await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
+  test('形式切替時に入力が保持され出力が再計算される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      await page.getByLabel('入力').fill('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
 
-    await page.getByRole('button', { name: 'デコード' }).click();
+      await page.getByRole('button', { name: 'URL-safe' }).click();
 
-    await expect(page.getByLabel('入力')).toHaveValue('');
-    await expect(page.getByLabel('変換結果')).toHaveValue('');
+      await expect(page.getByLabel('入力')).toHaveValue('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8');
+    });
   });
 
-  test('形式切替時に入力が保持され出力が再計算される', async ({ page }) => {
-    await page.getByLabel('入力').fill('Hello');
-    await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
-
-    await page.getByRole('button', { name: 'URL-safe' }).click();
-
-    await expect(page.getByLabel('入力')).toHaveValue('Hello');
-    await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8');
+  test('不正な入力でエラーメッセージを表示する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      await page.getByRole('button', { name: 'デコード' }).click();
+      await page.getByLabel('入力').fill('!!!invalid!!!');
+      await expect(page.getByRole('alert')).toBeVisible();
+    });
   });
 
-  test('不正な入力でエラーメッセージを表示する', async ({ page }) => {
-    await page.getByRole('button', { name: 'デコード' }).click();
-    await page.getByLabel('入力').fill('!!!invalid!!!');
-    await expect(page.getByRole('alert')).toBeVisible();
-  });
+  test('クリアボタンで入力・出力がリセットされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      await page.getByLabel('入力').fill('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
 
-  test('クリアボタンで入力・出力がリセットされる', async ({ page }) => {
-    await page.getByLabel('入力').fill('Hello');
-    await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
+      await page.getByRole('button', { name: 'クリア' }).click();
 
-    await page.getByRole('button', { name: 'クリア' }).click();
-
-    await expect(page.getByLabel('入力')).toHaveValue('');
-    await expect(page.getByLabel('変換結果')).toHaveValue('');
+      await expect(page.getByLabel('入力')).toHaveValue('');
+      await expect(page.getByLabel('変換結果')).toHaveValue('');
+    });
   });
 });

--- a/tests/e2e/dummy-text.spec.ts
+++ b/tests/e2e/dummy-text.spec.ts
@@ -1,42 +1,55 @@
 import { test, expect } from '@playwright/test';
+import { withProductionCsp } from './helpers';
 
-test.describe('ダミーテキスト生成', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/dummy-text');
-    // auto-generate on mount — テキストが表示されれば React ハイドレーション完了
-    await page.getByText(/\d+ 文字/).waitFor();
+test.describe('ダミーテキスト生成（production CSP 適用）', () => {
+  test('ページ読み込み時にデフォルトのテキストが自動生成される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/dummy-text', async (page) => {
+      await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+    });
   });
 
-  test('ページ読み込み時にデフォルトのテキストが自動生成される', async ({ page }) => {
-    await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+  test('デフォルト（漢字混じり日本語）でテキストが生成される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/dummy-text', async (page) => {
+      // 初期文字種は japanese（漢字混じり）
+      await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+    });
   });
 
-  test('デフォルト（漢字混じり日本語）でテキストが生成される', async ({ page }) => {
-    // 初期文字種は japanese（漢字混じり）
-    await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+  test('文字数を変更すると指定文字数のテキストが生成される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/dummy-text', async (page) => {
+      // number input は全選択してから入力
+      await page.getByLabel('文字数').click({ clickCount: 3 });
+      await page.keyboard.type('50');
+      // Tab キーで blur を発火（handleLengthBlur → generate 再実行）
+      await page.keyboard.press('Tab');
+      await expect(page.getByText('50 文字')).toBeVisible();
+    });
   });
 
-  test('文字数を変更すると指定文字数のテキストが生成される', async ({ page }) => {
-    // number input は全選択してから入力
-    await page.getByLabel('文字数').click({ clickCount: 3 });
-    await page.keyboard.type('50');
-    // Tab キーで blur を発火（handleLengthBlur → generate 再実行）
-    await page.keyboard.press('Tab');
-    await expect(page.getByText('50 文字')).toBeVisible();
+  test('ひらがな文字種でテキストが生成される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/dummy-text', async (page) => {
+      await page.getByRole('button', { name: 'ひらがな' }).click();
+      await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+    });
   });
 
-  test('ひらがな文字種でテキストが生成される', async ({ page }) => {
-    await page.getByRole('button', { name: 'ひらがな' }).click();
-    await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+  test('英数字文字種でテキストが生成される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/dummy-text', async (page) => {
+      await page.getByRole('button', { name: '英数字' }).click();
+      await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+    });
   });
 
-  test('英数字文字種でテキストが生成される', async ({ page }) => {
-    await page.getByRole('button', { name: '英数字' }).click();
-    await expect(page.getByText(/\d+ 文字/)).toBeVisible();
-  });
-
-  test('文字種切替で新しいテキストが生成される', async ({ page }) => {
-    await page.getByRole('button', { name: 'カタカナ' }).click();
-    await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+  test('文字種切替で新しいテキストが生成される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/dummy-text', async (page) => {
+      await page.getByRole('button', { name: 'カタカナ' }).click();
+      await expect(page.getByText(/\d+ 文字/)).toBeVisible();
+    });
   });
 });

--- a/tests/e2e/jan-code.spec.ts
+++ b/tests/e2e/jan-code.spec.ts
@@ -1,59 +1,67 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('JANコード生成', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/jan-code');
-    await page.getByRole('button', { name: 'サンプルを入力' }).waitFor();
-    await waitForReactHydration(page);
+test.describe('JANコード生成（production CSP 適用）', () => {
+  test('JAN-13: サンプルボタンで結果が表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      // exact: true で説明文との誤マッチを防ぐ
+      await expect(page.getByText('チェックディジット', { exact: true })).toBeVisible();
+      await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
+    });
   });
 
-  test('JAN-13: サンプルボタンで結果が表示される', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    // exact: true で説明文との誤マッチを防ぐ
-    await expect(page.getByText('チェックディジット', { exact: true })).toBeVisible();
-    await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
+  test('JAN-13: 12桁入力でチェックディジットと完成コードが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      // pressSequentially で React の onChange を確実に発火させる
+      await page.getByLabel(/桁を入力/).pressSequentially('490123456789');
+      await expect(page.getByText('チェックディジット', { exact: true })).toBeVisible();
+      await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
+    });
   });
 
-  test('JAN-13: 12桁入力でチェックディジットと完成コードが表示される', async ({ page }) => {
-    // pressSequentially で React の onChange を確実に発火させる
-    await page.getByLabel(/桁を入力/).pressSequentially('490123456789');
-    await expect(page.getByText('チェックディジット', { exact: true })).toBeVisible();
-    await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
+  test('JAN-13: 完成コードは13桁（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
+      // 結果エリア全体に13桁数字が含まれることを確認
+      await expect(
+        page
+          .getByTestId('jan-code-result')
+          .getByText(/^\d{13}$/)
+          .first()
+      ).toBeVisible();
+    });
   });
 
-  test('JAN-13: 完成コードは13桁', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
-    // 結果エリア全体に13桁数字が含まれることを確認
-    await expect(
-      page
-        .getByTestId('jan-code-result')
-        .getByText(/^\d{13}$/)
-        .first()
-    ).toBeVisible();
+  test('JAN-13: 数字以外の入力でエラーを表示する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByLabel(/桁を入力/).pressSequentially('abc');
+      await expect(page.getByRole('alert')).toContainText('数字のみ入力してください');
+    });
   });
 
-  test('JAN-13: 数字以外の入力でエラーを表示する', async ({ page }) => {
-    await page.getByLabel(/桁を入力/).pressSequentially('abc');
-    await expect(page.getByRole('alert')).toContainText('数字のみ入力してください');
+  test('JAN-13: 入力が不完全な場合は結果を表示しない（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByLabel(/桁を入力/).pressSequentially('490');
+      await expect(page.getByText('チェックディジット', { exact: true })).not.toBeVisible();
+    });
   });
 
-  test('JAN-13: 入力が不完全な場合は結果を表示しない', async ({ page }) => {
-    await page.getByLabel(/桁を入力/).pressSequentially('490');
-    await expect(page.getByText('チェックディジット', { exact: true })).not.toBeVisible();
-  });
-
-  test('JAN-8: モード切替後にサンプルで結果が表示される', async ({ page }) => {
-    await page.getByRole('button', { name: 'JAN-8' }).click();
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByText('チェックディジット', { exact: true })).toBeVisible();
-    // 完成コードは8桁
-    await expect(
-      page
-        .getByTestId('jan-code-result')
-        .getByText(/^\d{8}$/)
-        .first()
-    ).toBeVisible();
+  test('JAN-8: モード切替後にサンプルで結果が表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'JAN-8' }).click();
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByText('チェックディジット', { exact: true })).toBeVisible();
+      // 完成コードは8桁
+      await expect(
+        page
+          .getByTestId('jan-code-result')
+          .getByText(/^\d{8}$/)
+          .first()
+      ).toBeVisible();
+    });
   });
 });

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -1,86 +1,102 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('JSON / CSV 変換', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/json-csv');
-    await page.getByLabel('入力').waitFor();
-    await waitForReactHydration(page);
+test.describe('JSON / CSV 変換（production CSP 適用）', () => {
+  test('JSON → CSV: サンプルデータを変換できる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByLabel('変換結果')).not.toHaveValue('');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/id/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/name/);
+    });
   });
 
-  test('JSON → CSV: サンプルデータを変換できる', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByLabel('変換結果')).not.toHaveValue('');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/id/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/name/);
+  test('JSON → CSV: フラットなJSONをCSVに変換する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      await page.getByLabel('入力').fill('[{"id":1,"name":"太郎"},{"id":2,"name":"花子"}]');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/id,name/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/太郎/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/花子/);
+    });
   });
 
-  test('JSON → CSV: フラットなJSONをCSVに変換する', async ({ page }) => {
-    await page.getByLabel('入力').fill('[{"id":1,"name":"太郎"},{"id":2,"name":"花子"}]');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/id,name/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/太郎/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/花子/);
-  });
-
-  test('JSON → CSV: ネストオブジェクトをドット記法でフラット化する', async ({ page }) => {
-    await page.getByLabel('入力').fill('[{"name":"太郎","address":{"city":"東京"}}]');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/address\.city/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/東京/);
-  });
-
-  test('JSON → CSV: 不正なJSONでエラーを表示する', async ({ page }) => {
-    await page.getByLabel('入力').fill('not valid json');
-    await expect(page.getByRole('alert')).toBeVisible();
-  });
-
-  test('CSV → JSON: サンプルデータを変換できる', async ({ page }) => {
-    await page.getByRole('button', { name: 'CSV → JSON' }).click();
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByLabel('変換結果')).not.toHaveValue('');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/\[/);
-  });
-
-  test('CSV → JSON: CSVをJSONに変換する', async ({ page }) => {
-    await page.getByRole('button', { name: 'CSV → JSON' }).click();
-    await page.getByLabel('入力').fill('id,name\n1,太郎\n2,花子');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/"id"/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/太郎/);
-  });
-
-  test('モード切替で入出力がクリアされる', async ({ page }) => {
-    await page.getByLabel('入力').fill('[{"id":1}]');
-    await page.getByRole('button', { name: 'CSV → JSON' }).click();
-    await expect(page.getByLabel('入力')).toHaveValue('');
-  });
-
-  test('JSON → CSV: フォーミュラインジェクションをエスケープする', async ({ page }) => {
-    // 注: 本ツールは useCodec フックでリアルタイム変換しているため
-    // 「JSON → CSV」「CSV → JSON」はモード切替トグルであり明示的な変換ボタンは存在しない。
-    // 入力欄を埋めるだけで変換結果が反映される（他の JSON→CSV 系 e2e テストと同方針）。
-    await page.getByLabel('入力').fill('[{"formula":"=SUM(A1:A10)","plus":"+1+1","at":"@SUM"}]');
-    // 先頭にシングルクォートが付加され、Excel が数式として解釈しない
-    await expect(page.getByLabel('変換結果')).toHaveValue(/'=SUM\(A1:A10\)/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/'\+1\+1/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/'@SUM/);
-  });
-
-  test('JSON → CSV: タイピング直後はダウンロードボタンが disabled になり、デバウンス完了後に有効化される', async ({
-    page,
+  test('JSON → CSV: ネストオブジェクトをドット記法でフラット化する（CSP 違反なし）', async ({
+    browser,
   }) => {
-    const downloadBtn = page.getByRole('button', { name: 'CSVダウンロード' });
-    const inputField = page.getByLabel('入力');
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      await page.getByLabel('入力').fill('[{"name":"太郎","address":{"city":"東京"}}]');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/address\.city/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/東京/);
+    });
+  });
 
-    // 有効な JSON を入力してボタンを表示させ、デバウンス完了を待つ
-    await inputField.fill('[{"id":1}]');
-    await expect(downloadBtn).toBeVisible({ timeout: 2000 });
-    await expect(downloadBtn).toBeEnabled({ timeout: 2000 });
+  test('JSON → CSV: 不正なJSONでエラーを表示する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      await page.getByLabel('入力').fill('not valid json');
+      await expect(page.getByRole('alert')).toBeVisible();
+    });
+  });
 
-    // 新しい入力でデバウンス中（isPending = true）→ ボタンが disabled になる
-    await inputField.fill('[{"id":2}]');
-    await expect(downloadBtn).toBeDisabled();
+  test('CSV → JSON: サンプルデータを変換できる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      await page.getByRole('button', { name: 'CSV → JSON' }).click();
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByLabel('変換結果')).not.toHaveValue('');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/\[/);
+    });
+  });
 
-    // デバウンス完了（useCodec の既定値）後に再び有効化される
-    // timeout: 3000 は useCodec の既定 debounceMs（300ms）に対する余裕
-    await expect(downloadBtn).toBeEnabled({ timeout: 3000 });
+  test('CSV → JSON: CSVをJSONに変換する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      await page.getByRole('button', { name: 'CSV → JSON' }).click();
+      await page.getByLabel('入力').fill('id,name\n1,太郎\n2,花子');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/"id"/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/太郎/);
+    });
+  });
+
+  test('モード切替で入出力がクリアされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      await page.getByLabel('入力').fill('[{"id":1}]');
+      await page.getByRole('button', { name: 'CSV → JSON' }).click();
+      await expect(page.getByLabel('入力')).toHaveValue('');
+    });
+  });
+
+  test('JSON → CSV: フォーミュラインジェクションをエスケープする（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      // 注: 本ツールは useCodec フックでリアルタイム変換しているため
+      // 「JSON → CSV」「CSV → JSON」はモード切替トグルであり明示的な変換ボタンは存在しない。
+      // 入力欄を埋めるだけで変換結果が反映される（他の JSON→CSV 系 e2e テストと同方針）。
+      await page.getByLabel('入力').fill('[{"formula":"=SUM(A1:A10)","plus":"+1+1","at":"@SUM"}]');
+      // 先頭にシングルクォートが付加され、Excel が数式として解釈しない
+      await expect(page.getByLabel('変換結果')).toHaveValue(/'=SUM\(A1:A10\)/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/'\+1\+1/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/'@SUM/);
+    });
+  });
+
+  test('JSON → CSV: タイピング直後はダウンロードボタンが disabled になり、デバウンス完了後に有効化される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      const downloadBtn = page.getByRole('button', { name: 'CSVダウンロード' });
+      const inputField = page.getByLabel('入力');
+
+      // 有効な JSON を入力してボタンを表示させ、デバウンス完了を待つ
+      await inputField.fill('[{"id":1}]');
+      await expect(downloadBtn).toBeVisible({ timeout: 2000 });
+      await expect(downloadBtn).toBeEnabled({ timeout: 2000 });
+
+      // 新しい入力でデバウンス中（isPending = true）→ ボタンが disabled になる
+      await inputField.fill('[{"id":2}]');
+      await expect(downloadBtn).toBeDisabled();
+
+      // デバウンス完了（useCodec の既定値）後に再び有効化される
+      // timeout: 3000 は useCodec の既定 debounceMs（300ms）に対する余裕
+      await expect(downloadBtn).toBeEnabled({ timeout: 3000 });
+    });
   });
 });

--- a/tests/e2e/json-xml.spec.ts
+++ b/tests/e2e/json-xml.spec.ts
@@ -1,54 +1,62 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('JSON / XML 変換', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/json-xml');
-    await page.getByLabel('入力').waitFor();
-    await waitForReactHydration(page);
+test.describe('JSON / XML 変換（production CSP 適用）', () => {
+  test('JSON → XML: サンプルデータを変換できる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-xml', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByLabel('変換結果')).not.toHaveValue('');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/\<\?xml/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/\<root\>/);
+    });
   });
 
-  test('JSON → XML: サンプルデータを変換できる', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByLabel('変換結果')).not.toHaveValue('');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/\<\?xml/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/\<root\>/);
+  test('JSON → XML: シンプルなJSONをXMLに変換する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-xml', async (page) => {
+      await page.getByLabel('入力').fill('{"name":"太郎","age":30}');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/<name>太郎<\/name>/);
+      await expect(page.getByLabel('変換結果')).toHaveValue(/<age>30<\/age>/);
+    });
   });
 
-  test('JSON → XML: シンプルなJSONをXMLに変換する', async ({ page }) => {
-    await page.getByLabel('入力').fill('{"name":"太郎","age":30}');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/<name>太郎<\/name>/);
-    await expect(page.getByLabel('変換結果')).toHaveValue(/<age>30<\/age>/);
+  test('JSON → XML: 不正なJSONでエラーを表示する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-xml', async (page) => {
+      await page.getByLabel('入力').fill('not valid json');
+      await expect(page.getByRole('alert')).toBeVisible();
+    });
   });
 
-  test('JSON → XML: 不正なJSONでエラーを表示する', async ({ page }) => {
-    await page.getByLabel('入力').fill('not valid json');
-    await expect(page.getByRole('alert')).toBeVisible();
+  test('XML → JSON: サンプルデータを変換できる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-xml', async (page) => {
+      await page.getByRole('button', { name: 'XML → JSON' }).click();
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByLabel('変換結果')).not.toHaveValue('');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/\{/);
+    });
   });
 
-  test('XML → JSON: サンプルデータを変換できる', async ({ page }) => {
-    await page.getByRole('button', { name: 'XML → JSON' }).click();
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByLabel('変換結果')).not.toHaveValue('');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/\{/);
+  test('XML → JSON: シンプルなXMLをJSONに変換する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-xml', async (page) => {
+      await page.getByRole('button', { name: 'XML → JSON' }).click();
+      await page.getByLabel('入力').fill('<root><name>太郎</name></root>');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/太郎/);
+    });
   });
 
-  test('XML → JSON: シンプルなXMLをJSONに変換する', async ({ page }) => {
-    await page.getByRole('button', { name: 'XML → JSON' }).click();
-    await page.getByLabel('入力').fill('<root><name>太郎</name></root>');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/太郎/);
+  test('XML → JSON: 不正なXMLでエラーを表示する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-xml', async (page) => {
+      await page.getByRole('button', { name: 'XML → JSON' }).click();
+      await page.getByLabel('入力').fill('<<not xml');
+      await expect(page.getByRole('alert')).toBeVisible();
+    });
   });
 
-  test('XML → JSON: 不正なXMLでエラーを表示する', async ({ page }) => {
-    await page.getByRole('button', { name: 'XML → JSON' }).click();
-    await page.getByLabel('入力').fill('<<not xml');
-    await expect(page.getByRole('alert')).toBeVisible();
-  });
-
-  test('クリアボタンで出力が消える', async ({ page }) => {
-    await page.getByLabel('入力').fill('{"key":"value"}');
-    await expect(page.getByLabel('変換結果')).not.toHaveValue('');
-    await page.getByRole('button', { name: 'クリア' }).click();
-    await expect(page.getByLabel('変換結果')).toHaveValue('');
+  test('クリアボタンで出力が消える（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-xml', async (page) => {
+      await page.getByLabel('入力').fill('{"key":"value"}');
+      await expect(page.getByLabel('変換結果')).not.toHaveValue('');
+      await page.getByRole('button', { name: 'クリア' }).click();
+      await expect(page.getByLabel('変換結果')).toHaveValue('');
+    });
   });
 });

--- a/tests/e2e/url-encode.spec.ts
+++ b/tests/e2e/url-encode.spec.ts
@@ -1,45 +1,53 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('URLエンコード/デコード', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/url-encode');
-    await page.getByLabel('入力').waitFor();
-    await waitForReactHydration(page);
+test.describe('URLエンコード/デコード（production CSP 適用）', () => {
+  test('日本語テキストをエンコードできる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.getByLabel('入力').fill('テスト');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/%E3%83%86%E3%82%B9%E3%83%88/);
+    });
   });
 
-  test('日本語テキストをエンコードできる', async ({ page }) => {
-    await page.getByLabel('入力').fill('テスト');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/%E3%83%86%E3%82%B9%E3%83%88/);
+  test('URLをエンコードできる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.getByLabel('入力').pressSequentially('https://example.com/?q=テスト');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/https%3A%2F%2Fexample\.com/);
+    });
   });
 
-  test('URLをエンコードできる', async ({ page }) => {
-    await page.getByLabel('入力').pressSequentially('https://example.com/?q=テスト');
-    await expect(page.getByLabel('変換結果')).toHaveValue(/https%3A%2F%2Fexample\.com/);
+  test('デコードモードでデコードできる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.getByRole('button', { name: 'デコード' }).click();
+      await page.getByLabel('入力').fill('%E3%83%86%E3%82%B9%E3%83%88');
+      await expect(page.getByLabel('変換結果')).toHaveValue('テスト');
+    });
   });
 
-  test('デコードモードでデコードできる', async ({ page }) => {
-    await page.getByRole('button', { name: 'デコード' }).click();
-    await page.getByLabel('入力').fill('%E3%83%86%E3%82%B9%E3%83%88');
-    await expect(page.getByLabel('変換結果')).toHaveValue('テスト');
+  test('不正なエンコード文字列でエラーメッセージを表示する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.getByRole('button', { name: 'デコード' }).click();
+      await page.getByLabel('入力').fill('%GG');
+      await expect(page.getByRole('alert')).toContainText('不正なURLエンコード文字列です');
+    });
   });
 
-  test('不正なエンコード文字列でエラーメッセージを表示する', async ({ page }) => {
-    await page.getByRole('button', { name: 'デコード' }).click();
-    await page.getByLabel('入力').fill('%GG');
-    await expect(page.getByRole('alert')).toContainText('不正なURLエンコード文字列です');
+  test('サンプルボタンで入力が埋まり出力が表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByLabel('入力')).not.toHaveValue('');
+      await expect(page.getByLabel('変換結果')).not.toHaveValue('');
+    });
   });
 
-  test('サンプルボタンで入力が埋まり出力が表示される', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByLabel('入力')).not.toHaveValue('');
-    await expect(page.getByLabel('変換結果')).not.toHaveValue('');
-  });
-
-  test('クリアボタンで入力・出力がリセットされる', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByLabel('変換結果')).not.toHaveValue('');
-    await page.getByRole('button', { name: 'クリア' }).click();
-    await expect(page.getByLabel('入力')).toHaveValue('');
+  test('クリアボタンで入力・出力がリセットされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByLabel('変換結果')).not.toHaveValue('');
+      await page.getByRole('button', { name: 'クリア' }).click();
+      await expect(page.getByLabel('入力')).toHaveValue('');
+    });
   });
 });


### PR DESCRIPTION
## 概要

issue #234 の PR 1/5。`applyProductionCsp` を以下の単純変換系 6 spec へ展開し、本番相当 CSP 制約下で全 E2E が pass することを確認。

- `tests/e2e/base64.spec.ts`
- `tests/e2e/url-encode.spec.ts`
- `tests/e2e/json-xml.spec.ts`
- `tests/e2e/json-csv.spec.ts`
- `tests/e2e/dummy-text.spec.ts`
- `tests/e2e/jan-code.spec.ts`

## 移行パターン

`uuid-v7.spec.ts` / `ulid-generator.spec.ts` の先行実装に準拠:

- 各 `test` を `withProductionCsp(browser, path, async (page) => {...})` でラップ
- `async ({ page })` → `async ({ browser })` へ変更
- 既存の `test.beforeEach` (`page.goto` + `waitForReactHydration`) はラッパーが内包するため削除
- describe タイトルに「（production CSP 適用）」、各 test 名末尾に「（CSP 違反なし）」を付加

## メタテストの方針

陽性対照メタテスト（ゲート自体の動作確認）は本 PR では追加しない。既に
`config-converter.spec.ts` / `ulid-generator.spec.ts` / `uuid-v7.spec.ts` の
3 spec で gate を網羅しており、各 spec の goto path 違いは gate 検出ロジック
（CDP console error → CSP 文字列 regex マッチ）に対して redundant。

issue #234「`config-converter` で代表させて他は信頼する」案を採用。

## 検証結果

- `node_modules/.bin/astro check`: 0 errors（既存 link-styles.spec.ts の hints は本 PR と無関係）
- `npm run test`: 825 passed
- `npm run test:e2e tests/e2e/{base64,url-encode,json-xml,json-csv,dummy-text,jan-code}.spec.ts`: 41 passed (22.9s)

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] CI: 6 spec 全テストが production CSP 下で pass
- [ ] レビュー: `withProductionCsp` ラップ漏れがないこと
- [ ] レビュー: `test.beforeEach` 削除漏れ / `applyProductionCsp` 単独使用残りがないこと

## 関連

- 親 issue: #234
- 先行実装: PR #233 (config-converter 1 spec)、ulid-generator / uuid-v7 (full migration 済み)
- 続編予定: PR 2/5 UI 系 (copy-button / download-button / a11y-live-region / link-styles / mobile-drawer)
