### PR TITLE
chore: 軽量 issue 2 件対応 (#310 css-length 単位拡張 / #311 ResultTable JSDoc)

### DIFF
--- a/src/components/ui/ResultTable.tsx
+++ b/src/components/ui/ResultTable.tsx
@@ -11,7 +11,9 @@ export interface TableColumn<T> {
    * CSS length token (例: '3.5rem')。**hard-coded リテラルのみ許容**。
    * Constructable Stylesheets 経由で per-instance scoped rule に展開されるため、
    * `assertCssLength` で `{number}{unit?}` 形式以外を reject する (CSS injection 防御)。
-   * user input を bridge する場合は事前 sanitize 必須。
+   * **render-time throw**: validate 失敗時は render 中に例外を throw する。
+   * Error Boundary 不在の場合は UI 全体が落ちるため、user input を bridge する場合は
+   * 呼出側で必ず事前 sanitize すること。
    * 詳細は `docs/decisions.md [067]` / PR 9 spec § 4.2 / 4.3 参照。
    */
   width?: string;
@@ -28,7 +30,9 @@ interface Props<T> {
   getKey: (row: T) => string | number;
   /**
    * CSS length token (hard-coded literals only)。`TableColumn.width` と同じ origin discipline。
-   * `assertCssLength` で形式 validate。
+   * `assertCssLength` で形式 validate。**render-time throw**: validate 失敗時は render 中に
+   * 例外を throw する。Error Boundary 不在の場合は UI 全体が落ちるため、user input を
+   * bridge する場合は呼出側で必ず事前 sanitize すること。
    */
   minWidth?: string;
   selectedIndex?: number | null;

--- a/src/utils/__tests__/css-length.test.ts
+++ b/src/utils/__tests__/css-length.test.ts
@@ -47,6 +47,7 @@ describe('assertCssLength', () => {
     it.each([
       ['0', 'unitless 0'],
       ['-0', 'unitless -0'],
+      ['+0', 'unitless +0'],
     ])('%s (%s) は許容される', (value) => {
       expect(() => assertCssLength(value, 'test')).not.toThrow();
     });
@@ -58,6 +59,8 @@ describe('assertCssLength', () => {
       ['2', 'unitless integer'],
       ['-3', 'unitless negative integer'],
       ['-1.5', 'unitless negative decimal'],
+      ['+1', 'unitless +1 (符号付き非ゼロ)'],
+      ['+1.5', 'unitless +1.5 (符号付き非ゼロ decimal)'],
     ])('%s (%s) は throw する', (value) => {
       expect(() => assertCssLength(value, 'test')).toThrow(/Invalid CSS length for test/);
     });

--- a/src/utils/__tests__/css-length.test.ts
+++ b/src/utils/__tests__/css-length.test.ts
@@ -2,29 +2,79 @@ import { describe, expect, it } from 'vitest';
 import { assertCssLength } from '../css-length';
 
 describe('assertCssLength', () => {
-  it.each([
-    ['3.5rem', 'decimal rem'],
-    ['56px', 'integer px'],
-    ['100%', 'percent'],
-    ['1fr', 'fr unit'],
-    ['-1px', 'negative integer'],
-    ['0', 'unitless zero'],
-    ['10em', 'em'],
-    ['50vh', 'vh'],
-  ])('%s (%s) は許容される', (value) => {
-    expect(() => assertCssLength(value, 'test')).not.toThrow();
+  describe('既存単位 — 許容される値', () => {
+    it.each([
+      ['3.5rem', 'decimal rem'],
+      ['56px', 'integer px'],
+      ['100%', 'percent'],
+      ['1fr', 'fr unit'],
+      ['-1px', 'negative integer'],
+      ['0', 'unitless zero'],
+      ['10em', 'em'],
+      ['50vh', 'vh'],
+    ])('%s (%s) は許容される', (value) => {
+      expect(() => assertCssLength(value, 'test')).not.toThrow();
+    });
   });
 
-  it.each([
-    ['3.5rem; }body{display:none;', 'CSS injection attempt'],
-    ['calc(100% - 2px)', 'calc 関数'],
-    ['var(--foo)', 'var 関数'],
-    ['', 'empty string'],
-    ['3.5remm', 'invalid unit'],
-    ['rem', 'unit only'],
-    ['url(http://evil.com)', 'url'],
-  ])('%s (%s) は throw する', (value) => {
-    expect(() => assertCssLength(value, 'test')).toThrow(/Invalid CSS length for test/);
+  describe('追加単位 (viewport 系) — 許容される値', () => {
+    it.each([
+      ['10vmin', 'vmin'],
+      ['10vmax', 'vmax'],
+      ['50dvh', 'dvh'],
+      ['50dvw', 'dvw'],
+      ['50svh', 'svh'],
+      ['50svw', 'svw'],
+      ['50lvh', 'lvh'],
+      ['50lvw', 'lvw'],
+    ])('%s (%s) は許容される', (value) => {
+      expect(() => assertCssLength(value, 'test')).not.toThrow();
+    });
+  });
+
+  describe('追加単位 (物理単位) — 許容される値', () => {
+    it.each([
+      ['2cm', 'cm'],
+      ['10mm', 'mm'],
+      ['1in', 'in'],
+      ['6pc', 'pc'],
+    ])('%s (%s) は許容される', (value) => {
+      expect(() => assertCssLength(value, 'test')).not.toThrow();
+    });
+  });
+
+  describe('unitless 0 — 許容される値', () => {
+    it.each([
+      ['0', 'unitless 0'],
+      ['-0', 'unitless -0'],
+    ])('%s (%s) は許容される', (value) => {
+      expect(() => assertCssLength(value, 'test')).not.toThrow();
+    });
+  });
+
+  describe('unitless non-zero — throw する (silent fail 防止)', () => {
+    it.each([
+      ['1.5', 'unitless decimal'],
+      ['2', 'unitless integer'],
+      ['-3', 'unitless negative integer'],
+      ['-1.5', 'unitless negative decimal'],
+    ])('%s (%s) は throw する', (value) => {
+      expect(() => assertCssLength(value, 'test')).toThrow(/Invalid CSS length for test/);
+    });
+  });
+
+  describe('不正値 — throw する', () => {
+    it.each([
+      ['3.5rem; }body{display:none;', 'CSS injection attempt'],
+      ['calc(100% - 2px)', 'calc 関数'],
+      ['var(--foo)', 'var 関数'],
+      ['', 'empty string'],
+      ['3.5remm', 'invalid unit'],
+      ['rem', 'unit only'],
+      ['url(http://evil.com)', 'url'],
+    ])('%s (%s) は throw する', (value) => {
+      expect(() => assertCssLength(value, 'test')).toThrow(/Invalid CSS length for test/);
+    });
   });
 
   it('label がエラーメッセージに含まれる', () => {

--- a/src/utils/css-length.ts
+++ b/src/utils/css-length.ts
@@ -5,7 +5,8 @@
  *   `px|rem|em|%|fr|vw|vh|ch|ex|pt` (既存) +
  *   `vmin|vmax|dvh|dvw|svh|svw|lvh|lvw` (viewport 系) +
  *   `cm|mm|in|pc` (物理単位)
- * unitless: `0` (または `-0`) のみ許容。それ以外の unitless 値は reject
+ * unitless: `0` / `+0` / `-0` のみ許容 (CSS 仕様で符号付きゼロも有効)。
+ *   それ以外の unitless 値は reject
  *   (CSS では 0 以外の unitless は no-op rule になりブラウザが宣言を無視するため)。
  * 非対応: `calc()` / 複合値 / 数学演算子。必要になった時点で拡張。
  *
@@ -16,7 +17,7 @@
 // 単位リスト (既存 + viewport 系 + 物理単位)
 // 長い候補を先に並べて alternation の誤マッチを防ぐ
 const CSS_UNITS = 'vmin|vmax|dvh|dvw|svh|svw|lvh|lvw|px|rem|em|%|fr|vw|vh|ch|ex|pt|cm|mm|in|pc';
-// 単位付き値 (0 含む) または unitless の 0 のみ valid
+// 単位付き値 (0 含む) または unitless の `0` / `+0` / `-0` のみ valid
 const CSS_LENGTH = new RegExp(`^(-?\\d+(\\.\\d+)?(${CSS_UNITS})|[+-]?0)$`);
 
 export function assertCssLength(value: string, label: string): void {

--- a/src/utils/css-length.ts
+++ b/src/utils/css-length.ts
@@ -1,14 +1,23 @@
 /**
- * 簡易 CSS length token 検証。`{number}{unit?}` 形式のみ許容。
+ * 簡易 CSS length token 検証。`{number}{unit}` 形式、または `0` のみ許容。
  *
- * 対応: integer / decimal / 負値 / `px|rem|em|%|fr|vw|vh|ch|ex|pt`
+ * 対応: integer / decimal / 負値 /
+ *   `px|rem|em|%|fr|vw|vh|ch|ex|pt` (既存) +
+ *   `vmin|vmax|dvh|dvw|svh|svw|lvh|lvw` (viewport 系) +
+ *   `cm|mm|in|pc` (物理単位)
+ * unitless: `0` (または `-0`) のみ許容。それ以外の unitless 値は reject
+ *   (CSS では 0 以外の unitless は no-op rule になりブラウザが宣言を無視するため)。
  * 非対応: `calc()` / 複合値 / 数学演算子。必要になった時点で拡張。
  *
  * 採用根拠: ResultTable の `width` / `minWidth` を `replaceSync` (CSS パーサ) に
  * 渡すため、不正値混入で CSS injection になる経路を封じる
  * (`docs/decisions.md [067]` / PR 9 spec § 4.2)。
  */
-const CSS_LENGTH = /^-?\d+(\.\d+)?(px|rem|em|%|fr|vw|vh|ch|ex|pt)?$/;
+// 単位リスト (既存 + viewport 系 + 物理単位)
+// 長い候補を先に並べて alternation の誤マッチを防ぐ
+const CSS_UNITS = 'vmin|vmax|dvh|dvw|svh|svw|lvh|lvw|px|rem|em|%|fr|vw|vh|ch|ex|pt|cm|mm|in|pc';
+// 単位付き値 (0 含む) または unitless の 0 のみ valid
+const CSS_LENGTH = new RegExp(`^(-?\\d+(\\.\\d+)?(${CSS_UNITS})|[+-]?0)$`);
 
 export function assertCssLength(value: string, label: string): void {
   if (!CSS_LENGTH.test(value)) {


### PR DESCRIPTION
## 概要

直近で起票された軽量・独立 issue を 2 件まとめて対応。両者は別ファイル (utils / components) を触るため互いに干渉なし。

## 対応 issue

### #311 — `docs(ResultTable): assertCssLength の render-time throw を JSDoc に注記`

- `src/components/ui/ResultTable.tsx` の `TableColumn.width` / `Props.minWidth` JSDoc に「**render-time throw**: validate fail で Error Boundary 不在では UI 全体が落ちる」旨と「user input を bridge する場合は事前 sanitize 必須」を明記。
- 現状の callsite は hard-coded リテラルのみで発火しないが、将来 user-controlled width 経路ができた時の落とし穴を防ぐ事故予防。
- JSDoc 追記のみ。コード本体・型・テストには触れていない。

### #310 — `enhance(css-length): assertCssLength の対応単位拡張 + unitless decimal silent fail の対応`

- `src/utils/css-length.ts` の `CSS_LENGTH` regex を更新:
  - **新規許容単位 12 件**: viewport (`vmin` / `vmax` / `dvh` / `dvw` / `svh` / `svw` / `lvh` / `lvw`) + 物理 (`cm` / `mm` / `in` / `pc`)
  - **unitless 制限**: `0` / `-0` のみ valid。それ以外の unitless 値 (`1.5`, `2`, `-3` 等) は throw する (silent fail 防止)
- ヘッダコメントを対応単位リストと unitless ポリシーに合わせて更新。
- `src/utils/__tests__/css-length.test.ts` に陽性対照テストを追加 (unitless 非ゼロ reject / 不正値 reject)。

## 変更ファイル

- `src/components/ui/ResultTable.tsx` (JSDoc 2 箇所)
- `src/utils/css-length.ts` (regex + コメント)
- `src/utils/__tests__/css-length.test.ts` (新単位 + 陽性対照テスト)

## 検証

- ✅ `npx vitest run src/utils/__tests__/css-length.test.ts`: **34 / 34 passed**
- ✅ `npx astro check`: **0 errors / 0 warnings / 0 hints**
- ✅ `npx prettier --check`: pass (整形済み)

E2E は本変更が docs / 純粋関数のみで UI 挙動への影響ゼロのため CI に委譲。

## 実装方法

計画は Opus、実装は **sonnet サブエージェント 2 並列** で issue 毎に分担。各々別ファイルのみ触るため安全に並列化できた。

## チェックリスト

- [x] `Closes #310` / `Closes #311` で issue 自動クローズ
- [x] commit 単位を issue 毎に分離 (`docs(ResultTable):` / `feat(css-length):`)
- [x] Conventional Commits + 日本語準拠
- [x] 既存テスト・型チェック regression なし

Closes #310
Closes #311

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kzv3ixtY7wU3KknVmfUAyf)_