### PR TITLE
fix(vrt): スライダー生成で `-expected.png` 直参照に変更し baseline lookup 失敗を修正 (#362)

### DIFF
--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -240,3 +240,4 @@ baseline 更新は「意図した変更」を承認する操作であり、**真
 - Playwright 1.59 の attachment ファイル名は `node_modules/playwright/lib/util.js:208-217` の `trimLongString` で 60 文字 + 中央 SHA1 5 桁 (`-XXXXX-`) に truncate される (定数名 `windowsFilesystemFriendlyLength`、`kMaxAttachmentNameLength` という名前は存在しない)
 - baseline 名を文字列復元する前に、Playwright が同 test-results dir に置いている関連ファイル (`-expected.png` / `-diff.png` / `error-context.md`) を確認する。物理コピー経路の方が format 依存が少なく堅牢
 - issue 起票時の調査が「未確認」で見送った経路でも、node_modules source / 実 CI log で実証可能なら採用候補に戻す
+- **Playwright メジャー upgrade 時の回帰確認**: `-expected.png` を生成する Playwright 内識別子は `legacyExpectedPath` (`node_modules/playwright/lib/matchers/toMatchSnapshot.js:67`) で `legacy` prefix 付き = 将来 deprecation の兆候。upgrade 時は `-expected` suffix 生成経路が残っているか必ず grep 確認する。生成器自体が消えたら `scripts/generate-vrt-slider.mjs` の `-expected.png` 直参照経路も影響を受ける

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -230,3 +230,13 @@ baseline 更新は「意図した変更」を承認する操作であり、**真
 - PR 7a spec § VRT (Visual Regression Test): 「意図的差分があれば `update-visual-baseline.yml` workflow で baseline 更新」 (本ルールはこの判断基準を **明示化**)
 - 関連個人 memory (PC ローカル、本 repo 未収録): `feedback_vrt_ci_only.md` (VRT は CI Linux のみで検証)
 - （規約昇格候補）`docs/shared-agent-rules.md` の VRT 関連 sub-section として昇格検討。本 PR review (`#299` 軽微指摘 #3) で reviewer から「次 PR では VRT 差分が出た場合 baseline 更新前に必ず DOM diff / computed style diff を確認する手順を agent-lessons に明記する価値あり」と提案を受けて記録
+
+---
+
+## 2026-05-10 — Playwright attachment は windowsFilesystemFriendlyLength=60 で truncate される
+
+`scripts/generate-vrt-slider.mjs` (issue #362) で attachment 名と baseline 名の不一致による slider 生成失敗を修正。
+
+- Playwright 1.59 の attachment ファイル名は `node_modules/playwright/lib/util.js:208-217` の `trimLongString` で 60 文字 + 中央 SHA1 5 桁 (`-XXXXX-`) に truncate される (定数名 `windowsFilesystemFriendlyLength`、`kMaxAttachmentNameLength` という名前は存在しない)
+- baseline 名を文字列復元する前に、Playwright が同 test-results dir に置いている関連ファイル (`-expected.png` / `-diff.png` / `error-context.md`) を確認する。物理コピー経路の方が format 依存が少なく堅牢
+- issue 起票時の調査が「未確認」で見送った経路でも、node_modules source / 実 CI log で実証可能なら採用候補に戻す

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2839,3 +2839,38 @@ MySQL utf8mb3 カラムへの INSERT が SMP 文字 (U+10000 以上) で失敗�
 - 解消する issue: [#295](https://github.com/fumtas1k/devtools/issues/295)
 - 上位 issue: [#176](https://github.com/fumtas1k/devtools/issues/176) (B 案完了は [068])
 - rule 更新: `docs/shared-agent-rules.md` 7 章
+
+---
+
+## [074] 2026-05-10 — VRT slider レポートの baseline 解決を `-expected.png` 直参照に変更
+
+日付 2026-05-10 | ステータス: 採用 | issue #362
+
+### 背景
+
+`scripts/generate-vrt-slider.mjs` が VRT 失敗時に「baseline が見つかりません」を出して slider レポートを生成しないバグ (issue #362)。PR #361 で `/tools/char-count` に行追加した時に初の visual diff が発生して顕在化した。
+
+### 根本原因
+
+Playwright 1.59 の `windowsFilesystemFriendlyLength = 60` (`node_modules/playwright/lib/util.js:208-217` の `trimLongString`) により attachment 側ファイル名が 60 文字 + 中央 SHA1 5 桁で truncate される。一方 baseline (`tests/e2e/visual-regression.spec.ts-snapshots/`) は non-truncated の長いファイル名。スクリプトは両者を同名前提で照合していたため全ページで lookup 失敗。
+
+### 採用案: `-expected.png` 直参照 (C 案系統 ハイブリッド)
+
+`node_modules/playwright/lib/matchers/toMatchSnapshot.js:67,149` で `legacyExpectedPath = addSuffixToFilePath(outputBasePath, "-expected")` が定義され、diff 検出時に `writeFileSync(this.legacyExpectedPath, expected)` が同期実行される。`-actual.png` の隣に同じ truncated base 名で `-expected.png` が物理コピーされるため、baseline 名復元は不要。
+
+ラベル整形だけ `error-context.md` の `- Name:` 行 (`node_modules/playwright/lib/errorContext.js:44-90` の literal template) から best-effort で full title を復元。format 不一致時は raw fallback で slider 機能は止めない。
+
+### 不採用案: error-context.md parse + baseline 名復元 (issue #362 推奨の F 案)
+
+`error-context.md` の MD format と baseline naming テンプレート両方への format 依存があり脆弱。Playwright が既に物理コピーを置いているのに使わないのは冗長。
+
+### failure mode
+
+- `handleMissing` 経路 (baseline 不在で `--update-snapshots` 走った時) は `-expected.png` が出ないが、その経路では slider 比較が成立しないため `expected が見つかりません` で skip (正しい挙動)
+- `error-context.md` format ドリフト → `makeLabelFromContextContent` が null 返却 → 既存 `makeLabel` で raw 表示 (slider 本体は影響なし)
+
+### 関連
+
+- issue #362, PR #361 (再現 PR、既に merge 済み)
+- meta test: `tests/meta/vrt-slider-report.test.ts`
+- 教訓: `docs/agent-lessons.md`

--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -65,6 +65,9 @@ export function makeLabelFromContextContent(content) {
   return `[${vp[1]} ${vp[2]}] ${url}`;
 }
 
+// existsSync で先に確認するのは「ファイル無し」ケースを ENOENT 例外なく判別するため。
+// try/catch だけでも動作するが、race condition (確認後に削除) は対象外の前提
+// (本スクリプトは CI runner 上で test 直後に走るため別プロセスの干渉は想定しない)。
 function makeLabelFromContextPath(errorContextPath) {
   if (!existsSync(errorContextPath)) return null;
   let content;
@@ -76,6 +79,9 @@ function makeLabelFromContextPath(errorContextPath) {
   return makeLabelFromContextContent(content);
 }
 
+// 上限 80 は念のための過剰防衛。Playwright の test directory 名は実質
+// windowsFilesystemFriendlyLength=60 + SHA1 5 桁で収まるため通常 80 は超えない。
+// HTML 出力サイズ膨張の予防線として残す。
 function sanitizeId(s) {
   return s.replace(/[^\w]/g, '_').slice(0, 80);
 }
@@ -205,7 +211,8 @@ async function main() {
     const label = makeLabelFromContextPath(errorContextPath) ?? makeLabel(trimmedBase);
 
     // id は test directory 名で組む (Playwright が unique 保証)。
-    // retry attempt は別 dir になるため最初のものだけ slider に載せる。
+    // 防御的 dedup: 同 id が複数発生する未知ケース (Playwright の dir 命名衝突等)
+    // でも 1 件に絞る。retry attempt は別 dir 扱いのため通常 hit しない。
     const id = sanitizeId(basename(dir));
     if (seenIds.has(id)) continue;
     seenIds.add(id);

--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -1,17 +1,22 @@
 import { readdir, copyFile, mkdir, writeFile } from 'fs/promises';
 import { join, basename, dirname } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 
 // VRT スライダーレポート生成
-// test-results/ の *-actual.png と tests/e2e/.../snapshots/ のベースラインを突き合わせて
+// test-results/ の *-actual.png と隣接する *-expected.png を使って
 // img-comparison-slider 入りの HTML を vrt-slider-report/ に生成する。
 //
 // ファイル名の対応:
-//   actual:   test-results/**/{snapshot-name}-actual.png
-//   baseline: tests/e2e/visual-regression.spec.ts-snapshots/{snapshot-name}.png
-//   diff:     test-results/**/{snapshot-name}-diff.png
+//   actual:   test-results/**/{trimmed-base}-actual.png
+//   baseline: test-results/**/{trimmed-base}-expected.png  (Playwright が物理コピー)
+//   diff:     test-results/**/{trimmed-base}-diff.png
+//   ラベル整形: 同 dir の error-context.md から best-effort で full title 復元
+//
+// Playwright 1.59 は attachment ファイル名を windowsFilesystemFriendlyLength=60 で
+// truncate する (node_modules/playwright/lib/util.js の trimLongString)。
+// baseline (snapshots/) と attachment の名前が一致しないため、snapshots/ は参照せず
+// test-results/ 内の -expected.png を直接利用する (issue #362)。
 
-const SNAPSHOTS_DIR = 'tests/e2e/visual-regression.spec.ts-snapshots';
 const TEST_RESULTS_DIR = 'test-results';
 const OUTPUT_DIR = 'vrt-slider-report';
 
@@ -33,11 +38,46 @@ async function findFiles(dir, suffix) {
   return results;
 }
 
-function makeLabel(snapshotBase) {
-  return snapshotBase
+function makeLabel(trimmedBase) {
+  return trimmedBase
     .replace(/^visual-regression---/, '')
     .replace(/-の-screenshot-が-baseline-と一致-\d+-visual-regression-linux$/, '')
     .replace(/^(desktop|mobile)-(\d+x\d+)-/, '[$1 $2] ');
+}
+
+/**
+ * error-context.md の Playwright literal template (`- Name:` 行) を parse して
+ * `[viewport WxH] /url` 形式の整形ラベルを返す。失敗時 null。
+ * Playwright 1.59 の node_modules/playwright/lib/errorContext.js が source of truth。
+ * format が将来変わっても null を返すだけで slider 本体は動く。
+ */
+export function makeLabelFromContextContent(content) {
+  if (typeof content !== 'string') return null;
+  const m = content.match(/^- Name:\s*(.+)$/m);
+  if (!m) return null;
+  const parts = m[1].split(' >> ');
+  if (parts.length < 3) return null;
+  const describe = parts[parts.length - 2];
+  const title = parts[parts.length - 1];
+  const vp = describe.match(/(\w+)\s*\((\d+x\d+)\)/);
+  const url = title.replace(/\s*の\s*screenshot.*$/, '');
+  if (!vp) return null;
+  return `[${vp[1]} ${vp[2]}] ${url}`;
+}
+
+function makeLabelFromContextPath(errorContextPath) {
+  if (!existsSync(errorContextPath)) return null;
+  let content;
+  try {
+    content = readFileSync(errorContextPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  return makeLabelFromContextContent(content);
+}
+
+function sanitizeId(s) {
+  return s.replace(/[^\w]/g, '_').slice(0, 80);
 }
 
 function esc(s) {
@@ -141,25 +181,38 @@ async function main() {
   await mkdir(imagesDir, { recursive: true });
 
   const comparisons = [];
+  const seenIds = new Set();
 
   for (const actualPath of actualFiles) {
+    const dir = dirname(actualPath);
     const actualName = basename(actualPath);
-    const snapshotBase = actualName.replace(/-actual\.png$/, '');
-    const snapshotFileName = snapshotBase + '.png';
-    const baselinePath = join(SNAPSHOTS_DIR, snapshotFileName);
-    const diffPath = join(dirname(actualPath), snapshotBase + '-diff.png');
+    const trimmedBase = actualName.replace(/-actual\.png$/, '');
 
-    if (!existsSync(baselinePath)) {
-      console.warn(`baseline が見つかりません: ${baselinePath}`);
+    // baseline は同 dir の -expected.png を使う (Playwright が物理コピー済)。
+    // baseline 名を文字列復元する F 案より堅牢: attachment と baseline の
+    // 名前不一致 (windowsFilesystemFriendlyLength=60 truncate) は構造的に発生しない。
+    const expectedPath = join(dir, `${trimmedBase}-expected.png`);
+    const diffPath = join(dir, `${trimmedBase}-diff.png`);
+
+    if (!existsSync(expectedPath)) {
+      console.warn(`expected が見つかりません (skip): ${expectedPath}`);
       continue;
     }
 
-    const id = snapshotBase.replace(/[^\w]/g, '_');
-    const label = makeLabel(snapshotBase);
-    const hasDiff = existsSync(diffPath);
+    // ラベルは error-context.md から best-effort で full title 復元。
+    // 失敗時は truncated 名のまま (UX は劣化するが slider 機能は止まらない)。
+    const errorContextPath = join(dir, 'error-context.md');
+    const label = makeLabelFromContextPath(errorContextPath) ?? makeLabel(trimmedBase);
 
+    // id は test directory 名で組む (Playwright が unique 保証)。
+    // retry attempt は別 dir になるため最初のものだけ slider に載せる。
+    const id = sanitizeId(basename(dir));
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
+
+    const hasDiff = existsSync(diffPath);
     await copyFile(actualPath, join(imagesDir, `${id}-actual.png`));
-    await copyFile(baselinePath, join(imagesDir, `${id}-baseline.png`));
+    await copyFile(expectedPath, join(imagesDir, `${id}-baseline.png`));
     if (hasDiff) {
       await copyFile(diffPath, join(imagesDir, `${id}-diff.png`));
     }

--- a/tests/meta/vrt-slider-report.test.ts
+++ b/tests/meta/vrt-slider-report.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { makeLabelFromContextContent } from '../../scripts/generate-vrt-slider.mjs';
+
+/**
+ * meta test: generate-vrt-slider.mjs の error-context.md parse ロジック検証
+ *
+ * `makeLabelFromContextContent` は Playwright 1.59 の
+ * `node_modules/playwright/lib/errorContext.js:44-90` の literal template を前提とする。
+ * format が将来変わると null fallback になるだけで slider 本体は止まらないが、
+ * ここで陽性対照を固めておくことで format ドリフトを CI で検知できる。
+ */
+
+const VALID_CONTENT = `# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: visual-regression.spec.ts >> visual regression - mobile (390x844) >> /tools/char-count の screenshot が baseline と一致
+- Location: tests/e2e/visual-regression.spec.ts:32:7
+
+# Error details
+
+\`\`\`
+Error: expect(page).toHaveScreenshot(expected) failed
+\`\`\`
+`;
+
+describe('makeLabelFromContextContent (正常 format)', () => {
+  it('mobile + /tools/char-count から `[mobile 390x844] /tools/char-count` を返す', () => {
+    expect(makeLabelFromContextContent(VALID_CONTENT)).toBe('[mobile 390x844] /tools/char-count');
+  });
+
+  it('desktop + /tools/base64 から `[desktop 1280x800] /tools/base64` を返す', () => {
+    const c = VALID_CONTENT.replace('mobile (390x844)', 'desktop (1280x800)').replace(
+      '/tools/char-count',
+      '/tools/base64'
+    );
+    expect(makeLabelFromContextContent(c)).toBe('[desktop 1280x800] /tools/base64');
+  });
+
+  it('root url (/) から `[desktop 1280x800] /` を返す', () => {
+    const c = VALID_CONTENT.replace('mobile (390x844)', 'desktop (1280x800)').replace(
+      '/tools/char-count の screenshot が',
+      '/ の screenshot が'
+    );
+    expect(makeLabelFromContextContent(c)).toBe('[desktop 1280x800] /');
+  });
+});
+
+// 陽性対照: format 異常時に確実に null を返すことを保証。
+// 将来 Playwright が errorContext.md の format を変えた時、陰性対照のみでは
+// 「null 返却 → raw fallback」の検知機構が空回りしていることに気づけない。
+describe('[陽性対照] makeLabelFromContextContent (format 異常時に必ず null fallback)', () => {
+  it('content が文字列でないと null を返す', () => {
+    expect(makeLabelFromContextContent(null)).toBeNull();
+    expect(makeLabelFromContextContent(undefined)).toBeNull();
+    expect(makeLabelFromContextContent(123)).toBeNull();
+    expect(makeLabelFromContextContent({})).toBeNull();
+  });
+
+  it('`- Name:` 行が無いと null を返す', () => {
+    expect(makeLabelFromContextContent('# Test info\n\n- Location: foo.ts:1:1')).toBeNull();
+  });
+
+  it('`- Name:` 行はあるが `>>` 区切りが 1 個しかないと null を返す', () => {
+    expect(makeLabelFromContextContent('- Name: visual-regression.spec.ts')).toBeNull();
+    expect(makeLabelFromContextContent('- Name: spec.ts >> only-one-part')).toBeNull();
+  });
+
+  it('describe 部分に viewport regex がマッチしないと null を返す', () => {
+    const c =
+      '- Name: spec.ts >> describe without viewport >> /tools/foo の screenshot が baseline と一致';
+    expect(makeLabelFromContextContent(c)).toBeNull();
+  });
+
+  it('空文字列は null を返す', () => {
+    expect(makeLabelFromContextContent('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

VRT slider レポート生成スクリプトが「baseline が見つかりません」→「有効な比較ペアなし — スキップ」を出して slider レポートを生成しない問題を修正。

Closes #362

## 根本原因

Playwright 1.59 は attachment ファイル名を `windowsFilesystemFriendlyLength = 60` で truncate する（`node_modules/playwright/lib/util.js:208-217` の `trimLongString`）。

| 種類 | パス | ファイル名例 |
|---|---|---|
| baseline | `tests/e2e/visual-regression.spec.ts-snapshots/` | `visual-regression---desktop-1280x800-tools-char-count-の-screenshot-が-baseline-と一致-1-visual-regression-linux.png` (83 文字) |
| attachment | `test-results/**/{dir}/` | `visual-regression---deskto-b298d-screenshot-が-baseline-と一致-1-actual.png` (60 文字) |

旧スクリプトは `actualName.replace(/-actual\.png$/, '') + ".png"` で snapshots ディレクトリを探すため、全 19 ページで lookup 失敗していた。

## 変更内容

issue #362 推奨の **F 案**（`error-context.md` parse + baseline 名復元）ではなく、より堅牢な **ハイブリッド案**（C 案系統）を採用。

**採用理由**: Playwright は diff 検出時に `test-results/{dir}/{trimmed-base}-expected.png` として baseline を物理コピーする（`node_modules/playwright/lib/matchers/toMatchSnapshot.js:149`）。`-actual.png` の隣に同じ truncated 名で `-expected.png` が並ぶため、baseline 名を文字列復元する必要がない。

| 変更 | 詳細 |
|---|---|
| `scripts/generate-vrt-slider.mjs` | `test-results/**/*-expected.png` を baseline として直接利用。ラベルは `error-context.md` から best-effort 復元、失敗時は raw fallback |
| `tests/meta/vrt-slider-report.test.ts` | `makeLabelFromContextContent` の陰性対照 + 陽性対照（format 異常時に null fallback を確認） |
| `docs/decisions.md` | `[074]` に設計判断と F 案不採用の理由を記録 |
| `docs/agent-lessons.md` | `windowsFilesystemFriendlyLength=60` truncate と `-expected.png` 直参照の教訓を蓄積 |

## 検証

- `npm run test` (1039 tests) ✅
- `node_modules/.bin/astro check` (0 errors) ✅
- `npm run format:check` ✅

**CI での実動作確認**: 本 PR merge 後、別ブランチで意図的に visual diff を仕込んだ検証用 PR を立てて slider レポートが生成されることを確認予定。
