### PR TITLE
fix(char-count): X の複合絵文字を grapheme cluster 単位で weight 2 にカウント

### DIFF
--- a/src/utils/char-count/__tests__/char-count.test.ts
+++ b/src/utils/char-count/__tests__/char-count.test.ts
@@ -484,6 +484,22 @@ describe('twitterWeight', () => {
 
   // 改行
   it('改行 LF "a\\nb" → 3 (LF は U+0A、weight 1)', () => expect(twitterWeight('a\nb')).toBe(3));
+
+  // 複合絵文字: grapheme cluster 単位で weight 2 (emojiParsingEnabled=true 準拠)
+  it('皮膚トーン付き絵文字 "👋🏽" は weight 2 (U+1F44B + skin tone = 1 cluster)', () =>
+    expect(twitterWeight('👋🏽')).toBe(2));
+  it('VS16 付き絵文字 "❤️" は weight 2 (U+2764 + U+FE0F = 1 cluster)', () =>
+    expect(twitterWeight('❤️')).toBe(2));
+  it('家族 ZWJ 絵文字 "👨‍👩‍👧‍👦" は weight 2 (ZWJ sequence = 1 cluster)', () =>
+    expect(twitterWeight('👨‍👩‍👧‍👦')).toBe(2));
+  it('キーキャップ "1️⃣" は weight 2 (digit + VS16 + U+20E3 = 1 cluster)', () =>
+    expect(twitterWeight('1️⃣')).toBe(2));
+  it('国旗 "🇯🇵" は weight 2 (regional indicator pair = 1 cluster)', () =>
+    expect(twitterWeight('🇯🇵')).toBe(2));
+  it('© 単体 (VS16 なし, U+00A9) は weight 1 (weight-1 range, 挙動変化なし)', () =>
+    expect(twitterWeight('©')).toBe(1));
+  it('絵文字 + テキスト混在 "Hi 👋🏽" は weight 5 (H+i+space=3, 👋🏽=2)', () =>
+    expect(twitterWeight('Hi 👋🏽')).toBe(5));
 });
 
 describe('blueskyCount', () => {

--- a/src/utils/char-count/sns.ts
+++ b/src/utils/char-count/sns.ts
@@ -61,14 +61,20 @@ const SKIN_TONE_RE = /[\u{1F3FB}-\u{1F3FF}]/u;
  * - U+20E3 (COMBINING ENCLOSING KEYCAP): 1️⃣ など
  * - U+1F3FB–U+1F3FF (skin tone modifiers): 👋🏽 など
  * - 先頭が Regional Indicator (U+1F1E0–U+1F1FF): 🇯🇵 など
+ *
+ * 既知の対応外ケース:
+ * - subdivision flag tag sequence (🏴󠁧󠁢󠁥󠁮󠁧 等): U+E0020-E007F タグ chars を持つが検出しない。
+ *   構成 code point ごとに weight 2 となる（実害低のため別 issue 追跡推奨）。
+ * - VS15 text presentation (U+FE0E): 絵文字 cluster 判定外で fall-through し
+ *   code point 単位の weight に従う。X 公式値は未確認。
  */
 function isEmojiCluster(cluster: string): boolean {
   if ([...cluster].length === 1) return false;
   const cp0 = cluster.codePointAt(0) ?? 0;
   return (
-    cluster.includes('️') || // VS16: ❤️, ☺️ など
-    cluster.includes('‍') || // ZWJ: 👨‍👩‍👧‍👦 など
-    cluster.includes('⃣') || // COMBINING ENCLOSING KEYCAP: 1️⃣
+    cluster.includes('\u{FE0F}') || // VS16: ❤️, ☺️ など
+    cluster.includes('\u{200D}') || // ZWJ: 👨‍👩‍👧‍👦 など
+    cluster.includes('\u{20E3}') || // COMBINING ENCLOSING KEYCAP: 1️⃣
     SKIN_TONE_RE.test(cluster) ||
     (cp0 >= 0x1f1e0 && cp0 <= 0x1f1ff) // Regional Indicator pair: 🇯🇵
   );

--- a/src/utils/char-count/sns.ts
+++ b/src/utils/char-count/sns.ts
@@ -43,11 +43,48 @@ function isWeightOne(cp: number): boolean {
   );
 }
 
+// X (Twitter) v3 config: emojiParsingEnabled=true
+// 絵文字 grapheme cluster は構成コードポイント数に関わらず単一 weight-2 ユニットとして扱う
+const snsSegmenter = new Intl.Segmenter('ja', { granularity: 'grapheme' });
+const SKIN_TONE_RE = /[\u{1F3FB}-\u{1F3FF}]/u;
+
+/**
+ * grapheme cluster が絵文字シーケンスかどうか判定する。
+ *
+ * 単一コードポイントは weight ranges で処理するため false を返す:
+ * - BMP 記号 (© U+00A9) → weight-1 range で weight 1 のまま
+ * - SMP 絵文字 (😀 U+1F600) → weight 2 のまま（結果に変化なし）
+ *
+ * 複数コードポイントで以下を含む場合は絵文字クラスタ:
+ * - U+FE0F (VS16): ❤️, ☺️ など
+ * - U+200D (ZWJ): 家族絵文字 👨‍👩‍👧‍👦 など
+ * - U+20E3 (COMBINING ENCLOSING KEYCAP): 1️⃣ など
+ * - U+1F3FB–U+1F3FF (skin tone modifiers): 👋🏽 など
+ * - 先頭が Regional Indicator (U+1F1E0–U+1F1FF): 🇯🇵 など
+ */
+function isEmojiCluster(cluster: string): boolean {
+  if ([...cluster].length === 1) return false;
+  const cp0 = cluster.codePointAt(0) ?? 0;
+  return (
+    cluster.includes('️') || // VS16: ❤️, ☺️ など
+    cluster.includes('‍') || // ZWJ: 👨‍👩‍👧‍👦 など
+    cluster.includes('⃣') || // COMBINING ENCLOSING KEYCAP: 1️⃣
+    SKIN_TONE_RE.test(cluster) ||
+    (cp0 >= 0x1f1e0 && cp0 <= 0x1f1ff) // Regional Indicator pair: 🇯🇵
+  );
+}
+
 function weightSegment(segment: string): number {
   let w = 0;
-  for (const ch of segment) {
-    // for...of は string を code point 単位で iterate するため codePointAt(0) は必ず定義済み
-    w += isWeightOne(ch.codePointAt(0)!) ? 1 : 2;
+  for (const { segment: cluster } of snsSegmenter.segment(segment)) {
+    if (isEmojiCluster(cluster)) {
+      w += 2;
+    } else {
+      for (const ch of cluster) {
+        // for...of は string を code point 単位で iterate するため codePointAt(0) は必ず定義済み
+        w += isWeightOne(ch.codePointAt(0)!) ? 1 : 2;
+      }
+    }
   }
   return w;
 }


### PR DESCRIPTION
## 概要

X (Twitter) の文字数カウントで、複合絵文字が正しくカウントされていなかったバグを修正。

| 絵文字 | 種類 | 修正前 | 修正後 |
|--------|------|--------|--------|
| 👋🏽 | スキントーン修飾子 | 4 | **2** |
| ❤️ | VS16 付き | 4 | **2** |
| 👨‍👩‍👧‍👦 | ZWJ シーケンス | 11 | **2** |
| 1️⃣ | キーキャップ | 5 | **2** |
| 🇯🇵 | 国旗 (regional indicator) | 4 | **2** |

## 原因

`weightSegment` が `for...of`（コードポイント単位）でイテレートしていたため、視覚的に1文字の複合絵文字が構成コードポイントごとに weight 2 でカウントされていた。

## 修正

**X 公式仕様（twitter-text v3 config `emojiParsingEnabled: true`）:** 絵文字 grapheme cluster は単一 weight-2 ユニットとして扱う。

`Intl.Segmenter` で grapheme cluster に分割し、以下の複合シーケンスを `isEmojiCluster` で検出して weight 2 にカウント：
- `U+FE0F` (VS16) を含むクラスタ
- `U+200D` (ZWJ) を含むクラスタ
- `U+20E3` (keycap) を含むクラスタ
- スキントーン修飾子 (`U+1F3FB`–`U+1F3FF`) を含むクラスタ
- Regional Indicator ペア (`U+1F1E0`–`U+1F1FF` 始まり)

単一コードポイントのクラスタ（© 等）は従来の weight ranges で処理するため挙動変化なし。

## テスト計画

- [x] 新規テスト 7件追加（TDD: RED → GREEN 確認済み）
- [x] 既存テスト 166件 継続 pass（173/173）
- [x] `astro check` 型エラーなし
- [x] Prettier / TypeScript 事前フックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
