### PR TITLE
feat(ui): #238 ActionButton 全 variant に :hover フィードバックを統合

### DIFF
--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -51,6 +51,28 @@ CSP `style-src 'unsafe-inline'` 撤去（issue #176 B 案）に伴い、JSX の 
 }
 ```
 
+#### ActionButton variant 別 hover の例
+
+`ActionButton` は `btn-action` + `btn-action--{variant}` の semantic class を持ち、`global.css` の `@layer components` 内で variant ごとに `:hover:not(:disabled)` を定義する。`:not(:disabled)` で disabled 時に hover 反応が出ないことを保証する。
+
+```css
+/* global.css `@layer components` ブロック内 */
+.btn-action {
+  transition:
+    background-color 0.15s,
+    filter 0.15s;
+}
+.btn-action--primary:hover:not(:disabled) {
+  filter: brightness(0.92); /* ベース色を保ちつつ 8% 暗化 */
+}
+.btn-action--secondary:hover:not(:disabled) {
+  background: var(--color-bg-active); /* 透過 → blue-50 tint */
+}
+.btn-action--danger:hover:not(:disabled) {
+  background: var(--color-error-bg); /* 透過 → red-50 tint */
+}
+```
+
 ### 2.2 ボタン高さの揃え
 
 横並びでボタン高さを揃えたい場合は **`leading-none` Tailwind utility を併記する**（`.caption` / `.body-emphasis` class は line-height 1.7 のため意図より大きくなる）。

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -275,6 +275,9 @@
   .btn-action {
     border-style: solid;
     border-width: 1px;
+    transition:
+      background-color 0.15s,
+      filter 0.15s;
   }
   .btn-action--default {
     border-color: var(--color-border-input);
@@ -295,6 +298,16 @@
     border-color: var(--color-error);
     background: transparent;
     color: var(--color-error);
+  }
+  /* hover: variant 別フィードバック。disabled には適用しない (cursor:not-allowed の既存動作と整合) */
+  .btn-action--primary:hover:not(:disabled) {
+    filter: brightness(0.92);
+  }
+  .btn-action--secondary:hover:not(:disabled) {
+    background: var(--color-bg-active);
+  }
+  .btn-action--danger:hover:not(:disabled) {
+    background: var(--color-error-bg);
   }
   .btn-action:disabled {
     background: var(--color-bg-subtle);

--- a/tests/e2e/download-button.spec.ts
+++ b/tests/e2e/download-button.spec.ts
@@ -37,4 +37,43 @@ test.describe('DownloadButton（production CSP 適用）', () => {
     // 再現することが困難なため、テストをスキップする。
     // 将来的に無効化（disabled）を恒常的に使用するツールが追加された際に実装を検討。
   });
+
+  // hover フィードバック（issue #238）
+  // ActionButton は variant 別に :hover:not(:disabled) を global.css の @layer components で定義する。
+  // DownloadButton は ActionButton の thin wrapper のため、その hover 挙動を経路として検証する。
+  test('SVGダウンロードボタン（secondary）の hover で背景が var(--color-bg-active) になる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+
+      const button = page.getByRole('button', { name: 'SVGダウンロード' });
+      await expect(button).toBeVisible();
+
+      // 初期状態: 背景透明
+      await expect(button).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+      // hover: 背景が --color-bg-active (#eff6ff = blue-50) に変化
+      await button.hover();
+      await expect(button).toHaveCSS('background-color', 'rgb(239, 246, 255)');
+    });
+  });
+
+  test('PNGダウンロードボタン（primary）の hover で filter brightness が変化する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+
+      const button = page.getByRole('button', { name: 'PNGダウンロード' });
+      await expect(button).toBeVisible();
+
+      // 初期状態: filter なし (none)
+      await expect(button).toHaveCSS('filter', 'none');
+
+      // hover: filter brightness(0.92) で 8% 暗化
+      await button.hover();
+      await expect(button).toHaveCSS('filter', 'brightness(0.92)');
+    });
+  });
 });


### PR DESCRIPTION
## 概要

issue #238 対応。`ActionButton` の全 variant に `:hover:not(:disabled)` フィードバックを統合実装する PR。

PR #236 (#231) で `DownloadButton` を `ActionButton` ラッパー化した際、Tailwind `hover:` クラスを禁止する規約と整合させるため secondary / danger 系の hover 反応を意図的に廃止していた。結果として「枠だけボタン」(secondary / danger) でマウス操作時の状態変化が視覚的に分からない UX 退行が残っていた。本 PR で解消。

## 実装

### CSS rules (global.css `@layer components`)

| variant | hover 表現 | 設計意図 |
| --- | --- | --- |
| primary | `filter: brightness(0.92)` | ベース色を保ちつつ 8% 暗化（テーマ変更耐性あり） |
| secondary | `background: var(--color-bg-active)` | 透過 → blue-50 (#eff6ff) tint |
| danger | `background: var(--color-error-bg)` | 透過 → red-50 (#fef2f2) tint |
| default | (変更なし) | issue が指定なし、現状維持 |

- `:not(:disabled)` で disabled 時に hover 反応が出ないことを保証
- `transition: background-color 0.15s, filter 0.15s` を `.btn-action` 基底に追加して滑らかに遷移
- Tailwind v4 の `@layer components` 内手書き class は `hover:` variant 非対応のため、`:hover` 擬似クラスごと書く既存パターン (`.btn-clear`) に揃える

### docs/ui-conventions.md 2.1 章

ActionButton hover の canonical 例を追加。issue #238 の受け入れ基準「`hover:` クラスは禁止だが、`:hover` 擬似クラスは許容」を満たす。

### E2E 検証 (`tests/e2e/download-button.spec.ts`)

`DownloadButton` は `ActionButton` の thin wrapper のため、その hover 挙動を経路として検証:

- SVGダウンロード (secondary) の hover で背景が `rgb(239, 246, 255)` に変化
- PNGダウンロード (primary) の hover で `filter: brightness(0.92)` に変化

danger variant は `qr-ticket/VerifyTab.tsx` の stop-camera button (camera 起動後にのみ表示) で使われるが、navigator.mediaDevices mock 必須で複雑なため E2E スキップ。`:hover:not(:disabled)` の機構自体は secondary E2E で検証済みで、danger は CSS 変数のみ差替えのため低リスク。

## 受け入れ基準

- [x] primary hover: `filter: brightness(0.92)`（issue 案 0.95 より少し強め）
- [x] secondary hover: `background: var(--color-bg-active)`
- [x] danger hover: 何らかの視覚反応（red-50 tint）
- [x] disabled 状態では hover 反応が出ない（`:not(:disabled)`）
- [x] `docs/ui-conventions.md` 2.1 章に ActionButton hover 例を追加
- [x] Playwright E2E で hover スタイル変化を検証 (primary / secondary 2 件)
- [x] 既存 ActionButton 利用箇所への影響: `CountInput` / `ConfigConverter` / `qr-ticket` (`VerifyTab` `GenerateTab`) / `DownloadButton` ラッパー全てが既存 className のまま hover 反応を獲得

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test` (ActionButton.test.tsx): 17 passed
- `npm run test` (全体): 825 passed
- `npm run test:e2e tests/e2e/download-button.spec.ts`: 4 passed, 1 skipped (元から skip)

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] レビュー: hover 表現が UI として違和感なし (PC / スマホ両方の目視確認は merge 後に user 側で実施)
- [ ] レビュー: `:not(:disabled)` で disabled 時の hover 抑止が確実に効くこと
- [ ] レビュー: transition の 0.15s が UX としてちょうど良いか

## 関連

- 親 issue: #238
- 起源: PR #236 (#231) review コメント [major] secondary hover 削除
- 規約: `docs/ui-conventions.md` 2.1 章 (`hover:` クラス禁止 → `:hover` 擬似クラス許容)
- 関連: PR #229 (#162) `ActionButton` 導入
