### PR TITLE
fix(char-count): PR #346 post-merge レビュー指摘対応 (#348, #349, #350)

### DIFF
--- a/src/components/tools/CharCount.tsx
+++ b/src/components/tools/CharCount.tsx
@@ -54,17 +54,14 @@ export function CharCountTool() {
   }
 
   function handleSnsLimitChange(val: string) {
-    if (val === '') {
-      setSnsLimit('');
-      return;
+    if (val === '' || /^[1-9]\d*$/.test(val)) {
+      setSnsLimit(val);
     }
-    if (!/^\d+$/.test(val)) return;
-    setSnsLimit(val);
   }
 
   const { chars, bytes: enc, lines, sns, manuscript } = result;
-  const snsLimitNum = Math.max(1, parseInt(snsLimit, 10) || 1);
-  const snsRemaining = snsLimitNum - chars.graphemes;
+  const snsRemaining =
+    snsLimit === '' ? null : Math.max(1, parseInt(snsLimit, 10)) - chars.graphemes;
 
   return (
     <div className="space-y-6">
@@ -158,8 +155,10 @@ export function CharCountTool() {
             min="1"
           />
           <span>上限　残り:</span>
-          <span className={`font-mono${snsRemaining < 0 ? ' text-error' : ''}`}>
-            {snsRemaining}
+          <span
+            className={`font-mono${snsRemaining !== null && snsRemaining < 0 ? ' text-error' : ''}`}
+          >
+            {snsRemaining === null ? '—' : snsRemaining}
           </span>
         </div>
       </Section>

--- a/src/components/tools/CharCount.tsx
+++ b/src/components/tools/CharCount.tsx
@@ -60,8 +60,7 @@ export function CharCountTool() {
   }
 
   const { chars, bytes: enc, lines, sns, manuscript } = result;
-  const snsRemaining =
-    snsLimit === '' ? null : Math.max(1, parseInt(snsLimit, 10)) - chars.graphemes;
+  const snsRemaining = snsLimit === '' ? null : parseInt(snsLimit, 10) - chars.graphemes;
 
   return (
     <div className="space-y-6">
@@ -158,7 +157,14 @@ export function CharCountTool() {
           <span
             className={`font-mono${snsRemaining !== null && snsRemaining < 0 ? ' text-error' : ''}`}
           >
-            {snsRemaining === null ? '—' : snsRemaining}
+            {snsRemaining === null ? (
+              <>
+                <span aria-hidden="true">—</span>
+                <span className="sr-only">未指定</span>
+              </>
+            ) : (
+              snsRemaining
+            )}
           </span>
         </div>
       </Section>

--- a/src/pages/tools/char-count.astro
+++ b/src/pages/tools/char-count.astro
@@ -15,6 +15,12 @@ const tool = tools.find((t) => t.slug === 'char-count')!;
       入力テキストの文字数・エンコーディング互換性・行数・SNS文字数制限・原稿枚数を一括集計します。
       すべての処理はブラウザ内で完結し、サーバーへの送信は一切ありません。
     </p>
+    <h3 class="mb-2 mt-4 tool-info-heading">VARCHAR 最小長について</h3>
+    <p class="tool-info-body">
+      「VARCHAR 最小長 (utf8mb4)」は MySQL utf8mb4 / PostgreSQL の <code>VARCHAR(N)</code> に対応する値です（Unicode
+      code point 単位）。 SQL Server <code>NVARCHAR(N)</code> や Java <code>String.length()</code> は
+      UTF-16 code unit 単位（サロゲートペアで 2 消費）のため、 上の「JS .length (UTF-16)」の値を参照してください。
+    </p>
     <h3 class="mb-2 mt-4 tool-info-heading">DBエラー予測の使い方</h3>
     <p class="tool-info-body">
       絵文字や特殊文字を含む文字列をDBに投入するとエラーになることがあります。

--- a/src/utils/char-count/__tests__/char-count.test.ts
+++ b/src/utils/char-count/__tests__/char-count.test.ts
@@ -426,6 +426,10 @@ describe('countParagraphs', () => {
   it('"a\\n\\n\\nb" (3連改行) は 2 段落', () => expect(countParagraphs('a\n\n\nb')).toBe(2));
   it('前後の空行は段落数に含めない: "\\n\\na\\n\\n" は 1', () =>
     expect(countParagraphs('\n\na\n\n')).toBe(1));
+  it('CR 単独 "a\\r\\rb" は 2 段落 (Mac 旧式改行)', () =>
+    expect(countParagraphs('a\r\rb')).toBe(2));
+  it('CRLF 空行 "a\\r\\n\\r\\nb" は 2 段落', () => expect(countParagraphs('a\r\n\r\nb')).toBe(2));
+  it('LF+CR 混在空行 "a\\n\\rb" は 2 段落', () => expect(countParagraphs('a\n\rb')).toBe(2));
 });
 
 describe('countReadingMinutes', () => {

--- a/src/utils/char-count/__tests__/char-count.test.ts
+++ b/src/utils/char-count/__tests__/char-count.test.ts
@@ -428,8 +428,11 @@ describe('countParagraphs', () => {
     expect(countParagraphs('\n\na\n\n')).toBe(1));
   it('CR 単独 "a\\r\\rb" は 2 段落 (Mac 旧式改行)', () =>
     expect(countParagraphs('a\r\rb')).toBe(2));
+  it('CR 4 連 "a\\r\\r\\r\\rb" は 2 段落', () => expect(countParagraphs('a\r\r\r\rb')).toBe(2));
   it('CRLF 空行 "a\\r\\n\\r\\nb" は 2 段落', () => expect(countParagraphs('a\r\n\r\nb')).toBe(2));
-  it('LF+CR 混在空行 "a\\n\\rb" は 2 段落', () => expect(countParagraphs('a\n\rb')).toBe(2));
+  it('LF 直後の lone CR "a\\n\\rb" は 2 段落 (lone CR を空行として扱う)', () =>
+    expect(countParagraphs('a\n\rb')).toBe(2));
+  it('CR のみ "\\r\\r" は 0 段落 (本文なし)', () => expect(countParagraphs('\r\r')).toBe(0));
 });
 
 describe('countReadingMinutes', () => {

--- a/src/utils/char-count/manuscript.ts
+++ b/src/utils/char-count/manuscript.ts
@@ -8,7 +8,8 @@ export function countGenkoSheets(s: string): number {
 
 /** 空行区切りの段落数 */
 export function countParagraphs(s: string): number {
-  return s.split(/\n\s*\n+/).filter((p) => p.trim().length > 0).length;
+  const normalized = s.replace(/\r\n|\r/g, '\n');
+  return normalized.split(/\n\s*\n+/).filter((p) => p.trim().length > 0).length;
 }
 
 /** 推定読了時間 (日本語 600 字/分、最小 1 分) */

--- a/tests/e2e/char-count.spec.ts
+++ b/tests/e2e/char-count.spec.ts
@@ -44,7 +44,9 @@ test.describe('文字カウント', () => {
   test('任意上限を空にすると残数が "—" 表示になる', async ({ page }) => {
     await page.getByLabel('入力テキスト').fill('あいうえお');
     await page.getByLabel('任意上限').fill('');
-    await expect(page.getByText('—')).toBeVisible();
+    // 任意上限 input の親 div 内にある font-mono span (残数表示) を確認
+    const remaining = page.getByLabel('任意上限').locator('..').locator('span.font-mono');
+    await expect(remaining).toHaveText('—');
   });
 
   // 陽性対照: 入力 validator が "0" を実際に reject することを確認

--- a/tests/e2e/char-count.spec.ts
+++ b/tests/e2e/char-count.spec.ts
@@ -41,12 +41,14 @@ test.describe('文字カウント', () => {
     await expect(page.getByText('95')).toBeVisible();
   });
 
-  test('任意上限を空にすると残数が "—" 表示になる', async ({ page }) => {
+  test('任意上限を空にすると残数が "—" 表示 + SR 用に "未指定" が併記される', async ({ page }) => {
     await page.getByLabel('入力テキスト').fill('あいうえお');
     await page.getByLabel('任意上限').fill('');
     // 任意上限 input の親 div 内にある font-mono span (残数表示) を確認
     const remaining = page.getByLabel('任意上限').locator('..').locator('span.font-mono');
-    await expect(remaining).toHaveText('—');
+    // 視覚: aria-hidden="true" な span に '—' / SR: sr-only の '未指定'
+    await expect(remaining).toContainText('—');
+    await expect(remaining).toContainText('未指定');
   });
 
   // 陽性対照: 入力 validator が "0" を実際に reject することを確認
@@ -57,6 +59,14 @@ test.describe('文字カウント', () => {
     await limit.fill('0');
     // controlled input: setState されなければ value は直前の '100' のまま
     await expect(limit).not.toHaveValue('0');
+  });
+
+  // 陽性対照: 先頭ゼロ "01" も reject されること (validator 仕様変更検出力強化)
+  test('[陽性対照] 任意上限欄に "01" (先頭ゼロ) を入力しても reject される', async ({ page }) => {
+    const limit = page.getByLabel('任意上限');
+    await limit.fill('100');
+    await limit.fill('01');
+    await expect(limit).not.toHaveValue('01');
   });
 
   test('クリアボタンで textarea が空になる', async ({ page }) => {

--- a/tests/e2e/char-count.spec.ts
+++ b/tests/e2e/char-count.spec.ts
@@ -41,6 +41,22 @@ test.describe('文字カウント', () => {
     await expect(page.getByText('95')).toBeVisible();
   });
 
+  test('任意上限を空にすると残数が "—" 表示になる', async ({ page }) => {
+    await page.getByLabel('入力テキスト').fill('あいうえお');
+    await page.getByLabel('任意上限').fill('');
+    await expect(page.getByText('—')).toBeVisible();
+  });
+
+  // 陽性対照: 入力 validator が "0" を実際に reject することを確認
+  // 旧実装 (/^\d+$/) では '0' が通り value が '0' になるためこのテストは fail する
+  test('[陽性対照] 任意上限欄に "0" を入力しても reject されて値が変わらない', async ({ page }) => {
+    const limit = page.getByLabel('任意上限');
+    await limit.fill('100');
+    await limit.fill('0');
+    // controlled input: setState されなければ value は直前の '100' のまま
+    await expect(limit).not.toHaveValue('0');
+  });
+
   test('クリアボタンで textarea が空になる', async ({ page }) => {
     await page.getByLabel('入力テキスト').fill('テスト');
     await page.getByRole('button', { name: 'クリア' }).click();


### PR DESCRIPTION
## 概要

PR #346 (char-count ツール追加) の post-merge レビューで指摘された 3 件の不具合・補足不足を修正します。

- **#348**: SNS 任意上限欄の UX 不整合（空欄時の残数誤表示、`0` 入力で表示と計算がズレる）
- **#349**: VARCHAR 最小長ラベルに SQL Server/Java との単位差異の補足説明を追加
- **#350**: `countParagraphs` が CR 単独改行（Mac 旧式）を段落区切りとして扱わない不整合

## 変更内容

### fix: SNS 任意上限 UX (#348)

`src/components/tools/CharCount.tsx`

- `handleSnsLimitChange` の入力 validator を `/^\d+$/` → `/^[1-9]\d*$/` に変更し、`0` および先頭ゼロ（`01` 等）を即時 reject
- `snsLimit === ''` のとき `snsRemaining` を `null` にして残数表示を `—` に変更
- E2E: `0` reject 陽性対照テスト、空欄時 `—` 表示確認テストを追加

### docs: VARCHAR 最小長の補足 (#349)

`src/pages/tools/char-count.astro`

- ToolInfoSection に「VARCHAR 最小長について」セクションを追加
- MySQL utf8mb4/PostgreSQL（code point 単位）と SQL Server `NVARCHAR`/Java `String.length()`（UTF-16 unit 単位）の違いを案内

### fix: `countParagraphs` CR 単独改行対応 (#350)

`src/utils/char-count/manuscript.ts`

- `split` 前に `/\r\n|\r/g` を `\n` へ正規化。`analyzeLines` の CR 検出との一貫性を確保
- unit test: CR 単独 / CRLF 空行 / LF+CR 混在 の 3 ケースを追加

## テスト

- `npm run test`: 974/974 passed
- `astro check`: 0 errors / 0 warnings / 0 hints
- `npm run test:e2e --grep "文字カウント|char-count"`: 10/10 passed（陽性対照含む）

## チェックリスト

- [x] `develop` ベース確認済み
- [x] スコープ: char-count 関連 5 ファイルのみ
- [x] aria-* 属性の削除なし
- [x] コミットメッセージ・本文 日本語
