### PR TITLE
fix(a11y): OutputField に aria-live を追加しスクリーンリーダー通知を実現 (#382)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2960,5 +2960,5 @@ issue #382 で `OutputField` の a11y 欠落を改修。初期実装 (PR #402 �
 - ✅ `off→polite` の同一レンダー race condition を排除
 - ✅ `role="status"` のスコープが textarea のみで意味論的に明確
 - ✅ `aria-atomic="false"` 明示で SR 間の atomic 扱い差異を吸収
-- ⚠️ `readOnly textarea` の value 変更を live region 内でも通知しない SR（NVDA / VoiceOver の特定バージョン）が存在する—spec グレーゾーン。実機 SR 検証は別 issue で追跡
+- ⚠️ `readOnly textarea` の value 変更を live region 内でも通知しない SR（NVDA / VoiceOver の特定バージョン）が存在する—spec グレーゾーン。実機 SR 検証は issue #403 で追跡
 - ⚠️ 複数 OutputField を同一ツール内で使う場合の多重 `role="status"` は YAGNI で preemptive 対応なし。該当ケースが発生したら `ariaLabel` prop を status wrapper に転記して識別可能にする

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2929,3 +2929,36 @@ trade-off:
 - 設計書: `docs/superpowers/specs/2026-05-10-char-count-sns-redesign-design.md`
 - 実装計画: `docs/superpowers/plans/2026-05-10-char-count-sns-redesign.md`
 - twitter-text v3 conformance 仕様 (`twitter-text-config.json`)
+
+---
+
+## [076] 2026-05-11 — OutputField の aria-live を常時 polite + textarea wrap に統一
+
+**日付 2026-05-11 | ステータス: 採用 | issue #382, PR #402**
+
+### 背景
+
+issue #382 で `OutputField` の a11y 欠落を改修。初期実装 (PR #402 初版) は issue 提案通り最外殻 `<div>` に `role="status"` + `aria-live={hasValue ? 'polite' : 'off'}` の動的切替を採用した。PR レビューで以下 2 件の中優先度指摘を受領:
+
+1. `role="status"` のスコープが label + CopyButton + textarea の全体に及び、status region として広すぎる
+2. `off → polite` の同一レンダー切替は SR が announce を取りこぼす known anti-pattern（Safari/VoiceOver、JAWS での事例あり）
+
+### 決断
+
+- `aria-live` は **常時 `"polite"`** で固定（動的切替を廃止）
+- `role="status"` は **textarea を wrap する内側 `<div>`** に限定（label/CopyButton を status region から除外）
+- `aria-atomic="false"` を明示し、一部 SR が `role="status"` を atomic として扱う実装に備える
+- 初期 mount 時の過剰通知は ARIA spec の「live region 初期 content は announce しない」挙動に依拠
+
+### 却下した選択肢
+
+- **条件 mount (JanCode パターン)**: `hasValue` が真のときのみ live region をマウントする案。textarea 要素の重複描画または条件 wrapper によるツリー再 mount でフォーカス喪失リスクがある
+- **視覚隠し SR ミラー**: `<div class="sr-only" role="status">` に value を text node として複製する案。Base64 等の長い出力を全文読み上げる UX 課題と、2 つの真実の源が生じるメンテナンスコスト
+
+### 結果・トレードオフ
+
+- ✅ `off→polite` の同一レンダー race condition を排除
+- ✅ `role="status"` のスコープが textarea のみで意味論的に明確
+- ✅ `aria-atomic="false"` 明示で SR 間の atomic 扱い差異を吸収
+- ⚠️ `readOnly textarea` の value 変更を live region 内でも通知しない SR（NVDA / VoiceOver の特定バージョン）が存在する—spec グレーゾーン。実機 SR 検証は別 issue で追跡
+- ⚠️ 複数 OutputField を同一ツール内で使う場合の多重 `role="status"` は YAGNI で preemptive 対応なし。該当ケースが発生したら `ariaLabel` prop を status wrapper に転記して識別可能にする

--- a/src/components/ui/OutputField.tsx
+++ b/src/components/ui/OutputField.tsx
@@ -44,7 +44,7 @@ export function OutputField({
   const monoClass = mono ? 'font-mono' : '';
   const resizeClass = resize ? 'resize-y' : 'resize-none';
   return (
-    <div className="w-full" role="status" aria-live={hasValue ? 'polite' : 'off'}>
+    <div className="w-full">
       <div className="flex items-center justify-between mb-3 min-h-8">
         <label htmlFor={id} className="body-emphasis text-default">
           {label}
@@ -56,14 +56,16 @@ export function OutputField({
           </div>
         )}
       </div>
-      <textarea
-        id={id}
-        readOnly
-        value={value}
-        rows={rows}
-        className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide`.trim()}
-        aria-label={ariaLabel ?? label}
-      />
+      <div role="status" aria-live="polite" aria-atomic="false">
+        <textarea
+          id={id}
+          readOnly
+          value={value}
+          rows={rows}
+          className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide`.trim()}
+          aria-label={ariaLabel ?? label}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/ui/OutputField.tsx
+++ b/src/components/ui/OutputField.tsx
@@ -44,7 +44,7 @@ export function OutputField({
   const monoClass = mono ? 'font-mono' : '';
   const resizeClass = resize ? 'resize-y' : 'resize-none';
   return (
-    <div className="w-full">
+    <div className="w-full" role="status" aria-live={hasValue ? 'polite' : 'off'}>
       <div className="flex items-center justify-between mb-3 min-h-8">
         <label htmlFor={id} className="body-emphasis text-default">
           {label}

--- a/src/components/ui/__tests__/OutputField.test.tsx
+++ b/src/components/ui/__tests__/OutputField.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { OutputField } from '@/components/ui/OutputField';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('OutputField a11y contract', () => {
+  it('role="status" のラッパーが textarea を内包する', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper).not.toBeNull();
+    const textareaInside = statusWrapper!.querySelector('textarea');
+    expect(textareaInside).not.toBeNull();
+  });
+
+  it('aria-live="polite" が value="" でも常時存在する（off↔polite regression 検知）', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper).not.toBeNull();
+    expect(statusWrapper!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('aria-live="polite" が value 非空でも変わらない', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="SGVsbG8=" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('aria-atomic="false" が明示されている（SR の atomic 読み上げ抑制）', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper!.getAttribute('aria-atomic')).toBe('false');
+  });
+
+  it('role="status" が label/CopyButton を含む外側 div に付いていない', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const outerDiv = container.firstElementChild;
+    expect(outerDiv?.getAttribute('role')).not.toBe('status');
+  });
+
+  it('value 変化が textarea に反映される', () => {
+    render(<OutputField id="out" label="変換結果" value="SGVsbG8=" />);
+    const textarea = screen.getByLabelText('変換結果') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('SGVsbG8=');
+  });
+
+  it('value が空のとき CopyButton を表示しない', () => {
+    render(<OutputField id="out" label="変換結果" value="" />);
+    expect(screen.queryByRole('button', { name: 'コピー' })).toBeNull();
+  });
+
+  it('value が非空のとき CopyButton を表示する', () => {
+    render(<OutputField id="out" label="変換結果" value="Hello" />);
+    expect(screen.getByRole('button', { name: 'コピー' })).toBeTruthy();
+  });
+});

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -48,31 +48,35 @@ test.describe('a11y live region (issue #163, production CSP 適用)', () => {
     });
   });
 
-  test('Base64: 変換結果が role="status" で包まれ aria-live が off→polite に切り替わる（CSP 違反なし）', async ({
+  test('Base64: 変換結果が role="status" で包まれ常時 aria-live="polite" で SR 通知可能（CSP 違反なし）', async ({
     browser,
   }) => {
     await withProductionCsp(browser, '/tools/base64', async (page) => {
-      // 入力前: OutputField の status 領域は aria-live="off"（初期描画の過剰通知を防ぐ）
+      // OutputField は常時 role="status" aria-live="polite" を持つ
       const statusEl = page.getByRole('status').first();
-      await expect(statusEl).toHaveAttribute('aria-live', 'off');
-
-      // 入力後: aria-live="polite" に切り替わりスクリーンリーダーが通知可能になる
-      await page.getByLabel('入力').fill('Hello');
+      await expect(statusEl).toBeVisible();
       await expect(statusEl).toHaveAttribute('aria-live', 'polite');
+
+      // 入力後: status 領域内の textarea に変換結果が反映される
+      await page.getByLabel('入力').fill('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
+      await expect(statusEl.locator('textarea')).toHaveValue('SGVsbG8=');
     });
   });
 
-  test('JSON→CSV: 変換結果が role="status" で包まれ aria-live が off→polite に切り替わる（CSP 違反なし）', async ({
+  test('JSON→CSV: 変換結果が role="status" で包まれ常時 aria-live="polite" で SR 通知可能（CSP 違反なし）', async ({
     browser,
   }) => {
     await withProductionCsp(browser, '/tools/json-csv', async (page) => {
-      // 入力前: OutputField の status 領域は aria-live="off"
+      // OutputField は常時 role="status" aria-live="polite" を持つ
       const statusEl = page.getByRole('status').first();
-      await expect(statusEl).toHaveAttribute('aria-live', 'off');
-
-      // JSON 入力後: aria-live="polite" に切り替わる
-      await page.getByLabel('入力').fill('[{"id":1,"name":"太郎"}]');
+      await expect(statusEl).toBeVisible();
       await expect(statusEl).toHaveAttribute('aria-live', 'polite');
+
+      // JSON 入力後: status 領域内の textarea に CSV 結果が反映される
+      await page.getByLabel('入力').fill('[{"id":1,"name":"太郎"}]');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/id,name/);
+      await expect(statusEl.locator('textarea')).toHaveValue(/id,name/);
     });
   });
 });

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -47,6 +47,34 @@ test.describe('a11y live region (issue #163, production CSP 適用)', () => {
       await expect(statusRegions.first()).toBeVisible();
     });
   });
+
+  test('Base64: 変換結果が role="status" で包まれ aria-live が off→polite に切り替わる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      // 入力前: OutputField の status 領域は aria-live="off"（初期描画の過剰通知を防ぐ）
+      const statusEl = page.getByRole('status').first();
+      await expect(statusEl).toHaveAttribute('aria-live', 'off');
+
+      // 入力後: aria-live="polite" に切り替わりスクリーンリーダーが通知可能になる
+      await page.getByLabel('入力').fill('Hello');
+      await expect(statusEl).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+
+  test('JSON→CSV: 変換結果が role="status" で包まれ aria-live が off→polite に切り替わる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      // 入力前: OutputField の status 領域は aria-live="off"
+      const statusEl = page.getByRole('status').first();
+      await expect(statusEl).toHaveAttribute('aria-live', 'off');
+
+      // JSON 入力後: aria-live="polite" に切り替わる
+      await page.getByLabel('入力').fill('[{"id":1,"name":"太郎"}]');
+      await expect(statusEl).toHaveAttribute('aria-live', 'polite');
+    });
+  });
 });
 
 test.describe('a11y aria-expanded (issue #163, production CSP 適用)', () => {


### PR DESCRIPTION
## 概要

issue #382 対応。`OutputField` の最外殻 `<div>` に `role="status"` と動的 `aria-live` を追加し、変換系ツールの出力変化をスクリーンリーダーが認知できるようにした。

- `value` 非空のとき `aria-live="polite"`、空のとき `aria-live="off"` に切り替え、初期描画の過剰通知を防止
- 呼出側 6 ファイルは無変更（`OutputField` 内で完結）

## 影響範囲

| ツール | slug |
|---|---|
| Base64Codec | `/tools/base64` |
| UrlEncoder | `/tools/url-encode` |
| JsonCsv | `/tools/json-csv` |
| JsonXml | `/tools/json-xml` |
| ConfigConverter | `/tools/config-converter` |
| EncodingConverter | `/tools/encoding-converter` |

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/components/ui/OutputField.tsx` | 最外殻 div に `role="status"` + `aria-live={hasValue?'polite':'off'}` |
| `tests/e2e/a11y-live-region.spec.ts` | Base64・JSON→CSV の live region E2E 2 ケース追加 |

## テスト結果

- `node_modules/.bin/astro check`: 0 errors
- `npm run test`: 1093 tests passed
- `npm run test:e2e`: 174 passed / 1 skipped（新規 E2E 2 本含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
