### PR TITLE
chore: 陽性対照テスト併設ルールを共通ルール / hook で意識的に load させる仕組み

### DIFF
--- a/.claude/scripts/test-edit-context.sh
+++ b/.claude/scripts/test-edit-context.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# PreToolUse hook: テスト編集時に陽性対照ルールへの注意を additionalContext で注入する。
+#
+# 設計: skill `test-gates` が auto-trigger 不発のときの保険。Edit/Write/MultiEdit 系
+#       の file_path がテストパスにマッチしたら system-reminder を注入させる。
+#
+# 入力: stdin に Claude Code が tool 呼び出し情報を JSON で渡す。
+# 出力: stdout に hookSpecificOutput JSON を出すと additionalContext として
+#       Claude のコンテキストに注入される (Claude Code Hook 仕様)。
+#       マッチしないときは何も出さない (silent pass)。
+
+set -e
+
+# 入力 JSON 全体を読む
+input=$(cat)
+
+# ファイルパスを抽出 (Edit/Write/MultiEdit すべて tool_input.file_path を持つ)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)
+
+# 空ならパスなしで何もしない
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# テストパス判定:
+#   - tests/ または tests-* / __tests__/ 配下
+#   - 拡張子前に .test. / .spec. を含む
+case "$file_path" in
+  */tests/*|*/__tests__/*|*.test.*|*.spec.*|*/test/*)
+    cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": "テストファイル編集を検知しました。ガード / バリデータ / 違反検知機構 / regression 防止テストを追加 / 修正する場合は **`Skill` tool で `test-gates` を必ず呼んで** 陽性対照テスト併設ルールを確認してください。陰性対照のみだと検知機構として不完全 (過去 PR #233 で applyProductionCsp が空回りしたまま merge 寸前まで行った事故あり)。"
+  }
+}
+JSON
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/test-edit-context.sh"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/.claude/skills/test-gates/SKILL.md
+++ b/.claude/skills/test-gates/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: test-gates
+description: ガード / バリデータ / 違反検知機構 / リグレッション防止テスト実装時に必ず参照。陽性対照テスト併設の必須ルール。CSP / lint / validator / セキュリティヘッダ / E2E ガード / 検知器 / detector / 違反検知 / regex マッチ系 / 静的解析 / 入力検証 / fail させる仕組み を実装/修正する場合に発動。
+---
+
+# test-gates: ガード/検知器に必ず陽性対照を併設するルール
+
+## ルール
+
+「検出する / 拒否する / 違反したら fail させる」機構（ガード・バリデータ・lint・検知器・regression 防止テスト全般）を追加 / 修正したら、**意図的に違反を起こして検知できることを確認する陽性対照テスト** を **必ず同じ PR に同梱** する。
+
+## なぜ必要か
+
+陰性対照（正常系で green）だけでは「**検知能力ゼロで green**」と「検知能力ありで green」が区別できない。陽性対照を入れて初めて検知機構として証明される。過去に PR #233 で `applyProductionCsp` が **空回りしていた** にも関わらず陰性対照のみ green で merge 寸前まで行った事故がある。
+
+## 実装パターン
+
+| 対象                       | 陽性対照の作り方                                                                       |
+| -------------------------- | -------------------------------------------------------------------------------------- |
+| CSP 違反検知ゲート         | 故意に違反 (外部 origin の `<script src>` 注入等) → `violations.length > 0` を assert |
+| 入力 validator             | 不正入力で `valid: false` 返却とエラー詳細形式を assert                                 |
+| lint ルール                | 違反パターンで warning が出ることを assert                                              |
+| セキュリティヘッダ assert  | 意図的に値を変える / 別 header と入れ替えて fail することを別 spec で assert            |
+| E2E ガード（検知系）       | 故意に検出対象を発生させて test failure に昇格することを別 spec で確認                  |
+| Promise reject ハンドラ    | mock / override で reject を強制 → catch 経路の UI feedback / state 更新を assert       |
+| 静的解析 / regex マッチ    | 違反コード片をテストフィクスチャに含めて gate fail することを assert                    |
+
+## 設計の鉄則
+
+1. **「旧実装にこのテストを当てると必ず fail する」設計** にする。fix 前後で diff が出ないテストは陽性対照になっていない
+2. 別 spec / 別 test で書き、**陰性対照と分離**。混在させると改修時に陽性側を消しても気付きにくい
+3. 内部実装ではなく **観測可能な振る舞い** (UI 表示 / 戻り値 / log / state) を assert
+4. fixture / mock 経路は production code path を **確実に通る** こと (mock しすぎて gate を bypass してないか確認)
+
+## チェックリスト (ガード追加 / 修正 PR で必ず触る)
+
+- [ ] 陽性対照テストを **同じ PR に** 含めたか
+- [ ] そのテストは **fix 前 (旧実装) に当てると fail** することをローカルで実機確認したか
+- [ ] **観測可能な振る舞い** を assert しているか (内部 state ではなく)
+- [ ] 陰性対照と **別 spec / 別 test 関数** に分離したか
+- [ ] mock / override で **production code path を bypass していないか** 確認したか
+
+## 参考
+
+- 個人 memory: `feedback_positive_control_for_gates.md`
+- 過去判断ログ: `docs/decisions.md` の「陽性対照」検索 (4 箇所)
+- 過去事故: PR #233 (`applyProductionCsp` 空回り事故)

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage/
 .claude/scheduled_tasks.lock
 conductor/
 .claude/tmp/
+.claude/*.bak
 
 # Superpowers extension (Visual brainstorming artifacts and session info)
 .superpowers/

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -145,12 +145,7 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 
 3 行以上の bash・過去にも書いた覚えのある手順・覚えにくいフラグを伴う複合コマンドを書こうとしたら、その場で実行する前に `scripts/` への切り出しをユーザーに提案する（同意を得てからスクリプト化する。先回りして勝手に作らない）。
 
-スクリプト配置の使い分け:
-
-- `scripts/` … 人間 / CI workflow / `package.json` / Claude が Bash で叩く汎用ユーティリティ
-- `.claude/scripts/` … Claude Code harness 専用 (`.claude/settings.json` の `hooks.*` / `statusLine.command` 等から呼ばれるもののみ)
-
-汎用ユーティリティを `.claude/scripts/` に置くと Claude Code を使わない開発者には実行されないため、CI / package.json から参照する性質のものは必ず `scripts/` 側に置く。
+`scripts/` と `.claude/scripts/` の使い分けは `scripts/README.md` を参照。
 
 ### 6.6 settings.json permissions に整合した振る舞い
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -159,19 +159,11 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 
 solo dev 体制（PR 作成者 = レビュアー = merger が同一人物）では GitHub branch protection の `Require approvals` を有効化すると **self-approve 不可で自分の PR が永久 merge 不能** になる（GitHub policy）。`Require pull request before merging` 単体は他人 review を強制せず、`Restrict who can push` も PR 経由 self-merge を block しない。**team 体制前提の review 強制設計を solo dev に提案しないこと**。
 
-過去判断: `docs/decisions.md [069]` (PR #333、`#255` 監査結果)。VRT bot push の bypass 懸念は team 体制前提の概念で本 repo には適用不可、actionable 対策は「VRT PR comment が出た PR は merge 前に diff 目視」に集約。
+詳細経緯: `docs/decisions.md [069]`
 
 ### 6.8 VRT pixel diff の baseline 更新は recommend しない
 
-VRT が小さい pixel diff（例: 723 pixels = 0.07%）を検出したとき「diff が微小だから baseline 更新で OK」と recommend してはいけない。**pixel 数の小ささと visual design 品質の劣化有無は別軸**。design token 由来の意図しない変更が混入していても pixel ratio は小さく見える。
-
-判断順序:
-
-1. diff 画像 (Playwright artifact) を user が **目視確認**
-2. 意図的変更ならその時点で baseline 更新 workflow を trigger
-3. 意図しない regression なら fix
-
-エージェントは「数値的に小さい」を根拠に baseline 更新を勧めない。デザイン品質の SoT は user 視覚評価。
+VRT が小さい pixel diff (例: 0.07%) を検出しても「微小だから baseline 更新で OK」と recommend してはいけない。**pixel 数 ≠ visual design 品質** (design token 由来の意図しない変更でも pixel ratio は小さく見える)。判断は user の目視確認に委ね、エージェントは数値根拠で baseline 更新を勧めない。
 
 ### 6.9 サブエージェント運用の補足
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -49,6 +49,8 @@
 **push 前に必須**: `npm run test`（ユニット）／ `node_modules/.bin/astro check`（型）／ `npm run test:e2e`（E2E）。
 post-PR 代行は不要、CI が最終ゲート。
 
+**ガード / バリデータ / 検知機構には陽性対照を必須**: 検出する・拒否する・違反したら fail させる仕組み（CSP 違反検知 / 入力 validator / lint / セキュリティヘッダ assert / E2E ガード / regex マッチ系）を追加 / 修正する場合は **`Skill` tool で `test-gates` skill を必ず呼ぶ**。陰性対照のみでは「検知能力ゼロで green」と区別不能（PR #233 `applyProductionCsp` 空回り事故）。詳細・チェックリストは skill 本体に集約してこの doc では肥大化させない。
+
 詳細手順（サブエージェント / 親別 push 前必須チェックリスト・worktree 整地・失敗パターン判定） → **`docs/playbooks/e2e-validation.md`**
 
 ---

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -145,6 +145,13 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 
 3 行以上の bash・過去にも書いた覚えのある手順・覚えにくいフラグを伴う複合コマンドを書こうとしたら、その場で実行する前に `scripts/` への切り出しをユーザーに提案する（同意を得てからスクリプト化する。先回りして勝手に作らない）。
 
+スクリプト配置の使い分け:
+
+- `scripts/` … 人間 / CI workflow / `package.json` / Claude が Bash で叩く汎用ユーティリティ
+- `.claude/scripts/` … Claude Code harness 専用 (`.claude/settings.json` の `hooks.*` / `statusLine.command` 等から呼ばれるもののみ)
+
+汎用ユーティリティを `.claude/scripts/` に置くと Claude Code を使わない開発者には実行されないため、CI / package.json から参照する性質のものは必ず `scripts/` 側に置く。
+
 ### 6.6 settings.json permissions に整合した振る舞い
 
 `.claude/settings.json` で allow されている経路を優先し、ask に該当する経路を避けて権限プロンプトと待ち時間を減らす。
@@ -153,7 +160,25 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 - **PR コメント取得**: `gh api repos/.../pulls/<N>/comments` ではなく `gh pr view <PR> --comments`（必要なら `--json comments,reviews`）を使う。`Bash(gh pr view*)` は allow、`Bash(gh api *)` は ask。行単位のレビューコメントが本当に必要な場合のみユーザーに断ってから `gh api` を使う。
 - **sandbox `denyWithinAllow` を見て user に手動作業を振らない**: `.claude/settings.json` / `.claude/skills/` 等が sandbox の `denyWithinAllow` に含まれていても、それは **`Bash` の `mkdir` / `rm` / `tee` / `sed -i` 経由を deny する** だけ。**`Edit` / `Write` tool 経由は permissions の `ask` 経路に乗って通る**（user 環境の事前 allow/auto-approve で待ちなしに成功することも多い）。手動で別ターミナル作業を依頼する前に **必ず `Write` / `Edit` tool で実機検証** すること。tool で通れば `git add` 含む後続も Claude 内で完結する。Bash での `mkdir` / `rm` が必要な場合だけが手動依頼の対象。
 
-### 6.7 サブエージェント運用の補足
+### 6.7 solo dev 体制での branch protection 提案禁止
+
+solo dev 体制（PR 作成者 = レビュアー = merger が同一人物）では GitHub branch protection の `Require approvals` を有効化すると **self-approve 不可で自分の PR が永久 merge 不能** になる（GitHub policy）。`Require pull request before merging` 単体は他人 review を強制せず、`Restrict who can push` も PR 経由 self-merge を block しない。**team 体制前提の review 強制設計を solo dev に提案しないこと**。
+
+過去判断: `docs/decisions.md [069]` (PR #333、`#255` 監査結果)。VRT bot push の bypass 懸念は team 体制前提の概念で本 repo には適用不可、actionable 対策は「VRT PR comment が出た PR は merge 前に diff 目視」に集約。
+
+### 6.8 VRT pixel diff の baseline 更新は recommend しない
+
+VRT が小さい pixel diff（例: 723 pixels = 0.07%）を検出したとき「diff が微小だから baseline 更新で OK」と recommend してはいけない。**pixel 数の小ささと visual design 品質の劣化有無は別軸**。design token 由来の意図しない変更が混入していても pixel ratio は小さく見える。
+
+判断順序:
+
+1. diff 画像 (Playwright artifact) を user が **目視確認**
+2. 意図的変更ならその時点で baseline 更新 workflow を trigger
+3. 意図しない regression なら fix
+
+エージェントは「数値的に小さい」を根拠に baseline 更新を勧めない。デザイン品質の SoT は user 視覚評価。
+
+### 6.9 サブエージェント運用の補足
 
 - **完了報告は項目別ステータス必須**: 親プロンプトのスコープ箇条書きを subagent が一部のみで「完了」と返すケースがあるため、完了報告フォーマットに「項目ごとに 実装 / 既存で十分 / スキップ理由 を明示する」チェックリスト形式を要求する。親側でも依頼項目数 vs 実装項目数の機械的突き合わせを行う（過去事例: PR #218 で 3 件依頼中 1 件のみ実装で完了報告された）。
 - **`package.json` 変更時は `package-lock.json` 同期確認**: subagent が deps を追加・更新した場合、`git diff origin/develop --name-only` に `package.json` が含まれる場合は必ず `package-lock.json` も含まれているか確認する。漏れていれば親で `npm install --package-lock-only --cache "$TMPDIR/npm-cache" --no-audit --no-fund` を実行し別コミットで lock 同期を push する（過去事例: PR #181 で lock 不整合のまま push される寸前で発覚）。

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -151,6 +151,7 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 
 - **一時ファイル**: `/tmp/` 直下ではなく `$TMPDIR` または `/tmp/claude/` 配下に作成する（`Read` / `Write` / `Edit` ともに `/tmp/claude/**` および `$TMPDIR (/var/folders/*/*/T/**)` が allow、`/tmp/**` 直下は ask）。`gh pr create --body-file` のパス、一時スクリプト、ログ出力等すべて。**credential / secret 類は tmp に置かない**（同 user 配下の Claude セッション間で相互可読）。
 - **PR コメント取得**: `gh api repos/.../pulls/<N>/comments` ではなく `gh pr view <PR> --comments`（必要なら `--json comments,reviews`）を使う。`Bash(gh pr view*)` は allow、`Bash(gh api *)` は ask。行単位のレビューコメントが本当に必要な場合のみユーザーに断ってから `gh api` を使う。
+- **sandbox `denyWithinAllow` を見て user に手動作業を振らない**: `.claude/settings.json` / `.claude/skills/` 等が sandbox の `denyWithinAllow` に含まれていても、それは **`Bash` の `mkdir` / `rm` / `tee` / `sed -i` 経由を deny する** だけ。**`Edit` / `Write` tool 経由は permissions の `ask` 経路に乗って通る**（user 環境の事前 allow/auto-approve で待ちなしに成功することも多い）。手動で別ターミナル作業を依頼する前に **必ず `Write` / `Edit` tool で実機検証** すること。tool で通れば `git add` 含む後続も Claude 内で完結する。Bash での `mkdir` / `rm` が必要な場合だけが手動依頼の対象。
 
 ### 6.7 サブエージェント運用の補足
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,17 @@
 
 このディレクトリには、開発・CI 運用を補助する bash スクリプトを配置します。
 
+## `scripts/` vs `.claude/scripts/` の使い分け
+
+「誰が呼ぶか」で配置先を分ける:
+
+| 配置先             | 呼び出し元                                                                                    | 例                                       |
+| ------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `scripts/`         | 人間 / CI workflow / `package.json` script / Claude が Bash 経由で叩く汎用ユーティリティ      | `check-followup-refs.sh`                 |
+| `.claude/scripts/` | Claude Code harness のみ (`.claude/settings.json` の `hooks.*` / `statusLine.command` 等から) | `test-edit-context.sh` (PreToolUse hook) |
+
+汎用性のあるユーティリティは `scripts/` 側に置き、Claude Code 設定駆動の挙動 (hook handler、status line generator 等) は `.claude/scripts/` 側に置く。`.claude/scripts/` のスクリプトは Claude Code を使わない開発者には実行されないため、CI / package.json から参照しないこと。
+
 ---
 
 ## check-followup-refs.sh


### PR DESCRIPTION
## 概要

「ガード / バリデータ / 検知機構には陽性対照テストを必須とする」ルールを **個人 memory + デファクト実践** のみだった状態から、**共通ルール (shared-agent-rules.md) + PreToolUse hook + skill** の 3 層構成に昇格させて運用に乗せる。

## 背景

- 過去事故 PR #233: `applyProductionCsp` (CSP 違反検知ゲート) が **空回りしていた** にも関わらず陰性対照のみで green、merge 寸前まで行った
- 以降、`docs/decisions.md` で 4 箇所、プロジェクト進捗 doc でも複数 PR で実践してきた
- しかし共通ルールに codified されていないため、**新規 Claude セッション / 別 agent / 協業者には自動継承されない**
- 「ただ追記しても必要な時に読まない」という user 指摘を踏まえ、**auto-load を強制する仕組み** ごと整備する

## 3 層構成 (context bloat 最小化)

### 1. Skill 本体 `.claude/skills/test-gates/SKILL.md`

- frontmatter の `description` に強い trigger 文言 (test / ガード / validator / 検知 / CSP / lint / detector 等) を入れ、test 関連作業時に `Skill` tool 経由で auto-invoke させる
- 詳細チェックリスト・実装パターン表 (CSP / validator / lint / Promise reject / 静的解析 等) を集約

### 2. PreToolUse hook script `.claude/scripts/test-edit-context.sh`

- `Edit` / `Write` / `MultiEdit` 呼び出し前に走る
- stdin から tool 引数 JSON を受け取り、`tool_input.file_path` が以下にマッチする場合のみ動作:
  - `tests/`, `__tests__/`, `test/` 配下
  - 拡張子前に `.test.` / `.spec.`
- マッチ時 stdout に `hookSpecificOutput.additionalContext` を返し、Claude のコンテキストに「`Skill` tool で `test-gates` を呼べ」という system-reminder を注入
- マッチしないとき silent pass (output なし)
- `.claude/settings.json` の `hooks.PreToolUse` 配列で hook 登録

### 3. `docs/shared-agent-rules.md` § 3 への 1 段落 pointer

詳細・チェックリスト・実装パターン表は skill 本体に集約し、shared-agent-rules では pointer のみで context bloat を抑える。

## 動作フロー

```
テストファイル (tests/, __tests__/, *.test.*, *.spec.*) を Edit / Write
  ↓
PreToolUse hook 発火 (`bash .claude/scripts/test-edit-context.sh`)
  ↓
script が file_path をパス判定 → additionalContext 返却
  ↓
Claude コンテキストに system-reminder 注入「test-gates skill を呼べ」
  ↓
Claude が `Skill` tool で test-gates 呼び出し
  ↓
陽性対照ルール + チェックリストが context 展開 → 実装に反映
```

skill auto-trigger 単独ではなく hook で **harness 強制実行** に乗せることで、「必要な時に読まれない」問題を構造的に解決する。

## sandbox 制約の整理 (本 PR で codify)

当初 `.claude/skills/` および `.claude/settings.json` は sandbox `denyWithinAllow` に含まれるため Claude からは write 不可と判断し、user 手動 step として切り出していた。

実機検証の結果、**`Edit` / `Write` tool 経由は permissions の `ask` 経路に乗って通る** ことが判明 (deny は Bash の `mkdir` / `rm` / `tee` 等のみ)。当初の手動 step は不要となり全コンポーネントを本 PR にまとめた。この学びを `shared-agent-rules.md § 6.6` に追加し、将来の Claude セッションが同じ罠 (「sandbox 制約で諦めて user に手動配置を依頼する」) に落ちない構えにした。

## 含むファイル

| ファイル | 内容 |
|---------|------|
| `.claude/skills/test-gates/SKILL.md` | skill 本体 (陽性対照ルール詳細) |
| `.claude/scripts/test-edit-context.sh` | PreToolUse hook script |
| `.claude/settings.json` | `hooks.PreToolUse` 配列追加 |
| `.gitignore` | `.claude/*.bak` 追加 (誤コミット防止) |
| `docs/shared-agent-rules.md` § 3 | 陽性対照ルール pointer |
| `docs/shared-agent-rules.md` § 6.5 | `scripts/` vs `.claude/scripts/` pointer (SoT は scripts/README.md) |
| `docs/shared-agent-rules.md` § 6.6 | sandbox `denyWithinAllow` の正しい解釈 (本 PR の学び) |
| `docs/shared-agent-rules.md` § 6.7 | solo dev での branch protection 提案禁止 (memory 由来) |
| `docs/shared-agent-rules.md` § 6.8 | VRT pixel diff baseline 更新非推奨 (memory 由来) |
| `scripts/README.md` | `scripts/` vs `.claude/scripts/` 使い分け表 |

§ 6.7 / 6.8 は memory cleanup の流れで本 PR に同梱。core rule のみに圧縮済 (常時 load コスト抑制)。

## 動作確認

`.claude/scripts/test-edit-context.sh` を 4 ケースで smoke test:

```sh
# 相対パス
$ echo '{"tool_input":{"file_path":"tests/e2e/foo.spec.ts"}}' | bash .claude/scripts/test-edit-context.sh
{ "hookSpecificOutput": { "hookEventName": "PreToolUse", "additionalContext": "..." } }

# 絶対パス (Claude Code Edit/Write tool 仕様) — review 指摘で追加検証
$ echo '{"tool_input":{"file_path":"/Users/fumta/projects/devtools/tests/e2e/foo.spec.ts"}}' | bash .claude/scripts/test-edit-context.sh
{ "hookSpecificOutput": { "hookEventName": "PreToolUse", "additionalContext": "..." } }

# 絶対パス + __tests__/
$ echo '{"tool_input":{"file_path":"/Users/x/repo/src/utils/__tests__/bar.test.ts"}}' | bash .claude/scripts/test-edit-context.sh
{ "hookSpecificOutput": { ... } }

# 非テストファイル → silent pass
$ echo '{"tool_input":{"file_path":"/Users/x/repo/src/utils/foo.ts"}}' | bash .claude/scripts/test-edit-context.sh
# (no output)
```

## 関連

- 個人 memory: `feedback_positive_control_for_gates.md` (rationale 詳細)
- 過去判断ログ: `docs/decisions.md` の「陽性対照」言及 4 箇所
- 過去事故: PR #233 (`applyProductionCsp` 空回り)
