### PR TITLE
test(vrt): VRT slider レポート生成を検証するため /about に意図的 visual diff を投入 (#362 検証専用)

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -19,7 +19,7 @@ const jsonLd = {
 >
   <main class="mx-auto max-w-2xl px-6 py-12" id="main-content">
     <h1 class="mb-8 font-bold text-[1.75rem] leading-[1.4] tracking-[0.02em] text-default">
-      About
+      About — VRT slider verification
     </h1>
 
     <section class="mb-10">


### PR DESCRIPTION
## 概要

PR #370 (issue #362 fix) で導入した `-expected.png` 直参照型 slider レポート生成が CI で正しく動作することを検証するための **検証専用 PR**。

**マージしない**。CI で slider URL が live になることを確認後 close する。

## 変更内容

`src/pages/about.astro` の h1 を `"About"` → `"About — VRT slider verification"` に変更し、意図的に VRT を fail させる。

## 期待挙動

1. ✅ `visual-regression` job が **fail** する (`/about` の desktop / mobile 2 件)
2. ✅ `scripts/generate-vrt-slider.mjs` が `playwright-report/` artifact 生成 step の後で起動し、`vrt-slider-report/index.html` を生成する
3. ✅ slider レポートが `gh-pages` ブランチの `vrt/pr-<num>/` に deploy される
4. ✅ PR コメントの slider URL (`https://fumtas1k.github.io/devtools/vrt/pr-<num>/`) が live になる
5. ✅ slider 上で baseline / actual / diff の 3 画像が正しく表示される
6. ✅ ラベルが `[desktop 1280x800] /about` / `[mobile 390x844] /about` 形式で整形される

## 旧実装との比較ポイント

PR #370 マージ前 (旧実装) では:
- `baseline が見つかりません: tests/e2e/visual-regression.spec.ts-snapshots/visual-regression---deskto-XXXXX-...png` が出る
- `有効な比較ペアなし — スキップ` で slider 生成 skip
- PR コメントの slider URL は 404

PR #370 マージ後 (新実装) では上記が解消されることを本 PR で実証する。

## 後始末

- [ ] CI の `visual-regression` job 完了確認
- [ ] PR コメントの slider URL を live で確認
- [ ] slider 内で baseline/actual/diff 3 画像 + 整形ラベル確認
- [ ] **baseline は更新しない** (本 PR は破棄)
- [ ] PR を close (revert 不要、ブランチ削除のみ)
- [ ] `gh-pages` の `vrt/pr-<num>/` は `vrt-cleanup.yml` workflow が PR close 時に自動削除
