### PR TITLE
fix(a11y): #338 Gs1Databar の download UPR 解消 + ErrorMessage 表示

### DIFF
--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -72,11 +72,18 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
   const [aiFields, setAiFields] = useState<AiFieldState[]>(DEFAULT_AI_FIELDS);
   const [svgContent, setSvgContent] = useState('');
   const [bwipError, setBwipError] = useState('');
+  const [downloadError, setDownloadError] = useState('');
 
   const inputId = `gtin-input-${cardId}`;
 
-  const gtinResult =
-    gtinInput && !gtinError && gtinInput.length === 13 ? calcGtin14CheckDigit(gtinInput) : null;
+  // useMemo で参照安定化。inline で都度生成すると useEffect deps が render 毎に
+  // 「変化」と判定され、setDownloadError('') が PNG 失敗直後にも走って
+  // ErrorMessage を瞬時に消してしまう (issue #338 対応の race fix)。
+  const gtinResult = useMemo(
+    () =>
+      gtinInput && !gtinError && gtinInput.length === 13 ? calcGtin14CheckDigit(gtinInput) : null,
+    [gtinInput, gtinError]
+  );
 
   const allAiValid = aiFields.every((f) => f.error === '');
   const hasAnyAiValue = aiFields.some((f) => f.value.trim() !== '');
@@ -88,6 +95,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
   }, [onSvgChange]);
 
   useEffect(() => {
+    setDownloadError('');
     if (!gtinResult || !allAiValid) {
       setSvgContent('');
       setBwipError('');
@@ -158,12 +166,25 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
 
   const downloadSvg = () => {
     if (!svgContent || !gtinResult) return;
-    downloadSvgFile(svgContent, `gs1-databar-${gtinResult.fullGtin}.svg`);
+    setDownloadError('');
+    try {
+      downloadSvgFile(svgContent, `gs1-databar-${gtinResult.fullGtin}.svg`);
+    } catch (e) {
+      setDownloadError(getErrorMessage(e, 'SVG ダウンロードに失敗しました'));
+    }
   };
 
-  const downloadPng = () => {
+  // svgContentToPngBlob は img.onerror / canvas.toBlob 失敗で reject する。
+  // await + try/catch で例外を吸収し ErrorMessage 経由でユーザーに通知する
+  // (issue #338: 旧実装は fire-and-forget で unhandled promise rejection)。
+  const downloadPng = async () => {
     if (!svgContent || !gtinResult) return;
-    downloadPngFromSvgContent(svgContent, `gs1-databar-${gtinResult.fullGtin}.png`);
+    setDownloadError('');
+    try {
+      await downloadPngFromSvgContent(svgContent, `gs1-databar-${gtinResult.fullGtin}.png`);
+    } catch (e) {
+      setDownloadError(getErrorMessage(e, 'PNG ダウンロードに失敗しました'));
+    }
   };
 
   const usedAis = useMemo(() => new Set(aiFields.map((f) => f.ai)), [aiFields]);
@@ -324,6 +345,10 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
           <ErrorMessage message={`バーコード生成エラー: ${bwipError}`} variant="block" />
         )}
 
+        {downloadError && (
+          <ErrorMessage message={`ダウンロードエラー: ${downloadError}`} variant="block" />
+        )}
+
         {/* GS1文字列プレビュー */}
         {gtinResult && (
           <details className="rounded-lg border border-default">
@@ -362,6 +387,7 @@ export function Gs1DatabarTool() {
   const [cards, setCards] = useState<CardMeta[]>(() => [{ id: crypto.randomUUID() }]);
   const [cardSvgs, setCardSvgs] = useState<Record<string, CardSvgState>>({});
   const [isZipping, setIsZipping] = useState(false);
+  const [zipError, setZipError] = useState('');
 
   const addCard = () => {
     if (cards.length >= MAX_CARDS) return;
@@ -384,9 +410,13 @@ export function Gs1DatabarTool() {
   const validEntries = Object.entries(cardSvgs).filter(([, v]) => v.svg && v.gtin);
   const canDownloadAll = validEntries.length >= 2;
 
+  // svgContentToPngBlob / downloadZip は reject 可能。旧実装は try/finally のみで
+  // unhandled promise rejection を発生させていた (issue #338)。catch を追加し
+  // ZipError state 経由でユーザーに通知する。
   const downloadAllZip = async () => {
     if (!canDownloadAll || isZipping) return;
     setIsZipping(true);
+    setZipError('');
     try {
       // 各 SVG を PNG 変換してから flat なエントリ一覧を作る。
       // gtin はバリデーション済みだが defense-in-depth でサニタイズする。
@@ -409,6 +439,8 @@ export function Gs1DatabarTool() {
         })
       );
       await downloadZip(fileGroups.flat(), 'gs1-databars.zip');
+    } catch (e) {
+      setZipError(getErrorMessage(e, 'ZIP ダウンロードに失敗しました'));
     } finally {
       setIsZipping(false);
     }
@@ -452,6 +484,8 @@ export function Gs1DatabarTool() {
           />
         )}
       </div>
+
+      {zipError && <ErrorMessage message={`ZIP ダウンロードエラー: ${zipError}`} variant="block" />}
     </div>
   );
 }

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -78,4 +78,38 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
       await expect(page.getByLabel('AI コード 2')).toBeVisible();
     });
   });
+
+  // 陽性対照: PNG ダウンロード失敗時に ErrorMessage が表示されることを保証する
+  // (issue #338: 旧実装は fire-and-forget で unhandled promise rejection、UI feedback 無し)。
+  // svgContentToPngBlob 内の `URL.createObjectURL(svgBlob)` 経路を意図的に throw させ、
+  // Promise reject → downloadPng の try/catch → setDownloadError → role=alert 表示
+  // という全経路を実証する。
+  test('PNG ダウンロード失敗時に ErrorMessage が表示される（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // GTIN-14 を入力して SVG 生成を待つ
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      // svgContentToPngBlob 内 `URL.createObjectURL(svgBlob)` を意図的に throw させる。
+      // 同期 throw は Promise executor 内なので Promise reject に変換される (Promise spec)。
+      // blob.type は Chromium の正規化で `image/svg+xml;charset=utf-8` になる場合があるため
+      // startsWith で照合する。PNG 出力 blob (`image/png`) は除外され影響しない。
+      await page.evaluate(() => {
+        const orig = URL.createObjectURL.bind(URL);
+        URL.createObjectURL = (blob: Blob) => {
+          if (blob.type.startsWith('image/svg+xml')) {
+            throw new Error('forced failure for E2E positive control');
+          }
+          return orig(blob);
+        };
+      });
+
+      await page.getByRole('button', { name: 'PNGダウンロード' }).click();
+
+      // role=alert の ErrorMessage block に「ダウンロードエラー」が表示される
+      await expect(page.getByRole('alert').filter({ hasText: /ダウンロードエラー/ })).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## 概要

`#338` (PR #337 レビューで指摘された follow-up) を解消。

`Gs1Databar` の PNG / ZIP ダウンロード経路は async 関数を fire-and-forget で呼んでおり、`svgContentToPngBlob` の `img.onerror` / `canvas.toBlob` 失敗時に **unhandled promise rejection** が発生し、ユーザーには失敗が一切伝わらない状態だった。

`#323` 本番リリース前 TODO の post-release OK 項目をリリース前に倒す方針の延長。

## 変更点

### `src/components/tools/Gs1Databar.tsx`

- `BarcodeCard.downloadPng`: `async` + `try/catch` で例外吸収 → `downloadError` state 経由で `<ErrorMessage variant="block">` (`role="alert"`) を表示
- `BarcodeCard.downloadSvg`: 同期だが `getErrorMessage` で defense-in-depth
- `Gs1DatabarTool.downloadAllZip`: 既存 `try/finally` に `catch` を追加 → `zipError` state 経由で `<ErrorMessage>` を表示
- `gtinResult` を `useMemo` で参照安定化 (race fix)
  - inline で都度生成すると `useEffect` deps が render 毎に「変化」と判定され、`setDownloadError('')` が PNG 失敗直後にも走って `ErrorMessage` を瞬時に消してしまう問題があった
  - `[gtinInput, gtinError]` 依存にして実値変化時のみ参照更新

### `tests/e2e/gs1-databar.spec.ts`

陽性対照テスト追加 (memory `feedback_positive_control_for_gates.md` 準拠):

- `URL.createObjectURL` を override して SVG blob (`type.startsWith('image/svg+xml')`) 経路で意図的に throw
- 同期 throw は Promise executor 内で reject に変換される (Promise spec)
- `applyProductionCsp` 配下で `Promise reject → catch → setDownloadError → role=alert 表示` の全経路を実証
- PNG 出力 blob (`image/png`) は除外しており影響なし

注: 旧実装にこの陽性対照テストを当てると **必ず fail する** (UPR は出るが ErrorMessage は表示されない) のでガード自体の有効性も担保。

## #338 受け入れ基準

- [x] `downloadPngFromSvgContent` が reject した時に unhandled rejection が発生しない
- [x] ユーザーに失敗が伝わる UI feedback がある (`<ErrorMessage variant="block">` / `role="alert"`)
- [x] 既存の正常系 download 動作が維持される
- [x] 関連 E2E (`gs1-databar.spec.ts`) が pass

## 検証

- `npx astro check`: 0 errors / 0 warnings / 0 hints
- `npm run test`: 825 passed
- `npm run test:e2e`: 154 passed / 1 skipped (前回 152 → 陽性対照追加で 154)

## 関連

- 起票元: PR #337 レビューコメント
- 親 issue: `#323` (本番リリース前 TODO 集約)
- 残 follow-up: `#339` (CI hint count assertion) を別 PR で対応予定

Closes #338
