### PR TITLE
ci(vrt): #255 baseline secret 焼き付き防御 2 層 + branch protection 監査結果文書化

### DIFF
--- a/.github/workflows/update-visual-baseline.yml
+++ b/.github/workflows/update-visual-baseline.yml
@@ -43,7 +43,10 @@ jobs:
         # baseline PNG への secret 焼き付き → git 履歴 permanent leak を防ぐ最終防御層。
         run: |
           set -euo pipefail
-          SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(GITHUB_TOKEN|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
+          # `GITHUB_TOKEN=` は exact match (末尾 `=` で `GITHUB_TOKEN_FOO=` の意図せぬ allow を防ぐ)。
+          # 他の `RUNNER_` / `GITHUB_RUN_` / `ACTIONS_` / `GH_` / `PIP_` / `PYPI_` は GH Actions runtime 由来の env が
+          # 多数あるため prefix allow を維持。
+          SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(GITHUB_TOKEN=|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
           if [ -n "$SUSPECT" ]; then
             echo "::error::Secret-like env vars detected. Baseline 生成中止 (PNG への焼き付き leak 防止)。"
             # 値は redact、key 名のみ出力

--- a/.github/workflows/update-visual-baseline.yml
+++ b/.github/workflows/update-visual-baseline.yml
@@ -36,6 +36,21 @@ jobs:
       - run: npm ci
       # Playwright ブラウザは container image に preinstalled 済 (#291)。
       # PLAYWRIGHT_BROWSERS_PATH=/ms-playwright が image で設定済みのため install step 不要。
+      - name: Secret-like env var の audit (issue #255 I-2)
+        # 想定 secret 命名規則 (*_KEY / *_TOKEN / *_SECRET / *_PASSWORD / *_CREDENTIAL) を
+        # 持つ env var が baseline 生成 step に流れていないか early-fail check。
+        # 例外: GITHUB_TOKEN は steps[0].with.token で push に必要、RUNNER_* は GH Actions runtime 由来。
+        # baseline PNG への secret 焼き付き → git 履歴 permanent leak を防ぐ最終防御層。
+        run: |
+          set -euo pipefail
+          SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(GITHUB_TOKEN|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
+          if [ -n "$SUSPECT" ]; then
+            echo "::error::Secret-like env vars detected. Baseline 生成中止 (PNG への焼き付き leak 防止)。"
+            # 値は redact、key 名のみ出力
+            echo "$SUSPECT" | sed 's/=.*$/=<redacted>/'
+            exit 1
+          fi
+          echo "OK: no secret-like env vars exposed to baseline generation"
       - name: 本番相当アセットを build
         run: npm run build
       - name: Visual regression baseline を再生成

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2699,11 +2699,12 @@ B 案完了後も継続運用する検出網:
 
 ### 決定
 
-**I-1: branch protection 監査**
+**I-1: branch protection 監査 — solo dev 体制での適用不可を確認**
 
-- `gh api repos/<owner>/<repo>/branches/develop/protection` は 2026-05-09 時点で **404 "Branch not protected"** を返した。develop は **branch protection 未設定**。issue が当初懸念した「bypass list 経由の許可漏れ」以前に protection そのものが無い。
-- 本 PR は audit 結果の文書化に留める (`docs/playbooks/e2e-validation.md` 7.5)。短期対策 (Settings UI から protection 追加) と中期対策 (`peter-evans/create-pull-request` 化) は user 判断 / 別 issue で扱う。
-- `update-visual-baseline.yml` には既に `if: github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main'` があり、default branch 上での `workflow_dispatch` 誤 trigger は no-op になる二次 safety は確保。
+- `gh api repos/<owner>/<repo>/branches/develop/protection` は 2026-05-09 時点で **404 "Branch not protected"** を返した。develop は **branch protection 未設定**。
+- ただし solo dev 体制（PR 作成者 = レビュアー = merger が同一人物）では `Require approvals` を有効化すると **self-approve 不可で自分の PR が永久 merge 不能になり詰む**（GitHub policy）。`Require pull request before merging` 単体では「他人による review」を強制せず、`Restrict who can push` も PR 経由の self-merge を block しない。**branch protection 単体で「review なしマージを block する」効果は solo dev では得られない**。
+- bot push (`update-visual-baseline.yml` の最終 step) は `actions/checkout@v6` の `ref: ${{ github.head_ref || github.ref_name }}` により PR の feature branch に push されるため、bot の baseline 変更は **既存 PR の diff の一部** として review pipeline に乗る（develop へ直 push していない）。`if: github.ref != 'refs/heads/develop' && !main` で default branch 上の `workflow_dispatch` 誤 trigger は no-op の二次 safety も既存。
+- → I-1 の **issue 当初想定（bypass list 経由の許可漏れ）は team 体制前提の概念**で solo dev には直接適用できないと結論。短期対策（protection 追加）も中期対策（peter-evans/create-pull-request 化）も solo dev では実効薄。本 PR は audit 結果と適用不可の理由を `docs/playbooks/e2e-validation.md` 7.5 に文書化し、actionable な対策は「VRT PR comment が出た PR は merge 前に diff 目視」運用の継続（既存 7.2 章）に集約する。
 
 **I-2: baseline PNG への secret 混入予防 (本 PR で 2 層実装)**
 
@@ -2712,13 +2713,13 @@ B 案完了後も継続運用する検出網:
 
 ### Lessons learned
 
-- **Audit 前提が事実と異なるケース**: issue は「bypass list の許可漏れ」を懸念したが、実態は protection 未設定だった。`gh api` 経由の事実確認が無いと存在しない監査対象を議論し続ける危険。**教訓**: ops 系 issue は最初に `gh api` / `gh pr/issue view` で前提事実を読み取る。
+- **Audit 前提が事実と異なるケース**: issue は「bypass list の許可漏れ」を懸念したが、実態は protection 未設定 + solo dev で `Require approvals` 適用不可の二重ズレだった。`gh api` 経由の事実確認 + 体制（solo / team）の文脈確認 が無いと存在しない監査対象や適用不可な対策を議論し続ける危険。**教訓**: ops 系 issue は最初に `gh api` / `gh pr/issue view` で前提事実を読み取り、team / solo の体制差分も明示してから設計する。
 - **PNG への secret 焼き付きは text scan の盲点**: gitleaks / git-secrets は textual content を scan するため、image 内 OCR レベルの leak は検出できない。**教訓**: 画像生成系 workflow は spec 側 (storage clear) と workflow 側 (env audit) の 2 層防御が原則。
 - **Allow list の例外管理**: `GITHUB_TOKEN` 等の GH Actions runtime 由来 env を allow に入れる際は、push 用途で必要であることを明示。allow list が肥大化したら audit 範囲が崩れるため PR review で都度評価。
 
 ### 関連 PR / issue
 
-- 本 entry を記録: PR `#332` follow-up (`#255` 対応)
+- 本 entry を記録: PR `#333` (`#255` 対応)
 - 起源: `#254` (VRT 専用 PR 導入) のセルフレビュー I-1 / I-2
 - 親 issue: `#255` (本 PR で短期 + 防御 2 層完了、長期の peter-evans 化は別議論)
 - 関連: `#176` B 案 [066] (VRT 導入)、本番リリース前 TODO `#323`

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2690,3 +2690,35 @@ B 案完了後も継続運用する検出網:
 - **ガード/バリデータには陽性対照を必須とする**: PR 5b の `withProductionCsp` meta-test (#281) や本 PR の Astro hash 検出網メタテストのように、検出網自体が silent pass しないことを陽性対照で能動確認する運用が定着。memory `feedback_positive_control_for_gates.md`。
 - **段階的 PR の本数管理**: B 案は当初 PR 1〜6 想定だったが、実際は PR 0〜10 + follow-up で計 15 PR (含む scope 縮小 PR / 計画外発覚での分割)。「PR の自然分割は infra / foundation / 個別 migration / docs」の方針 (memory `feedback_pr_size.md`) に従ったため、各 PR は review 単位で適切な大きさを維持できた。
 - **subagent 委譲方針の使い分け**: PR 4 / 5a / 5b で「subagent 非 commit + 親で順次 commit」運用を確立、PR 7a / 7b / 8 / 9 / 10 では「親 Opus 直接実装」へ移行 (CSP flip / 高 stakes 検証は subagent verification trust の観点で親直接が安全)。memory `feedback_subagent_verification_trust.md` / `feedback_subagent_model.md`。
+
+## [069] 2026-05-09 — VRT baseline 更新経路の audit + secret 焼き付き防御 2 層導入 (`#255`)
+
+### 背景
+
+`#254` (VRT 専用 PR 導入) のセルフレビューで提起された 2 件 (I-1: bot push の branch protection bypass 可能性、I-2: baseline PNG への secret 焼き付き leak リスク) を `#255` として fix。
+
+### 決定
+
+**I-1: branch protection 監査**
+
+- `gh api repos/<owner>/<repo>/branches/develop/protection` は 2026-05-09 時点で **404 "Branch not protected"** を返した。develop は **branch protection 未設定**。issue が当初懸念した「bypass list 経由の許可漏れ」以前に protection そのものが無い。
+- 本 PR は audit 結果の文書化に留める (`docs/playbooks/e2e-validation.md` 7.5)。短期対策 (Settings UI から protection 追加) と中期対策 (`peter-evans/create-pull-request` 化) は user 判断 / 別 issue で扱う。
+- `update-visual-baseline.yml` には既に `if: github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main'` があり、default branch 上での `workflow_dispatch` 誤 trigger は no-op になる二次 safety は確保。
+
+**I-2: baseline PNG への secret 混入予防 (本 PR で 2 層実装)**
+
+1. **spec 層 (`tests/e2e/visual-regression.spec.ts`)**: `addInitScript` 冒頭で `localStorage.clear()` / `sessionStorage.clear()` を実行。将来 spec に `setItem('apiKey', ...)` 等が誤って追加されても、init script で直前に clear することで永続化前の baseline 撮影を保証。
+2. **workflow 層 (`.github/workflows/update-visual-baseline.yml`)**: build 前に `*_KEY` / `*_TOKEN` / `*_SECRET` / `*_PASSWORD` / `*_CREDENTIAL` 命名の env var が baseline 生成 step に流れていないか early-fail check。allow list は `GITHUB_TOKEN` / `RUNNER_*` / `GITHUB_RUN_*` / `ACTIONS_*` / `GH_*` / `PIP_*` / `PYPI_*` (GH Actions runtime 由来)。
+
+### Lessons learned
+
+- **Audit 前提が事実と異なるケース**: issue は「bypass list の許可漏れ」を懸念したが、実態は protection 未設定だった。`gh api` 経由の事実確認が無いと存在しない監査対象を議論し続ける危険。**教訓**: ops 系 issue は最初に `gh api` / `gh pr/issue view` で前提事実を読み取る。
+- **PNG への secret 焼き付きは text scan の盲点**: gitleaks / git-secrets は textual content を scan するため、image 内 OCR レベルの leak は検出できない。**教訓**: 画像生成系 workflow は spec 側 (storage clear) と workflow 側 (env audit) の 2 層防御が原則。
+- **Allow list の例外管理**: `GITHUB_TOKEN` 等の GH Actions runtime 由来 env を allow に入れる際は、push 用途で必要であることを明示。allow list が肥大化したら audit 範囲が崩れるため PR review で都度評価。
+
+### 関連 PR / issue
+
+- 本 entry を記録: PR `#332` follow-up (`#255` 対応)
+- 起源: `#254` (VRT 専用 PR 導入) のセルフレビュー I-1 / I-2
+- 親 issue: `#255` (本 PR で短期 + 防御 2 層完了、長期の peter-evans 化は別議論)
+- 関連: `#176` B 案 [066] (VRT 導入)、本番リリース前 TODO `#323`

--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -199,31 +199,45 @@ npm run test:vrt
 `gh api repos/<owner>/<repo>/branches/develop/protection` は 2026-05-09 時点で
 **404 "Branch not protected"** を返す。develop は **branch protection 未設定** の状態。
 
-**意味するところ**:
+**solo dev 体制での影響評価（重要）**:
 
-- `update-visual-baseline.yml` の bot push (`secrets.GITHUB_TOKEN`) は protection 違反すらせず
-  develop へ直 push 可能。issue #255 が当初懸念した「bypass list 経由の許可漏れ」以前に、
-  protection そのものが無いため audit 対象が存在しない。
-- 手動 `git push origin develop` も無制限に通る（PR を経ない直 push 可）。
-- workflow 側では `if: github.ref != 'refs/heads/develop'` で **default branch 上の trigger は no-op**
-  にしているため、`workflow_dispatch` が誤って develop で trigger された場合の安全装置はある。
+本リポジトリは「PR 作成者 = レビュアー = merger が同一人物」の solo dev 体制。
+GitHub branch protection の主要オプションを solo dev に当てはめると:
 
-**推奨する短期対策（user 側 manual 設定）**:
+| protection オプション                 | solo dev での効果                                                               |
+| ------------------------------------- | ------------------------------------------------------------------------------- |
+| `Require pull request before merging` | △ PR workflow を強制するだけで「他人による review」を強制しない                 |
+| `Require approvals` (N≥1)             | × **self-approve 不可で自分の PR が永久 merge 不能になり詰む**（GitHub policy） |
+| `Restrict who can push`               | △ direct push を禁じるが、PR 経由の self-merge は依然可能                       |
+| `Bypass list` 管理                    | × そもそも protection 無効のため audit 対象なし                                 |
 
-1. Settings → Branches → "Add classic branch protection rule"
-   - Branch name pattern: `develop`
-   - Require a pull request before merging
-   - Restrict who can push to matching branches（PR 経由のみ）
-   - Bypass list に `github-actions[bot]` を**含めない**（baseline 更新 PR 化の意義）
-2. enable 後、`update-visual-baseline.yml` の最終 step (`git push`) は本来 fail するため、
-   後述「中期対策」の peter-evans/create-pull-request 化と組み合わせて運用する必要がある。
-3. classic protection から ruleset への移行は別議論。
+→ **`Require approvals` が使えない以上、branch protection 単体では「review なしマージを block する」
+効果は solo dev では得られない**。issue #255 が当初想定した「bypass list 経由の許可漏れ」概念は
+team 体制を前提としており、solo dev には直接適用できない。
 
-**中期対策（採用判断後）**:
+**bot push の実体は「PR diff の一部」**:
 
-baseline 更新 workflow を `peter-evans/create-pull-request` action に置換し、
-bot は branch を作るだけ → 人間レビューで baseline PNG diff を audit してから merge。
-新 PR は本 issue ではなく別 issue で扱う。
+`update-visual-baseline.yml` の最終 step は `git push` で baseline を更新するが:
+
+- `actions/checkout@v6` の `ref: ${{ github.head_ref || github.ref_name }}` により
+  bot は **PR の feature branch に push する**（develop に直 push しない）。
+- bot の baseline 変更は **既存 PR の diff の一部** として PR comment / files changed に表示され、
+  user (= 自分) が PR 上で目視確認可能。
+- workflow には `if: github.ref != 'refs/heads/develop' && !main` で default branch 上での
+  `workflow_dispatch` 誤 trigger を no-op にする二次 safety がある。
+
+→ bot は review pipeline を bypass せず、user 通常 PR review (7.2 章のフロー) に乗っている。
+solo dev で必要なのは **「VRT PR comment が出た PR は merge 前に必ず diff 目視」という運用規律**であって、
+branch protection 設定変更ではない。この目視運用は 7.2 章で既に明文化済み。
+
+**結論（本 issue I-1 の actionable 範囲）**:
+
+- 短期: **追加対策不要**。既存 workflow 設計 (`if: !default-branch` + bot push を PR branch 限定 + 7.2 章の目視運用) で
+  solo dev に妥当な review 経路は確保されている。
+- 中期: `peter-evans/create-pull-request` 化は team 体制 (review 担当 vs PR 作成者が別人) なら有効だが、
+  solo dev では「baseline 専用 PR が分離されて視認性向上」程度の限定的効果。**pursue は user 判断**。
+- 体制が team に移行した場合は本章を再評価し、`Require approvals` + bypass list 管理 + peter-evans 化を
+  まとめて検討する。
 
 ### 7.6 Baseline PNG への secret 混入予防（issue #255 I-2）
 
@@ -240,8 +254,30 @@ baseline PNG は CI runner で生成され git にコミットされる。一度
    永続化前の baseline 撮影を保証する。
 2. **workflow 層**: `update-visual-baseline.yml` の build 前に
    `*_KEY` / `*_TOKEN` / `*_SECRET` / `*_PASSWORD` / `*_CREDENTIAL` 命名の env var が
-   流れていないか early-fail check。`GITHUB_TOKEN` / `RUNNER_*` / `GITHUB_RUN_*` /
-   `ACTIONS_*` / `GH_*` / `PIP_*` / `PYPI_*` は GH Actions runtime 由来として allow。
+   流れていないか early-fail check。`GITHUB_TOKEN` のみ exact match (`GITHUB_TOKEN_FOO=` の意図せぬ allow を防ぐ)、
+   `RUNNER_*` / `GITHUB_RUN_*` / `ACTIONS_*` / `GH_*` / `PIP_*` / `PYPI_*` は GH Actions runtime 由来として prefix allow。
+
+**Layer 1 の scope 限定（重要）**:
+
+`localStorage.clear()` / `sessionStorage.clear()` は **storage-based 焼き付き** のみ対処する。以下の経路は **未カバー**:
+
+- `document.cookie` (cookie viewer 系ツールが render すれば leak 可能)
+- IndexedDB (より複雑だが原理的に同じ leak 経路)
+- URL params (`?token=xyz` をページ内で表示する設計があれば leak)
+- form pre-fills (`<input value="${secret}">` 直書き)
+
+これらの primary defense は **「spec が secret を扱わない」原則**。Layer 1 / Layer 2 は last resort として位置付ける。spec を新規追加 / 拡張する際は、cookie / IndexedDB / URL / form value に secret を流さないことを reviewer がチェックする。
+
+**Layer 2 audit step の coverage gap（既知）**:
+
+regex `^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=` は接尾辞のみマッチし、以下を取りこぼす:
+
+- 複数形 (`SECRETS=`、`KEYS=`)
+- 中間出現 (`MY_TOKEN_VALUE=`)
+- 別命名 (`AUTH=`、`BEARER_*=`、`PIN=`、`JWT=`、`SESSION=`)
+- `_` 開始 (`_PRIVATE_KEY=`)
+
+false positive 増加とのトレードオフで現状は acceptable な ROI 判断。secret naming convention が拡張された際は本 docs を再評価。
 
 **contributor への注意**:
 

--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -193,3 +193,61 @@ npm run test:vrt
 - 新 page を VRT 対象に追加: spec の `PAGES` 配列に path 追記 → baseline 再生成
 - 新 viewport 追加: `VIEWPORTS` 配列に追記 → baseline 再生成
 - 詳細: `docs/decisions.md` [066]
+
+### 7.5 develop branch protection の現状（issue #255 I-1）
+
+`gh api repos/<owner>/<repo>/branches/develop/protection` は 2026-05-09 時点で
+**404 "Branch not protected"** を返す。develop は **branch protection 未設定** の状態。
+
+**意味するところ**:
+
+- `update-visual-baseline.yml` の bot push (`secrets.GITHUB_TOKEN`) は protection 違反すらせず
+  develop へ直 push 可能。issue #255 が当初懸念した「bypass list 経由の許可漏れ」以前に、
+  protection そのものが無いため audit 対象が存在しない。
+- 手動 `git push origin develop` も無制限に通る（PR を経ない直 push 可）。
+- workflow 側では `if: github.ref != 'refs/heads/develop'` で **default branch 上の trigger は no-op**
+  にしているため、`workflow_dispatch` が誤って develop で trigger された場合の安全装置はある。
+
+**推奨する短期対策（user 側 manual 設定）**:
+
+1. Settings → Branches → "Add classic branch protection rule"
+   - Branch name pattern: `develop`
+   - Require a pull request before merging
+   - Restrict who can push to matching branches（PR 経由のみ）
+   - Bypass list に `github-actions[bot]` を**含めない**（baseline 更新 PR 化の意義）
+2. enable 後、`update-visual-baseline.yml` の最終 step (`git push`) は本来 fail するため、
+   後述「中期対策」の peter-evans/create-pull-request 化と組み合わせて運用する必要がある。
+3. classic protection から ruleset への移行は別議論。
+
+**中期対策（採用判断後）**:
+
+baseline 更新 workflow を `peter-evans/create-pull-request` action に置換し、
+bot は branch を作るだけ → 人間レビューで baseline PNG diff を audit してから merge。
+新 PR は本 issue ではなく別 issue で扱う。
+
+### 7.6 Baseline PNG への secret 混入予防（issue #255 I-2）
+
+baseline PNG は CI runner で生成され git にコミットされる。一度焼き付くと:
+
+- text-based scan（git-secrets / gitleaks）の盲点で検出されない
+- git 履歴は rewrite 困難で permanent leak になりがち
+
+**実装済み防御層 (PR #255 系)**:
+
+1. **spec 層**: `tests/e2e/visual-regression.spec.ts` の `addInitScript` 冒頭で
+   `localStorage.clear()` / `sessionStorage.clear()` を実行。将来 spec に
+   `setItem('apiKey', ...)` 等が誤って追加されても、init script で直前に clear することで
+   永続化前の baseline 撮影を保証する。
+2. **workflow 層**: `update-visual-baseline.yml` の build 前に
+   `*_KEY` / `*_TOKEN` / `*_SECRET` / `*_PASSWORD` / `*_CREDENTIAL` 命名の env var が
+   流れていないか early-fail check。`GITHUB_TOKEN` / `RUNNER_*` / `GITHUB_RUN_*` /
+   `ACTIONS_*` / `GH_*` / `PIP_*` / `PYPI_*` は GH Actions runtime 由来として allow。
+
+**contributor への注意**:
+
+- spec に `localStorage.setItem(...)` / `sessionStorage.setItem(...)` を追加する場合、
+  その値は **baseline PNG に焼き付く可能性がある**（特に rendered DOM が storage を
+  visualize するツールでは確実に映り込む）。secret-like な値を spec で扱う場合は
+  baseline 生成対象 page を除外するか、screenshot 前に値を masking する。
+- workflow に新規 secret env を追加する場合は spec / job のスコープを最小化し、
+  上記 audit step の allow list を更新するときは PR review で焼き付きリスクを再評価。

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -54,6 +54,16 @@ for (const viewport of VIEWPORTS) {
       test(`${url} の screenshot が baseline と一致`, async ({ page }) => {
         // navigation 前に deterministic mock を注入（production code 無変更）
         await page.addInitScript(() => {
+          // localStorage / sessionStorage を sterile に保つ（baseline 再生成時の secret 混入予防）
+          // 将来 spec に setItem('apiKey', ...) 等が誤って追加された場合でも、init script で
+          // 直前に clear することで永続化前の baseline 撮影を保証する (issue #255 I-2)。
+          try {
+            localStorage.clear();
+            sessionStorage.clear();
+          } catch {
+            // 静的ページ等で storage 未許可の context では無視
+          }
+
           // Seeded LCG: Math.random を固定 seed (42) から再現可能な乱数列に
           let seed = 42;
           Math.random = () => {


### PR DESCRIPTION
## 概要

issue #255 (PR #254 セルフレビュー I-1 / I-2 follow-up) を fix する PR。VRT baseline 更新経路の audit 結果文書化 + baseline PNG への secret 焼き付き leak 予防 2 層を実装。

## I-1: branch protection 監査結果（`docs/playbooks/e2e-validation.md` 7.5）

### 監査の前提が事実と異なっていた

`gh api repos/fumtas1k/devtools/branches/develop/protection` を 2026-05-09 時点で実行したところ **404 "Branch not protected"** を返した。

> develop は **branch protection 未設定**。issue が当初懸念した「bypass list 経由の許可漏れ」以前に、監査対象 (protection) そのものが存在しない。

### 短期対策（user 判断、本 PR では文書化のみ）

- Settings → Branches → "Add classic branch protection rule"
  - Branch name pattern: `develop`
  - Require a pull request before merging
  - Restrict who can push（PR 経由のみ）
  - Bypass list に `github-actions[bot]` を**含めない**

### 中期対策（別 issue 化候補）

baseline 更新 workflow を `peter-evans/create-pull-request` action 経由の人間レビュー強制設計へ refactor。本 PR scope 外。

### 既存の二次 safety

`update-visual-baseline.yml` には既に `if: github.ref != 'refs/heads/develop' && !main` で default branch 上での `workflow_dispatch` 誤 trigger を no-op にする二次 safety がある。protection 設定後もこれは併用。

## I-2: baseline PNG への secret 焼き付き予防 2 層

PNG への secret 焼き付きは text-based scan (gitleaks 等) の盲点で permanent leak リスクが高い。

### 防御層 1: spec 層 (`tests/e2e/visual-regression.spec.ts`)

`addInitScript` 冒頭で `localStorage.clear()` / `sessionStorage.clear()` を実行。

```ts
await page.addInitScript(() => {
  // localStorage / sessionStorage を sterile に保つ
  try {
    localStorage.clear();
    sessionStorage.clear();
  } catch {
    // 静的ページ等で storage 未許可の context では無視
  }
  // ... existing deterministic mocks ...
});
```

将来 spec に `setItem('apiKey', ...)` 等が誤って追加されても、init script で直前に clear することで永続化前の baseline 撮影を保証。Playwright 既定の test-level isolation で各 test は fresh context のため baseline 視覚差は無い想定。

### 防御層 2: workflow 層 (`.github/workflows/update-visual-baseline.yml`)

build 前に secret-like env var の audit step を追加:

```yaml
- name: Secret-like env var の audit (issue #255 I-2)
  run: |
    set -euo pipefail
    SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(GITHUB_TOKEN|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
    if [ -n "$SUSPECT" ]; then
      echo "::error::Secret-like env vars detected. Baseline 生成中止 (PNG への焼き付き leak 防止)。"
      echo "$SUSPECT" | sed 's/=.*$/=<redacted>/'
      exit 1
    fi
```

- 検知パターン: `*_KEY` / `*_TOKEN` / `*_SECRET` / `*_PASSWORD` / `*_CREDENTIAL`
- allow list: GH Actions runtime 由来の `GITHUB_TOKEN` / `RUNNER_*` / `GITHUB_RUN_*` / `ACTIONS_*` / `GH_*` / `PIP_*` / `PYPI_*`
- 検知時は key 名のみ output、値は `<redacted>` で exit 1

## docs 更新

- `docs/playbooks/e2e-validation.md` 7.5: develop branch protection 現状監査
- `docs/playbooks/e2e-validation.md` 7.6: baseline PNG secret 混入予防
- `docs/decisions.md` [069]: 本決定の SoT 記録 + Lessons learned (audit 前提の事実確認 / PNG scan 盲点 / allow list 管理)

## 受け入れ基準

- [x] develop branch protection 設定が監査され文書化されている (7.5 章で 404 結果と推奨手順を明記)
- [x] baseline PNG への secret 混入を防ぐ ops gate が spec / workflow の両層で実装されている
- [x] それぞれの対処が `docs/decisions.md` [069] に記録されている

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test`: 825 passed
- VRT 自体は CI Linux runner 専用 (memory `feedback_vrt_ci_only.md`)。Playwright per-test isolation で localStorage は元々空のため baseline 視覚差なしの想定だが、**CI visual-regression check で確定検証** (差分が出れば baseline 再生成 workflow を本 PR で trigger して update)。

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] CI: visual-regression check が pass する (baseline 視覚差なしの想定。万一差分が出たら本 PR で baseline 更新)
- [ ] レビュー: I-1 の audit 結果文書化が user の運用判断で十分か (短期対策の Settings 反映は別タスク)
- [ ] レビュー: workflow audit step の allow list / 検知パターンが妥当か
- [ ] レビュー: spec 層の `localStorage.clear()` 配置が `addInitScript` 内で正しいか

## 関連

- 親 issue: #255 (本 PR で短期 + 防御 2 層完了、長期の peter-evans 化は別議論)
- 起源: PR #254 セルフレビュー I-1 / I-2
- decisions: [069] (本 PR) / [066] (VRT 導入)
- 関連: 本番リリース前 TODO #323
