### PR TITLE
refactor(css): semantic token 重複手動 class を削除し drawer-backdrop を color-mix() 化 (#295)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2802,3 +2802,40 @@ MySQL utf8mb3 カラムへの INSERT が SMP 文字 (U+10000 以上) で失敗�
 ### 結果・トレードオフ
 
 ユーザーは「なぜ ❌ か」を不可文字数・内訳で把握できる。byte 数は互換時のみ意味のある情報として提示。
+
+---
+
+## [073] 2026-05-10 — `#176` B 案完了後の semantic alias 整理 (`@theme` auto-utility 重複削減 + `.drawer-backdrop` `color-mix()` 化)
+
+### 状況
+
+`#176` B 案完了 ([068]) 後、PR 1〜5b / 7a で `@layer components` に追加した「色 token text utility」series が Tailwind v4 の `@theme` auto-utility と一部重複していることが判明 (#295 で観察)。
+
+| `@layer components` 手動 class | `@theme` 登録 var                 | Tailwind auto-utility (重複) |
+| ------------------------------ | --------------------------------- | ---------------------------- |
+| `.text-primary`                | `--color-primary`                 | `text-primary`               |
+| `.text-tertiary`               | `--color-tertiary`                | `text-tertiary`              |
+| `.text-icon`                   | `--color-neutral-700` (primitive) | `text-neutral-700`           |
+
+加えて `.drawer-backdrop` は `rgba(17,24,39,0.5)` を hardcode しており、`--color-neutral-900` の 50% alpha と同値だが token 値変更に追従しない。
+
+### 判断
+
+**(a) `.text-primary` / `.text-tertiary` を削除**: semantic token 経由のため auto-utility と完全同名・同挙動。callsite 変更ゼロで重複定義のみ排除できる。
+
+**(b) `.text-icon` は維持**: `--color-neutral-700` は primitive scale。auto-utility (`text-neutral-700`) 直書きは「なぜ 700? 600 じゃダメ?」が読み取れず保守性が下がる。意味クラスで隠蔽することで、将来 hover/focus/disabled 状態追加時に `.text-icon:hover { ... }` で集約定義できる余地も残す (7.1 章の variant 非対応問題により、`@layer components` 手動 class の方が擬似クラス追加で柔軟)。
+
+**(c) `.drawer-backdrop` を `color-mix()` 化**: `color-mix(in srgb, var(--color-neutral-900) 50%, transparent)` で token 値変更に自動追従。ブラウザ対応 (Chrome 111+ / Firefox 113+ / Safari 16.2+) は十分。
+
+**(d) 「Tailwind カラークラス禁止」rule の精緻化** (`docs/shared-agent-rules.md` 7 章): semantic token (`text-primary` 等) は意味的命名のため auto-utility 使用可、primitive scale (`text-blue-500` / `text-neutral-700` 等) は引き続き禁止。境界基準は「token 名から用途が読み取れる (semantic) か、palette 段階値に過ぎない (primitive) か」。
+
+### 残課題 / 副次効果
+
+- `.text-error` / `.text-success` も `@theme` 登録 token 経由のため理論上は同様に削除可能だが、callsite 影響が広く、本 PR では `.text-primary` / `.text-tertiary` のみに留める (issue #295 のスコープ外、必要に応じて別 issue で追加判断)。
+- 他の rgba 直書きは `--elevation-*` の黒シャドウのみで、`var(--color-X)` の alpha 違いではないため `color-mix()` 化対象外。
+
+### 関連
+
+- 解消する issue: [#295](https://github.com/fumtas1k/devtools/issues/295)
+- 上位 issue: [#176](https://github.com/fumtas1k/devtools/issues/176) (B 案完了は [068])
+- rule 更新: `docs/shared-agent-rules.md` 7 章

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2661,7 +2661,7 @@ PR 9 Phase 2 で発覚した、Astro 島ランタイムが React island を含�
 
 PR 6 必須チェックリスト末尾の未消化項目を本 entry で「現状維持」と確定:
 
-- **`.text-primary` 命名衝突リスク**: PR 2 で導入した `.text-primary` (`--color-primary` 由来) は Tailwind `text-primary` auto-utility と衝突する可能性があるが、現状 `@theme` に `--color-primary` を登録していないため衝突は発生していない。**現状維持**: 将来 `@theme` 切替する場合は `text-brand` 等への rename を検討。
+- **`.text-primary` 命名衝突リスク**: PR 2 で導入した `.text-primary` (`--color-primary` 由来) は Tailwind `text-primary` auto-utility と衝突する可能性があるが、現状 `@theme` に `--color-primary` を登録していないため衝突は発生していない。**現状維持**: 将来 `@theme` 切替する場合は `text-brand` 等への rename を検討。→ **[073] で再評価済**: その後 `--color-primary` は `@theme` 登録済となり、auto-utility と完全同名・同挙動の重複となったため、本 entry の「現状維持」を更新し `.text-primary` 手動定義を削除して auto-utility に統一した。
 - **Tailwind `border` utility と `@layer components` の `border-color` 優先度**: PR 2 で導入した `.alert-success` / `.alert-error` は `<div className="rounded-lg p-4 border alert-success">` のように Tailwind `border` と併用。layer 順序によっては期待色にならないリスクが PR 2 review で指摘済だが、CSP strict 化後の VRT 再撮影でも diff が出ていないため実害は未顕在。**現状維持**: 将来 Tailwind v4 layer 仕様変更で問題が顕在化したら再評価。
 
 ### 検出網運用ノート

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -158,7 +158,7 @@ Tailwind のカラークラス（`text-blue-500`, `bg-red-50`, `hover:bg-red-50`
 
 ただし `@theme` 登録された **semantic token** (`--color-primary` / `--color-tertiary` / `--color-success` 等) の auto-utility (`text-primary` / `text-tertiary` / `text-success` 等) は意味的命名のため使用可。primitive scale (`text-blue-500` / `text-neutral-700` 等) は引き続き禁止。判断基準: 「token 名から用途が読み取れる (semantic) か、palette 段階値に過ぎない (primitive) か」。
 
-- React (`.tsx`): `src/styles/global.css` の `@layer components` で定義された意味クラス（`text-primary` / `bg-subtle` / `alert-success` 等）を `className` で使用。新規 component で既存意味クラスに無い色組み合わせが必要な場合は、まず `@layer components` に意味クラスを追加してから使う（`#176` B 案で `style={{ color: colors.primary }}` 形式は全廃済、`@/utils/styles` import も無効）
+- React (`.tsx`): `src/styles/global.css` の `@layer components` で定義された意味クラス（`bg-subtle` / `alert-success` / `text-icon` 等）を `className` で使用。`@theme` 登録 semantic token は同名 auto-utility (`text-primary` 等) を直接使ってよい。新規 component で既存意味クラスに無い色組み合わせが必要な場合は、まず `@layer components` に意味クラスを追加してから使う（`#176` B 案で `style={{ color: colors.primary }}` 形式は全廃済、`@/utils/styles` import も無効）
 - Astro (`.astro`): 現状 `var(--color-*)` を `style` 属性で書く箇所が残存（[#289](https://github.com/fumtas1k/devtools/issues/289) で CSS class 化を進行中）。新規追加は React と同じ `@layer components` 意味クラスを推奨
 
 ※ レイアウト用クラス（`flex`, `gap`, `p-*`, `rounded` 等）は使用可。
@@ -168,7 +168,7 @@ UI 変更時は **PC (1280x800)** と **スマホ (390x844)** 両方でスクリ
 
 ### 7.1 Tailwind v4 `@layer components` の variant 非対応
 
-`global.css` の `@layer components` 内で **手書き定義** した class (`bg-subtle` / `text-primary` / `alert-success` 等) は Tailwind v4 の variant prefix (`hover:` / `focus:` / `aria-pressed:` 等) に **対応しない**。`hover:bg-subtle` のように書いても CSS rule (`.hover\:bg-subtle:hover { ... }`) が生成されず silent regression する。
+`global.css` の `@layer components` 内で **手書き定義** した class (`bg-subtle` / `text-icon` / `alert-success` 等) は Tailwind v4 の variant prefix (`hover:` / `focus:` / `aria-pressed:` 等) に **対応しない**。`hover:bg-subtle` のように書いても CSS rule (`.hover\:bg-subtle:hover { ... }`) が生成されず silent regression する。
 
 - ✅ `@theme` トークンから auto-generate される utility (`hover:bg-blue-50`, `hover:text-primary` 等) は variant 対応
 - ❌ `@layer components` 内手書き class への variant prefix は CSS rule 不生成

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -154,7 +154,9 @@ VRT が小さい pixel diff (例: 0.07%) を検出しても「微小だから ba
 
 ## 7. スタイル・UI ルール（基本）
 
-Tailwind のカラークラス（`text-blue-500`, `bg-red-50`, `hover:bg-red-50` 等）は **絶対に使用しない**。色は CSS 変数経由で指定する:
+Tailwind のカラークラス（`text-blue-500`, `bg-red-50`, `hover:bg-red-50` 等の **primitive scale 直書き**）は **絶対に使用しない**。色は CSS 変数経由で指定する:
+
+ただし `@theme` 登録された **semantic token** (`--color-primary` / `--color-tertiary` / `--color-success` 等) の auto-utility (`text-primary` / `text-tertiary` / `text-success` 等) は意味的命名のため使用可。primitive scale (`text-blue-500` / `text-neutral-700` 等) は引き続き禁止。判断基準: 「token 名から用途が読み取れる (semantic) か、palette 段階値に過ぎない (primitive) か」。
 
 - React (`.tsx`): `src/styles/global.css` の `@layer components` で定義された意味クラス（`text-primary` / `bg-subtle` / `alert-success` 等）を `className` で使用。新規 component で既存意味クラスに無い色組み合わせが必要な場合は、まず `@layer components` に意味クラスを追加してから使う（`#176` B 案で `style={{ color: colors.primary }}` 形式は全廃済、`@/utils/styles` import も無効）
 - Astro (`.astro`): 現状 `var(--color-*)` を `style` 属性で書く箇所が残存（[#289](https://github.com/fumtas1k/devtools/issues/289) で CSS class 化を進行中）。新規追加は React と同じ `@layer components` 意味クラスを推奨

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -394,7 +394,7 @@
 
   /* === PR 2: qr-ticket migration helpers === */
 
-  /* 色 token の text utility (Tailwind auto-utility 不在) */
+  /* 色 token の text utility */
   .text-error {
     color: var(--color-error);
   }
@@ -403,9 +403,6 @@
   }
   .text-success {
     color: var(--color-success);
-  }
-  .text-primary {
-    color: var(--color-primary);
   }
 
   /* Validation alert box (VerifyTab 検証結果) */
@@ -601,10 +598,7 @@
     color: var(--color-text);
   }
 
-  /* CategoryBadge: tertiary color text/bg (PR 2 .text-primary 系列に追従) */
-  .text-tertiary {
-    color: var(--color-tertiary);
-  }
+  /* CategoryBadge: badge background (`--color-badge-bg` は `:root` 定義、auto-utility 不在のため意味クラス維持) */
   .bg-badge {
     background: var(--color-badge-bg);
   }
@@ -619,10 +613,9 @@
   }
 
   /* MobileDrawer backdrop (modal 背景の半透明 overlay)
-     注意: rgba(17,24,39,0.5) は --color-neutral-900 の 50% alpha と同等。
-     CSS variable 化は B 案完了後の semantic alias 整理 PR で検討 (今 YAGNI)。 */
+     `--color-neutral-900` 50% alpha。将来 dark mode / theme 切替で token 値変更に自動追従。 */
   .drawer-backdrop {
-    background: rgba(17, 24, 39, 0.5);
+    background: color-mix(in srgb, var(--color-neutral-900) 50%, transparent);
   }
 
   /* === PR 7b (#289): Astro pages inline migration helpers === */


### PR DESCRIPTION
## 概要

`#176` B 案完了 ([068]) を受けた **semantic alias 整理 PR**。issue #295 で観察された 3 つの整理ポイントに対応。

## 対応内容

### 1. `@theme` auto-utility と重複する手動 class を削除 (`src/styles/global.css`)

| 削除した手動 class | `@theme` 登録 var | 代替 (Tailwind auto-utility) |
| --- | --- | --- |
| `.text-primary` | `--color-primary` | `text-primary` (同名・同挙動) |
| `.text-tertiary` | `--color-tertiary` | `text-tertiary` (同名・同挙動) |

callsite の class 名は同名なので **置換不要**。重複定義のみ排除。

**`.text-icon` は維持** (`--color-neutral-700` は primitive scale のため、auto-utility 直書きは「なぜ 700? 600 じゃダメ?」が読み取れず保守性が下がる。意味クラスで隠蔽し将来 hover/focus 状態追加の余地も残す)。

### 2. `.drawer-backdrop` を `color-mix()` 化

```diff
- background: rgba(17, 24, 39, 0.5);
+ background: color-mix(in srgb, var(--color-neutral-900) 50%, transparent);
```

- 同色 (`--color-neutral-900` = `#111827` の 50% alpha) のため見た目は不変
- 将来 dark mode / theme 切替で `--color-neutral-900` 値変更に **自動追従**
- ブラウザ対応: Chrome 111+ / Firefox 113+ / Safari 16.2+ で十分

### 3. `docs/shared-agent-rules.md` 7 章「Tailwind カラークラス禁止」rule の精緻化

- `@theme` 登録 **semantic** token (`text-primary` / `text-tertiary` / `text-success` 等) の auto-utility は意味的命名のため使用可
- **primitive scale** (`text-blue-500` / `text-neutral-700` 等) は引き続き禁止
- 境界基準: 「token 名から用途が読み取れる (semantic) か、palette 段階値に過ぎない (primitive) か」

### 4. `docs/decisions.md` に `[073]` 追記

判断根拠と semantic vs primitive の境界基準を記録。

## スコープ外 (本 PR で扱わない)

- `.text-error` / `.text-success` も理論上削除可能だが、callsite 影響が広く本 PR では `.text-primary` / `.text-tertiary` のみに留めた (必要なら別 issue で判断)
- 他の rgba 直書きは `--elevation-*` の黒シャドウのみで `var(--color-X)` の alpha 違いではないため `color-mix()` 化対象外

## 検証

- ✅ `node_modules/.bin/astro check`: 0 errors
- ✅ `npm run test`: **1031 / 1031 passed**
- ✅ `npm run build`: エラーなく完了 (`dist/_astro/BaseLayout.*.css` に `color-mix` 出力確認済)
- VRT は CI に委譲 (背景色は同色のため diff 無しが期待値)

## 実装方法

計画は **Opus**、実装は **Sonnet サブエージェント** で分担。CLAUDE.md 6.9 に従い項目別ステータスで完了報告 → 親で trust-but-verify diff 確認 → push & PR 作成。

## チェックリスト

- [x] `--base develop`
- [x] aria-* 削除なし (CLAUDE.md 9.6)
- [x] Conventional Commits + 日本語
- [x] テスト・型チェック regression なし
- [x] `Closes #295` で issue 自動クローズ

Closes #295

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9SubGjJb5umzaMmuVkvng)_