### PR TITLE
chore(vrt): カバレッジ漏れ検出 meta test + ツール追加ルール明文化 (#355)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -156,7 +156,15 @@ jobs:
             echo "## 🖼️ Visual Regression Test 結果"
             echo ""
             if [ "${{ steps.vrt.outcome }}" = "success" ]; then
-              echo "- **Status**: ✅ 全 36 件 pass"
+              # vrt-output.log の playwright 集計行 "N passed" から件数を動的抽出。
+              # PAGES × VIEWPORTS 数を hardcode していると新規ページ追加時に
+              # 文言と実態が乖離するため (issue #355 の派生対応)。
+              PASS_COUNT=$(grep -oE '[0-9]+ passed' vrt-output.log 2>/dev/null | tail -1 | grep -oE '^[0-9]+' || echo "")
+              if [ -n "$PASS_COUNT" ]; then
+                echo "- **Status**: ✅ 全 ${PASS_COUNT} 件 pass"
+              else
+                echo "- **Status**: ✅ pass"
+              fi
             else
               echo "- **Status**: ❌ 一部 fail"
             fi

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -77,8 +77,9 @@ post-PR 代行は不要、CI が最終ゲート。
 
 1. `src/components/tools/ToolName.tsx` を作成
 2. `src/pages/tools/tool-slug.astro` を作成（`client:load` で React コンポーネントをマウント）
-3. `src/pages/index.astro` のツール一覧に追加
-4. 4 章「ドキュメント更新ルール」に従い `README.md` / `SPEC.md` / `docs/decisions.md` を更新
+3. `src/data/tools.ts` の `tools` 配列にエントリを追加（slug / name / description / category）
+4. `tests/e2e/visual-regression-pages.ts` の `PAGES` 配列に `/tools/<slug>` を追加（VRT 対象に登録）。baseline は CI Linux runner で `Update Visual Regression Baseline` workflow を `workflow_dispatch` trigger して生成（mac との font 描画差を回避するためローカル生成は不可）。**漏れた場合は `tests/meta/vrt-pages-coverage.test.ts` が `npm run test` で fail させる**ため CI で必ず検知される（issue #355 で導入）。
+5. 4 章「ドキュメント更新ルール」に従い `README.md` / `SPEC.md` / `docs/decisions.md` を更新
 
 新しい入力欄・ボタン・エラー表示等を実装する前に、`src/components/ui/` の既存共通コンポーネント（`InputField`, `CopyButton`, `DownloadButton` 等）を確認すること。一覧と用途は `docs/ui-conventions.md` を参照。
 

--- a/tests/e2e/visual-regression-pages.ts
+++ b/tests/e2e/visual-regression-pages.ts
@@ -1,0 +1,36 @@
+/**
+ * VRT 対象ページ一覧。
+ *
+ * 新規ツール追加時は本配列に `/tools/<slug>` を追加すること。
+ * baseline は CI Linux runner で `Update Visual Regression Baseline` workflow を
+ * `workflow_dispatch` trigger して生成する (mac との font 描画差を回避)。
+ *
+ * `tests/meta/vrt-pages-coverage.test.ts` が `src/data/tools.ts` の全 slug と
+ * 本配列の整合性を機械的に検証する (issue #355 で導入された再発防止策)。
+ *
+ * 切り出し理由: Playwright spec ファイルからの直接 import は spec 副作用 (test.describe 等) を
+ * vitest 環境に持ち込むため、定数のみを別ファイルに分離。
+ */
+export const PAGES = [
+  '/',
+  '/about',
+  '/privacy',
+  '/tools/ulid-generator',
+  '/tools/uuid-v7',
+  '/tools/dummy-text',
+  '/tools/qr-code',
+  '/tools/jan-code',
+  '/tools/gs1-databar',
+  '/tools/qr-ticket',
+  '/tools/qr-reader',
+  '/tools/url-encode',
+  '/tools/jwt-decoder',
+  '/tools/base64',
+  '/tools/json-xml',
+  '/tools/json-csv',
+  '/tools/encoding-converter',
+  '/tools/config-converter',
+  '/tools/char-count',
+] as const;
+
+export const STATIC_PAGES = new Set<string>(['/', '/about', '/privacy']);

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { waitForReactHydration } from './helpers';
+import { PAGES, STATIC_PAGES } from './visual-regression-pages';
 
 /**
  * Visual Regression Test (VRT) — `#176` B 案 ui migration の visual change を CI で検出する。
@@ -17,30 +18,6 @@ import { waitForReactHydration } from './helpers';
  *
  * 詳細: docs/superpowers/specs/2026-05-03-vrt-setup-design.md
  */
-
-const PAGES = [
-  '/',
-  '/about',
-  '/privacy',
-  '/tools/ulid-generator',
-  '/tools/uuid-v7',
-  '/tools/dummy-text',
-  '/tools/qr-code',
-  '/tools/jan-code',
-  '/tools/gs1-databar',
-  '/tools/qr-ticket',
-  '/tools/qr-reader',
-  '/tools/url-encode',
-  '/tools/jwt-decoder',
-  '/tools/base64',
-  '/tools/json-xml',
-  '/tools/json-csv',
-  '/tools/encoding-converter',
-  '/tools/config-converter',
-  '/tools/char-count',
-] as const;
-
-const STATIC_PAGES = new Set(['/', '/about', '/privacy']);
 
 const VIEWPORTS = [
   { name: 'desktop', width: 1280, height: 800 },

--- a/tests/meta/vrt-pages-coverage.test.ts
+++ b/tests/meta/vrt-pages-coverage.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { tools } from '../../src/data/tools';
+import { PAGES } from '../e2e/visual-regression-pages';
+
+/**
+ * meta test: VRT カバレッジ漏れ検出 (issue #355 再発防止策)
+ *
+ * `src/data/tools.ts` の全 tool slug が `tests/e2e/visual-regression-pages.ts` の
+ * `PAGES` 配列に登録されているかを機械的に検証。
+ *
+ * 背景: PR #346 で char-count tool 追加時に PAGES への登録漏れが発生し、
+ * その後 PR #354 のレビューで初めて発覚した (人間の checklist 確認に依存していた)。
+ * 本 test を CI (`npm run test`) で走らせることで、新規ツール追加 PR で
+ * VRT 登録漏れが merge 前に必ず fail として検知される。
+ */
+
+/** tool 一覧と PAGES の差分を返す純粋関数 (陰性/陽性両対照で共有) */
+function findUnregisteredTools(toolList: { slug: string }[], pages: readonly string[]): string[] {
+  const toolUrls = toolList.map((t) => `/tools/${t.slug}`);
+  return toolUrls.filter((url) => !pages.includes(url));
+}
+
+describe('VRT PAGES coverage', () => {
+  it('src/data/tools.ts の全 tool slug が visual-regression PAGES に登録されている', () => {
+    const missing = findUnregisteredTools(tools, PAGES);
+    expect(missing).toEqual([]);
+  });
+});
+
+// 陽性対照: 検知機構が空回りしていないことを保証 (test-gates skill 準拠)。
+// fixture を注入して旧実装 (検知ロジック無し) では fail する設計を別 spec で確認する。
+describe('[陽性対照] VRT PAGES coverage 検知機構', () => {
+  it('未登録 slug を fixture に注入すると findUnregisteredTools が検出する', () => {
+    const fakeTools = [{ slug: 'unregistered-fake-tool' }];
+    const missing = findUnregisteredTools(fakeTools, PAGES);
+    expect(missing).toEqual(['/tools/unregistered-fake-tool']);
+  });
+
+  it('登録済み + 未登録の混在 fixture で未登録のみを列挙する (過検知なし)', () => {
+    const fakeTools = [
+      { slug: 'fake-a' },
+      { slug: 'url-encode' }, // 既存 (登録済み)
+      { slug: 'fake-b' },
+    ];
+    const missing = findUnregisteredTools(fakeTools, PAGES);
+    expect(missing.sort()).toEqual(['/tools/fake-a', '/tools/fake-b']);
+  });
+
+  it('全登録済み fixture では何も検出しない (過検知なし)', () => {
+    const fakeTools = [{ slug: 'url-encode' }, { slug: 'qr-code' }];
+    const missing = findUnregisteredTools(fakeTools, PAGES);
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/meta/vrt-pages-coverage.test.ts
+++ b/tests/meta/vrt-pages-coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { tools } from '../../src/data/tools';
+import { tools } from '@/data/tools';
 import { PAGES } from '../e2e/visual-regression-pages';
 
 /**

--- a/tests/meta/vrt-pages-coverage.test.ts
+++ b/tests/meta/vrt-pages-coverage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { tools } from '@/data/tools';
-import { PAGES } from '../e2e/visual-regression-pages';
+import { PAGES, STATIC_PAGES } from '../e2e/visual-regression-pages';
 
 /**
  * meta test: VRT カバレッジ漏れ検出 (issue #355 再発防止策)
@@ -22,12 +22,12 @@ function findUnregisteredTools(toolList: { slug: string }[], pages: readonly str
 
 /**
  * PAGES にだけ存在する orphan エントリ (tools.ts から削除されたが PAGES に残存) を返す。
- * STATIC ページ (`/`, `/about`, `/privacy`) は除外。
+ * STATIC ページ (`/`, `/about`, `/privacy`) は visual-regression-pages.ts で定義済みの
+ * `STATIC_PAGES` を import して除外 (重複定義による drift 防止)。
  */
-const STATIC_PAGE_PATHS = new Set<string>(['/', '/about', '/privacy']);
 function findOrphanPages(toolList: { slug: string }[], pages: readonly string[]): string[] {
   const toolUrls = new Set(toolList.map((t) => `/tools/${t.slug}`));
-  return pages.filter((url) => !STATIC_PAGE_PATHS.has(url) && !toolUrls.has(url));
+  return pages.filter((url) => !STATIC_PAGES.has(url) && !toolUrls.has(url));
 }
 
 describe('VRT PAGES coverage', () => {

--- a/tests/meta/vrt-pages-coverage.test.ts
+++ b/tests/meta/vrt-pages-coverage.test.ts
@@ -20,6 +20,16 @@ function findUnregisteredTools(toolList: { slug: string }[], pages: readonly str
   return toolUrls.filter((url) => !pages.includes(url));
 }
 
+/**
+ * PAGES にだけ存在する orphan エントリ (tools.ts から削除されたが PAGES に残存) を返す。
+ * STATIC ページ (`/`, `/about`, `/privacy`) は除外。
+ */
+const STATIC_PAGE_PATHS = new Set<string>(['/', '/about', '/privacy']);
+function findOrphanPages(toolList: { slug: string }[], pages: readonly string[]): string[] {
+  const toolUrls = new Set(toolList.map((t) => `/tools/${t.slug}`));
+  return pages.filter((url) => !STATIC_PAGE_PATHS.has(url) && !toolUrls.has(url));
+}
+
 describe('VRT PAGES coverage', () => {
   it('src/data/tools.ts の全 tool slug が visual-regression PAGES に登録されている', () => {
     const missing = findUnregisteredTools(tools, PAGES);
@@ -50,5 +60,45 @@ describe('[陽性対照] VRT PAGES coverage 検知機構', () => {
     const fakeTools = [{ slug: 'url-encode' }, { slug: 'qr-code' }];
     const missing = findUnregisteredTools(fakeTools, PAGES);
     expect(missing).toEqual([]);
+  });
+});
+
+// orphan 検出 (PAGES にあるが tools.ts には無い): ツール削除時の PAGES 削除忘れ検知
+describe('VRT PAGES orphan 検出', () => {
+  it('PAGES に存在するが tools.ts に対応する slug が無い orphan エントリがない', () => {
+    const orphans = findOrphanPages(tools, PAGES);
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe('[陽性対照] orphan 検出機構', () => {
+  it('tools.ts に無い slug が PAGES にあると orphan として検出される', () => {
+    // ツールが url-encode 1 つだけ存在する fixture → 他の /tools/* は全部 orphan
+    const fakeTools = [{ slug: 'url-encode' }];
+    const orphans = findOrphanPages(fakeTools, PAGES);
+    expect(orphans.length).toBeGreaterThan(0);
+    expect(orphans).not.toContain('/tools/url-encode'); // 登録済みは含まない
+  });
+
+  it('STATIC ページ (`/`, `/about`, `/privacy`) は orphan として検出されない', () => {
+    // ツール 0 件 fixture でも STATIC は除外される
+    const orphans = findOrphanPages([], PAGES);
+    expect(orphans).not.toContain('/');
+    expect(orphans).not.toContain('/about');
+    expect(orphans).not.toContain('/privacy');
+  });
+});
+
+// PAGES の重複登録検出: 同じ URL を 2 回追加してしまった場合の検知
+describe('VRT PAGES 重複登録検出', () => {
+  it('PAGES 配列に重複登録がない', () => {
+    expect(new Set(PAGES).size).toBe(PAGES.length);
+  });
+});
+
+describe('[陽性対照] 重複検出機構', () => {
+  it('重複を含む配列では Set サイズが配列長より小さくなる', () => {
+    const dup = ['/tools/a', '/tools/b', '/tools/a'] as const;
+    expect(new Set(dup).size).toBeLessThan(dup.length);
   });
 });


### PR DESCRIPTION
## 概要

#355 対応。PR #346 (char-count tool 追加) で発覚した VRT カバレッジ漏れの再発防止策として、**機械的検知 (meta test) + AI エージェント向け共通ルール明文化** の二層を導入する infra 単独 PR。

加えて、本 PR レビュー中に発覚した派生バグ (VRT comment の pass 件数 hardcode) と、レビュー指摘の補強 (orphan / 重複検出) も同 PR で巻き取り対応。

## 変更内容

### 1. PAGES 切り出し (refactor)

- `tests/e2e/visual-regression.spec.ts` の `PAGES` / `STATIC_PAGES` を新規ファイル `tests/e2e/visual-regression-pages.ts` に分離
- 切り出し理由: meta test (vitest) から共有するため。Playwright spec 全体を vitest で import すると `test.describe` 等の副作用が走るため、定数のみを抽出する形

### 2. meta test 追加 (test)

- `tests/meta/vrt-pages-coverage.test.ts` を新設
- `src/data/tools.ts` の全 slug が `PAGES` に登録されているかを `npm run test` で機械的に検証
- **陽性対照**: 未登録 slug を fixture に注入して検知関数 `findUnregisteredTools` が拾うことを別 spec で assert (test-gates skill 準拠)
- **陰性対照** + **過検知防止**: 全登録 fixture / 混在 fixture で過検知しないことも assert
- **import を `@/data/tools` alias に統一** (レビュー指摘 #1 対応)
- **orphan 検出**: `findOrphanPages` で `PAGES` に存在するが `tools.ts` に対応 slug が無いエントリを検出 (ツール削除時の silent failure 防止)
- **重複登録検出**: `PAGES` 配列に同 URL が二重登録されていないか Set サイズで検証

### 3. AI エージェント共通ルール更新 (docs)

- `docs/shared-agent-rules.md` (Claude Code / Gemini CLI 等が参照する共通規約) の 5 章「ツール追加・実装フロー」に以下を追記:
  - `src/data/tools.ts` への登録 (元々暗黙だった手順を明示化)
  - `tests/e2e/visual-regression-pages.ts` の `PAGES` 追加 + baseline 生成手順
- 「漏れた場合は meta test が CI で fail させる」旨も明示

### 4. VRT workflow の pass 件数 hardcode を動的化 (派生修正)

- `.github/workflows/visual-regression.yml` の PR comment 本文組み立て step で「**全 36 件 pass**」と固定値表示していた問題を修正
- `vrt-output.log` の playwright 集計行 `N passed` から `grep` で件数を抽出し、`✅ 全 N 件 pass` を動的に表示するよう変更
- 件数が抽出できない fallback 時は `✅ pass` (件数なし) で安全側に倒す
- 動作確認: 本 PR push 後の comment 再生成で **「✅ 全 38 件 pass」** と動的表示されることを確認済み

## テスト

- `npm run test`: Test Files 49/49 / Tests 985/985 passed (+9 新規 meta test ケース)
- `astro check`: 0 errors / 0 warnings / 0 hints
- VRT (CI): 38/38 pass、comment 表示も「全 38 件」で正常

## 関連

- Closes #355
- 元発生 PR: #346 (char-count 追加時の VRT 登録漏れ)
- 応急修正: #354 (char-count を VRT に登録 + baseline 再生成)
- 補強 follow-up: #357 (本 PR で巻き取り対応のため close 済み)

## チェックリスト

- [x] develop ベース
- [x] スコープ: meta test (本体 + orphan + 重複) + PAGES 切り出し + rule doc + workflow fix のみ (infra 単独 PR)
- [x] aria-* 削除なし
- [x] 言語: 日本語
- [x] 陽性対照テスト併設 (test-gates skill)
