### PR TITLE
refactor(ui): #239 ActionButton に gap-1.5 を追加し DownloadButton の inline-flex span を削除

### DIFF
--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -292,7 +292,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
           </div>
           <div className="flex flex-wrap items-center gap-2 mt-3">
             <ActionButton onClick={onAddTicket} disabled={tickets.length >= MAX_TICKETS}>
-              <span aria-hidden="true">＋ </span>行を追加
+              <span aria-hidden="true">＋</span>行を追加
             </ActionButton>
             <ActionButton
               onClick={onGenerate}

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -55,7 +55,7 @@ export function ActionButton({
       onClick={onClick}
       disabled={isDisabled}
       aria-busy={loading ? 'true' : undefined}
-      className={`caption inline-flex items-center rounded-lg whitespace-nowrap btn-action btn-action--${variant} ${SIZE_CLASS[size]}`}
+      className={`caption inline-flex items-center gap-1.5 rounded-lg whitespace-nowrap btn-action btn-action--${variant} ${SIZE_CLASS[size]}`}
       {...rest}
     >
       {children}

--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -54,10 +54,8 @@ export function DownloadButton({
       loading={loading}
       aria-label={ariaLabel ?? label}
     >
-      <span className="inline-flex items-center gap-1.5">
-        <DownloadIcon />
-        {label}
-      </span>
+      <DownloadIcon />
+      {label}
     </ActionButton>
   );
 }


### PR DESCRIPTION
## 概要

issue #239 (PR #236 review Should-fix #2 follow-up) を解消。`DownloadButton` の冗長な inline-flex ラッパー span を削除し、`ActionButton` に直接アイコンとラベルを children として配置。間隔は ActionButton 側に追加した `gap-1.5` (= 0.375rem) で確保。

## 変更内容

### `ActionButton.tsx`

`className` に `gap-1.5` を追加。

```diff
- className={`caption inline-flex items-center rounded-lg ... ${SIZE_CLASS[size]}`}
+ className={`caption inline-flex items-center gap-1.5 rounded-lg ... ${SIZE_CLASS[size]}`}
```

children 1 個の利用箇所では flex item が単独で gap が空回りするため視覚的に変化なし。children 2 個のケース (DownloadButton 経由 / GenerateTab `行を追加`) で gap が機能する。

### `DownloadButton.tsx`

```diff
  <ActionButton ...>
-   <span className="inline-flex items-center gap-1.5">
-     <DownloadIcon />
-     {label}
-   </span>
+   <DownloadIcon />
+   {label}
  </ActionButton>
```

旧 span の `gap-1.5` → 新 ActionButton の `gap-1.5` に移譲。視覚的に不変、DOM 階層が 1 段浅くなる。

### `qr-ticket/GenerateTab.tsx` `行を追加` ボタン

```diff
- <span aria-hidden="true">＋ </span>行を追加
+ <span aria-hidden="true">＋</span>行を追加
```

旧実装は span 内の trailing ASCII space で `＋` と `行を追加` の間隔を確保していた。ActionButton への gap-1.5 追加で、span 内 space (~6-8px) + gap (6px) の **2 重 spacing regression** が発生するため、span 内 space を除去して gap 一本化。

## 影響評価（全 ActionButton 利用箇所の children 数 audit）

| 利用箇所 | children 数 | gap-1.5 の影響 |
|---|---|---|
| `CountInput.tsx:53` | 1 (`{buttonLabel}`) | 空回り、視覚変化なし |
| `ConfigConverter.tsx:242` | 1 (検証中…/検証する) | 空回り、視覚変化なし |
| `qr-ticket/GenerateTab.tsx:105` | 1 (生成中…/鍵ペアを新規生成) | 空回り、視覚変化なし |
| `qr-ticket/GenerateTab.tsx:137` | 1 (インポート) | 空回り、視覚変化なし |
| `qr-ticket/GenerateTab.tsx:294` | 2 (`<span>＋</span>` + 行を追加) | **trailing space 除去で対処** |
| `qr-ticket/GenerateTab.tsx:297` | 1 (生成中…/一括生成) | 空回り、視覚変化なし |
| `qr-ticket/VerifyTab.tsx:75` | 1 (カメラを起動) | 空回り、視覚変化なし |
| `qr-ticket/VerifyTab.tsx:97` | 1 (カメラを停止) | 空回り、視覚変化なし |
| `DownloadButton.tsx` | 2 (`<DownloadIcon />` + `{label}`) | **wrapping span 削除で対処** |

## issue #239 本文との差分（書き換え後分析）

issue #239 本文の案 A 推奨理由「**全 ActionButton 利用箇所は children を 1 つしか渡していない**」は本 PR 着手時点では **古い分析**で、`GenerateTab.tsx:294` の `行を追加` ボタンが children 2 個（span + テキスト）になっていた。`gap-1.5` をそのまま追加すると 2 重 spacing の regression が発生するため、`行を追加` の trailing space 除去を同 PR で同梱した。

→ 結果として案 A の趣旨（DownloadButton ラッパー span を綺麗に除去 / API 表面を増やさない）は達成、副次的に GenerateTab の 1 ボタンも gap 一本化で整理。

## 検証結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test`: 825 passed (ActionButton.test.tsx 17 件含む)
- `npm run test:e2e tests/e2e/{download-button,qr-ticket}.spec.ts`: 14 passed, 1 skipped (元から skip)
  - DownloadButton hover E2E (PR #331/#332 で追加) は gap-1.5 移譲後も pass
  - qr-ticket E2E (鍵生成 / イベント情報 / QR生成 / 検証 / ラウンドトリップ等) も pass

## Test plan

- [ ] CI: ユニット / 型 / E2E 全 green
- [ ] レビュー: DownloadButton のアイコン + ラベル間隔が visual で従前と同等か (PC / スマホ目視確認は merge 後)
- [ ] レビュー: GenerateTab `行を追加` ボタンの `＋` と `行を追加` 間の間隔が違和感なし
- [ ] レビュー: ActionButton に gap-1.5 を追加した影響で他の children 1 個利用箇所の高さ / 余白に意図せぬ変化がないこと

## 関連

- 親 issue: #239 (closes)
- 起源: PR #236 (#231) review Should-fix #2
- 直接の前提: PR #331 (#238 hover 統合) で ActionButton の className を触らなかったため、本 PR で改めて gap 追加
- 関連: `docs/ui-conventions.md` 2.1 章
