### PR TITLE
fix(vrt): スライダー handle hover の scale 切替に transition を追加 (#372 review 指摘 1)

### DIFF
--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -172,7 +172,7 @@ function generateHTML(comparisons) {
     h2{margin:0 0 .75rem;font-size:.9rem;color:#374151;word-break:break-all}
     img-comparison-slider{width:100%;--default-handle-color:#1e40af;--default-handle-width:6px;--default-handle-opacity:1}
     img-comparison-slider img{width:100%;display:block}
-    .handle-icon{width:48px;height:48px;cursor:ew-resize;filter:drop-shadow(0 2px 6px rgba(0,0,0,.35))}
+    .handle-icon{width:48px;height:48px;cursor:ew-resize;filter:drop-shadow(0 2px 6px rgba(0,0,0,.35));transition:transform .15s ease}
     @media (hover:hover){.handle-icon:hover{transform:scale(1.1)}}
     figure{margin:0;position:relative}
     figcaption{position:absolute;bottom:0;left:0;right:0;background:rgba(0,0,0,.55);color:#fff;font-size:.7rem;padding:.2rem .5rem}


### PR DESCRIPTION
## 概要

PR #372 self-review 指摘 1 の対応。本来 #372 で巻き取るべきだった軽微 nit (1 行) を、私が self-review 待たずに #372 を merge してしまったため別 PR 化したもの。

## 変更内容

`scripts/generate-vrt-slider.mjs` の `.handle-icon` CSS に `transition:transform .15s ease` を 1 文字追加:

```diff
- .handle-icon{width:48px;height:48px;cursor:ew-resize;filter:drop-shadow(0 2px 6px rgba(0,0,0,.35))}
+ .handle-icon{width:48px;height:48px;cursor:ew-resize;filter:drop-shadow(0 2px 6px rgba(0,0,0,.35));transition:transform .15s ease}
```

これにより `@media (hover:hover){.handle-icon:hover{transform:scale(1.1)}}` の hover scale が瞬時切替ではなく 0.15s で滑らかに変化する。

## 検証

- `npm run test` (1044 tests) ✅
- `npm run format:check` ✅
- 型チェック ✅

実 hover 動作確認は merge 後の検証 PR で実施 (PR #371 と同パターン)。

## 関連

- PR #372 (本指摘の出所): retry skip + handle UX 改善
- self-review 該当部分: https://github.com/fumtas1k/devtools/pull/372#issuecomment-4415057769
