### PR TITLE
fix(vrt): スライダー全体に ew-resize cursor 設定 + GitHub Pages 設定確認 warning を削除

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -126,17 +126,6 @@ jobs:
             fi
           done
 
-      - name: GitHub Pages 設定確認（未設定なら Actions warning を出す）
-        if: ${{ !cancelled() && steps.gen-slider.outputs.generated == 'true' }}
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          STATUS=$(gh api "repos/${{ github.repository }}/pages" --jq '.status' 2>/dev/null || echo "not_found")
-          if [ "$STATUS" = "not_found" ] || [ "$STATUS" = "null" ] || [ -z "$STATUS" ]; then
-            echo "::warning::GitHub Pages が未設定のためスライダー URL が 404 になります。Settings → Pages → Branch: gh-pages / (root) → Save を実行してください。"
-          fi
-
       - name: 既存の VRT comment を検索（dedup 用）
         if: ${{ !cancelled() && github.event.pull_request.number }}
         id: find-vrt-comment

--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -170,7 +170,7 @@ function generateHTML(comparisons) {
     .badge{display:inline-block;background:#dc2626;color:#fff;font-size:.75rem;font-weight:600;padding:.2rem .5rem;border-radius:4px;margin-bottom:1rem}
     .card{background:#fff;border-radius:8px;padding:1.5rem;margin-bottom:1.5rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
     h2{margin:0 0 .75rem;font-size:.9rem;color:#374151;word-break:break-all}
-    img-comparison-slider{width:100%;--default-handle-color:#1e40af;--default-handle-width:6px;--default-handle-opacity:1}
+    img-comparison-slider{width:100%;cursor:ew-resize;--default-handle-color:#1e40af;--default-handle-width:6px;--default-handle-opacity:1}
     img-comparison-slider img{width:100%;display:block}
     .handle-icon{width:48px;height:48px;cursor:ew-resize;filter:drop-shadow(0 2px 6px rgba(0,0,0,.35));transition:transform .15s ease}
     @media (hover:hover){.handle-icon:hover{transform:scale(1.1)}}


### PR DESCRIPTION
## 概要

PR #374 (検証 PR) で発覚した 2 つの UX / CI ノイズ問題を修正。

## 変更内容

### 1. slider 領域全体の cursor が変わらない問題

`.handle-icon` (中央 SVG icon) だけ `cursor:ew-resize` で、画像エリア (baseline / actual の合成画像) にマウスを乗せても default cursor のままで「動かせる」と気づきにくかった。

**修正**: `img-comparison-slider` Web Component 自体に `cursor:ew-resize` を 1 文字追加。

```diff
- img-comparison-slider{width:100%;--default-handle-color:#1e40af;...}
+ img-comparison-slider{width:100%;cursor:ew-resize;--default-handle-color:#1e40af;...}
```

### 2. GitHub Pages 設定確認 step の false warning

`.github/workflows/visual-regression.yml` の「GitHub Pages 設定確認」step が、PR ごとに以下の警告を出していた:

> `::warning::GitHub Pages が未設定のためスライダー URL が 404 になります。Settings → Pages → Branch: gh-pages / (root) → Save を実行してください。`

実態: `gh api repos/.../pages` が **`pages: read` 権限不足** で fail → API が "not_found" 扱い → 毎回 false warning 発火。本リポジトリの Pages は status=built で正常稼働中 (PR #374 の slider URL も live で動作確認済)。

**修正**: 当該 step ごと削除。
- Pages は永続設定済みで初期 setup 用 safeguard としての役目を終えた
- Pages が実際に壊れた場合は前段の **deploy step が noisy fail** するため検知漏れにはならない
- `pages: read` 権限を追加して check を残す案もあるが、step 自体を削除する方がメンテ surface 縮小に有利

## 検証

- `npm run test` (1044 tests) ✅
- `npm run format:check` ✅
- 型チェック ✅
- 実 cursor 動作: merge 後の検証 PR #374 で再確認 (PR は close せず再 trigger 可能)

## 関連

- PR #370 / #372 / #373: VRT slider 一連の修正
- PR #374: 検証 PR (本 PR の修正点を発見した PR、本 PR merge 後再 push して動作確認)
