### PR TITLE
fix(sw): CACHE_NAME を build 時に commit SHA で bump し hydration mismatch を防ぐ

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,10 +2,11 @@ import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
+import { injectSwBuildId } from './astro/integrations/inject-sw-build-id';
 
 export default defineConfig({
   site: 'https://devtools-d9w.pages.dev',
-  integrations: [react(), sitemap()],
+  integrations: [react(), sitemap(), injectSwBuildId()],
   // #176 A-1: Astro built-in CSP で `<meta http-equiv="content-security-policy">` を各ページに注入し、
   // bundled scripts (Astro island loader 等の inline `<script type="module">` 含む) を自動で SHA-256 hash 化。
   // 結果として `public/_headers` の `script-src` から `'unsafe-inline'` を安全に削除できる。

--- a/astro/integrations/inject-sw-build-id.ts
+++ b/astro/integrations/inject-sw-build-id.ts
@@ -7,8 +7,8 @@ const PLACEHOLDER = '__BUILD_ID__';
 
 export function resolveBuildId(): string {
   const sha =
-    process.env.CF_PAGES_COMMIT_SHA ??
-    process.env.GITHUB_SHA ??
+    process.env.CF_PAGES_COMMIT_SHA ||
+    process.env.GITHUB_SHA ||
     execSync('git rev-parse --short HEAD').toString().trim();
   return sha.slice(0, 7);
 }

--- a/astro/integrations/inject-sw-build-id.ts
+++ b/astro/integrations/inject-sw-build-id.ts
@@ -1,0 +1,32 @@
+import type { AstroIntegration } from 'astro';
+import { readFile, writeFile } from 'node:fs/promises';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const PLACEHOLDER = '__BUILD_ID__';
+
+export function resolveBuildId(): string {
+  const sha =
+    process.env.CF_PAGES_COMMIT_SHA ??
+    process.env.GITHUB_SHA ??
+    execSync('git rev-parse --short HEAD').toString().trim();
+  return sha.slice(0, 7);
+}
+
+export function injectSwBuildId(): AstroIntegration {
+  return {
+    name: 'inject-sw-build-id',
+    hooks: {
+      'astro:build:done': async ({ dir, logger }) => {
+        const swPath = fileURLToPath(new URL('sw.js', dir));
+        const original = await readFile(swPath, 'utf8');
+        if (!original.includes(PLACEHOLDER)) {
+          throw new Error(`[inject-sw-build-id] placeholder ${PLACEHOLDER} not found in ${swPath}`);
+        }
+        const buildId = resolveBuildId();
+        await writeFile(swPath, original.replaceAll(PLACEHOLDER, buildId));
+        logger.info(`Injected BUILD_ID=${buildId} into sw.js`);
+      },
+    },
+  };
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'devtools-v1';
+const CACHE_NAME = 'devtools-__BUILD_ID__';
 
 // オフライン時のフォールバック先
 const OFFLINE_URL = '/';

--- a/tests/meta/sw-cache-version.test.ts
+++ b/tests/meta/sw-cache-version.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { readFile, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * meta test: SW cache versioning 検証 (issue #358)
+ *
+ * build 後の `dist/sw.js` を読み、`CACHE_NAME` が commit SHA で置換済みかを機械的に検証。
+ * `CACHE_NAME = 'devtools-v1'` 固定のまま deploy すると古い cache が永続化し
+ * hydration mismatch が起きうるため、build pipeline の注入が確実に動いていることを CI で保証する。
+ */
+
+const swDistPath = fileURLToPath(new URL('../../dist/sw.js', import.meta.url));
+
+const PLACEHOLDER = '__BUILD_ID__';
+const CACHE_NAME_RE = /const CACHE_NAME = 'devtools-[a-f0-9]{7,40}'/;
+
+/** dist/sw.js に未置換 placeholder が残っているか検出する */
+function hasPlaceholder(content: string): boolean {
+  return content.includes(PLACEHOLDER);
+}
+
+/** CACHE_NAME が期待形式 devtools-{sha} ではないか検出する (true = NG) */
+function hasInvalidCacheName(content: string): boolean {
+  return !CACHE_NAME_RE.test(content);
+}
+
+async function readSwDist(): Promise<string> {
+  try {
+    await access(swDistPath);
+  } catch {
+    throw new Error('dist/sw.js が存在しません。先に `npm run build` を実行してください。');
+  }
+  return readFile(swDistPath, 'utf8');
+}
+
+describe('SW cache versioning (build artifact 検証)', () => {
+  it('dist/sw.js に placeholder __BUILD_ID__ が残っていない', async () => {
+    const content = await readSwDist();
+    expect(hasPlaceholder(content)).toBe(false);
+  });
+
+  it('CACHE_NAME が devtools-{sha} 形式になっている', async () => {
+    const content = await readSwDist();
+    expect(hasInvalidCacheName(content)).toBe(false);
+  });
+});
+
+// 陽性対照: test-gates skill 準拠 — 検知関数が空回りしていないことを保証
+describe('[陽性対照] SW cache versioning 検知機構', () => {
+  it('未置換 placeholder を含む文字列は hasPlaceholder が true を返す', () => {
+    const bad = `const CACHE_NAME = 'devtools-${PLACEHOLDER}';`;
+    expect(hasPlaceholder(bad)).toBe(true);
+  });
+
+  it('devtools-v1 (固定値) は hasInvalidCacheName が true を返す', () => {
+    const legacy = `const CACHE_NAME = 'devtools-v1';`;
+    expect(hasInvalidCacheName(legacy)).toBe(true);
+  });
+
+  it('正しい形式は hasPlaceholder が false を返す', () => {
+    const good = `const CACHE_NAME = 'devtools-a1b2c3d';`;
+    expect(hasPlaceholder(good)).toBe(false);
+  });
+
+  it('正しい形式は hasInvalidCacheName が false を返す', () => {
+    const good = `const CACHE_NAME = 'devtools-a1b2c3d';`;
+    expect(hasInvalidCacheName(good)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

- `public/sw.js` の `CACHE_NAME` を `'devtools-v1'` 固定から `'devtools-__BUILD_ID__'` placeholder 形式に変更
- `astro/integrations/inject-sw-build-id.ts` を新設: `astro:build:done` hook で `dist/sw.js` の placeholder を commit SHA (7 文字) に置換
- BUILD_ID の取得は `CF_PAGES_COMMIT_SHA` → `GITHUB_SHA` → `git rev-parse --short HEAD` の三段 fallback
- `tests/meta/sw-cache-version.test.ts` を新設: placeholder 残留 / 固定値 (`v1`) を検出する meta test + 陽性対照 (test-gates skill 準拠)

## 背景

PR #356 のレビュー中に以下の hydration mismatch を観測:

```
- server: <span>Twitter weight </span>          (旧 HTML、SW cache fallback 経路)
- client: <span>X (旧 Twitter) weight </span>   (新 JS bundle)
→ Uncaught Error: Hydration failed because the server rendered text didn't match the client.
```

現状の `activate` event は `name \!== CACHE_NAME` の cache を全削除するロジックを既に持っているため、`CACHE_NAME` を deploy ごとに bump さえすれば旧 cache が確実に消える設計。本 PR はその bump を build pipeline で自動化する。

## 検証

- `npm run build` → `dist/sw.js` 先頭行が `const CACHE_NAME = 'devtools-b905fc0';` に置換されることを確認済み
- `npm run test` (Tests 991 passed) 通過確認済み
- `astro check` (0 errors) 確認済み
- placeholder 削除時に `npm run build` が `[inject-sw-build-id] placeholder __BUILD_ID__ not found` で fail することを確認済み (gate の動作保証)
- `npm run test:e2e` (166 passed, 1 skipped) 通過確認済み

## スコープ外

- **dev mode** での SW 動作: dev では `public/sw.js` がそのまま serve されるため placeholder のままになるが、文字列として有効で動作する。dev 改善は別 issue で扱う
- **SW register script の変更なし**: `BaseLayout.astro` の `navigator.serviceWorker.register('/sw.js')` は据え置き (CSP hash 再計算回避)

## 関連

- closes #358
- PR #356 (本 issue の発生元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
