### PR TITLE
fix(vrt): スライダーレポートで retry attempt を除外しハンドル可視性を改善 (#362 派生)

### DIFF
--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -86,6 +86,18 @@ function sanitizeId(s) {
   return s.replace(/[^\w]/g, '_').slice(0, 80);
 }
 
+/**
+ * Playwright の retry attempt 用 dir かどうかを判定。
+ * Playwright は retry 時に `<test-dir>-retry1`, `-retry2` のような suffix を付けて
+ * 別 dir を作る。同じ test の再試行を slider に重複表示しないため、本判定で skip する。
+ *
+ * 注意: sanitize 前の raw な basename(dir) を渡すこと
+ * (sanitize 後だと `slice(0, 80)` で `-retry1` が途中で切れる場合がある)。
+ */
+export function isRetryDir(dirName) {
+  return /-retry\d+$/.test(dirName);
+}
+
 function esc(s) {
   return s
     .replace(/&/g, '&amp;')
@@ -98,6 +110,15 @@ function generateHTML(comparisons) {
   const navItems = comparisons
     .map(({ label, id }) => `<li><a href="#${id}">${esc(label)}</a></li>`)
     .join('\n      ');
+
+  // handle slot に左右矢印 SVG を入れて「drag できる UI」であることを視覚的に示す。
+  // 矢印アイコン単独では PointerDown が拾えない場合があるため、circle 背景で十分な
+  // クリック領域 (40px) を確保する。
+  const handleSvg = `<svg slot="handle" class="handle-icon" viewBox="0 0 100 100" aria-hidden="true">
+        <circle cx="50" cy="50" r="22" fill="#1e40af" stroke="#fff" stroke-width="3"/>
+        <path d="M40 42 L32 50 L40 58" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M60 42 L68 50 L60 58" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>`;
 
   const cards = comparisons
     .map(
@@ -113,6 +134,7 @@ function generateHTML(comparisons) {
         <img src="images/${id}-actual.png" alt="Actual">
         <figcaption>Actual（実際）</figcaption>
       </figure>
+      ${handleSvg}
     </img-comparison-slider>${
       hasDiff
         ? `
@@ -148,8 +170,10 @@ function generateHTML(comparisons) {
     .badge{display:inline-block;background:#dc2626;color:#fff;font-size:.75rem;font-weight:600;padding:.2rem .5rem;border-radius:4px;margin-bottom:1rem}
     .card{background:#fff;border-radius:8px;padding:1.5rem;margin-bottom:1.5rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
     h2{margin:0 0 .75rem;font-size:.9rem;color:#374151;word-break:break-all}
-    img-comparison-slider{width:100%;--default-handle-color:#1e40af;--default-handle-width:3px}
+    img-comparison-slider{width:100%;--default-handle-color:#1e40af;--default-handle-width:6px;--default-handle-opacity:1}
     img-comparison-slider img{width:100%;display:block}
+    .handle-icon{width:48px;height:48px;cursor:ew-resize;filter:drop-shadow(0 2px 6px rgba(0,0,0,.35))}
+    @media (hover:hover){.handle-icon:hover{transform:scale(1.1)}}
     figure{margin:0;position:relative}
     figcaption{position:absolute;bottom:0;left:0;right:0;background:rgba(0,0,0,.55);color:#fff;font-size:.7rem;padding:.2rem .5rem}
     details{margin-top:.75rem}
@@ -160,7 +184,7 @@ function generateHTML(comparisons) {
 <body>
 <header>
   <h1>🖼️ Visual Regression Diff Viewer</h1>
-  <p>← スライドして比較 &nbsp;|&nbsp; 左: <strong>Baseline（期待値）</strong> &nbsp; 右: <strong>Actual（実際）</strong></p>
+  <p>中央の <strong>⇆ ハンドル</strong> を左右に drag して比較 &nbsp;|&nbsp; 左半分: <strong>Baseline（期待値）</strong> &nbsp; 右半分: <strong>Actual（実際）</strong></p>
 </header>
 <nav>
   <ul>
@@ -191,6 +215,11 @@ async function main() {
 
   for (const actualPath of actualFiles) {
     const dir = dirname(actualPath);
+
+    // retry attempt の dir (`-retry1`, `-retry2` 等) は skip。
+    // 同じ test の再試行を slider に重複表示しないため (initial attempt のみ採用)。
+    if (isRetryDir(basename(dir))) continue;
+
     const actualName = basename(actualPath);
     const trimmedBase = actualName.replace(/-actual\.png$/, '');
 

--- a/tests/meta/vrt-slider-report.test.ts
+++ b/tests/meta/vrt-slider-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { makeLabelFromContextContent } from '../../scripts/generate-vrt-slider.mjs';
+import { isRetryDir, makeLabelFromContextContent } from '../../scripts/generate-vrt-slider.mjs';
 
 /**
  * meta test: generate-vrt-slider.mjs の error-context.md parse ロジック検証
@@ -78,5 +78,39 @@ describe('[陽性対照] makeLabelFromContextContent (format 異常時に必ず 
 
   it('空文字列は null を返す', () => {
     expect(makeLabelFromContextContent('')).toBeNull();
+  });
+});
+
+/**
+ * isRetryDir: Playwright の retry attempt dir を判定するフィルタ。
+ * regex `/-retry\d+$/` は raw な dir 名 (sanitize 前) を渡される前提。
+ * 誤検知 (非 retry を retry と判定) / 見逃し (retry を見逃す) 両方の陽性対照を網羅。
+ */
+describe('isRetryDir (retry attempt 検出)', () => {
+  it('retry suffix を含む dir 名は true', () => {
+    expect(isRetryDir('visual-regression-foo-retry1')).toBe(true);
+    expect(isRetryDir('foo-retry2')).toBe(true);
+    expect(isRetryDir('foo-retry99')).toBe(true);
+  });
+});
+
+describe('[陽性対照] isRetryDir (誤検知・見逃しの検出)', () => {
+  it('retry なしの dir 名は false (見逃しゼロ確認用)', () => {
+    expect(isRetryDir('visual-regression-foo')).toBe(false);
+    expect(isRetryDir('foo')).toBe(false);
+  });
+
+  it('retry が末尾でないと false (中間/先頭で誤検知しない)', () => {
+    expect(isRetryDir('foo-retry1-suffix')).toBe(false);
+    expect(isRetryDir('retry1-foo')).toBe(false);
+  });
+
+  it('retry の後ろが数字以外だと false', () => {
+    expect(isRetryDir('foo-retry')).toBe(false);
+    expect(isRetryDir('foo-retryX')).toBe(false);
+  });
+
+  it('"retry" の前にハイフンが無いと false', () => {
+    expect(isRetryDir('fooretry1')).toBe(false);
   });
 });


### PR DESCRIPTION
## 概要

PR #370 (issue #362 fix) の動作検証 (PR #371) で発覚した 2 つの課題に対応する派生 PR。

## 課題と対応

### 1. retry attempt の重複表示

PR #371 検証で slider に **4 件** (1 viewport あたり initial + retry1 で 2 件ずつ) 表示された。Playwright が retry 時に `<test-dir>-retry1`, `-retry2` のような別 dir を作るため、現状 dedup ロジック (`seenIds`) では `basename(dir)` が異なるため hit しなかった。

**対応**: `isRetryDir(dirName)` を新規 export 関数として追加し、`basename(dir)` が `-retry\d+` で終わる dir を skip するようにした。

### 2. slider ハンドル可視性 (UX)

handle が幅 3px で細く「drag できる」と気づきにくく、「画像 3 枚を並べてるだけの固定表示」と誤認されやすい UX 問題。

**対応**:
- `--default-handle-width` を 3px → **6px** に倍化
- `--default-handle-opacity` を **1** に明示
- handle slot に左右矢印 SVG (48px circle、青背景 + 白枠 + drop-shadow) を追加して drag UI を視覚化
- hover で 1.1x scale + `cursor:ew-resize`
- ヘッダー説明文を「← スライドして比較」から「中央の ⇆ ハンドルを左右に drag」へ具体化

## 検証

- `npm run test` (1044 tests, +5: `isRetryDir` の陰性 + 陽性対照 4 ケース) ✅
- `node_modules/.bin/astro check` (0 errors) ✅
- `npm run format:check` ✅

`isRetryDir` は test-gates 規約準拠で誤検知 (非 retry を retry と判定) / 見逃し (retry を見逃す) 両方の陽性対照を網羅:

- 「retry が末尾でないと false (中間/先頭で誤検知しない)」
- 「retry の後ろが数字以外だと false」
- 「"retry" の前にハイフンが無いと false」

## 動作確認

merge 後、別ブランチで意図的 visual diff を仕込んだ検証 PR (#371 と同パターン) を立てて以下を確認予定:

- [ ] slider に **2 件** だけ表示される (4 → 2、retry 除外確認)
- [ ] handle が太く目立ち、左右矢印 SVG icon が中央に出る
- [ ] hover で handle が 1.1x scale する

## 関連

- PR #370 (本 PR の前提): VRT slider レポート baseline 解決を `-expected.png` 直参照に変更
- PR #371 (検証 PR、close 済): #370 の動作検証で本 PR の課題を発見
- issue #362 (元 issue、PR #370 で close 済): VRT slider 名前不一致バグ
