### PR TITLE
feat(a11y): #164 outline-none 削除 + ActionButton :focus-visible 統合 (#331 nit 2 同梱)

### DIFF
--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -51,9 +51,9 @@ CSP `style-src 'unsafe-inline'` 撤去（issue #176 B 案）に伴い、JSX の 
 }
 ```
 
-#### ActionButton variant 別 hover の例
+#### ActionButton variant 別 hover / :focus-visible の例
 
-`ActionButton` は `btn-action` + `btn-action--{variant}` の semantic class を持ち、`global.css` の `@layer components` 内で variant ごとに `:hover:not(:disabled)` を定義する。`:not(:disabled)` で disabled 時に hover 反応が出ないことを保証する。
+`ActionButton` は `btn-action` + `btn-action--{variant}` の semantic class を持ち、`global.css` の `@layer components` 内で variant ごとに `:hover:not(:disabled)` と `:focus-visible:not(:disabled)` を**同じ視覚反応で**定義する。キーボードユーザにも mouse hover と同等のフィードバックを与えるための a11y 配慮。`:not(:disabled)` で disabled 時に反応が出ないことを保証する。`:focus` 全般ではなく `:focus-visible` に限定することで click 押下中の残留視覚反応を避ける（`global.css` の `:where(...):focus-visible` outline ring と併用）。
 
 ```css
 /* global.css `@layer components` ブロック内 */
@@ -62,16 +62,23 @@ CSP `style-src 'unsafe-inline'` 撤去（issue #176 B 案）に伴い、JSX の 
     background-color 0.15s,
     filter 0.15s;
 }
-.btn-action--primary:hover:not(:disabled) {
+.btn-action--primary:hover:not(:disabled),
+.btn-action--primary:focus-visible:not(:disabled) {
   filter: brightness(0.92); /* ベース色を保ちつつ 8% 暗化 */
 }
-.btn-action--secondary:hover:not(:disabled) {
+.btn-action--secondary:hover:not(:disabled),
+.btn-action--secondary:focus-visible:not(:disabled) {
   background: var(--color-bg-active); /* 透過 → blue-50 tint */
 }
-.btn-action--danger:hover:not(:disabled) {
+.btn-action--danger:hover:not(:disabled),
+.btn-action--danger:focus-visible:not(:disabled) {
   background: var(--color-error-bg); /* 透過 → red-50 tint */
 }
 ```
+
+#### `outline-none` Tailwind utility は使わない
+
+input / textarea / button などのフォーカス可能要素の className に `outline-none` を付けると、`:where(button, a, [role='button'], input, textarea, select):focus-visible` の global rule (specificity 0) を Tailwind utility (specificity 1) が上書きし、**キーボード focus 時のフォーカスリングが消滅**する。focus 表示は `global.css` の `:focus-visible` ルールに委ねること。デフォルトの mouse focus アウトラインは `:where(...)` 側で `:focus-visible` 限定なので mouse click では出ない（visible feedback は不要）。
 
 ### 2.2 ボタン高さの揃え
 

--- a/src/components/tools/DummyText.tsx
+++ b/src/components/tools/DummyText.tsx
@@ -124,7 +124,7 @@ export function DummyTextTool() {
               handleLengthBlur();
             }
           }}
-          className="rounded-lg px-3 py-2 caption w-32 border border-input outline-none bg-default text-default"
+          className="rounded-lg px-3 py-2 caption w-32 border border-input bg-default text-default"
         />
         <p className="caption text-muted mt-1">1〜5000文字</p>
       </div>
@@ -155,7 +155,7 @@ export function DummyTextTool() {
                 value={chunkInput}
                 onChange={(e) => handleChunkChange(e.target.value)}
                 onBlur={handleChunkBlur}
-                className="rounded-lg px-3 py-2 caption w-20 border border-input outline-none bg-default text-default"
+                className="rounded-lg px-3 py-2 caption w-20 border border-input bg-default text-default"
               />
               <span className="caption text-muted">文字ごと（1〜1000）</span>
             </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -299,14 +299,20 @@
     background: transparent;
     color: var(--color-error);
   }
-  /* hover: variant 別フィードバック。disabled には適用しない (cursor:not-allowed の既存動作と整合) */
-  .btn-action--primary:hover:not(:disabled) {
+  /* hover / :focus-visible: variant 別フィードバック。disabled には適用しない。
+     キーボードユーザにも mouse hover と同等のフィードバックを与える (a11y 観点)。
+     :focus 全般ではなく :focus-visible に限定することで、click 押下中の不要な
+     残留視覚反応を避ける。global.css の `:where(...):focus-visible` outline ring と併用。 */
+  .btn-action--primary:hover:not(:disabled),
+  .btn-action--primary:focus-visible:not(:disabled) {
     filter: brightness(0.92);
   }
-  .btn-action--secondary:hover:not(:disabled) {
+  .btn-action--secondary:hover:not(:disabled),
+  .btn-action--secondary:focus-visible:not(:disabled) {
     background: var(--color-bg-active);
   }
-  .btn-action--danger:hover:not(:disabled) {
+  .btn-action--danger:hover:not(:disabled),
+  .btn-action--danger:focus-visible:not(:disabled) {
     background: var(--color-error-bg);
   }
   .btn-action:disabled {


### PR DESCRIPTION
## 概要

issue #164 のサブタスク C (`outline:'none'` 棚卸し) と PR #331 review nit 2 (:focus-visible 統合) を同梱で解消する PR。a11y 観点でキーボードユーザのフォーカスリング消失リスクとフィードバック欠如を解消。

issue #164 のサブタスク A / B は B 案 strict 化 (PR #315) で大半が obsolete 化したため本 PR では見送り、A はダークモード実装時に palette 設計を一括で行う方針へ移管。

## C. `outline-none` 削除（DummyText.tsx 2 箇所）

### 問題

`DummyText.tsx:127,158` の Tailwind `outline-none` utility を削除。

`global.css` の `:where(input, ...):focus-visible` rule (`:where` で **specificity 0**) を Tailwind `outline-none` utility (specificity 0,1,0) が上書きし、キーボード focus 時のフォーカスリングが消失していた。

### 対応

```diff
- className="rounded-lg px-3 py-2 caption w-32 border border-input outline-none bg-default text-default"
+ className="rounded-lg px-3 py-2 caption w-32 border border-input bg-default text-default"
```

utility 削除で `global.css` の `:focus-visible` rule 経由で focus ring (2px solid var(--color-focus)) が復活する。

### issue #164 内 outline 棚卸しの完了状況

issue 本文記載の 8 箇所のうち 6 箇所は B 案 strict 化 (PR #315) で削除済み:
- Gs1Databar.tsx:308 — 削除済み
- qr-ticket/GenerateTab.tsx:229,307,331,355 — 削除済み
- CountInput.tsx:58 — 削除済み

残 2 箇所 (DummyText.tsx) を本 PR で消化、サブタスク C 完了。

## ActionButton `:focus-visible` 統合（PR #331 nit 2）

### 問題

PR #331 で `:hover:not(:disabled)` のみ追加したため、キーボードユーザは hover と同じ視覚フィードバック（filter brightness / bg tint）を受けられなかった。

### 対応

`.btn-action--{primary,secondary,danger}` の `:hover` rule に `:focus-visible` を **selector list で並列追加**:

```css
.btn-action--primary:hover:not(:disabled),
.btn-action--primary:focus-visible:not(:disabled) {
  filter: brightness(0.92);
}
.btn-action--secondary:hover:not(:disabled),
.btn-action--secondary:focus-visible:not(:disabled) {
  background: var(--color-bg-active);
}
.btn-action--danger:hover:not(:disabled),
.btn-action--danger:focus-visible:not(:disabled) {
  background: var(--color-error-bg);
}
```

- `:focus` 全般ではなく `:focus-visible` 限定で click 押下中の残留視覚反応を回避
- `global.css` の `:where(button):focus-visible` outline ring と併用（focus ring + bg/filter で多層的に focus を表現）
- `:not(:disabled)` で disabled 時の反応を抑止

## docs/ui-conventions.md 2.1 章

ActionButton hover/:focus-visible の canonical 例を更新。`outline-none` Tailwind utility が specificity で global `:focus-visible` を override する問題を**新章として明記**し再発防止。

## スコープ外 (見送り)

- **サブタスク A (accent palette)**: hex 6 値のうち 2 値 (`#9333ea` / `#d97706`) が WCAG contrast 制約により canonical palette に収まらないため、ダークモード実装時に palette 設計を一括で行う方針へ。issue #164 の本来意図 (将来のダークモード対応に備えた palette 整理) は dark mode 実装時に再評価が最適。
- **サブタスク B (microCaption)**: inline 0.75rem 直書きは既に消滅済み (B 案 migration で `.jwt-pre` `.uuid-field-key` 等の CSS class に分離済み)、scope obsolete。

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test`: 825 passed
- `npm run test:e2e tests/e2e/{dummy-text,download-button}.spec.ts`: 10 passed, 1 skipped (元から skip)
- 既存 hover E2E (PR #331 で追加) は本 PR の selector list 拡張後も pass

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] レビュー: DummyText 入力欄に Tab focus → focus ring が表示されるか目視確認
- [ ] レビュー: ActionButton (primary/secondary/danger) を Tab focus → hover と同じ視覚反応 + outline ring が表示されるか目視確認
- [ ] レビュー: A/B の見送り判断 (dark mode 実装時に持ち越し / obsolete) が妥当か

## 関連

- 親 issue: #164 (本 PR で C 完了、A/B 見送り → 本 issue close 候補)
- フォローアップ起源: PR #331 review nit 2 (:focus-visible 統合)
- 関連: PR #315 (CSP B 案 strict 化、A/B が obsolete 化した経緯)
