### PR TITLE
test(e2e): #234 PR 3/5 — encoding-converter / filename-sanitize を applyProductionCsp 配下に移行

### DIFF
--- a/tests/e2e/encoding-converter.spec.ts
+++ b/tests/e2e/encoding-converter.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
 // Shift_JIS "あいうえお\n" (0x82A0 82A2 82A4 82A6 82A8 0A)
 const SJIS_AIUEO = Buffer.from([0x82, 0xa0, 0x82, 0xa2, 0x82, 0xa4, 0x82, 0xa6, 0x82, 0xa8, 0x0a]);
@@ -20,257 +20,294 @@ const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf, 0xe3, 0x81, 0x82]);
 // JPEG magic bytes (non-text binary)
 const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
 
-test.describe('文字コード判定・変換', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/encoding-converter');
-    await waitForReactHydration(page);
-  });
-
-  test('ページが正しく表示される', async ({ page }) => {
-    await expect(page.getByRole('button', { name: '判定' })).toBeVisible();
-    await expect(page.getByRole('button', { name: '変換' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'テキスト' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'ファイル' })).toBeVisible();
-  });
-
-  test('ケースA: UTF-8 テキスト入力 → UTF-8 と判定される', async ({ page }) => {
-    await page.getByLabel('入力テキスト').fill('あいうえお');
-    await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
-    await expect(page.getByTestId('detection-bom')).toContainText('なし');
-  });
-
-  test('ケースB: Shift_JIS ファイルアップロード → SJIS 判定とプレビュー', async ({ page }) => {
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_sjis.txt',
-      mimeType: 'text/plain',
-      buffer: SJIS_AIUEO,
+test.describe('文字コード判定・変換（production CSP 適用）', () => {
+  test('ページが正しく表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await expect(page.getByRole('button', { name: '判定' })).toBeVisible();
+      await expect(page.getByRole('button', { name: '変換' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'テキスト' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'ファイル' })).toBeVisible();
     });
-    await expect(page.getByTestId('detection-encoding')).toContainText('Shift_JIS');
-    await expect(page.getByTestId('detection-result')).toContainText('あいうえお');
   });
 
-  test('ケースC: Shift_JIS → UTF-8 BOM 付き変換', async ({ page }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_sjis.txt',
-      mimeType: 'text/plain',
-      buffer: SJIS_AIUEO,
+  test('ケースA: UTF-8 テキスト入力 → UTF-8 と判定される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByLabel('入力テキスト').fill('あいうえお');
+      await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
+      await expect(page.getByTestId('detection-bom')).toContainText('なし');
     });
-
-    await page.getByLabel('BOM を付与する').check();
-
-    await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
-    await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
-    // hex プレビューに BOM バイト EF BB BF が含まれる
-    await expect(page.getByTestId('output-hex-preview')).toContainText('EF BB BF');
   });
 
-  test('ケースD: EUC-JP → UTF-8 変換', async ({ page }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_eucjp.txt',
-      mimeType: 'text/plain',
-      buffer: EUCJP_AIUEO,
-    });
-    await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
-  });
-
-  test('ケースE: UTF-8 BOM 付きファイル → BOM あり と判定', async ({ page }) => {
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_utf8bom.txt',
-      mimeType: 'text/plain',
-      buffer: UTF8_BOM,
-    });
-    await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
-    await expect(page.getByTestId('detection-bom')).toContainText('あり');
-  });
-
-  test('ケースF: 非テキストバイナリ (JPEG) → バリデーションエラーが表示される', async ({
-    page,
+  test('ケースB: Shift_JIS ファイルアップロード → SJIS 判定とプレビュー（CSP 違反なし）', async ({
+    browser,
   }) => {
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test.jpg',
-      mimeType: 'image/jpeg',
-      buffer: JPEG_MAGIC,
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_sjis.txt',
+        mimeType: 'text/plain',
+        buffer: SJIS_AIUEO,
+      });
+      await expect(page.getByTestId('detection-encoding')).toContainText('Shift_JIS');
+      await expect(page.getByTestId('detection-result')).toContainText('あいうえお');
     });
-    // バリデーションで WRONG_TYPE として弾かれ、エラーメッセージが表示される
-    await expect(page.getByRole('alert')).toBeVisible();
-    await expect(page.getByTestId('detection-result')).not.toBeVisible();
   });
 
-  test('ケースG: クリアボタンで入力がリセットされる', async ({ page }) => {
-    await page.getByLabel('入力テキスト').fill('テスト');
-    await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
-    await page.getByRole('button', { name: 'クリア' }).click();
-    await expect(page.getByLabel('入力テキスト')).toHaveValue('');
-    await expect(page.getByTestId('detection-result')).not.toBeVisible();
+  test('ケースC: Shift_JIS → UTF-8 BOM 付き変換（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_sjis.txt',
+        mimeType: 'text/plain',
+        buffer: SJIS_AIUEO,
+      });
+
+      await page.getByLabel('BOM を付与する').check();
+
+      await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
+      await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
+      // hex プレビューに BOM バイト EF BB BF が含まれる
+      await expect(page.getByTestId('output-hex-preview')).toContainText('EF BB BF');
+    });
   });
 
-  test('ケースH: 変換モードの文字コード Select に全選択肢がありデフォルト値が正しい', async ({
-    page,
+  test('ケースD: EUC-JP → UTF-8 変換（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_eucjp.txt',
+        mimeType: 'text/plain',
+        buffer: EUCJP_AIUEO,
+      });
+      await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
+    });
+  });
+
+  test('ケースE: UTF-8 BOM 付きファイル → BOM あり と判定（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_utf8bom.txt',
+        mimeType: 'text/plain',
+        buffer: UTF8_BOM,
+      });
+      await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
+      await expect(page.getByTestId('detection-bom')).toContainText('あり');
+    });
+  });
+
+  test('ケースF: 非テキストバイナリ (JPEG) → バリデーションエラーが表示される（CSP 違反なし）', async ({
+    browser,
   }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-
-    const srcSelect = page.getByLabel('元の文字コード');
-    const tgtSelect = page.getByLabel('変換後の文字コード');
-
-    // デフォルト値
-    await expect(srcSelect).toHaveValue('AUTO');
-    await expect(tgtSelect).toHaveValue('UTF8');
-
-    // 元の文字コードを JIS に変更できる
-    await srcSelect.selectOption('JIS');
-    await expect(srcSelect).toHaveValue('JIS');
-
-    // 変換後の文字コードを SJIS に変更できる
-    await tgtSelect.selectOption('SJIS');
-    await expect(tgtSelect).toHaveValue('SJIS');
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test.jpg',
+        mimeType: 'image/jpeg',
+        buffer: JPEG_MAGIC,
+      });
+      // バリデーションで WRONG_TYPE として弾かれ、エラーメッセージが表示される
+      await expect(page.getByRole('alert')).toBeVisible();
+      await expect(page.getByTestId('detection-result')).not.toBeVisible();
+    });
   });
 
-  test('ケースI: UTF-8 以外ターゲット選択時はコピーボタンが非表示になる', async ({ page }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-    await page.getByLabel('入力テキスト').fill('あいうえお');
-
-    const tgtSelect = page.getByLabel('変換後の文字コード');
-
-    // UTF-8 ターゲット（デフォルト）→ コピーボタンが表示される
-    await tgtSelect.selectOption('UTF8');
-    await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible();
-
-    // SJIS ターゲット → コピーボタンが非表示になる
-    await tgtSelect.selectOption('SJIS');
-    await expect(page.getByRole('button', { name: 'コピー' })).not.toBeVisible();
-
-    // UTF-8 に戻すとコピーボタンが再表示される
-    await tgtSelect.selectOption('UTF8');
-    await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible();
+  test('ケースG: クリアボタンで入力がリセットされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByLabel('入力テキスト').fill('テスト');
+      await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
+      await page.getByRole('button', { name: 'クリア' }).click();
+      await expect(page.getByLabel('入力テキスト')).toHaveValue('');
+      await expect(page.getByTestId('detection-result')).not.toBeVisible();
+    });
   });
 
-  test('ケースJ: ファイルアップロード変換時のダウンロード名が元拡張子を保持する', async ({
-    page,
+  test('ケースH: 変換モードの文字コード Select に全選択肢がありデフォルト値が正しい（CSP 違反なし）', async ({
+    browser,
   }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_sjis.csv',
-      mimeType: 'text/csv',
-      buffer: SJIS_AIUEO,
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+
+      const srcSelect = page.getByLabel('元の文字コード');
+      const tgtSelect = page.getByLabel('変換後の文字コード');
+
+      // デフォルト値
+      await expect(srcSelect).toHaveValue('AUTO');
+      await expect(tgtSelect).toHaveValue('UTF8');
+
+      // 元の文字コードを JIS に変更できる
+      await srcSelect.selectOption('JIS');
+      await expect(srcSelect).toHaveValue('JIS');
+
+      // 変換後の文字コードを SJIS に変更できる
+      await tgtSelect.selectOption('SJIS');
+      await expect(tgtSelect).toHaveValue('SJIS');
     });
-
-    await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
-
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
-    const download = await downloadPromise;
-    expect(download.suggestedFilename()).toBe('test_sjis_utf8.csv');
   });
 
-  test('サンプルボタンでサンプルテキストが入力される', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByLabel('入力テキスト')).not.toBeEmpty();
-    await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
-  });
+  test('ケースI: UTF-8 以外ターゲット選択時はコピーボタンが非表示になる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+      await page.getByLabel('入力テキスト').fill('あいうえお');
 
-  test('ケースK: 改行コード「そのまま」でCRLFがそのまま保持される', async ({ page }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_sjis_crlf.txt',
-      mimeType: 'text/plain',
-      buffer: SJIS_CRLF,
+      const tgtSelect = page.getByLabel('変換後の文字コード');
+
+      // UTF-8 ターゲット（デフォルト）→ コピーボタンが表示される
+      await tgtSelect.selectOption('UTF8');
+      await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible();
+
+      // SJIS ターゲット → コピーボタンが非表示になる
+      await tgtSelect.selectOption('SJIS');
+      await expect(page.getByRole('button', { name: 'コピー' })).not.toBeVisible();
+
+      // UTF-8 に戻すとコピーボタンが再表示される
+      await tgtSelect.selectOption('UTF8');
+      await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible();
     });
-
-    // デフォルトは「そのまま」
-    await expect(
-      page.getByRole('group', { name: '改行コード' }).getByRole('button', { name: 'そのまま' })
-    ).toHaveAttribute('aria-pressed', 'true');
-    await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
-
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
-    const download = await downloadPromise;
-    const downloadPath = await download.path();
-    const bytes = fs.readFileSync(downloadPath!);
-
-    // CRLF (0x0D 0x0A) が保持されている
-    expect(bytes.indexOf(Buffer.from([0x0d, 0x0a]))).toBeGreaterThan(-1);
   });
 
-  test('ケースL: 改行コード「LF」でCRLFがLFに正規化される', async ({ page }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_sjis_crlf.txt',
-      mimeType: 'text/plain',
-      buffer: SJIS_CRLF,
+  test('ケースJ: ファイルアップロード変換時のダウンロード名が元拡張子を保持する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_sjis.csv',
+        mimeType: 'text/csv',
+        buffer: SJIS_AIUEO,
+      });
+
+      await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
+
+      const downloadPromise = page.waitForEvent('download');
+      await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toBe('test_sjis_utf8.csv');
     });
-
-    await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
-
-    await page
-      .getByRole('group', { name: '改行コード' })
-      .getByRole('button', { name: 'LF', exact: true })
-      .click();
-
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
-    const download = await downloadPromise;
-    const downloadPath = await download.path();
-    const bytes = fs.readFileSync(downloadPath!);
-
-    // CRLF が除去されている（0x0D が残っていない）
-    expect(bytes.indexOf(0x0d)).toBe(-1);
-    // LF は残っている
-    expect(bytes.indexOf(0x0a)).toBeGreaterThan(-1);
   });
 
-  test('ケースM: 改行コード「CRLF」でLFがCRLFに正規化される', async ({ page }) => {
-    await page.getByRole('button', { name: '変換' }).click();
-    await page.getByRole('button', { name: 'ファイル' }).click();
-    await page.getByLabel('ファイルを選択').setInputFiles({
-      name: 'test_utf8_lf.txt',
-      mimeType: 'text/plain',
-      buffer: UTF8_LF,
+  test('サンプルボタンでサンプルテキストが入力される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByLabel('入力テキスト')).not.toBeEmpty();
+      await expect(page.getByTestId('detection-encoding')).toContainText('UTF-8');
     });
-
-    await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
-
-    await page
-      .getByRole('group', { name: '改行コード' })
-      .getByRole('button', { name: 'CRLF' })
-      .click();
-
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
-    const download = await downloadPromise;
-    const downloadPath = await download.path();
-    const bytes = fs.readFileSync(downloadPath!);
-
-    // CRLF に変換されている
-    expect(bytes.indexOf(Buffer.from([0x0d, 0x0a]))).toBeGreaterThan(-1);
   });
 
-  test('ケースN: UTF-16LE ターゲット選択時は改行コードトグルが非表示になる', async ({ page }) => {
-    await page.getByRole('button', { name: '変換' }).click();
+  test('ケースK: 改行コード「そのまま」でCRLFがそのまま保持される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_sjis_crlf.txt',
+        mimeType: 'text/plain',
+        buffer: SJIS_CRLF,
+      });
 
-    const tgtSelect = page.getByLabel('変換後の文字コード');
+      // デフォルトは「そのまま」
+      await expect(
+        page.getByRole('group', { name: '改行コード' }).getByRole('button', { name: 'そのまま' })
+      ).toHaveAttribute('aria-pressed', 'true');
+      await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
 
-    // UTF-8 ターゲットでは改行コードトグルが表示される
-    await expect(page.getByRole('group', { name: '改行コード' })).toBeVisible();
+      const downloadPromise = page.waitForEvent('download');
+      await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
+      const download = await downloadPromise;
+      const downloadPath = await download.path();
+      const bytes = fs.readFileSync(downloadPath!);
 
-    // UTF-16LE ターゲットに切り替えると非表示になる
-    await tgtSelect.selectOption('UTF16LE');
-    await expect(page.getByRole('group', { name: '改行コード' })).not.toBeVisible();
-    // UTF-16 向けの注記が表示される
-    await expect(page.getByText('UTF-16 では改行コード正規化は適用されません')).toBeVisible();
+      // CRLF (0x0D 0x0A) が保持されている
+      expect(bytes.indexOf(Buffer.from([0x0d, 0x0a]))).toBeGreaterThan(-1);
+    });
+  });
 
-    // UTF-8 に戻すと再表示される
-    await tgtSelect.selectOption('UTF8');
-    await expect(page.getByRole('group', { name: '改行コード' })).toBeVisible();
+  test('ケースL: 改行コード「LF」でCRLFがLFに正規化される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_sjis_crlf.txt',
+        mimeType: 'text/plain',
+        buffer: SJIS_CRLF,
+      });
+
+      await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
+
+      await page
+        .getByRole('group', { name: '改行コード' })
+        .getByRole('button', { name: 'LF', exact: true })
+        .click();
+
+      const downloadPromise = page.waitForEvent('download');
+      await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
+      const download = await downloadPromise;
+      const downloadPath = await download.path();
+      const bytes = fs.readFileSync(downloadPath!);
+
+      // CRLF が除去されている（0x0D が残っていない）
+      expect(bytes.indexOf(0x0d)).toBe(-1);
+      // LF は残っている
+      expect(bytes.indexOf(0x0a)).toBeGreaterThan(-1);
+    });
+  });
+
+  test('ケースM: 改行コード「CRLF」でLFがCRLFに正規化される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+      await page.getByRole('button', { name: 'ファイル' }).click();
+      await page.getByLabel('ファイルを選択').setInputFiles({
+        name: 'test_utf8_lf.txt',
+        mimeType: 'text/plain',
+        buffer: UTF8_LF,
+      });
+
+      await expect(page.getByLabel('変換結果プレビュー')).not.toBeEmpty();
+
+      await page
+        .getByRole('group', { name: '改行コード' })
+        .getByRole('button', { name: 'CRLF' })
+        .click();
+
+      const downloadPromise = page.waitForEvent('download');
+      await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
+      const download = await downloadPromise;
+      const downloadPath = await download.path();
+      const bytes = fs.readFileSync(downloadPath!);
+
+      // CRLF に変換されている
+      expect(bytes.indexOf(Buffer.from([0x0d, 0x0a]))).toBeGreaterThan(-1);
+    });
+  });
+
+  test('ケースN: UTF-16LE ターゲット選択時は改行コードトグルが非表示になる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+      await page.getByRole('button', { name: '変換' }).click();
+
+      const tgtSelect = page.getByLabel('変換後の文字コード');
+
+      // UTF-8 ターゲットでは改行コードトグルが表示される
+      await expect(page.getByRole('group', { name: '改行コード' })).toBeVisible();
+
+      // UTF-16LE ターゲットに切り替えると非表示になる
+      await tgtSelect.selectOption('UTF16LE');
+      await expect(page.getByRole('group', { name: '改行コード' })).not.toBeVisible();
+      // UTF-16 向けの注記が表示される
+      await expect(page.getByText('UTF-16 では改行コード正規化は適用されません')).toBeVisible();
+
+      // UTF-8 に戻すと再表示される
+      await tgtSelect.selectOption('UTF8');
+      await expect(page.getByRole('group', { name: '改行コード' })).toBeVisible();
+    });
   });
 });

--- a/tests/e2e/filename-sanitize.spec.ts
+++ b/tests/e2e/filename-sanitize.spec.ts
@@ -1,69 +1,72 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
 // Shift_JIS "あいうえお\n"
 const SJIS_AIUEO = Buffer.from([0x82, 0xa0, 0x82, 0xa2, 0x82, 0xa4, 0x82, 0xa6, 0x82, 0xa8, 0x0a]);
 
-test.describe('セキュリティ: ファイル名サニタイズ', () => {
+test.describe('セキュリティ: ファイル名サニタイズ（production CSP 適用）', () => {
   // ──────────────────────────────────────────────────────────
   // EncodingConverter: ダウンロード名の安全化
   // ──────────────────────────────────────────────────────────
 
   test.describe('EncodingConverter', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.goto('/tools/encoding-converter');
-      await waitForReactHydration(page);
+    test('日本語を含むファイル名はダウンロード時に許可文字のみに変換される（CSP 違反なし）', async ({
+      browser,
+    }) => {
+      await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+        await page.getByRole('button', { name: '変換' }).click();
+        await page.getByRole('button', { name: 'ファイル' }).click();
+        // 日本語混じり・スペース付きのファイル名（OS 由来の信頼できない値）
+        await page.getByLabel('ファイルを選択').setInputFiles({
+          name: 'テスト データ.csv',
+          mimeType: 'text/csv',
+          buffer: SJIS_AIUEO,
+        });
+
+        await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
+
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
+        const download = await downloadPromise;
+        const filename = download.suggestedFilename();
+
+        // 日本語・スペースは許可されないため _ に置換される
+        expect(filename).toMatch(/^[A-Za-z0-9._-]+$/);
+        // 拡張子はホワイトリストに含まれる .csv が維持される
+        expect(filename.endsWith('.csv')).toBe(true);
+        // 変換ターゲット名（utf8）が保持される
+        expect(filename).toContain('utf8');
+      });
     });
 
-    test('日本語を含むファイル名はダウンロード時に許可文字のみに変換される', async ({ page }) => {
-      await page.getByRole('button', { name: '変換' }).click();
-      await page.getByRole('button', { name: 'ファイル' }).click();
-      // 日本語混じり・スペース付きのファイル名（OS 由来の信頼できない値）
-      await page.getByLabel('ファイルを選択').setInputFiles({
-        name: 'テスト データ.csv',
-        mimeType: 'text/csv',
-        buffer: SJIS_AIUEO,
+    test('path separator を含むファイル名はダウンロード名から除去される（CSP 違反なし）', async ({
+      browser,
+    }) => {
+      await withProductionCsp(browser, '/tools/encoding-converter', async (page) => {
+        await page.getByRole('button', { name: '変換' }).click();
+        await page.getByRole('button', { name: 'ファイル' }).click();
+        // 攻撃者が制御可能な名前として path traversal 風の名前を渡す
+        await page.getByLabel('ファイルを選択').setInputFiles({
+          name: '../../etc/passwd.csv',
+          mimeType: 'text/csv',
+          buffer: SJIS_AIUEO,
+        });
+
+        await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
+
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
+        const download = await downloadPromise;
+        const filename = download.suggestedFilename();
+
+        // path separator が含まれていない
+        expect(filename).not.toContain('/');
+        expect(filename).not.toContain('\\');
+        // 先頭ドット（隠しファイル化）も発生しない
+        expect(filename.startsWith('.')).toBe(false);
+        // .csv はホワイトリストに含まれるため維持される
+        expect(filename.endsWith('.csv')).toBe(true);
       });
-
-      await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
-
-      const downloadPromise = page.waitForEvent('download');
-      await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
-      const download = await downloadPromise;
-      const filename = download.suggestedFilename();
-
-      // 日本語・スペースは許可されないため _ に置換される
-      expect(filename).toMatch(/^[A-Za-z0-9._-]+$/);
-      // 拡張子はホワイトリストに含まれる .csv が維持される
-      expect(filename.endsWith('.csv')).toBe(true);
-      // 変換ターゲット名（utf8）が保持される
-      expect(filename).toContain('utf8');
-    });
-
-    test('path separator を含むファイル名はダウンロード名から除去される', async ({ page }) => {
-      await page.getByRole('button', { name: '変換' }).click();
-      await page.getByRole('button', { name: 'ファイル' }).click();
-      // 攻撃者が制御可能な名前として path traversal 風の名前を渡す
-      await page.getByLabel('ファイルを選択').setInputFiles({
-        name: '../../etc/passwd.csv',
-        mimeType: 'text/csv',
-        buffer: SJIS_AIUEO,
-      });
-
-      await expect(page.getByLabel('変換結果プレビュー')).toContainText('あいうえお');
-
-      const downloadPromise = page.waitForEvent('download');
-      await page.getByRole('button', { name: '変換後ファイルをダウンロード' }).click();
-      const download = await downloadPromise;
-      const filename = download.suggestedFilename();
-
-      // path separator が含まれていない
-      expect(filename).not.toContain('/');
-      expect(filename).not.toContain('\\');
-      // 先頭ドット（隠しファイル化）も発生しない
-      expect(filename.startsWith('.')).toBe(false);
-      // .csv はホワイトリストに含まれるため維持される
-      expect(filename.endsWith('.csv')).toBe(true);
     });
   });
 
@@ -74,56 +77,60 @@ test.describe('セキュリティ: ファイル名サニタイズ', () => {
   test.describe('QrTicket', () => {
     test.setTimeout(30000);
 
-    test.beforeEach(async ({ page }) => {
-      await page.goto('/tools/qr-ticket');
-      await page.getByRole('button', { name: '鍵ペアを新規生成' }).waitFor();
-      await waitForReactHydration(page);
+    test('チケット ID にスラッシュを含めると一括生成時にエラー表示される（CSP 違反なし）', async ({
+      browser,
+    }) => {
+      await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+        await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+        await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+
+        await page.getByLabel('イベントID').fill('event-2099');
+        await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+        // path separator を含む危険なチケット ID
+        await page.getByLabel('チケットID 1').fill('../evil');
+
+        await page.getByRole('button', { name: '一括生成' }).click();
+
+        await expect(page.getByRole('alert')).toContainText(
+          '英数字・ピリオド・アンダースコア・ハイフンのみ'
+        );
+        // 生成結果セクションは表示されない
+        await expect(page.getByText(/生成結果（\d+件）/)).not.toBeVisible();
+      });
     });
 
-    test('チケット ID にスラッシュを含めると一括生成時にエラー表示される', async ({ page }) => {
-      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+    test('チケット ID に .. を含めると一括生成時にエラー表示される（CSP 違反なし）', async ({
+      browser,
+    }) => {
+      await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+        await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+        await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
 
-      await page.getByLabel('イベントID').fill('event-2099');
-      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-      // path separator を含む危険なチケット ID
-      await page.getByLabel('チケットID 1').fill('../evil');
+        await page.getByLabel('イベントID').fill('event-2099');
+        await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+        await page.getByLabel('チケットID 1').fill('foo..bar');
 
-      await page.getByRole('button', { name: '一括生成' }).click();
+        await page.getByRole('button', { name: '一括生成' }).click();
 
-      await expect(page.getByRole('alert')).toContainText(
-        '英数字・ピリオド・アンダースコア・ハイフンのみ'
-      );
-      // 生成結果セクションは表示されない
-      await expect(page.getByText(/生成結果（\d+件）/)).not.toBeVisible();
+        await expect(page.getByRole('alert')).toContainText(
+          '英数字・ピリオド・アンダースコア・ハイフンのみ'
+        );
+      });
     });
 
-    test('チケット ID に .. を含めると一括生成時にエラー表示される', async ({ page }) => {
-      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+    test('安全なチケット ID（T-00001 等）は受け入れられる（CSP 違反なし）', async ({ browser }) => {
+      await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+        await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+        await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
 
-      await page.getByLabel('イベントID').fill('event-2099');
-      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-      await page.getByLabel('チケットID 1').fill('foo..bar');
+        await page.getByLabel('イベントID').pressSequentially('event-2099');
+        await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+        // 既定値 T-00001 のまま生成
+        await page.getByRole('button', { name: '一括生成' }).click();
 
-      await page.getByRole('button', { name: '一括生成' }).click();
-
-      await expect(page.getByRole('alert')).toContainText(
-        '英数字・ピリオド・アンダースコア・ハイフンのみ'
-      );
-    });
-
-    test('安全なチケット ID（T-00001 等）は受け入れられる', async ({ page }) => {
-      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
-
-      await page.getByLabel('イベントID').pressSequentially('event-2099');
-      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-      // 既定値 T-00001 のまま生成
-      await page.getByRole('button', { name: '一括生成' }).click();
-
-      await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
-      await expect(page.getByText('T-00001')).toBeVisible();
+        await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText('T-00001')).toBeVisible();
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要

issue #234 の PR 3/5。`applyProductionCsp` を以下の 2 spec へ展開し、本番相当 CSP 制約下で全 E2E が pass することを確認。

- `tests/e2e/encoding-converter.spec.ts` (16 tests)
- `tests/e2e/filename-sanitize.spec.ts` (5 tests, nested describes)

## 移行内容

### encoding-converter

16 tests 全てを `withProductionCsp(browser, '/tools/encoding-converter', async (page) => {...})` でラップ。ファイルアップロード（Shift_JIS / EUC-JP / UTF-8 BOM / JPEG バイナリ）、ダウンロード（CRLF / LF 切替、suggestedFilename 検証）、`detection-encoding` / `output-hex-preview` の testid 検証を全て CSP 下で実行。

### filename-sanitize

EncodingConverter / QrTicket の 2 階層 describe を保持。QrTicket は `test.setTimeout(30000)` と「鍵ペアを新規生成」→ パス traversal 検証の既存フローを維持。

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test:e2e tests/e2e/{encoding-converter,filename-sanitize}.spec.ts`: 21 passed (17.7s)

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] レビュー: ファイルアップロード / ダウンロード経路で CSP 違反が出ないこと
- [ ] レビュー: aria-* 属性削除なし（grep で `aria-pressed` 確認済み、+ 側で保持）

## 関連

- 親 issue: #234
- 先行 PR: #325 (1/5 単純変換系)、#326 (2/5 UI 系 + skipHydration オプション)
- 続編予定: PR 4/5 バーコード系 (gs1-databar / qr-code / qr-reader / qr-ticket)
