### PR TITLE
ci: #339 astro check の errors / warnings / hints すべて 0 を CI で強制

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,17 +35,38 @@ jobs:
       # 内訳をログに残して debug 容易性も担保。
       - name: astro check（errors / warnings / hints すべて 0 を強制）
         run: |
+          # exit code を保持して二重チェック (PR #341 review a/b 反映)。
+          # `npx astro check` は errors > 0 なら exit 1 (Astro CLI 仕様) のため、
+          # parser とは独立した検知経路として併用する。
+          set +e
           output=$(npx astro check 2>&1)
+          exit_code=$?
+          set -e
           echo "$output"
+
+          # フォーマット変更耐性: サマリ行 `Result (N files):` が無い場合は
+          # parser が機能しない false negative を防ぐため明示 fail させる。
+          # `if !` 形式は histexpand 設定によってはノイズ警告が出るため `||` で書く。
+          echo "$output" | grep -qE '^Result \([0-9]+ files\):' || {
+            echo "::error::astro check の出力フォーマットが変わりサマリ行を抽出できない (false negative 防止)"
+            exit 1
+          }
+
           errors=$(echo "$output" | grep -oE '^- [0-9]+ errors?' | tail -1 | grep -oE '[0-9]+' || true)
           warnings=$(echo "$output" | grep -oE '^- [0-9]+ warnings?' | tail -1 | grep -oE '[0-9]+' || true)
           hints=$(echo "$output" | grep -oE '^- [0-9]+ hints?' | tail -1 | grep -oE '[0-9]+' || true)
           errors=${errors:-0}
           warnings=${warnings:-0}
           hints=${hints:-0}
-          echo "Parsed summary: errors=$errors / warnings=$warnings / hints=$hints"
+          echo "Parsed summary: errors=$errors / warnings=$warnings / hints=$hints (astro exit=$exit_code)"
           if [ "$errors" != "0" ] || [ "$warnings" != "0" ] || [ "$hints" != "0" ]; then
             echo "::error::astro check requires 0/0/0 but got errors=$errors / warnings=$warnings / hints=$hints"
+            exit 1
+          fi
+          # 二重チェック: errors=0 なのに astro exit code が非ゼロなら parser と矛盾
+          # → 出力フォーマット変更を疑って fail させる。
+          if [ "$exit_code" != "0" ]; then
+            echo "::error::astro check exit=$exit_code だが parser は errors=0。出力フォーマット変更の可能性"
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,25 @@ jobs:
       - name: フォーマットチェックを実行
         run: npm run format:check
 
+      # #339: astro check は CI で走っていなかったため hint debt が蓄積していた。
+      # errors / warnings / hints すべて 0 を強制し、新規 hint 混入を即時 fail させる。
+      # 内訳をログに残して debug 容易性も担保。
+      - name: astro check（errors / warnings / hints すべて 0 を強制）
+        run: |
+          output=$(npx astro check 2>&1)
+          echo "$output"
+          errors=$(echo "$output" | grep -oE '^- [0-9]+ errors?' | tail -1 | grep -oE '[0-9]+' || true)
+          warnings=$(echo "$output" | grep -oE '^- [0-9]+ warnings?' | tail -1 | grep -oE '[0-9]+' || true)
+          hints=$(echo "$output" | grep -oE '^- [0-9]+ hints?' | tail -1 | grep -oE '[0-9]+' || true)
+          errors=${errors:-0}
+          warnings=${warnings:-0}
+          hints=${hints:-0}
+          echo "Parsed summary: errors=$errors / warnings=$warnings / hints=$hints"
+          if [ "$errors" != "0" ] || [ "$warnings" != "0" ] || [ "$hints" != "0" ]; then
+            echo "::error::astro check requires 0/0/0 but got errors=$errors / warnings=$warnings / hints=$hints"
+            exit 1
+          fi
+
       - name: 本番相当アセットを build（meta-csp.test.ts が dist/ を入力とするため必要 / #250）
         run: npm run build
 


### PR DESCRIPTION
## 概要

`#339` (PR #337 レビューで指摘された follow-up) を解消。

これまで `astro check` は **pre-commit hook (errors のみ block)** でしか走っておらず、CI では実行されていなかった。そのため warning / hint が 1 でも増えても CI green となり、debt が再蓄積する経路が開いていた。

PR #337 で 5 件一掃した「0 errors / 0 warnings / 0 hints」状態を維持するためのガードを追加。

## 変更点

### `.github/workflows/test.yml`

`test` ジョブに `astro check` step を追加し、以下を強制:

```yaml
- name: astro check（errors / warnings / hints すべて 0 を強制）
  run: |
    output=$(npx astro check 2>&1)
    echo "$output"
    errors=$(echo "$output" | grep -oE '^- [0-9]+ errors?' | tail -1 | grep -oE '[0-9]+' || true)
    warnings=$(echo "$output" | grep -oE '^- [0-9]+ warnings?' | tail -1 | grep -oE '[0-9]+' || true)
    hints=$(echo "$output" | grep -oE '^- [0-9]+ hints?' | tail -1 | grep -oE '[0-9]+' || true)
    errors=${errors:-0}
    warnings=${warnings:-0}
    hints=${hints:-0}
    echo "Parsed summary: errors=$errors / warnings=$warnings / hints=$hints"
    if [ "$errors" != "0" ] || [ "$warnings" != "0" ] || [ "$hints" != "0" ]; then
      echo "::error::astro check requires 0/0/0 but got errors=$errors / warnings=$warnings / hints=$hints"
      exit 1
    fi
```

ポイント:

- サマリ行 `- N errors` / `- N warnings` / `- N hints` を grep でパース
- `errors?` / `warnings?` / `hints?` (s 任意) で `1 hint` (singular) も検知
- 0/0/0 以外なら `::error::` GitHub Actions ログ出力 + `exit 1`
- 内訳をログに残して debug 容易性も担保

format:check と build の間に挿入し、build が失敗する前に hint 違反で fail-fast する。

## 陽性対照 (memory `feedback_positive_control_for_gates.md` 準拠)

ガード自体が機能することをローカル実機で実証:

```sh
# 一時的に未使用 import を含む test ファイルを追加
$ cp _unused_template.ts src/utils/__tests__/_temp_hint_test.ts

$ npx astro check
Result (177 files):
- 0 errors
- 0 warnings
- 1 hint   # ← 注: singular (hints じゃない)

# parser 動作:
errors=0 / warnings=0 / hints=1
GATE WOULD FAIL ✓
```

`develop` の現状 (0/0/0) では parser は通過することも確認済み。

## なぜ pre-commit hook 更新ではなく CI 追加なのか

- pre-commit hook は `.git/hooks/pre-commit` でローカルのみ・version control 外
- husky / simple-git-hooks も導入されておらず、複数 dev / CI への propagation 不可
- CI を authoritative gate にする方が team-wide enforcement として正しい
- pre-commit hook の更新は別途 versioned hook system 導入とセットで検討（追加 follow-up issue 候補）

## 検証

- ローカル `npx astro check`: 0 errors / 0 warnings / 0 hints
- 陽性対照 (synthetic unused import): parser が `1 hint` 検知 → gate fail 動作確認
- 本 PR の CI run でも green 確認 (push 後)

## 関連

- 起票元: PR #337 レビューコメント
- 親 issue: `#323` (本番リリース前 TODO 集約)
- 並行 PR: `#340` (`#338` Gs1Databar download UPR 解消)

Closes #339
