### PR TITLE
test(vrt): VRT slider 改善 (#362 / #370 / #372 / #373) の最終検証 PR

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -19,7 +19,7 @@ const jsonLd = {
 >
   <main class="mx-auto max-w-2xl px-6 py-12" id="main-content">
     <h1 class="mb-8 font-bold text-[1.75rem] leading-[1.4] tracking-[0.02em] text-default">
-      About
+      About — final VRT slider verification
     </h1>
 
     <section class="mb-10">


### PR DESCRIPTION
## 概要

PR #370 / #372 / #373 で実装した VRT slider レポート改善が CI 上で正しく動作するか検証する用の PR。**マージしない**。CI 完了 → 動作確認 → close (baseline 更新せず破棄)。

## 変更内容

`src/pages/about.astro` の h1 を `"About"` → `"About — final VRT slider verification"` に変更し、意図的に VRT を fail させる。

## 確認項目

| # | PR | 確認 |
|---|---|---|
| 1 | #372 | slider に **2 件** だけ表示される (4 → 2、retry 除外) |
| 2 | #372 | handle SVG (青 circle + 左右矢印) が中央に出る |
| 3 | #372 | hover cursor が `ew-resize` になる |
| 4 | #373 | hover で 1.1x scale が **0.15s で滑らかに** 切り替わる |
| 5 | #370 | ラベル `[desktop 1280x800] /about` / `[mobile 390x844] /about` 整形 |
| 6 | #370 | baseline / actual / diff 3 画像表示 |

## 後始末

- [ ] CI の `visual-regression` job 完了 (fail 期待)
- [ ] PR コメントの slider URL を live で確認
- [ ] Playwright MCP で 1〜6 全項目を実機確認
- [ ] **baseline は更新しない** (本 PR は破棄)
- [ ] PR を close (revert 不要、ブランチ削除)
