### PR TITLE
test(e2e): #234 PR 2/5 — UI 系 5 spec を applyProductionCsp 配下に移行 + skipHydration オプション追加

### DIFF
--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -1,87 +1,85 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
 /**
  * issue #163 で追加した live region / aria-expanded / アイコン分離 のスモーク E2E。
  * SR が結果領域を読めることを `getByRole('status')` 経由で検証する。
  */
 
-test.describe('a11y live region (issue #163)', () => {
-  test('JANコード: チェック結果が role="status" として読める', async ({ page }) => {
-    await page.goto('/tools/jan-code', { waitUntil: 'domcontentloaded' });
-    await page.getByRole('button', { name: 'サンプルを入力' }).waitFor();
-    await waitForReactHydration(page);
+test.describe('a11y live region (issue #163, production CSP 適用)', () => {
+  test('JANコード: チェック結果が role="status" として読める（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      // 入力前は status が存在しない
+      await expect(page.getByRole('status')).toHaveCount(0);
 
-    // 入力前は status が存在しない
-    await expect(page.getByRole('status')).toHaveCount(0);
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
 
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-
-    const status = page.getByRole('status').first();
-    await expect(status).toBeVisible();
-    await expect(status).toContainText('チェックディジット');
-    await expect(status).toContainText('完成コード');
+      const status = page.getByRole('status').first();
+      await expect(status).toBeVisible();
+      await expect(status).toContainText('チェックディジット');
+      await expect(status).toContainText('完成コード');
+    });
   });
 
-  test('UUID v7: 生成結果が role="status" として読める', async ({ page }) => {
-    await page.goto('/tools/uuid-v7', { waitUntil: 'domcontentloaded' });
-    await page.getByRole('button', { name: '生成' }).waitFor();
-    await waitForReactHydration(page);
+  test('UUID v7: 生成結果が role="status" として読める（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/uuid-v7', async (page) => {
+      await page.getByRole('button', { name: '生成' }).click();
 
-    await page.getByRole('button', { name: '生成' }).click();
-
-    const status = page.getByRole('status').first();
-    await expect(status).toBeVisible();
-    await expect(status).toContainText('件生成');
+      const status = page.getByRole('status').first();
+      await expect(status).toBeVisible();
+      await expect(status).toContainText('件生成');
+    });
   });
 
-  test('JWTデコーダ: デコード結果が role="status" として読める', async ({ page }) => {
-    await page.goto('/tools/jwt-decoder', { waitUntil: 'domcontentloaded' });
-    await page.getByLabel('JWTトークンを貼り付け').waitFor();
-    await waitForReactHydration(page);
+  test('JWTデコーダ: デコード結果が role="status" として読める（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jwt-decoder', async (page) => {
+      const SAMPLE_JWT =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
 
-    const SAMPLE_JWT =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-    await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
+      await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
 
-    await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
-
-    const statusRegions = page.getByRole('status');
-    await expect(statusRegions.first()).toBeVisible();
+      const statusRegions = page.getByRole('status');
+      await expect(statusRegions.first()).toBeVisible();
+    });
   });
 });
 
-test.describe('a11y aria-expanded (issue #163)', () => {
-  test('ConfigConverter: JSON Schema 折りたたみが aria-expanded を反映する', async ({ page }) => {
-    await page.goto('/tools/config-converter', { waitUntil: 'domcontentloaded' });
-    await page.getByRole('button', { name: 'JSON Schema で検証する' }).waitFor();
-    await waitForReactHydration(page);
+test.describe('a11y aria-expanded (issue #163, production CSP 適用)', () => {
+  test('ConfigConverter: JSON Schema 折りたたみが aria-expanded を反映する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/config-converter', async (page) => {
+      const toggle = page.getByRole('button', { name: 'JSON Schema で検証する' });
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
-    const toggle = page.getByRole('button', { name: 'JSON Schema で検証する' });
-    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
-    await toggle.click();
-    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
-
-    await toggle.click();
-    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    });
   });
 });
 
-test.describe('a11y CopyButton compact tap target (issue #163)', () => {
-  test('UUID 一覧の compact コピーボタンは 32x32 以上の領域を持つ', async ({ page }) => {
-    await page.goto('/tools/uuid-v7', { waitUntil: 'domcontentloaded' });
-    await page.getByRole('button', { name: '生成' }).waitFor();
-    await waitForReactHydration(page);
+test.describe('a11y CopyButton compact tap target (issue #163, production CSP 適用)', () => {
+  test('UUID 一覧の compact コピーボタンは 32x32 以上の領域を持つ（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/uuid-v7', async (page) => {
+      await page.getByRole('button', { name: '生成' }).click();
 
-    await page.getByRole('button', { name: '生成' }).click();
+      const compactCopy = page.getByRole('button', { name: 'コピー' }).nth(1);
+      await compactCopy.waitFor({ state: 'visible' });
 
-    const compactCopy = page.getByRole('button', { name: 'コピー' }).nth(1);
-    await compactCopy.waitFor({ state: 'visible' });
-
-    const box = await compactCopy.boundingBox();
-    expect(box, 'compact ボタンの bounding box が取得できる').not.toBeNull();
-    expect(box!.width).toBeGreaterThanOrEqual(32);
-    expect(box!.height).toBeGreaterThanOrEqual(32);
+      const box = await compactCopy.boundingBox();
+      expect(box, 'compact ボタンの bounding box が取得できる').not.toBeNull();
+      expect(box!.width).toBeGreaterThanOrEqual(32);
+      expect(box!.height).toBeGreaterThanOrEqual(32);
+    });
   });
 });

--- a/tests/e2e/copy-button.spec.ts
+++ b/tests/e2e/copy-button.spec.ts
@@ -1,61 +1,73 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
 const SUCCESS_COLOR = 'rgb(22, 163, 74)';
 
-test.describe('CopyButton', () => {
-  test.beforeEach(async ({ page, context }) => {
-    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.goto('/tools/jan-code');
-    await page.getByRole('button', { name: 'サンプルを入力' }).waitFor();
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
+async function setupJanCodeWithSample(page: import('@playwright/test').Page): Promise<void> {
+  // CopyButton を表示するため /tools/jan-code でサンプル入力 → 結果を生成
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.getByRole('button', { name: 'サンプルを入力' }).click();
+}
+
+test.describe('CopyButton（production CSP 適用）', () => {
+  test('コピー成功時にボタン幅が変化しない（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await setupJanCodeWithSample(page);
+      const button = page.getByRole('button', { name: 'コピー' }).first();
+      await button.waitFor({ state: 'visible' });
+
+      const before = await button.boundingBox();
+      await button.click();
+      await button.getByRole('status').waitFor();
+      const after = await button.boundingBox();
+
+      expect(before?.width).toBe(after?.width);
+    });
   });
 
-  test('コピー成功時にボタン幅が変化しない', async ({ page }) => {
-    const button = page.getByRole('button', { name: 'コピー' }).first();
-    await button.waitFor({ state: 'visible' });
+  test('コピー成功時に緑色に切り替わる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await setupJanCodeWithSample(page);
+      const button = page.getByRole('button', { name: 'コピー' }).first();
+      await button.waitFor({ state: 'visible' });
 
-    const before = await button.boundingBox();
-    await button.click();
-    await button.getByRole('status').waitFor();
-    const after = await button.boundingBox();
+      await expect(button).not.toHaveCSS('color', SUCCESS_COLOR);
 
-    expect(before?.width).toBe(after?.width);
+      await button.click();
+      await button.getByRole('status').waitFor();
+
+      await expect(button).toHaveCSS('color', SUCCESS_COLOR);
+    });
   });
 
-  test('コピー成功時に緑色に切り替わる', async ({ page }) => {
-    const button = page.getByRole('button', { name: 'コピー' }).first();
-    await button.waitFor({ state: 'visible' });
+  test('コピー成功時に aria-live 領域が「コピーしました」を返す（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await setupJanCodeWithSample(page);
+      const button = page.getByRole('button', { name: 'コピー' }).first();
+      await button.waitFor({ state: 'visible' });
 
-    await expect(button).not.toHaveCSS('color', SUCCESS_COLOR);
+      const liveRegion = button.getByRole('status');
+      await expect(liveRegion).toHaveCount(0);
 
-    await button.click();
-    await button.getByRole('status').waitFor();
-
-    await expect(button).toHaveCSS('color', SUCCESS_COLOR);
+      await button.click();
+      await expect(liveRegion).toHaveText('コピーしました');
+    });
   });
 
-  test('コピー成功時に aria-live 領域が「コピーしました」を返す', async ({ page }) => {
-    const button = page.getByRole('button', { name: 'コピー' }).first();
-    await button.waitFor({ state: 'visible' });
+  test('2 秒後に idle 状態に戻る（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await setupJanCodeWithSample(page);
+      const button = page.getByRole('button', { name: 'コピー' }).first();
+      await button.waitFor({ state: 'visible' });
 
-    const liveRegion = button.getByRole('status');
-    await expect(liveRegion).toHaveCount(0);
+      await button.click();
+      const liveRegion = button.getByRole('status');
+      await expect(liveRegion).toHaveText('コピーしました');
 
-    await button.click();
-    await expect(liveRegion).toHaveText('コピーしました');
-  });
-
-  test('2 秒後に idle 状態に戻る', async ({ page }) => {
-    const button = page.getByRole('button', { name: 'コピー' }).first();
-    await button.waitFor({ state: 'visible' });
-
-    await button.click();
-    const liveRegion = button.getByRole('status');
-    await expect(liveRegion).toHaveText('コピーしました');
-
-    await expect(liveRegion).toHaveCount(0);
-    await expect(button).not.toHaveCSS('color', SUCCESS_COLOR);
+      await expect(liveRegion).toHaveCount(0);
+      await expect(button).not.toHaveCSS('color', SUCCESS_COLOR);
+    });
   });
 });

--- a/tests/e2e/download-button.spec.ts
+++ b/tests/e2e/download-button.spec.ts
@@ -1,34 +1,34 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
 const PRIMARY_COLOR = 'rgb(26, 86, 219)';
 
-test.describe('DownloadButton', () => {
-  test.beforeEach(async ({ page }) => {
-    // DownloadButton が使用されているツール（JANコード生成）へ移動
-    await page.goto('/tools/jan-code');
-    await page.getByRole('button', { name: 'サンプルを入力' }).waitFor();
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
+test.describe('DownloadButton（production CSP 適用）', () => {
+  test('SVGダウンロードボタン（secondary）が表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+
+      const button = page.getByRole('button', { name: 'SVGダウンロード' });
+      await expect(button).toBeVisible();
+
+      // スタイルの検証（背景が透明、枠線がプライマリ色であること）
+      await expect(button).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+      await expect(button).toHaveCSS('border', `1px solid ${PRIMARY_COLOR}`);
+      await expect(button).toHaveCSS('color', PRIMARY_COLOR);
+    });
   });
 
-  test('SVGダウンロードボタン（secondary）が表示される', async ({ page }) => {
-    const button = page.getByRole('button', { name: 'SVGダウンロード' });
-    await expect(button).toBeVisible();
+  test('PNGダウンロードボタン（primary）が表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
 
-    // スタイルの検証（背景が透明、枠線がプライマリ色であること）
-    await expect(button).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
-    await expect(button).toHaveCSS('border', `1px solid ${PRIMARY_COLOR}`);
-    await expect(button).toHaveCSS('color', PRIMARY_COLOR);
-  });
+      const button = page.getByRole('button', { name: 'PNGダウンロード' });
+      await expect(button).toBeVisible();
 
-  test('PNGダウンロードボタン（primary）が表示される', async ({ page }) => {
-    const button = page.getByRole('button', { name: 'PNGダウンロード' });
-    await expect(button).toBeVisible();
-
-    // スタイルの検証（背景がプライマリ色であること）
-    await expect(button).toHaveCSS('background-color', PRIMARY_COLOR);
-    await expect(button).toHaveCSS('color', 'rgb(255, 255, 255)');
+      // スタイルの検証（背景がプライマリ色であること）
+      await expect(button).toHaveCSS('background-color', PRIMARY_COLOR);
+      await expect(button).toHaveCSS('color', 'rgb(255, 255, 255)');
+    });
   });
 
   test.skip('disabled 状態のスタイルが正しい', async () => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -188,18 +188,32 @@ export async function applyProductionCsp(page: Page): Promise<CspGuard> {
  * **fn throw 時の挙動**: `fn` が例外を投げると `assertNoViolations` は呼ばれず、
  * `finally` で `context.close()` のみ実行される。元の例外が伝播しテストが
  * 失敗する (inline pattern と等価)。
+ *
+ * **`skipHydration` オプション**: 静的ページ (`/privacy` / `/about` / `/` 等の
+ * React island を含まないページ) では `waitForReactHydration` が
+ * `__react*` キーを持つ要素を見つけられず timeout する。これらのページに対しては
+ * `{ skipHydration: true }` を渡してハイドレーション待機を skip する。
+ * tools 配下 (React island あり) では skip しない。
  */
+export interface WithProductionCspOptions {
+  /** true のときは `waitForReactHydration` を skip (static page 用) */
+  skipHydration?: boolean;
+}
+
 export async function withProductionCsp(
   browser: Browser,
   path: string,
-  fn: (page: Page, guard: CspGuard) => Promise<void>
+  fn: (page: Page, guard: CspGuard) => Promise<void>,
+  options?: WithProductionCspOptions
 ): Promise<void> {
   const context = await browser.newContext();
   try {
     const page = await context.newPage();
     const guard = await applyProductionCsp(page);
     await page.goto(path);
-    await waitForReactHydration(page);
+    if (!options?.skipHydration) {
+      await waitForReactHydration(page);
+    }
     await fn(page, guard);
     guard.assertNoViolations();
   } finally {

--- a/tests/e2e/link-styles.spec.ts
+++ b/tests/e2e/link-styles.spec.ts
@@ -1,128 +1,152 @@
 import { test, expect } from '@playwright/test';
+import { withProductionCsp } from './helpers';
 
 // global.css の CSS 変数と対応
 const COLOR_LINK = 'rgb(37, 99, 235)'; // --color-link: #2563eb
 const COLOR_PRIMARY = 'rgb(26, 86, 219)'; // --color-primary: #1a56db
-const COLOR_LINK_VISITED = 'rgb(124, 58, 237)'; // --color-link-visited: #7c3aed
 const COLOR_TEXT = 'rgb(17, 24, 39)'; // --color-text: #111827
 
-test.describe('Link Styles', () => {
-  test.beforeEach(async ({ page }) => {
-    // UI 規約 §3.1 に従い状態をクリア
-    await page.addInitScript(() => {
-      window.localStorage.clear();
-      window.sessionStorage.clear();
+test.describe('Link Styles（production CSP 適用）', () => {
+  // withProductionCsp が test ごとに fresh context を作成するため
+  // localStorage / sessionStorage は常に空。旧 addInitScript は不要。
+  // /privacy, /about, / は React island を持たない静的ページのため
+  // skipHydration: true を指定する。/tools/* は island ありで skip 不要。
+
+  test('privacy page link has correct color and hover color（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(
+      browser,
+      '/privacy',
+      async (page) => {
+        const link = page.getByRole('link', { name: 'Cloudflare のプライバシーポリシー' });
+        await expect(link).toBeVisible();
+
+        // Normal state
+        await expect(link).toHaveCSS('color', COLOR_LINK);
+        await expect(link).toHaveCSS('text-decoration-line', 'underline');
+        await expect(link).toHaveCSS('text-decoration-thickness', '1px');
+
+        // Hover state
+        await link.hover();
+        await expect(link).toHaveCSS('color', COLOR_PRIMARY);
+        await expect(link).toHaveCSS('text-decoration-thickness', '2px');
+      },
+      { skipHydration: true }
+    );
+  });
+
+  test('about page tool links have correct color（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(
+      browser,
+      '/about',
+      async (page) => {
+        // メインコンテンツ内の最初のリンクを取得
+        const link = page.getByRole('main').getByRole('link').first();
+        await expect(link).toBeVisible();
+
+        await expect(link).toHaveCSS('color', COLOR_LINK);
+        await expect(link).toHaveCSS('text-decoration-thickness', '1px');
+
+        await link.hover();
+        await expect(link).toHaveCSS('color', COLOR_PRIMARY);
+        await expect(link).toHaveCSS('text-decoration-thickness', '2px');
+      },
+      { skipHydration: true }
+    );
+  });
+
+  test('tool layout breadcrumb link has correct color（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      const link = page.getByRole('link', { name: 'ホーム' });
+      await expect(link).toBeVisible();
+
+      await expect(link).toHaveCSS('color', COLOR_LINK);
+      await expect(link).toHaveCSS('text-decoration-thickness', '1px');
+
+      await link.hover();
+      await expect(link).toHaveCSS('color', COLOR_PRIMARY);
+      await expect(link).toHaveCSS('text-decoration-thickness', '2px');
     });
   });
 
-  test('privacy page link has correct color and hover color', async ({ page }) => {
-    await page.goto('/privacy');
+  test('index page tool card title and link have correct hover color（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(
+      browser,
+      '/',
+      async (page) => {
+        // 最初のツールカードを取得
+        const card = page.getByRole('main').getByRole('link').first();
+        const title = card.getByRole('heading', { level: 2 });
+        const link = card.locator('.text-link-color');
 
-    const link = page.getByRole('link', { name: 'Cloudflare のプライバシーポリシー' });
-    await expect(link).toBeVisible();
+        await expect(card).toBeVisible();
 
-    // Normal state
-    await expect(link).toHaveCSS('color', COLOR_LINK);
-    await expect(link).toHaveCSS('text-decoration-line', 'underline');
-    await expect(link).toHaveCSS('text-decoration-thickness', '1px');
+        // Normal state
+        await expect(title).toHaveCSS('color', COLOR_TEXT);
+        await expect(link).toHaveCSS('color', COLOR_LINK);
+        // ツールカード内の「開く ›」 (span) には下線がないことを確認 (回帰防止)
+        await expect(link).toHaveCSS('text-decoration-line', 'none');
 
-    // Hover state
-    await link.hover();
-    await expect(link).toHaveCSS('color', COLOR_PRIMARY);
-    await expect(link).toHaveCSS('text-decoration-thickness', '2px');
+        // Hover state
+        await card.hover();
+        await expect(title).toHaveCSS('color', COLOR_PRIMARY);
+
+        // リンク自体をホバー
+        await link.hover();
+        await expect(link).toHaveCSS('color', COLOR_PRIMARY);
+      },
+      { skipHydration: true }
+    );
   });
 
-  test('about page tool links have correct color', async ({ page }) => {
-    await page.goto('/about');
-    // メインコンテンツ内の最初のリンクを取得
-    const link = page.getByRole('main').getByRole('link').first();
-    await expect(link).toBeVisible();
-
-    await expect(link).toHaveCSS('color', COLOR_LINK);
-    await expect(link).toHaveCSS('text-decoration-thickness', '1px');
-
-    await link.hover();
-    await expect(link).toHaveCSS('color', COLOR_PRIMARY);
-    await expect(link).toHaveCSS('text-decoration-thickness', '2px');
-  });
-
-  test('tool layout breadcrumb link has correct color', async ({ page }) => {
-    await page.goto('/tools/base64');
-
-    const link = page.getByRole('link', { name: 'ホーム' });
-    await expect(link).toBeVisible();
-
-    await expect(link).toHaveCSS('color', COLOR_LINK);
-    await expect(link).toHaveCSS('text-decoration-thickness', '1px');
-
-    await link.hover();
-    await expect(link).toHaveCSS('color', COLOR_PRIMARY);
-    await expect(link).toHaveCSS('text-decoration-thickness', '2px');
-  });
-
-  test('index page tool card title and link have correct hover color', async ({ page }) => {
-    await page.goto('/');
-
-    // 最初のツールカードを取得
-    const card = page.getByRole('main').getByRole('link').first();
-    const title = card.getByRole('heading', { level: 2 });
-    const link = card.locator('.text-link-color');
-
-    await expect(card).toBeVisible();
-
-    // Normal state
-    await expect(title).toHaveCSS('color', COLOR_TEXT);
-    await expect(link).toHaveCSS('color', COLOR_LINK);
-    // ツールカード内の「開く ›」 (span) には下線がないことを確認 (回帰防止)
-    await expect(link).toHaveCSS('text-decoration-line', 'none');
-
-    // Hover state
-    await card.hover();
-    await expect(title).toHaveCSS('color', COLOR_PRIMARY);
-
-    // リンク自体をホバー
-    await link.hover();
-    await expect(link).toHaveCSS('color', COLOR_PRIMARY);
-  });
-
-  test('should have correct :visited style definitions for link classes', async ({ page }) => {
-    await page.goto('/');
-
-    // :visited は getComputedStyle が偽値を返すため、CSSStyleRule を直接走査して定義を確認するヘルパー
-    const getVisitedColor = async (className: string) => {
-      return await page.evaluate((cls) => {
-        // セレクタが .<cls>:visited に厳密にマッチする正規表現
-        // (文字境界を考慮し、他のクラス名の一部としてマッチするのを防ぐ)
-        const selectorRegex = new RegExp(
-          `(^|[^\\w-])\\.${cls}:(visited|where\\(:visited\\))($|[^\\w-])`
-        );
-
-        for (const sheet of Array.from(document.styleSheets)) {
-          try {
-            const rule = Array.from(sheet.cssRules).find(
-              (r): r is CSSStyleRule =>
-                r instanceof CSSStyleRule && selectorRegex.test(r.selectorText)
+  test('should have correct :visited style definitions for link classes（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(
+      browser,
+      '/',
+      async (page) => {
+        // :visited は getComputedStyle が偽値を返すため、CSSStyleRule を直接走査して定義を確認するヘルパー
+        const getVisitedColor = async (className: string): Promise<string | null> => {
+          return await page.evaluate((cls) => {
+            // セレクタが .<cls>:visited に厳密にマッチする正規表現
+            // (文字境界を考慮し、他のクラス名の一部としてマッチするのを防ぐ)
+            const selectorRegex = new RegExp(
+              `(^|[^\\w-])\\.${cls}:(visited|where\\(:visited\\))($|[^\\w-])`
             );
-            if (rule) return rule.style.color;
-          } catch (e) {
-            continue;
-          }
-        }
-        return null;
-      }, className);
-    };
 
-    const expectVisitedColor = (color: string | null) => {
-      expect(color).not.toBeNull();
-      const normalized = color?.replace(/\s/g, '').toLowerCase();
-      // 定義された CSS 変数名、計算済みの RGB 値、または HEX 値のいずれかにマッチすることを確認
-      expect(normalized).toMatch(/^(var\(--color-link-visited\)|rgb\(124,58,237\)|#7c3aed)$/);
-    };
+            for (const sheet of Array.from(document.styleSheets)) {
+              try {
+                const rule = Array.from(sheet.cssRules).find(
+                  (r): r is CSSStyleRule =>
+                    r instanceof CSSStyleRule && selectorRegex.test(r.selectorText)
+                );
+                if (rule) return rule.style.color;
+              } catch (e) {
+                continue;
+              }
+            }
+            return null;
+          }, className);
+        };
 
-    // .text-link の :visited 定義確認
-    await expectVisitedColor(await getVisitedColor('text-link'));
+        const expectVisitedColor = (color: string | null): void => {
+          expect(color).not.toBeNull();
+          const normalized = color?.replace(/\s/g, '').toLowerCase();
+          // 定義された CSS 変数名、計算済みの RGB 値、または HEX 値のいずれかにマッチすることを確認
+          expect(normalized).toMatch(/^(var\(--color-link-visited\)|rgb\(124,58,237\)|#7c3aed)$/);
+        };
 
-    // .text-link-color の :visited 定義確認
-    await expectVisitedColor(await getVisitedColor('text-link-color'));
+        // .text-link の :visited 定義確認
+        expectVisitedColor(await getVisitedColor('text-link'));
+
+        // .text-link-color の :visited 定義確認
+        expectVisitedColor(await getVisitedColor('text-link-color'));
+      },
+      { skipHydration: true }
+    );
   });
 });

--- a/tests/e2e/mobile-drawer.spec.ts
+++ b/tests/e2e/mobile-drawer.spec.ts
@@ -1,86 +1,105 @@
 import { test, expect } from '@playwright/test';
+import { withProductionCsp } from './helpers';
 
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
 
-test.describe('モバイルドロワー', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.setViewportSize(MOBILE_VIEWPORT);
-    await page.goto('/tools/url-encode');
+test.describe('モバイルドロワー（production CSP 適用）', () => {
+  test('モバイルでハンバーガーボタンが表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await expect(page.getByRole('button', { name: 'メニューを開く' })).toBeVisible();
+    });
   });
 
-  test('モバイルでハンバーガーボタンが表示される', async ({ page }) => {
-    await expect(page.getByRole('button', { name: 'メニューを開く' })).toBeVisible();
+  test('デスクトップではハンバーガーボタンが非表示（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(DESKTOP_VIEWPORT);
+      await expect(page.getByRole('button', { name: 'メニューを開く' })).not.toBeVisible();
+    });
   });
 
-  test('デスクトップではハンバーガーボタンが非表示', async ({ page }) => {
-    await page.setViewportSize(DESKTOP_VIEWPORT);
-    await expect(page.getByRole('button', { name: 'メニューを開く' })).not.toBeVisible();
+  test('ハンバーガーボタンでドロワーが開く（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      const dialog = page.getByRole('dialog', { name: 'ナビゲーション' });
+      await expect(dialog).not.toBeVisible();
+
+      await page.getByRole('button', { name: 'メニューを開く' }).click();
+
+      await expect(dialog).toBeVisible();
+      await expect(page.getByRole('button', { name: 'メニューを閉じる' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'メニューを開く' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    });
   });
 
-  test('ハンバーガーボタンでドロワーが開く', async ({ page }) => {
-    const dialog = page.getByRole('dialog', { name: 'ナビゲーション' });
-    await expect(dialog).not.toBeVisible();
+  test('閉じるボタンでドロワーが閉じる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await page.getByRole('button', { name: 'メニューを開く' }).click();
+      await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'メニューを開く' }).click();
+      await page.getByRole('button', { name: 'メニューを閉じる' }).click();
 
-    await expect(dialog).toBeVisible();
-    await expect(page.getByRole('button', { name: 'メニューを閉じる' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'メニューを開く' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    );
+      await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+      await expect(page.getByRole('button', { name: 'メニューを開く' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+    });
   });
 
-  test('閉じるボタンでドロワーが閉じる', async ({ page }) => {
-    await page.getByRole('button', { name: 'メニューを開く' }).click();
-    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
+  test('Escape キーでドロワーが閉じる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await page.getByRole('button', { name: 'メニューを開く' }).click();
+      await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'メニューを閉じる' }).click();
+      await page.keyboard.press('Escape');
 
-    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
-    await expect(page.getByRole('button', { name: 'メニューを開く' })).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    );
+      await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+    });
   });
 
-  test('Escape キーでドロワーが閉じる', async ({ page }) => {
-    await page.getByRole('button', { name: 'メニューを開く' }).click();
-    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
+  test('現在のツールがドロワー内でハイライトされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await page.getByRole('button', { name: 'メニューを開く' }).click();
 
-    await page.keyboard.press('Escape');
-
-    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+      const currentLink = page
+        .getByRole('dialog', { name: 'ナビゲーション' })
+        .getByRole('link', { name: 'URLエンコード/デコード' });
+      await expect(currentLink).toHaveAttribute('aria-current', 'page');
+    });
   });
 
-  test('現在のツールがドロワー内でハイライトされる', async ({ page }) => {
-    await page.getByRole('button', { name: 'メニューを開く' }).click();
+  test('ドロワーのツールリンクで遷移できる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await page.getByRole('button', { name: 'メニューを開く' }).click();
 
-    const currentLink = page
-      .getByRole('dialog', { name: 'ナビゲーション' })
-      .getByRole('link', { name: 'URLエンコード/デコード' });
-    await expect(currentLink).toHaveAttribute('aria-current', 'page');
+      await page
+        .getByRole('dialog', { name: 'ナビゲーション' })
+        .getByRole('link', { name: 'JWTデコーダー' })
+        .click();
+
+      await expect(page).toHaveURL('/tools/jwt-decoder');
+    });
   });
 
-  test('ドロワーのツールリンクで遷移できる', async ({ page }) => {
-    await page.getByRole('button', { name: 'メニューを開く' }).click();
+  test('背景クリックでドロワーが閉じる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/url-encode', async (page) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await page.getByRole('button', { name: 'メニューを開く' }).click();
+      await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
 
-    await page
-      .getByRole('dialog', { name: 'ナビゲーション' })
-      .getByRole('link', { name: 'JWTデコーダー' })
-      .click();
+      // ドロワーパネル (右 256px) より左側の背景部分をクリック
+      await page.mouse.click(40, 400);
 
-    await expect(page).toHaveURL('/tools/jwt-decoder');
-  });
-
-  test('背景クリックでドロワーが閉じる', async ({ page }) => {
-    await page.getByRole('button', { name: 'メニューを開く' }).click();
-    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).toBeVisible();
-
-    // ドロワーパネル (右 256px) より左側の背景部分をクリック
-    await page.mouse.click(40, 400);
-
-    await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+      await expect(page.getByRole('dialog', { name: 'ナビゲーション' })).not.toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## 概要

issue #234 の PR 2/5。`applyProductionCsp` を以下の UI 系 5 spec へ展開し、本番相当 CSP 制約下で全 E2E が pass することを確認。

- `tests/e2e/copy-button.spec.ts`
- `tests/e2e/download-button.spec.ts`
- `tests/e2e/a11y-live-region.spec.ts`
- `tests/e2e/link-styles.spec.ts`
- `tests/e2e/mobile-drawer.spec.ts`

## helper 拡張: `skipHydration` オプション

静的ページ (`/privacy` / `/about` / `/`) には React island がなく、
`waitForReactHydration` が `__react*` キー要素を見つけられず timeout する。
`withProductionCsp` に `WithProductionCspOptions` を追加し、
`{ skipHydration: true }` でハイドレーション待機を skip 可能にした。

- 後方互換: デフォルト挙動は不変 (`/tools/*` 配下では skip しない)
- link-styles の 4 テスト (privacy / about / index card / visited definitions) で適用
- /tools/base64 の breadcrumb テストは React island あり、skip 不要

## 各 spec の特殊要件への対応

| spec | 特殊要件 | 対応 |
| --- | --- | --- |
| copy-button | clipboard 権限が必要 | `fn` 内で `page.context().grantPermissions(...)` |
| mobile-drawer | mobile/desktop viewport 切替 | `fn` 内で `page.setViewportSize(...)`（goto 後でも CSS media query で動作） |
| link-styles | 旧 `addInitScript` で localStorage clear | `withProductionCsp` が fresh context を毎回作成するため不要、削除 |
| link-styles | 静的ページ 4 件 | `{ skipHydration: true }` を指定 |
| a11y-live-region | test ごとに異なる path | 各 test で個別 `withProductionCsp(browser, path, ...)` |
| download-button | 1 テストが skip 設定 | スキップ理由コメントを保持し継続スキップ |

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test`: 825 passed
- `npm run test:e2e tests/e2e/{copy-button,download-button,a11y-live-region,link-styles,mobile-drawer}.spec.ts`:
  - 24 passed, 1 skipped (download-button の disabled スタイルテストは元から skip)
  - 16.2s

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] CI: 5 spec 全テストが production CSP 下で pass
- [ ] レビュー: helper の `skipHydration` オプション導入が後方互換であること
- [ ] レビュー: `grantPermissions` / `setViewportSize` を fn 内で呼ぶ pattern が想定通り
- [ ] レビュー: aria 属性削除なし（grep + 側で保持確認済み）

## 関連

- 親 issue: #234
- 先行 PR: #325 (PR 1/5 単純変換系 6 spec)
- 続編予定: PR 3/5 encoding-converter / filename-sanitize
