### PR TITLE
test(e2e): #234 PR 4/5 — バーコード/QR系 4 spec を applyProductionCsp 配下に移行

### DIFF
--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -1,72 +1,81 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('GS1 DataBar 生成', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/gs1-databar');
-    await waitForReactHydration(page);
+test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
+  test('ページが正しく表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      await expect(page.getByRole('heading', { name: 'GS1 DataBar 生成' })).toBeVisible();
+      await expect(page.getByLabel('AI コード 1')).toBeVisible();
+      await expect(page.getByRole('button', { name: '+ フィールド追加' })).toBeVisible();
+    });
   });
 
-  test('ページが正しく表示される', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'GS1 DataBar 生成' })).toBeVisible();
-    await expect(page.getByLabel('AI コード 1')).toBeVisible();
-    await expect(page.getByRole('button', { name: '+ フィールド追加' })).toBeVisible();
+  test('AI コード Select のデフォルト値が正しい（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // 初期フィールドは賞味/消費期限(17) と ロット番号(10)
+      await expect(page.getByLabel('AI コード 1')).toHaveValue('17');
+      await expect(page.getByLabel('AI コード 2')).toHaveValue('10');
+    });
   });
 
-  test('AI コード Select のデフォルト値が正しい', async ({ page }) => {
-    // 初期フィールドは賞味/消費期限(17) と ロット番号(10)
-    await expect(page.getByLabel('AI コード 1')).toHaveValue('17');
-    await expect(page.getByLabel('AI コード 2')).toHaveValue('10');
+  test('別フィールドで選択済みの AI は disabled になる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // 1 行目は '17'（賞味/消費期限）、2 行目は '10'（ロット番号）
+      // 2 行目 Select で '17' の option は disabled のはず
+      const opt17InSelect2 = page
+        .getByLabel('AI コード 2')
+        .getByRole('option', { name: '賞味/消費期限 (17)' });
+      await expect(opt17InSelect2).toBeDisabled();
+
+      // 2 行目 Select で '10' の option は disabled でない
+      const opt10InSelect2 = page
+        .getByLabel('AI コード 2')
+        .getByRole('option', { name: 'ロット番号 (10)' });
+      await expect(opt10InSelect2).toBeEnabled();
+    });
   });
 
-  test('別フィールドで選択済みの AI は disabled になる', async ({ page }) => {
-    // 1 行目は '17'（賞味/消費期限）、2 行目は '10'（ロット番号）
-    // 2 行目 Select で '17' の option は disabled のはず
-    const opt17InSelect2 = page
-      .getByLabel('AI コード 2')
-      .getByRole('option', { name: '賞味/消費期限 (17)' });
-    await expect(opt17InSelect2).toBeDisabled();
+  test('1 行目の AI を変更すると 2 行目の disabled が連動する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // 初期状態: Select1='17', Select2='10'。未使用の '11'（製造日）を 1 行目に選択
+      await page.getByLabel('AI コード 1').selectOption('11');
+      await expect(page.getByLabel('AI コード 1')).toHaveValue('11');
 
-    // 2 行目 Select で '10' の option は disabled でない
-    const opt10InSelect2 = page
-      .getByLabel('AI コード 2')
-      .getByRole('option', { name: 'ロット番号 (10)' });
-    await expect(opt10InSelect2).toBeEnabled();
+      // React 再レンダリング後に '11' が Select 2 で disabled になるのを expect のオートリトライで待つ
+      await expect(
+        page.getByLabel('AI コード 2').getByRole('option', { name: '製造日 (11)' })
+      ).toBeDisabled();
+
+      // '17' は 2 行目で enabled になる
+      await expect(
+        page.getByLabel('AI コード 2').getByRole('option', { name: '賞味/消費期限 (17)' })
+      ).toBeEnabled();
+    });
   });
 
-  test('1 行目の AI を変更すると 2 行目の disabled が連動する', async ({ page }) => {
-    // 初期状態: Select1='17', Select2='10'。未使用の '11'（製造日）を 1 行目に選択
-    await page.getByLabel('AI コード 1').selectOption('11');
-    await expect(page.getByLabel('AI コード 1')).toHaveValue('11');
+  test('削除ボタンでフィールドが減る（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // 初期状態: 2 フィールド
+      await expect(page.getByLabel('AI コード 1')).toBeVisible();
+      await expect(page.getByLabel('AI コード 2')).toBeVisible();
 
-    // React 再レンダリング後に '11' が Select 2 で disabled になるのを expect のオートリトライで待つ
-    await expect(
-      page.getByLabel('AI コード 2').getByRole('option', { name: '製造日 (11)' })
-    ).toBeDisabled();
+      await page.getByRole('button', { name: 'フィールドを削除' }).first().click();
 
-    // '17' は 2 行目で enabled になる
-    await expect(
-      page.getByLabel('AI コード 2').getByRole('option', { name: '賞味/消費期限 (17)' })
-    ).toBeEnabled();
+      await expect(page.getByLabel('AI コード 2')).toBeHidden();
+      await expect(page.getByLabel('AI コード 1')).toBeVisible();
+    });
   });
 
-  test('削除ボタンでフィールドが減る', async ({ page }) => {
-    // 初期状態: 2 フィールド
-    await expect(page.getByLabel('AI コード 1')).toBeVisible();
-    await expect(page.getByLabel('AI コード 2')).toBeVisible();
+  test('+ フィールド追加でフィールドが増える（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // 初期状態: 2 フィールド。1 行削除してから追加
+      await page.getByRole('button', { name: 'フィールドを削除' }).first().click();
+      await expect(page.getByLabel('AI コード 1')).toBeVisible();
 
-    await page.getByRole('button', { name: 'フィールドを削除' }).first().click();
-
-    await expect(page.getByLabel('AI コード 2')).toBeHidden();
-    await expect(page.getByLabel('AI コード 1')).toBeVisible();
-  });
-
-  test('+ フィールド追加でフィールドが増える', async ({ page }) => {
-    // 初期状態: 2 フィールド。1 行削除してから追加
-    await page.getByRole('button', { name: 'フィールドを削除' }).first().click();
-    await expect(page.getByLabel('AI コード 1')).toBeVisible();
-
-    await page.getByRole('button', { name: '+ フィールド追加' }).click();
-    await expect(page.getByLabel('AI コード 2')).toBeVisible();
+      await page.getByRole('button', { name: '+ フィールド追加' }).click();
+      await expect(page.getByLabel('AI コード 2')).toBeVisible();
+    });
   });
 });

--- a/tests/e2e/qr-code.spec.ts
+++ b/tests/e2e/qr-code.spec.ts
@@ -1,65 +1,69 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('QRコード生成', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/qr-code');
-    await page.getByLabel('テキスト / URL').waitFor();
-    await waitForReactHydration(page);
+test.describe('QRコード生成（production CSP 適用）', () => {
+  test('テキスト入力でQRコードが生成される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const input = page.getByLabel('テキスト / URL');
+      await input.fill('https://example.com');
+
+      // プレビュー領域が表示され、SVGが含まれていることを確認
+      const preview = page.getByText('プレビュー');
+      await expect(preview).toBeVisible();
+
+      const qrContainer = page.getByTestId('qr-code-container');
+      await expect(qrContainer).toBeVisible();
+      await expect(qrContainer.locator('svg')).toBeVisible();
+    });
   });
 
-  test('テキスト入力でQRコードが生成される', async ({ page }) => {
-    const input = page.getByLabel('テキスト / URL');
-    await input.fill('https://example.com');
+  test('誤り訂正レベルを切り替えられる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      await page.getByLabel('テキスト / URL').fill('Test Text');
 
-    // プレビュー領域が表示され、SVGが含まれていることを確認
-    const preview = page.getByText('プレビュー');
-    await expect(preview).toBeVisible();
+      // デフォルトは M
+      await expect(page.getByText('復元率: 15%')).toBeVisible();
 
-    const qrContainer = page.getByTestId('qr-code-container');
-    await expect(qrContainer).toBeVisible();
-    await expect(qrContainer.locator('svg')).toBeVisible();
+      // H に切り替え
+      await page.getByRole('button', { name: 'H' }).click();
+      await expect(page.getByText('復元率: 30%')).toBeVisible();
+
+      // Q に切り替え
+      await page.getByRole('button', { name: 'Q' }).click();
+      await expect(page.getByText('復元率: 25%')).toBeVisible();
+
+      // L に切り替え
+      await page.getByRole('button', { name: 'L' }).click();
+      await expect(page.getByText('復元率: 7%')).toBeVisible();
+    });
   });
 
-  test('誤り訂正レベルを切り替えられる', async ({ page }) => {
-    await page.getByLabel('テキスト / URL').fill('Test Text');
-
-    // デフォルトは M
-    await expect(page.getByText('復元率: 15%')).toBeVisible();
-
-    // H に切り替え
-    await page.getByRole('button', { name: 'H' }).click();
-    await expect(page.getByText('復元率: 30%')).toBeVisible();
-
-    // Q に切り替え
-    await page.getByRole('button', { name: 'Q' }).click();
-    await expect(page.getByText('復元率: 25%')).toBeVisible();
-
-    // L に切り替え
-    await page.getByRole('button', { name: 'L' }).click();
-    await expect(page.getByText('復元率: 7%')).toBeVisible();
+  test('サンプルテキストを挿入できる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプル' }).click();
+      await expect(page.getByLabel('テキスト / URL')).toHaveValue('https://example.com');
+      await expect(page.getByTestId('qr-code-container')).toBeVisible();
+    });
   });
 
-  test('サンプルテキストを挿入できる', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプル' }).click();
-    await expect(page.getByLabel('テキスト / URL')).toHaveValue('https://example.com');
-    await expect(page.getByTestId('qr-code-container')).toBeVisible();
+  test('テキストを空にするとプレビューが消える（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const input = page.getByLabel('テキスト / URL');
+      await input.fill('Hello');
+      await expect(page.getByTestId('qr-code-container')).toBeVisible();
+
+      await input.fill('');
+      await expect(page.getByTestId('qr-code-container')).not.toBeVisible();
+      await expect(page.getByText('プレビュー')).not.toBeVisible();
+    });
   });
 
-  test('テキストを空にするとプレビューが消える', async ({ page }) => {
-    const input = page.getByLabel('テキスト / URL');
-    await input.fill('Hello');
-    await expect(page.getByTestId('qr-code-container')).toBeVisible();
-
-    await input.fill('');
-    await expect(page.getByTestId('qr-code-container')).not.toBeVisible();
-    await expect(page.getByText('プレビュー')).not.toBeVisible();
-  });
-
-  test('ダウンロードボタンが存在する', async ({ page }) => {
-    await page.getByLabel('テキスト / URL').fill('https://example.com');
-    const downloadButton = page.getByRole('button', { name: 'SVGダウンロード' });
-    await expect(downloadButton).toBeVisible();
-    await expect(downloadButton).toBeEnabled();
+  test('ダウンロードボタンが存在する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      await page.getByLabel('テキスト / URL').fill('https://example.com');
+      const downloadButton = page.getByRole('button', { name: 'SVGダウンロード' });
+      await expect(downloadButton).toBeVisible();
+      await expect(downloadButton).toBeEnabled();
+    });
   });
 });

--- a/tests/e2e/qr-reader.spec.ts
+++ b/tests/e2e/qr-reader.spec.ts
@@ -1,12 +1,16 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { waitForReactHydration, withProductionCsp } from './helpers';
 
 /**
- * qr-code ツールでテキストからQR SVGを生成し、768px PNG に変換して base64 で返す
+ * 既に /tools/qr-code 上に居る page で、テキストから QR SVG を生成し
+ * 768px PNG に変換して base64 で返す。withProductionCsp の path に
+ * '/tools/qr-code' を渡すことで goto + ハイドレーション待機は wrapper が行うため、
+ * 本関数は現在の page に対して入力 → 描画変換のみ行う。
  */
-async function generateQrPng(page: import('@playwright/test').Page, text: string): Promise<string> {
-  await page.goto('/tools/qr-code');
-  await waitForReactHydration(page);
+async function generateQrPngOnQrCodePage(
+  page: import('@playwright/test').Page,
+  text: string
+): Promise<string> {
   await page.getByLabel('テキスト / URL').fill(text);
   await page.waitForSelector('[data-testid="qr-code-container"] svg');
 
@@ -45,161 +49,179 @@ async function generateQrPng(page: import('@playwright/test').Page, text: string
   });
 }
 
-test.describe('QRリーダー', () => {
+test.describe('QRリーダー（production CSP 適用）', () => {
   test.setTimeout(30000);
-
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/qr-reader');
-    await waitForReactHydration(page);
-  });
 
   // ────────────────────────────────
   // 基本構造
   // ────────────────────────────────
 
-  test('ページが表示されカメラ/アップロードの切替ボタンがある', async ({ page }) => {
-    await expect(page.getByRole('button', { name: 'カメラ', exact: true })).toBeVisible();
-    await expect(page.getByRole('button', { name: '画像アップロード' })).toBeVisible();
+  test('ページが表示されカメラ/アップロードの切替ボタンがある（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-reader', async (page) => {
+      await expect(page.getByRole('button', { name: 'カメラ', exact: true })).toBeVisible();
+      await expect(page.getByRole('button', { name: '画像アップロード' })).toBeVisible();
+    });
   });
 
   // ────────────────────────────────
   // 画像アップロード: テキスト読取
   // ────────────────────────────────
 
-  test('プレーンテキストを含むQR画像をアップロードして読み取れる', async ({ page }) => {
-    const text = 'Hello DevTools QR Reader';
-    const pngBase64 = await generateQrPng(page, text);
+  test('プレーンテキストを含むQR画像をアップロードして読み取れる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const text = 'Hello DevTools QR Reader';
+      const pngBase64 = await generateQrPngOnQrCodePage(page, text);
 
-    await page.goto('/tools/qr-reader');
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'qr.png',
-      mimeType: 'image/png',
-      buffer: Buffer.from(pngBase64, 'base64'),
+      await page.goto('/tools/qr-reader');
+      await waitForReactHydration(page);
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'qr.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(pngBase64, 'base64'),
+      });
+
+      await expect(page.getByText(text)).toBeVisible({ timeout: 10000 });
     });
-
-    await expect(page.getByText(text)).toBeVisible({ timeout: 10000 });
   });
 
-  test('読み取り結果にコピーボタンが表示される', async ({ page }) => {
-    const text = 'copy button test';
-    const pngBase64 = await generateQrPng(page, text);
+  test('読み取り結果にコピーボタンが表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const text = 'copy button test';
+      const pngBase64 = await generateQrPngOnQrCodePage(page, text);
 
-    await page.goto('/tools/qr-reader');
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'qr.png',
-      mimeType: 'image/png',
-      buffer: Buffer.from(pngBase64, 'base64'),
+      await page.goto('/tools/qr-reader');
+      await waitForReactHydration(page);
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'qr.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(pngBase64, 'base64'),
+      });
+
+      await expect(page.getByText(text)).toBeVisible({ timeout: 10000 });
+      await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible();
     });
-
-    await expect(page.getByText(text)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible();
   });
 
-  test('再スキャンボタンを押すと結果がクリアされる', async ({ page }) => {
-    const text = 'rescan test';
-    const pngBase64 = await generateQrPng(page, text);
+  test('再スキャンボタンを押すと結果がクリアされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const text = 'rescan test';
+      const pngBase64 = await generateQrPngOnQrCodePage(page, text);
 
-    await page.goto('/tools/qr-reader');
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'qr.png',
-      mimeType: 'image/png',
-      buffer: Buffer.from(pngBase64, 'base64'),
+      await page.goto('/tools/qr-reader');
+      await waitForReactHydration(page);
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'qr.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(pngBase64, 'base64'),
+      });
+
+      await expect(page.getByText(text)).toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: '再スキャン' }).click();
+      await expect(page.getByText(text)).toHaveCount(0);
     });
-
-    await expect(page.getByText(text)).toBeVisible({ timeout: 10000 });
-    await page.getByRole('button', { name: '再スキャン' }).click();
-    await expect(page.getByText(text)).toHaveCount(0);
   });
 
   // ────────────────────────────────
   // URL 検出 & フィッシング警告
   // ────────────────────────────────
 
-  test('URL を含むQR読取時に警告メッセージと「URLを開く」ボタンが表示される', async ({ page }) => {
-    const url = 'https://example.com/path';
-    const pngBase64 = await generateQrPng(page, url);
+  test('URL を含むQR読取時に警告メッセージと「URLを開く」ボタンが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const url = 'https://example.com/path';
+      const pngBase64 = await generateQrPngOnQrCodePage(page, url);
 
-    await page.goto('/tools/qr-reader');
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'qr.png',
-      mimeType: 'image/png',
-      buffer: Buffer.from(pngBase64, 'base64'),
+      await page.goto('/tools/qr-reader');
+      await waitForReactHydration(page);
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'qr.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(pngBase64, 'base64'),
+      });
+
+      await expect(page.getByText(url)).toBeVisible({ timeout: 10000 });
+      await expect(page.getByRole('link', { name: 'URLを開く' })).toBeVisible();
+      await expect(page.getByText('example.com', { exact: true })).toBeVisible();
     });
-
-    await expect(page.getByText(url)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByRole('link', { name: 'URLを開く' })).toBeVisible();
-    await expect(page.getByText('example.com', { exact: true })).toBeVisible();
   });
 
-  test('「URLを開く」リンクは target=_blank かつ rel=noopener noreferrer で安全に開く', async ({
-    page,
+  test('「URLを開く」リンクは target=_blank かつ rel=noopener noreferrer で安全に開く（CSP 違反なし）', async ({
+    browser,
   }) => {
-    const url = 'https://example.com';
-    const pngBase64 = await generateQrPng(page, url);
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const url = 'https://example.com';
+      const pngBase64 = await generateQrPngOnQrCodePage(page, url);
 
-    await page.goto('/tools/qr-reader');
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'qr.png',
-      mimeType: 'image/png',
-      buffer: Buffer.from(pngBase64, 'base64'),
+      await page.goto('/tools/qr-reader');
+      await waitForReactHydration(page);
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'qr.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(pngBase64, 'base64'),
+      });
+
+      const link = page.getByRole('link', { name: 'URLを開く' });
+      await expect(link).toBeVisible({ timeout: 10000 });
+      await expect(link).toHaveAttribute('target', '_blank');
+      await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      await expect(link).toHaveAttribute('href', url);
     });
-
-    const link = page.getByRole('link', { name: 'URLを開く' });
-    await expect(link).toBeVisible({ timeout: 10000 });
-    await expect(link).toHaveAttribute('target', '_blank');
-    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-    await expect(link).toHaveAttribute('href', url);
   });
 
   // ────────────────────────────────
   // エラーケース
   // ────────────────────────────────
 
-  test('navigator.mediaDevices が未定義のときカメラ起動で HTTPS 必須メッセージを表示する', async ({
-    page,
+  test('navigator.mediaDevices が未定義のときカメラ起動で HTTPS 必須メッセージを表示する（CSP 違反なし）', async ({
+    browser,
   }) => {
-    // 非HTTPS / localhost 以外の環境では navigator.mediaDevices が undefined になる挙動を再現
-    await page.addInitScript(() => {
-      Object.defineProperty(navigator, 'mediaDevices', {
-        configurable: true,
-        get: () => undefined,
+    await withProductionCsp(browser, '/tools/qr-reader', async (page) => {
+      // 非HTTPS / localhost 以外の環境では navigator.mediaDevices が undefined になる挙動を再現。
+      // addInitScript は次回ロードから反映されるため再ナビゲートして適用する。
+      await page.addInitScript(() => {
+        Object.defineProperty(navigator, 'mediaDevices', {
+          configurable: true,
+          get: () => undefined,
+        });
       });
+      await page.goto('/tools/qr-reader');
+      await waitForReactHydration(page);
+      await page.getByRole('button', { name: 'カメラを起動' }).click();
+
+      await expect(page.getByRole('alert')).toContainText(
+        'カメラの起動には HTTPS 環境または localhost が必要です'
+      );
     });
-
-    // beforeEach で既に goto 済みだが、addInitScript は次回ロードから反映されるため再ナビゲートする
-    await page.goto('/tools/qr-reader');
-    await waitForReactHydration(page);
-    await page.getByRole('button', { name: 'カメラを起動' }).click();
-
-    await expect(page.getByRole('alert')).toContainText(
-      'カメラの起動には HTTPS 環境または localhost が必要です'
-    );
   });
 
-  test('QRコードを含まない画像をアップロードするとエラーが表示される', async ({ page }) => {
-    // 1x1 の白 PNG (QR なし)
-    const blankPng = Buffer.from(
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
-      'base64'
-    );
+  test('QRコードを含まない画像をアップロードするとエラーが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-reader', async (page) => {
+      // 1x1 の白 PNG (QR なし)
+      const blankPng = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+        'base64'
+      );
 
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'blank.png',
-      mimeType: 'image/png',
-      buffer: blankPng,
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'blank.png',
+        mimeType: 'image/png',
+        buffer: blankPng,
+      });
+
+      await expect(page.getByRole('alert')).toContainText('QRコードが見つかりませんでした');
     });
-
-    await expect(page.getByRole('alert')).toContainText('QRコードが見つかりませんでした');
   });
 });

--- a/tests/e2e/qr-ticket.spec.ts
+++ b/tests/e2e/qr-ticket.spec.ts
@@ -1,252 +1,280 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
-test.describe('QRチケット', () => {
+test.describe('QRチケット（production CSP 適用）', () => {
   test.setTimeout(30000);
-
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/qr-ticket');
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).waitFor();
-    await waitForReactHydration(page);
-  });
 
   // ──────────────────────────────────────────────────────────
   // 基本構造
   // ──────────────────────────────────────────────────────────
 
-  test('生成タブの各セクションが表示される', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: '鍵ペア' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'イベント情報' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /チケットリスト/ })).toBeVisible();
+  test('生成タブの各セクションが表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      await expect(page.getByRole('heading', { name: '鍵ペア' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'イベント情報' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: /チケットリスト/ })).toBeVisible();
+    });
   });
 
-  test('検証タブに切り替えると公開鍵・QR読取セクションが表示される', async ({ page }) => {
-    await page.getByRole('button', { name: '検証' }).click();
-    await expect(page.getByRole('heading', { name: '公開鍵' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'QR読取' })).toBeVisible();
+  test('検証タブに切り替えると公開鍵・QR読取セクションが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      await page.getByRole('button', { name: '検証' }).click();
+      await expect(page.getByRole('heading', { name: '公開鍵' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'QR読取' })).toBeVisible();
+    });
   });
 
   // ──────────────────────────────────────────────────────────
   // 鍵ペア生成
   // ──────────────────────────────────────────────────────────
 
-  test('「鍵ペアを新規生成」で秘密鍵・公開鍵が表示される', async ({ page }) => {
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-    await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('公開鍵（検証スタッフへ共有）')).toBeVisible({ timeout: 10000 });
+  test('「鍵ペアを新規生成」で秘密鍵・公開鍵が表示される（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText('公開鍵（検証スタッフへ共有）')).toBeVisible({ timeout: 10000 });
+    });
   });
 
   // ──────────────────────────────────────────────────────────
   // バリデーション
   // ──────────────────────────────────────────────────────────
 
-  test('鍵なし状態では一括生成ボタンが無効化されている', async ({ page }) => {
-    // 鍵ペアがない場合は disabled={!cryptoKeyPair} により無効化される
-    await expect(page.getByRole('button', { name: '一括生成' })).toBeDisabled();
+  test('鍵なし状態では一括生成ボタンが無効化されている（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      // 鍵ペアがない場合は disabled={!cryptoKeyPair} により無効化される
+      await expect(page.getByRole('button', { name: '一括生成' })).toBeDisabled();
+    });
   });
 
-  test('イベントIDが空の状態で一括生成するとエラーメッセージが表示される', async ({ page }) => {
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-    await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
-    await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-    await page.getByRole('button', { name: '一括生成' }).click();
-    await expect(page.getByRole('alert')).toContainText('イベントIDを入力してください');
+  test('イベントIDが空の状態で一括生成するとエラーメッセージが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+      await page.getByRole('button', { name: '一括生成' }).click();
+      await expect(page.getByRole('alert')).toContainText('イベントIDを入力してください');
+    });
   });
 
-  test('入力項目の合計が250バイトを超えるとエラーが表示される', async ({ page }) => {
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-    await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+  test('入力項目の合計が250バイトを超えるとエラーが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
 
-    // 日本語50文字 = 150バイト → 合計約263B (> 250)
-    const longName = 'あ'.repeat(50);
+      // 日本語50文字 = 150バイト → 合計約263B (> 250)
+      const longName = 'あ'.repeat(50);
 
-    await page.getByLabel('イベントID').fill('event');
-    await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-    await page.getByLabel('参加者名 1').fill(longName);
+      await page.getByLabel('イベントID').fill('event');
+      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+      await page.getByLabel('参加者名 1').fill(longName);
 
-    await page.getByRole('button', { name: '一括生成' }).click();
-    await expect(page.getByRole('alert')).toContainText(
-      '上限（250バイト）を超えているチケットがあります'
-    );
+      await page.getByRole('button', { name: '一括生成' }).click();
+      await expect(page.getByRole('alert')).toContainText(
+        '上限（250バイト）を超えているチケットがあります'
+      );
+    });
   });
 
   // ──────────────────────────────────────────────────────────
   // QR生成フロー
   // ──────────────────────────────────────────────────────────
 
-  test('鍵生成→イベント情報入力→一括生成でQRコードグリッドが表示される', async ({ page }) => {
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-    await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+  test('鍵生成→イベント情報入力→一括生成でQRコードグリッドが表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
 
-    await page.getByLabel('イベントID').pressSequentially('event-2099');
-    await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-    await page.getByRole('button', { name: '一括生成' }).click();
+      await page.getByLabel('イベントID').pressSequentially('event-2099');
+      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+      await page.getByRole('button', { name: '一括生成' }).click();
 
-    await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText('T-00001')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'SVGダウンロード' }).first()).toBeVisible();
+      await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
+      await expect(page.getByText('T-00001')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'SVGダウンロード' }).first()).toBeVisible();
+    });
   });
 
   // ──────────────────────────────────────────────────────────
   // 鍵インポートバリデーション
   // ──────────────────────────────────────────────────────────
 
-  test('秘密鍵欄に公開鍵を貼り付けると適切なエラーを表示する', async ({ page }) => {
-    // まず鍵ペアを生成して公開鍵を取得
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-    await expect(page.getByText('公開鍵（検証スタッフへ共有）')).toBeVisible({ timeout: 10000 });
+  test('秘密鍵欄に公開鍵を貼り付けると適切なエラーを表示する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      // まず鍵ペアを生成して公開鍵を取得
+      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+      await expect(page.getByText('公開鍵（検証スタッフへ共有）')).toBeVisible({ timeout: 10000 });
 
-    // 2つ目のtextarea（readOnly）が公開鍵JWK
-    const pubKeyJwk = await page.getByLabel('公開鍵（検証スタッフへ共有）').inputValue();
+      // 2つ目のtextarea（readOnly）が公開鍵JWK
+      const pubKeyJwk = await page.getByLabel('公開鍵（検証スタッフへ共有）').inputValue();
 
-    await page.getByText('▼ 既存の秘密鍵をインポート').click();
-    await page.getByLabel('秘密鍵 JWK').fill(pubKeyJwk);
-    // exact: true で「▲ 秘密鍵インポートを閉じる」との混同を防ぐ
-    await page.getByRole('button', { name: 'インポート', exact: true }).click();
-    await expect(page.getByRole('alert')).toContainText('公開鍵です');
+      await page.getByText('▼ 既存の秘密鍵をインポート').click();
+      await page.getByLabel('秘密鍵 JWK').fill(pubKeyJwk);
+      // exact: true で「▲ 秘密鍵インポートを閉じる」との混同を防ぐ
+      await page.getByRole('button', { name: 'インポート', exact: true }).click();
+      await expect(page.getByRole('alert')).toContainText('公開鍵です');
+    });
   });
 
   // ──────────────────────────────────────────────────────────
   // 生成→検証ラウンドトリップ（画像アップロード経由）
   // ──────────────────────────────────────────────────────────
 
-  test('生成したQRを画像アップロードで検証すると有効と判定される', async ({ page }) => {
-    // 1. 鍵ペア生成
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-    await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+  test('生成したQRを画像アップロードで検証すると有効と判定される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      // 1. 鍵ペア生成
+      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
 
-    // 2. イベント情報入力・QR生成
-    await page.getByLabel('イベントID').pressSequentially('roundtrip-test');
-    await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-    await page.getByRole('button', { name: '一括生成' }).click();
-    await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
+      // 2. イベント情報入力・QR生成
+      await page.getByLabel('イベントID').pressSequentially('roundtrip-test');
+      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+      await page.getByRole('button', { name: '一括生成' }).click();
+      await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
 
-    // 3. 生成されたQR SVGをPNGに変換
-    //    dangerouslySetInnerHTML で注入された SVG は data-testid="qr-code-container" の div 内にある。
-    //    ページ上の他の SVG（アイコン等）と区別するため、このコンテナを使用して取得する。
-    const pngBase64 = await page.evaluate((): Promise<string> => {
-      return new Promise((resolve, reject) => {
-        // QRカードのコンテナ内の SVG を取得
-        const container = document.querySelector('[data-testid="qr-code-container"]');
-        const svgEl = container?.querySelector('svg') as SVGSVGElement | null;
-        if (!svgEl) {
-          reject(new Error('QR SVG not found'));
-          return;
-        }
+      // 3. 生成されたQR SVGをPNGに変換
+      //    dangerouslySetInnerHTML で注入された SVG は data-testid="qr-code-container" の div 内にある。
+      //    ページ上の他の SVG（アイコン等）と区別するため、このコンテナを使用して取得する。
+      const pngBase64 = await page.evaluate((): Promise<string> => {
+        return new Promise((resolve, reject) => {
+          // QRカードのコンテナ内の SVG を取得
+          const container = document.querySelector('[data-testid="qr-code-container"]');
+          const svgEl = container?.querySelector('svg') as SVGSVGElement | null;
+          if (!svgEl) {
+            reject(new Error('QR SVG not found'));
+            return;
+          }
 
-        // viewBox から実寸を取得して width/height を設定
-        const vb = svgEl.getAttribute('viewBox');
-        const dim = vb ? parseInt(vb.split(' ')[2]) : 200;
-        const clone = svgEl.cloneNode(true) as SVGSVGElement;
-        clone.setAttribute('width', String(dim));
-        clone.setAttribute('height', String(dim));
+          // viewBox から実寸を取得して width/height を設定
+          const vb = svgEl.getAttribute('viewBox');
+          const dim = vb ? parseInt(vb.split(' ')[2]) : 200;
+          const clone = svgEl.cloneNode(true) as SVGSVGElement;
+          clone.setAttribute('width', String(dim));
+          clone.setAttribute('height', String(dim));
 
-        const svgStr = new XMLSerializer().serializeToString(clone);
-        const dataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgStr);
+          const svgStr = new XMLSerializer().serializeToString(clone);
+          const dataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgStr);
 
-        const img = new Image();
-        img.onload = () => {
-          // jsQR が読み取れるよう十分な解像度で描画
-          const size = 768;
-          const canvas = document.createElement('canvas');
-          canvas.width = size;
-          canvas.height = size;
-          const ctx = canvas.getContext('2d')!;
-          ctx.fillStyle = '#ffffff';
-          ctx.fillRect(0, 0, size, size);
-          ctx.drawImage(img, 0, 0, size, size);
-          resolve(canvas.toDataURL('image/png').replace(/^data:image\/png;base64,/, ''));
-        };
-        img.onerror = () => reject(new Error('SVG image load failed'));
-        img.src = dataUrl;
+          const img = new Image();
+          img.onload = () => {
+            // jsQR が読み取れるよう十分な解像度で描画
+            const size = 768;
+            const canvas = document.createElement('canvas');
+            canvas.width = size;
+            canvas.height = size;
+            const ctx = canvas.getContext('2d')!;
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(0, 0, size, size);
+            ctx.drawImage(img, 0, 0, size, size);
+            resolve(canvas.toDataURL('image/png').replace(/^data:image\/png;base64,/, ''));
+          };
+          img.onerror = () => reject(new Error('SVG image load failed'));
+          img.src = dataUrl;
+        });
       });
+
+      // 4. 検証タブに切替（公開鍵は handleGenerateKeys で verifyPubKeyStr に自動セット済み）
+      await page.getByRole('button', { name: '検証' }).click();
+      await expect(page.getByRole('heading', { name: '公開鍵' })).toBeVisible();
+
+      // 5. 画像アップロードモードを選択
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+
+      // 6. PNG を fileInput にセット（hidden input は setInputFiles で直接操作可能）
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'ticket.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(pngBase64, 'base64'),
+      });
+
+      // 7. 検証結果を確認
+      await expect(page.getByText('有効なチケット')).toBeVisible({ timeout: 15000 });
     });
-
-    // 4. 検証タブに切替（公開鍵は handleGenerateKeys で verifyPubKeyStr に自動セット済み）
-    await page.getByRole('button', { name: '検証' }).click();
-    await expect(page.getByRole('heading', { name: '公開鍵' })).toBeVisible();
-
-    // 5. 画像アップロードモードを選択
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-
-    // 6. PNG を fileInput にセット（hidden input は setInputFiles で直接操作可能）
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'ticket.png',
-      mimeType: 'image/png',
-      buffer: Buffer.from(pngBase64, 'base64'),
-    });
-
-    // 7. 検証結果を確認
-    await expect(page.getByText('有効なチケット')).toBeVisible({ timeout: 15000 });
   });
 
-  test('日本語を含むイベント情報を画像アップロードで検証できる', async ({ page }) => {
-    // 1. 鍵ペア生成
-    await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
-    await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
+  test('日本語を含むイベント情報を画像アップロードで検証できる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-ticket', async (page) => {
+      // 1. 鍵ペア生成
+      await page.getByRole('button', { name: '鍵ペアを新規生成' }).click();
+      await expect(page.getByText('秘密鍵（主催者が保管）')).toBeVisible({ timeout: 10000 });
 
-    // 2. 日本語を含むイベント情報入力・QR生成
-    await page.getByLabel('イベントID').pressSequentially('春 of プログラミング 2026');
-    await page.getByLabel('参加者名 1').pressSequentially('山田 太郎');
-    await page.getByLabel('有効期限').fill('2099-12-31T23:59');
-    await page.getByRole('button', { name: '一括生成' }).click();
-    await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
+      // 2. 日本語を含むイベント情報入力・QR生成
+      await page.getByLabel('イベントID').pressSequentially('春 of プログラミング 2026');
+      await page.getByLabel('参加者名 1').pressSequentially('山田 太郎');
+      await page.getByLabel('有効期限').fill('2099-12-31T23:59');
+      await page.getByRole('button', { name: '一括生成' }).click();
+      await expect(page.getByText(/生成結果（\d+件）/)).toBeVisible({ timeout: 15000 });
 
-    // 3. 生成されたQR SVGをPNGに変換
-    //    dangerouslySetInnerHTML で注入された SVG は data-testid="qr-code-container" の div 内にある。
-    //    ページ上の他の SVG（アイコン等）と区別するため、このコンテナを使用して取得する。
-    const pngBase64 = await page.evaluate((): Promise<string> => {
-      return new Promise((resolve, reject) => {
-        // QRカードのコンテナ内の SVG を取得
-        const container = document.querySelector('[data-testid="qr-code-container"]');
-        const svgEl = container?.querySelector('svg') as SVGSVGElement | null;
-        if (!svgEl) {
-          reject(new Error('QR SVG not found'));
-          return;
-        }
+      // 3. 生成されたQR SVGをPNGに変換
+      //    dangerouslySetInnerHTML で注入された SVG は data-testid="qr-code-container" の div 内にある。
+      //    ページ上の他の SVG（アイコン等）と区別するため、このコンテナを使用して取得する。
+      const pngBase64 = await page.evaluate((): Promise<string> => {
+        return new Promise((resolve, reject) => {
+          // QRカードのコンテナ内の SVG を取得
+          const container = document.querySelector('[data-testid="qr-code-container"]');
+          const svgEl = container?.querySelector('svg') as SVGSVGElement | null;
+          if (!svgEl) {
+            reject(new Error('QR SVG not found'));
+            return;
+          }
 
-        const vb = svgEl.getAttribute('viewBox');
-        const dim = vb ? parseInt(vb.split(' ')[2]) : 200;
-        const clone = svgEl.cloneNode(true) as SVGSVGElement;
-        clone.setAttribute('width', String(dim));
-        clone.setAttribute('height', String(dim));
+          const vb = svgEl.getAttribute('viewBox');
+          const dim = vb ? parseInt(vb.split(' ')[2]) : 200;
+          const clone = svgEl.cloneNode(true) as SVGSVGElement;
+          clone.setAttribute('width', String(dim));
+          clone.setAttribute('height', String(dim));
 
-        const svgStr = new XMLSerializer().serializeToString(clone);
-        const dataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgStr);
+          const svgStr = new XMLSerializer().serializeToString(clone);
+          const dataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgStr);
 
-        const img = new Image();
-        img.onload = () => {
-          const size = 768;
-          const canvas = document.createElement('canvas');
-          canvas.width = size;
-          canvas.height = size;
-          const ctx = canvas.getContext('2d')!;
-          ctx.fillStyle = '#ffffff';
-          ctx.fillRect(0, 0, size, size);
-          ctx.drawImage(img, 0, 0, size, size);
-          resolve(canvas.toDataURL('image/png').replace(/^data:image\/png;base64,/, ''));
-        };
-        img.onerror = () => reject(new Error('SVG image load failed'));
-        img.src = dataUrl;
+          const img = new Image();
+          img.onload = () => {
+            const size = 768;
+            const canvas = document.createElement('canvas');
+            canvas.width = size;
+            canvas.height = size;
+            const ctx = canvas.getContext('2d')!;
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(0, 0, size, size);
+            ctx.drawImage(img, 0, 0, size, size);
+            resolve(canvas.toDataURL('image/png').replace(/^data:image\/png;base64,/, ''));
+          };
+          img.onerror = () => reject(new Error('SVG image load failed'));
+          img.src = dataUrl;
+        });
       });
+
+      // 4. 検証タブに切替
+      await page.getByRole('button', { name: '検証' }).click();
+
+      // 5. 画像アップロードモードを選択
+      await page.getByRole('button', { name: '画像アップロード' }).click();
+
+      // 6. PNG を fileInput にセット
+      await page.getByLabel('画像を選択').setInputFiles({
+        name: 'ticket-ja.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(pngBase64, 'base64'),
+      });
+
+      // 7. 検証結果を確認（日本語が正しく表示されることも確認）
+      await expect(page.getByText('有効なチケット')).toBeVisible({ timeout: 15000 });
+      await expect(page.getByText('春 of プログラミング 2026')).toBeVisible();
+      await expect(page.getByText('山田 太郎')).toBeVisible();
     });
-
-    // 4. 検証タブに切替
-    await page.getByRole('button', { name: '検証' }).click();
-
-    // 5. 画像アップロードモードを選択
-    await page.getByRole('button', { name: '画像アップロード' }).click();
-
-    // 6. PNG を fileInput にセット
-    await page.getByLabel('画像を選択').setInputFiles({
-      name: 'ticket-ja.png',
-      mimeType: 'image/png',
-      buffer: Buffer.from(pngBase64, 'base64'),
-    });
-
-    // 7. 検証結果を確認（日本語が正しく表示されることも確認）
-    await expect(page.getByText('有効なチケット')).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText('春 of プログラミング 2026')).toBeVisible();
-    await expect(page.getByText('山田 太郎')).toBeVisible();
   });
 });


### PR DESCRIPTION
## 概要

issue #234 の PR 4/5。`applyProductionCsp` を以下のバーコード/QR 系 4 spec へ展開し、本番相当 CSP 制約下で全 E2E が pass することを確認。

- `tests/e2e/gs1-databar.spec.ts` (6 tests)
- `tests/e2e/qr-code.spec.ts` (5 tests)
- `tests/e2e/qr-reader.spec.ts` (8 tests, `test.setTimeout(30000)`)
- `tests/e2e/qr-ticket.spec.ts` (9 tests, `test.setTimeout(30000)`)

## CSP 観点

`PRODUCTION_CSP` の `img-src 'self' data: blob:` により、SVG → `data:image/svg+xml` → canvas → PNG 経路は許容され、QR 生成 (qrcode) / 読取 (jsQR) ともに違反なく動作することを確認。Web Crypto API (qr-ticket の ES256 鍵生成) も production CSP 下で動作。

## 主な書き換えポイント

### qr-reader: `generateQrPng` の二重 goto 解消

旧実装は helper 内で `page.goto('/tools/qr-code')` していたため、`withProductionCsp(browser, '/tools/qr-reader', ...)` で包むと「reader → code → reader」の三重 goto になる。helper を `generateQrPngOnQrCodePage` にリネームし「現在の page (qr-code) で QR 生成のみ行う」責務に絞り、wrapper の path を `/tools/qr-code` に渡してから fn 内で `/tools/qr-reader` へ移動する設計に修正。

### qr-reader: `navigator.mediaDevices` mock

`addInitScript` は次回ロードから反映されるため、wrapper 初期 goto 後に init script を追加して再 navigate する既存 pattern を踏襲。

### qr-ticket: 既存ロジック保持

`page.evaluate` 内の SVG → PNG 変換ロジック、ラウンドトリップ検証 (生成→検証タブ→画像アップロード) はそのまま wrapper 内で動作。

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test:e2e tests/e2e/{gs1-databar,qr-code,qr-reader,qr-ticket}.spec.ts`: 29 passed (36.4s)

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] レビュー: qr-reader の `generateQrPngOnQrCodePage` への責務分離が妥当か
- [ ] レビュー: qrcode / jsQR / Web Crypto の CSP 違反なし
- [ ] レビュー: aria-* 属性削除なし（grep で確認済み）

## 関連

- 親 issue: #234
- 先行 PR: #325 (1/5)、#326 (2/5)、#327 (3/5)
- 続編予定: PR 5/5 jwt-decoder
