### PR TITLE
chore: astro check の warning / hint 全 5 件を解消し完全クリーン化

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).href;
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
     <meta name="theme-color" content="#1A56DB" />
-    {jsonLd && <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
+    {jsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
   </head>
   <body class="min-h-screen bg-surface text-default">
     <a href="#main-content" class="skip-link">本文へスキップ</a>

--- a/src/utils/__tests__/jwt.test.ts
+++ b/src/utils/__tests__/jwt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { base64UrlToBytes, parseJwt, formatTimestamp, formatRemaining } from '@/utils/jwt';
 
 // HS256 で署名されたサンプルトークン（有効期限なし）

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -72,8 +72,12 @@ export function svgContentToPngBlob(svgContent: string): Promise<Blob> {
 }
 
 /** SVG文字列からPNGをダウンロードする（Retina x2倍）。SVGにwidth/height属性が必要 */
-export function downloadPngFromSvgContent(svgContent: string, filename: string): Promise<void> {
-  return svgContentToPngBlob(svgContent).then((blob) => downloadBlob(blob, filename));
+export async function downloadPngFromSvgContent(
+  svgContent: string,
+  filename: string
+): Promise<void> {
+  const blob = await svgContentToPngBlob(svgContent);
+  downloadBlob(blob, filename);
 }
 
 /**


### PR DESCRIPTION
## 概要

`astro check` で長らく出力されていた warning / hint 計 5 件を完全に解消。

スコープを「不要 import のみ」に絞らず、astro check 出力に残る全 5 件を一括処理。warning をスコープで絞って後回しにすると負債が積み上がるため、一気に消す方針で対応。

## 変更点

### 1. `src/utils/__tests__/jwt.test.ts` (ts(6133) × 3 件)

```diff
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
```

`vi` / `beforeEach` / `afterEach` はファイル内で一度も使用されていなかった。`tsc --noUnusedLocals --noUnusedParameters` で全コードベース sweep し、本ファイル以外に未使用 import / local が無いことも確認済み。

### 2. `src/layouts/BaseLayout.astro` (astro(4000) × 1 件)

```diff
-{jsonLd && <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
+{jsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
```

`<script>` に `set:html` 属性が付いているため Astro は暗黙的に `is:inline` 扱いするが、推奨どおり明示する。JSON-LD 構造化データはバンドル処理不要のためそもそも `is:inline` が正しい。

### 3. `src/utils/download.ts` (ts(80006) × 1 件)

```diff
-export function downloadPngFromSvgContent(svgContent: string, filename: string): Promise<void> {
-  return svgContentToPngBlob(svgContent).then((blob) => downloadBlob(blob, filename));
-}
+export async function downloadPngFromSvgContent(
+  svgContent: string,
+  filename: string
+): Promise<void> {
+  const blob = await svgContentToPngBlob(svgContent);
+  downloadBlob(blob, filename);
+}
```

`.then()` chain を `async/await` に変換。振る舞いは完全に同等 (`downloadBlob` は `void` 返却の同期関数のため `await` 不要)。consumer は `Gs1Databar.tsx` のみで戻り値の `Promise<void>` を待ってないため影響なし。

## astro check 結果

| 項目     | before | after |
| -------- | ------ | ----- |
| errors   | 0      | 0     |
| warnings | 0      | 0     |
| hints    | **5**  | **0** |

## 検証

- `npm run test`: 825 passed (45 files)
- `npm run test:e2e`: 151 passed / 1 skipped (既存の意図的 skip)
- `npx astro check`: 0 errors / 0 warnings / 0 hints

## 関連

並行 PR: #336 (#263 #264 ResultTable a11y) — 本 PR とコンフリクトなし
