### PR TITLE
test(e2e): #234 PR 5/5 — jwt-decoder を applyProductionCsp 配下に移行（issue #234 完了）

### DIFF
--- a/tests/e2e/jwt-decoder.spec.ts
+++ b/tests/e2e/jwt-decoder.spec.ts
@@ -1,52 +1,60 @@
 import { test, expect } from '@playwright/test';
-import { waitForReactHydration } from './helpers';
+import { withProductionCsp } from './helpers';
 
 // jwt.io のサンプル JWT（HS256）
 const SAMPLE_JWT =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
 
-test.describe('JWTデコーダー', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/jwt-decoder');
-    await page.getByLabel('JWTトークンを貼り付け').waitFor();
-    await waitForReactHydration(page);
+test.describe('JWTデコーダー（production CSP 適用）', () => {
+  test('有効なJWTをデコードしてHeader・Payloadセクションを表示する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jwt-decoder', async (page) => {
+      await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
+      await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Payload (Claims)' })).toBeVisible();
+    });
   });
 
-  test('有効なJWTをデコードしてHeader・Payloadセクションを表示する', async ({ page }) => {
-    await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
-    await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Payload (Claims)' })).toBeVisible();
+  test('Headerに alg と typ が含まれる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jwt-decoder', async (page) => {
+      await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
+      await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
+      await expect(page.getByTestId('jwt-header')).toContainText('"HS256"');
+      await expect(page.getByTestId('jwt-header')).toContainText('"JWT"');
+    });
   });
 
-  test('Headerに alg と typ が含まれる', async ({ page }) => {
-    await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
-    await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
-    await expect(page.getByTestId('jwt-header')).toContainText('"HS256"');
-    await expect(page.getByTestId('jwt-header')).toContainText('"JWT"');
+  test('Payloadに sub と name が含まれる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jwt-decoder', async (page) => {
+      await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
+      await expect(page.getByRole('heading', { name: 'Payload (Claims)' })).toBeVisible();
+      await expect(page.getByTestId('jwt-payload')).toContainText('"1234567890"');
+      await expect(page.getByTestId('jwt-payload')).toContainText('"John Doe"');
+    });
   });
 
-  test('Payloadに sub と name が含まれる', async ({ page }) => {
-    await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
-    await expect(page.getByRole('heading', { name: 'Payload (Claims)' })).toBeVisible();
-    await expect(page.getByTestId('jwt-payload')).toContainText('"1234567890"');
-    await expect(page.getByTestId('jwt-payload')).toContainText('"John Doe"');
+  test('不正なJWTでエラーメッセージを表示する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jwt-decoder', async (page) => {
+      await page.getByLabel('JWTトークンを貼り付け').fill('not-a-valid-jwt');
+      await expect(page.getByRole('alert')).toContainText('有効なJWTトークンではありません');
+    });
   });
 
-  test('不正なJWTでエラーメッセージを表示する', async ({ page }) => {
-    await page.getByLabel('JWTトークンを貼り付け').fill('not-a-valid-jwt');
-    await expect(page.getByRole('alert')).toContainText('有効なJWTトークンではありません');
+  test('サンプルボタンでJWTが生成・デコードされる（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jwt-decoder', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
+      await expect(page.getByLabel('JWTトークンを貼り付け')).not.toHaveValue('');
+    });
   });
 
-  test('サンプルボタンでJWTが生成・デコードされる', async ({ page }) => {
-    await page.getByRole('button', { name: 'サンプルを入力' }).click();
-    await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
-    await expect(page.getByLabel('JWTトークンを貼り付け')).not.toHaveValue('');
-  });
-
-  test('入力クリアでデコード結果が消える', async ({ page }) => {
-    await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
-    await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
-    await page.getByLabel('JWTトークンを貼り付け').fill('');
-    await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).not.toBeVisible();
+  test('入力クリアでデコード結果が消える（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/jwt-decoder', async (page) => {
+      await page.getByLabel('JWTトークンを貼り付け').fill(SAMPLE_JWT);
+      await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).toBeVisible();
+      await page.getByLabel('JWTトークンを貼り付け').fill('');
+      await expect(page.getByRole('heading', { name: 'Header (JOSE)' })).not.toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## 概要

issue #234 の PR 5/5 (最終)。`applyProductionCsp` を `tests/e2e/jwt-decoder.spec.ts` (6 tests) へ展開し、本番相当 CSP 制約下で全 E2E が pass することを確認。

これで issue #234 の対象 19 spec（PR #233 で先行した `config-converter` を含めると 20 spec）全てが production CSP gate 配下に揃う。

## CSP 観点

- `jose` ライブラリの decode 経路は `base64url decode` + `JSON.parse` のみで eval 不要
- `PRODUCTION_CSP` の `script-src 'self' 'unsafe-inline'` (`unsafe-eval` なし) 下で違反は発生しない

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test:e2e tests/e2e/jwt-decoder.spec.ts`: 6 passed (15.0s)

## issue #234 累計

| PR | spec | 結果 |
| --- | --- | --- |
| #325 | base64 / url-encode / json-xml / json-csv / dummy-text / jan-code | 41 passed |
| #326 | copy-button / download-button / a11y-live-region / link-styles / mobile-drawer + helper `skipHydration` | 24 passed, 1 skipped |
| #327 | encoding-converter / filename-sanitize | 21 passed |
| #328 | gs1-databar / qr-code / qr-reader / qr-ticket | 29 passed |
| #329 (本 PR) | jwt-decoder | 6 passed |

合計: **121 passed** (合計 122 tests, 1 元から skip)。違反検出 / 修正 PR は発生せず（issue 想定の「違反が浮上したら別 PR」は不要）。

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] 5 PR 全マージ後、issue #234 を close する

## 関連

- 親 issue: #234（本 PR で全 spec 展開完了）
- 先行 PR: #325 / #326 / #327 / #328
- 後続: #176 で `unsafe-inline` を削減する際の安全網として機能
