### PR TITLE
feat(vrt): VRT 差分をスライダーで GitHub Pages 上から確認できる仕組みを追加

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write # gh-pages push 用
   pull-requests: write # PR comment 投稿用
 
 jobs:
@@ -57,6 +57,55 @@ jobs:
           path: playwright-report/
           retention-days: 14
 
+      - name: スライダーレポートを生成
+        if: ${{ !cancelled() && steps.vrt.outcome == 'failure' }}
+        id: gen-slider
+        shell: bash
+        run: |
+          node scripts/generate-vrt-slider.mjs
+          if [ -f vrt-slider-report/index.html ]; then
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: スライダーレポートを GitHub Pages へ deploy
+        if: ${{ !cancelled() && steps.gen-slider.outputs.generated == 'true' && github.event.pull_request.number }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+          # --user 1001 環境でも /tmp は書き込み可能
+          export GIT_CONFIG_GLOBAL=/tmp/.gitconfig
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global --add safe.directory '*'
+
+          # gh-pages worktree を作成（既存なら fetch、なければ孤立ブランチ作成）
+          if git ls-remote --exit-code origin gh-pages 2>/dev/null; then
+            git fetch origin gh-pages:refs/remotes/origin/gh-pages
+            git worktree add /tmp/gh-pages remotes/origin/gh-pages
+          else
+            git worktree add --orphan -b gh-pages /tmp/gh-pages
+          fi
+
+          # VRT レポートをコピー
+          mkdir -p /tmp/gh-pages/vrt/pr-${PR_NUM}
+          cp -r vrt-slider-report/. /tmp/gh-pages/vrt/pr-${PR_NUM}/
+
+          # コミット & push
+          cd /tmp/gh-pages
+          git add .
+          if git diff --staged --quiet; then
+            echo "変更なし — スキップ"
+          else
+            git commit -m "chore: VRT スライダーレポート更新 PR #${PR_NUM}"
+            git push "${REPO_URL}" gh-pages
+          fi
+
       - name: 既存の VRT comment を検索（dedup 用）
         if: ${{ !cancelled() && github.event.pull_request.number }}
         id: find-vrt-comment
@@ -82,6 +131,10 @@ jobs:
             fi
             echo "- **Workflow run**: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
             echo "- **Artifact (diff 画像 / playwright-report)**: 上記 workflow run の \`Artifacts\` セクションから download"
+            if [ "${{ steps.gen-slider.outputs.generated }}" = "true" ]; then
+              PAGES_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/vrt/pr-${{ github.event.pull_request.number }}/"
+              echo "- **🖼️ スライダー比較レポート**: [差分をブラウザで確認]($PAGES_URL)（deploy 完了まで 1〜2 分）"
+            fi
 
             if [ "${{ steps.vrt.outcome }}" = "failure" ] && [ -f vrt-output.log ]; then
               echo ""

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -82,7 +82,8 @@ jobs:
           export GIT_CONFIG_GLOBAL=/tmp/.gitconfig
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global --add safe.directory '*'
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          git config --global --add safe.directory /tmp/gh-pages
 
           # gh-pages を local branch として worktree 化
           # （既存: fetch して local branch 作成、なければ孤立ブランチ作成）
@@ -124,6 +125,17 @@ jobs:
               exit 1
             fi
           done
+
+      - name: GitHub Pages 設定確認（未設定なら Actions warning を出す）
+        if: ${{ !cancelled() && steps.gen-slider.outputs.generated == 'true' }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATUS=$(gh api "repos/${{ github.repository }}/pages" --jq '.status' 2>/dev/null || echo "not_found")
+          if [ "$STATUS" = "not_found" ] || [ "$STATUS" = "null" ] || [ -z "$STATUS" ]; then
+            echo "::warning::GitHub Pages が未設定のためスライダー URL が 404 になります。Settings → Pages → Branch: gh-pages / (root) → Save を実行してください。"
+          fi
 
       - name: 既存の VRT comment を検索（dedup 用）
         if: ${{ !cancelled() && github.event.pull_request.number }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -84,27 +84,46 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory '*'
 
-          # gh-pages worktree を作成（既存なら fetch、なければ孤立ブランチ作成）
+          # gh-pages を local branch として worktree 化
+          # （既存: fetch して local branch 作成、なければ孤立ブランチ作成）
           if git ls-remote --exit-code origin gh-pages 2>/dev/null; then
-            git fetch origin gh-pages:refs/remotes/origin/gh-pages
-            git worktree add /tmp/gh-pages remotes/origin/gh-pages
+            git fetch origin gh-pages:gh-pages
+            git worktree add /tmp/gh-pages gh-pages
           else
             git worktree add --orphan -b gh-pages /tmp/gh-pages
           fi
 
-          # VRT レポートをコピー
+          # VRT レポートをコピー（cd 後も参照できるよう絶対パスを使用）
+          WS="${GITHUB_WORKSPACE}"
           mkdir -p /tmp/gh-pages/vrt/pr-${PR_NUM}
-          cp -r vrt-slider-report/. /tmp/gh-pages/vrt/pr-${PR_NUM}/
+          cp -r "${WS}/vrt-slider-report/." /tmp/gh-pages/vrt/pr-${PR_NUM}/
 
-          # コミット & push
           cd /tmp/gh-pages
           git add .
           if git diff --staged --quiet; then
             echo "変更なし — スキップ"
-          else
-            git commit -m "chore: VRT スライダーレポート更新 PR #${PR_NUM}"
-            git push "${REPO_URL}" gh-pages
+            exit 0
           fi
+          git commit -m "chore: VRT スライダーレポート更新 PR #${PR_NUM}"
+
+          # push（複数 PR 並走による競合時は fetch → reset → reapply して最大 3 回リトライ）
+          for attempt in 1 2 3; do
+            if git push "${REPO_URL}" gh-pages; then
+              break
+            elif [ $attempt -lt 3 ]; then
+              echo "push 競合 (attempt ${attempt}/3): 最新を取得してリトライ..."
+              git fetch "${REPO_URL}" refs/heads/gh-pages:refs/remotes/tmp/gh-pages
+              git reset --hard refs/remotes/tmp/gh-pages
+              mkdir -p vrt/pr-${PR_NUM}
+              cp -r "${WS}/vrt-slider-report/." vrt/pr-${PR_NUM}/
+              git add .
+              git diff --staged --quiet || git commit -m "chore: VRT スライダーレポート更新 PR #${PR_NUM}"
+              sleep $((attempt * 3))
+            else
+              echo "push 失敗: ${attempt} 回試行しました" >&2
+              exit 1
+            fi
+          done
 
       - name: 既存の VRT comment を検索（dedup 用）
         if: ${{ !cancelled() && github.event.pull_request.number }}

--- a/.github/workflows/vrt-cleanup.yml
+++ b/.github/workflows/vrt-cleanup.yml
@@ -1,0 +1,39 @@
+name: VRT Report Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: gh-pages から VRT レポートを削除
+        shell: bash
+        run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+
+          # gh-pages ブランチが存在しない場合は何もしない
+          if ! git ls-remote --exit-code origin gh-pages 2>/dev/null; then
+            echo "gh-pages ブランチが存在しません — スキップ"
+            exit 0
+          fi
+
+          git fetch origin gh-pages:gh-pages
+          git checkout gh-pages
+
+          if [ ! -d "vrt/pr-${PR_NUM}" ]; then
+            echo "vrt/pr-${PR_NUM} は存在しません — スキップ"
+            exit 0
+          fi
+
+          git rm -rf "vrt/pr-${PR_NUM}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: VRT レポート削除 PR #${PR_NUM}"
+          git push origin gh-pages

--- a/.github/workflows/vrt-cleanup.yml
+++ b/.github/workflows/vrt-cleanup.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: write
 
+# 複数 PR を一括 close した場合の push 競合を防ぐ。
+# cancel-in-progress: false — cleanup を途中 cancel すると残骸が残るため
+concurrency:
+  group: vrt-cleanup-gh-pages
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/vrt-cleanup.yml
+++ b/.github/workflows/vrt-cleanup.yml
@@ -42,4 +42,25 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: VRT レポート削除 PR #${PR_NUM}"
-          git push origin gh-pages
+
+          # push（deploy と同時実行による競合時は fetch → reset → re-rm して最大 3 回リトライ）
+          for attempt in 1 2 3; do
+            if git push origin gh-pages; then
+              break
+            elif [ $attempt -lt 3 ]; then
+              echo "push 競合 (attempt ${attempt}/3): 最新を取得してリトライ..."
+              git fetch origin gh-pages
+              git reset --hard origin/gh-pages
+              if [ -d "vrt/pr-${PR_NUM}" ]; then
+                git rm -rf "vrt/pr-${PR_NUM}"
+                git commit -m "chore: VRT レポート削除 PR #${PR_NUM}"
+              else
+                echo "vrt/pr-${PR_NUM} は既に削除済み"
+                exit 0
+              fi
+              sleep $((attempt * 3))
+            else
+              echo "push 失敗: ${attempt} 回試行しました" >&2
+              exit 1
+            fi
+          done

--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -1,0 +1,182 @@
+import { readdir, copyFile, mkdir, writeFile } from 'fs/promises';
+import { join, basename, dirname } from 'path';
+import { existsSync } from 'fs';
+
+// VRT スライダーレポート生成
+// test-results/ の *-actual.png と tests/e2e/.../snapshots/ のベースラインを突き合わせて
+// img-comparison-slider 入りの HTML を vrt-slider-report/ に生成する。
+//
+// ファイル名の対応:
+//   actual:   test-results/**/{snapshot-name}-actual.png
+//   baseline: tests/e2e/visual-regression.spec.ts-snapshots/{snapshot-name}.png
+//   diff:     test-results/**/{snapshot-name}-diff.png
+
+const SNAPSHOTS_DIR = 'tests/e2e/visual-regression.spec.ts-snapshots';
+const TEST_RESULTS_DIR = 'test-results';
+const OUTPUT_DIR = 'vrt-slider-report';
+
+async function findFiles(dir, suffix) {
+  const results = [];
+  if (!existsSync(dir)) {
+    return results;
+  }
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await findFiles(full, suffix);
+      results.push(...nested);
+    } else if (entry.name.endsWith(suffix)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function makeLabel(snapshotBase) {
+  return snapshotBase
+    .replace(/^visual-regression---/, '')
+    .replace(/-の-screenshot-が-baseline-と一致-\d+-visual-regression-linux$/, '')
+    .replace(/^(desktop|mobile)-(\d+x\d+)-/, '[$1 $2] ');
+}
+
+function esc(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function generateHTML(comparisons) {
+  const navItems = comparisons
+    .map(({ label, id }) => `<li><a href="#${id}">${esc(label)}</a></li>`)
+    .join('\n      ');
+
+  const cards = comparisons
+    .map(
+      ({ label, id, hasDiff }) => `
+  <section id="${id}" class="card">
+    <h2>${esc(label)}</h2>
+    <img-comparison-slider>
+      <figure slot="first">
+        <img src="images/${id}-baseline.png" alt="Baseline">
+        <figcaption>Baseline（期待値）</figcaption>
+      </figure>
+      <figure slot="second">
+        <img src="images/${id}-actual.png" alt="Actual">
+        <figcaption>Actual（実際）</figcaption>
+      </figure>
+    </img-comparison-slider>${
+      hasDiff
+        ? `
+    <details>
+      <summary>Diff 画像を表示</summary>
+      <img class="diff-img" src="images/${id}-diff.png" alt="Diff">
+    </details>`
+        : ''
+    }
+  </section>`
+    )
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>VRT Diff Viewer</title>
+  <script type="module" src="https://unpkg.com/img-comparison-slider@8/dist/index.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/img-comparison-slider@8/dist/styles.css">
+  <style>
+    *{box-sizing:border-box}
+    body{font-family:system-ui,sans-serif;margin:0;background:#f3f4f6;color:#111}
+    header{background:#1e3a8a;color:#fff;padding:1rem 1.5rem}
+    header h1{margin:0;font-size:1.2rem}
+    header p{margin:.25rem 0 0;font-size:.85rem;opacity:.85}
+    nav{background:#fff;border-bottom:1px solid #e5e7eb;padding:.6rem 1.5rem;position:sticky;top:0;z-index:10}
+    nav ul{margin:0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:.4rem}
+    nav a{font-size:.75rem;color:#1e40af;text-decoration:none;background:#eff6ff;padding:.2rem .45rem;border-radius:4px}
+    nav a:hover{background:#dbeafe}
+    main{max-width:1200px;margin:0 auto;padding:1.5rem}
+    .badge{display:inline-block;background:#dc2626;color:#fff;font-size:.75rem;font-weight:600;padding:.2rem .5rem;border-radius:4px;margin-bottom:1rem}
+    .card{background:#fff;border-radius:8px;padding:1.5rem;margin-bottom:1.5rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
+    h2{margin:0 0 .75rem;font-size:.9rem;color:#374151;word-break:break-all}
+    img-comparison-slider{width:100%;--default-handle-color:#1e40af;--default-handle-width:3px}
+    img-comparison-slider img{width:100%;display:block}
+    figure{margin:0;position:relative}
+    figcaption{position:absolute;bottom:0;left:0;right:0;background:rgba(0,0,0,.55);color:#fff;font-size:.7rem;padding:.2rem .5rem}
+    details{margin-top:.75rem}
+    summary{cursor:pointer;color:#1e40af;font-size:.85rem}
+    .diff-img{width:100%;margin-top:.4rem;border:1px solid #fecaca}
+  </style>
+</head>
+<body>
+<header>
+  <h1>🖼️ Visual Regression Diff Viewer</h1>
+  <p>← スライドして比較 &nbsp;|&nbsp; 左: <strong>Baseline（期待値）</strong> &nbsp; 右: <strong>Actual（実際）</strong></p>
+</header>
+<nav>
+  <ul>
+      ${navItems}
+  </ul>
+</nav>
+<main>
+  <p class="badge">${comparisons.length} 件の差分</p>
+  ${cards}
+</main>
+</body>
+</html>`;
+}
+
+async function main() {
+  const actualFiles = await findFiles(TEST_RESULTS_DIR, '-actual.png');
+
+  if (actualFiles.length === 0) {
+    console.log('差分なし — スライダーレポートの生成をスキップ');
+    return;
+  }
+
+  const imagesDir = join(OUTPUT_DIR, 'images');
+  await mkdir(imagesDir, { recursive: true });
+
+  const comparisons = [];
+
+  for (const actualPath of actualFiles) {
+    const actualName = basename(actualPath);
+    const snapshotBase = actualName.replace(/-actual\.png$/, '');
+    const snapshotFileName = snapshotBase + '.png';
+    const baselinePath = join(SNAPSHOTS_DIR, snapshotFileName);
+    const diffPath = join(dirname(actualPath), snapshotBase + '-diff.png');
+
+    if (!existsSync(baselinePath)) {
+      console.warn(`baseline が見つかりません: ${baselinePath}`);
+      continue;
+    }
+
+    const id = snapshotBase.replace(/[^\w]/g, '_');
+    const label = makeLabel(snapshotBase);
+    const hasDiff = existsSync(diffPath);
+
+    await copyFile(actualPath, join(imagesDir, `${id}-actual.png`));
+    await copyFile(baselinePath, join(imagesDir, `${id}-baseline.png`));
+    if (hasDiff) {
+      await copyFile(diffPath, join(imagesDir, `${id}-diff.png`));
+    }
+
+    comparisons.push({ label, id, hasDiff });
+  }
+
+  if (comparisons.length === 0) {
+    console.log('有効な比較ペアなし — スキップ');
+    return;
+  }
+
+  await writeFile(join(OUTPUT_DIR, 'index.html'), generateHTML(comparisons), 'utf-8');
+  console.log(`VRT スライダーレポート生成完了: ${comparisons.length} 件`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要

VRT 失敗時にダウンロード不要でブラウザから差分を確認できるスライダービューワーを追加。

- `img-comparison-slider` を使った Before/After スライダー
- 失敗テストごとに Baseline（期待値）と Actual（実際）をスライドして比較
- Diff 画像も `<details>` で展開可能
- PR コメントに GitHub Pages URL が自動追記（VRT 失敗時のみ）
- PR close 時に Pages のレポートを自動削除

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `scripts/generate-vrt-slider.mjs` | actual/baseline/diff を突き合わせてスライダー HTML を生成 |
| `.github/workflows/visual-regression.yml` | レポート生成 → gh-pages push → PR コメントに URL 追記 |
| `.github/workflows/vrt-cleanup.yml` | PR close 時に `vrt/pr-{番号}/` を削除 |

## セットアップ（初回のみ手動）

リポジトリの **Settings → Pages → Source** を以下に設定:

```
Branch: gh-pages  /  (root)  → Save
```

## テスト計画

- [ ] VRT 失敗する PR で CI を走らせ、PR コメントにスライダー URL が追記されることを確認
- [ ] URL を開いてスライダーが動作することを確認
- [ ] PR close 後に Pages のパスが削除されることを確認
- [ ] VRT 全通過時はスライダー URL が追記されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)