### PR TITLE
release: develop → main (fix: X 絵文字カウント / a11y aria-live)

### DIFF
--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -241,3 +241,61 @@ baseline 更新は「意図した変更」を承認する操作であり、**真
 - baseline 名を文字列復元する前に、Playwright が同 test-results dir に置いている関連ファイル (`-expected.png` / `-diff.png` / `error-context.md`) を確認する。物理コピー経路の方が format 依存が少なく堅牢
 - issue 起票時の調査が「未確認」で見送った経路でも、node_modules source / 実 CI log で実証可能なら採用候補に戻す
 - **Playwright メジャー upgrade 時の回帰確認**: `-expected.png` を生成する Playwright 内識別子は `legacyExpectedPath` (`node_modules/playwright/lib/matchers/toMatchSnapshot.js:67`) で `legacy` prefix 付き = 将来 deprecation の兆候。upgrade 時は `-expected` suffix 生成経路が残っているか必ず grep 確認する。生成器自体が消えたら `scripts/generate-vrt-slider.mjs` の `-expected.png` 直参照経路も影響を受ける
+
+---
+
+## 2026-05-11 — gh CLI の TLS verification が macOS で intermittent / method 依存で失敗する。curl にフォールバックする
+
+### 現象
+
+19 件の issue 一括ラベル付与・タイトル変更で `gh issue edit` および `gh api repos/.../issues/N --method PATCH` が **全件** 次のエラーで失敗:
+
+```
+tls: failed to verify certificate: x509: OSStatus -26276
+```
+
+OSStatus -26276 (`errSecHostNameMismatch` 付近の cert validation エラー) は macOS Security framework の証明書検証拒否。
+
+### 計測した再現条件
+
+| 操作                                       | 件数       | 結果                     |
+| ------------------------------------------ | ---------- | ------------------------ |
+| `gh issue create` (POST)                   | 19 件連続  | **全件 OK**              |
+| `gh api repos/.../labels --method POST`    | 8 件連続   | **全件 OK**              |
+| `gh api user` (GET)                        | 1 件       | OK                       |
+| `gh label list` (GraphQL GET)              | 1 件       | FAIL (TLS) — 再実行で OK |
+| `gh issue edit` (GraphQL PATCH)            | 19 件 bulk | **全件 FAIL**            |
+| `gh api repos/.../issues/N --method PATCH` | 19 件 bulk | **全件 FAIL**            |
+| 同上 standalone 1 回呼び                   | 1 件       | OK                       |
+| `curl -X PATCH` + `gh auth token`          | 19 件 bulk | **全件 OK**              |
+
+POST / GET は安定、PATCH (REST PATCH も GraphQL も) が著しく不安定。standalone では通る場合があるため flake 性もある。
+
+### 推測される原因
+
+- gh CLI が使う Go `net/http` クライアントが macOS の SecTrustEvaluate を経由する際、PATCH のような pre-flight CONNECT 後の追加 round-trip で certificate chain の検証に失敗するケースがある
+- POST/GET が連続成功する一方 PATCH だけ落ちる理由は未特定だが、`net/http` の `Transport` 内部 state（keep-alive / TLS session resumption）と SecTrust のキャッシュ整合性のずれが疑わしい
+
+### 回復手順 (今後 PATCH が固まったら即適用)
+
+```bash
+TOKEN=$(gh auth token)
+# title + labels の例 (jq で JSON body を組む)
+body=$(jq -n -c --arg t "[P1] foo" --argjson l '["P1","refactor"]' '{title:$t,labels:$l}')
+curl -s -X PATCH "https://api.github.com/repos/<owner>/<repo>/issues/<n>" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -d "$body" -o /dev/null -w "%{http_code}\n"
+```
+
+### 注意点
+
+- `gh auth token` の取り出しは `.claude/settings.json` で許可済み経路。token 自体を memory / log に書かない
+- curl 直接叩き経路は `permissions.ask` 相当になる可能性がある。`gh` で失敗を 1 度は確認してから curl にフォールバックする運用が無難
+- 単発呼び出しでは通ることが多いので、最初に PATCH 1 件で疎通確認 → 全件 bulk に進む手順がコスト的に最良
+
+### 関連
+
+- 本セッション (2026-05-11) のリファクタ監査 issue 化（#382–#400）でタイトル + ラベル一括変更時に発生
+- 個人 memory: `feedback_settings_allow_first.md` (gh コマンドは permissions.allow に乗せる) — 今回は curl fallback も同じ精神で `gh` 経路を優先しつつ failover を持つ運用が妥当

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2929,3 +2929,36 @@ trade-off:
 - 設計書: `docs/superpowers/specs/2026-05-10-char-count-sns-redesign-design.md`
 - 実装計画: `docs/superpowers/plans/2026-05-10-char-count-sns-redesign.md`
 - twitter-text v3 conformance 仕様 (`twitter-text-config.json`)
+
+---
+
+## [076] 2026-05-11 — OutputField の aria-live を常時 polite + textarea wrap に統一
+
+**日付 2026-05-11 | ステータス: 採用 | issue #382, PR #402**
+
+### 背景
+
+issue #382 で `OutputField` の a11y 欠落を改修。初期実装 (PR #402 初版) は issue 提案通り最外殻 `<div>` に `role="status"` + `aria-live={hasValue ? 'polite' : 'off'}` の動的切替を採用した。PR レビューで以下 2 件の中優先度指摘を受領:
+
+1. `role="status"` のスコープが label + CopyButton + textarea の全体に及び、status region として広すぎる
+2. `off → polite` の同一レンダー切替は SR が announce を取りこぼす known anti-pattern（Safari/VoiceOver、JAWS での事例あり）
+
+### 決断
+
+- `aria-live` は **常時 `"polite"`** で固定（動的切替を廃止）
+- `role="status"` は **textarea を wrap する内側 `<div>`** に限定（label/CopyButton を status region から除外）
+- `aria-atomic="false"` を明示し、一部 SR が `role="status"` を atomic として扱う実装に備える
+- 初期 mount 時の過剰通知は ARIA spec の「live region 初期 content は announce しない」挙動に依拠
+
+### 却下した選択肢
+
+- **条件 mount (JanCode パターン)**: `hasValue` が真のときのみ live region をマウントする案。textarea 要素の重複描画または条件 wrapper によるツリー再 mount でフォーカス喪失リスクがある
+- **視覚隠し SR ミラー**: `<div class="sr-only" role="status">` に value を text node として複製する案。Base64 等の長い出力を全文読み上げる UX 課題と、2 つの真実の源が生じるメンテナンスコスト
+
+### 結果・トレードオフ
+
+- ✅ `off→polite` の同一レンダー race condition を排除
+- ✅ `role="status"` のスコープが textarea のみで意味論的に明確
+- ✅ `aria-atomic="false"` 明示で SR 間の atomic 扱い差異を吸収
+- ⚠️ `readOnly textarea` の value 変更を live region 内でも通知しない SR（NVDA / VoiceOver の特定バージョン）が存在する—spec グレーゾーン。実機 SR 検証は issue #403 で追跡
+- ⚠️ 複数 OutputField を同一ツール内で使う場合の多重 `role="status"` は YAGNI で preemptive 対応なし。該当ケースが発生したら `ariaLabel` prop を status wrapper に転記して識別可能にする

--- a/src/components/ui/OutputField.tsx
+++ b/src/components/ui/OutputField.tsx
@@ -56,14 +56,16 @@ export function OutputField({
           </div>
         )}
       </div>
-      <textarea
-        id={id}
-        readOnly
-        value={value}
-        rows={rows}
-        className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide`.trim()}
-        aria-label={ariaLabel ?? label}
-      />
+      <div role="status" aria-live="polite" aria-atomic="false">
+        <textarea
+          id={id}
+          readOnly
+          value={value}
+          rows={rows}
+          className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide`.trim()}
+          aria-label={ariaLabel ?? label}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/ui/__tests__/OutputField.test.tsx
+++ b/src/components/ui/__tests__/OutputField.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { OutputField } from '@/components/ui/OutputField';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('OutputField a11y contract', () => {
+  it('role="status" のラッパーが textarea を内包する', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper).not.toBeNull();
+    const textareaInside = statusWrapper!.querySelector('textarea');
+    expect(textareaInside).not.toBeNull();
+  });
+
+  it('aria-live="polite" が value="" でも常時存在する（off↔polite regression 検知）', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper).not.toBeNull();
+    expect(statusWrapper!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('aria-live="polite" が value 非空でも変わらない', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="SGVsbG8=" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('aria-atomic="false" が明示されている（SR の atomic 読み上げ抑制）', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const statusWrapper = container.querySelector('[role="status"]');
+    expect(statusWrapper!.getAttribute('aria-atomic')).toBe('false');
+  });
+
+  it('role="status" が label/CopyButton を含む外側 div に付いていない', () => {
+    const { container } = render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const outerDiv = container.firstElementChild;
+    expect(outerDiv?.getAttribute('role')).not.toBe('status');
+  });
+
+  it('value 変化が textarea に反映される', () => {
+    render(<OutputField id="out" label="変換結果" value="SGVsbG8=" />);
+    const textarea = screen.getByLabelText('変換結果') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('SGVsbG8=');
+  });
+
+  it('value が空のとき CopyButton を表示しない', () => {
+    render(<OutputField id="out" label="変換結果" value="" />);
+    expect(screen.queryByRole('button', { name: 'コピー' })).toBeNull();
+  });
+
+  it('value が非空のとき CopyButton を表示する', () => {
+    render(<OutputField id="out" label="変換結果" value="Hello" />);
+    expect(screen.getByRole('button', { name: 'コピー' })).toBeTruthy();
+  });
+});

--- a/src/utils/char-count/__tests__/char-count.test.ts
+++ b/src/utils/char-count/__tests__/char-count.test.ts
@@ -484,6 +484,22 @@ describe('twitterWeight', () => {
 
   // 改行
   it('改行 LF "a\\nb" → 3 (LF は U+0A、weight 1)', () => expect(twitterWeight('a\nb')).toBe(3));
+
+  // 複合絵文字: grapheme cluster 単位で weight 2 (emojiParsingEnabled=true 準拠)
+  it('皮膚トーン付き絵文字 "👋🏽" は weight 2 (U+1F44B + skin tone = 1 cluster)', () =>
+    expect(twitterWeight('👋🏽')).toBe(2));
+  it('VS16 付き絵文字 "❤️" は weight 2 (U+2764 + U+FE0F = 1 cluster)', () =>
+    expect(twitterWeight('❤️')).toBe(2));
+  it('家族 ZWJ 絵文字 "👨‍👩‍👧‍👦" は weight 2 (ZWJ sequence = 1 cluster)', () =>
+    expect(twitterWeight('👨‍👩‍👧‍👦')).toBe(2));
+  it('キーキャップ "1️⃣" は weight 2 (digit + VS16 + U+20E3 = 1 cluster)', () =>
+    expect(twitterWeight('1️⃣')).toBe(2));
+  it('国旗 "🇯🇵" は weight 2 (regional indicator pair = 1 cluster)', () =>
+    expect(twitterWeight('🇯🇵')).toBe(2));
+  it('© 単体 (VS16 なし, U+00A9) は weight 1 (weight-1 range, 挙動変化なし)', () =>
+    expect(twitterWeight('©')).toBe(1));
+  it('絵文字 + テキスト混在 "Hi 👋🏽" は weight 5 (H+i+space=3, 👋🏽=2)', () =>
+    expect(twitterWeight('Hi 👋🏽')).toBe(5));
 });
 
 describe('blueskyCount', () => {

--- a/src/utils/char-count/sns.ts
+++ b/src/utils/char-count/sns.ts
@@ -43,11 +43,54 @@ function isWeightOne(cp: number): boolean {
   );
 }
 
+// X (Twitter) v3 config: emojiParsingEnabled=true
+// 絵文字 grapheme cluster は構成コードポイント数に関わらず単一 weight-2 ユニットとして扱う
+const snsSegmenter = new Intl.Segmenter('ja', { granularity: 'grapheme' });
+const SKIN_TONE_RE = /[\u{1F3FB}-\u{1F3FF}]/u;
+
+/**
+ * grapheme cluster が絵文字シーケンスかどうか判定する。
+ *
+ * 単一コードポイントは weight ranges で処理するため false を返す:
+ * - BMP 記号 (© U+00A9) → weight-1 range で weight 1 のまま
+ * - SMP 絵文字 (😀 U+1F600) → weight 2 のまま（結果に変化なし）
+ *
+ * 複数コードポイントで以下を含む場合は絵文字クラスタ:
+ * - U+FE0F (VS16): ❤️, ☺️ など
+ * - U+200D (ZWJ): 家族絵文字 👨‍👩‍👧‍👦 など
+ * - U+20E3 (COMBINING ENCLOSING KEYCAP): 1️⃣ など
+ * - U+1F3FB–U+1F3FF (skin tone modifiers): 👋🏽 など
+ * - 先頭が Regional Indicator (U+1F1E0–U+1F1FF): 🇯🇵 など
+ *
+ * 既知の対応外ケース:
+ * - subdivision flag tag sequence (🏴󠁧󠁢󠁥󠁮󠁧 等): U+E0020-E007F タグ chars を持つが検出しない。
+ *   構成 code point ごとに weight 2 となる（実害低のため別 issue 追跡推奨）。
+ * - VS15 text presentation (U+FE0E): 絵文字 cluster 判定外で fall-through し
+ *   code point 単位の weight に従う。X 公式値は未確認。
+ */
+function isEmojiCluster(cluster: string): boolean {
+  if ([...cluster].length === 1) return false;
+  const cp0 = cluster.codePointAt(0) ?? 0;
+  return (
+    cluster.includes('\u{FE0F}') || // VS16: ❤️, ☺️ など
+    cluster.includes('\u{200D}') || // ZWJ: 👨‍👩‍👧‍👦 など
+    cluster.includes('\u{20E3}') || // COMBINING ENCLOSING KEYCAP: 1️⃣
+    SKIN_TONE_RE.test(cluster) ||
+    (cp0 >= 0x1f1e0 && cp0 <= 0x1f1ff) // Regional Indicator pair: 🇯🇵
+  );
+}
+
 function weightSegment(segment: string): number {
   let w = 0;
-  for (const ch of segment) {
-    // for...of は string を code point 単位で iterate するため codePointAt(0) は必ず定義済み
-    w += isWeightOne(ch.codePointAt(0)!) ? 1 : 2;
+  for (const { segment: cluster } of snsSegmenter.segment(segment)) {
+    if (isEmojiCluster(cluster)) {
+      w += 2;
+    } else {
+      for (const ch of cluster) {
+        // for...of は string を code point 単位で iterate するため codePointAt(0) は必ず定義済み
+        w += isWeightOne(ch.codePointAt(0)!) ? 1 : 2;
+      }
+    }
   }
   return w;
 }

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -47,6 +47,38 @@ test.describe('a11y live region (issue #163, production CSP 適用)', () => {
       await expect(statusRegions.first()).toBeVisible();
     });
   });
+
+  test('Base64: 変換結果が role="status" で包まれ常時 aria-live="polite" で SR 通知可能（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      // OutputField は常時 role="status" aria-live="polite" を持つ
+      const statusEl = page.getByRole('status').first();
+      await expect(statusEl).toBeVisible();
+      await expect(statusEl).toHaveAttribute('aria-live', 'polite');
+
+      // 入力後: status 領域内の textarea に変換結果が反映される
+      await page.getByLabel('入力').fill('Hello');
+      await expect(page.getByLabel('変換結果')).toHaveValue('SGVsbG8=');
+      await expect(statusEl.locator('textarea')).toHaveValue('SGVsbG8=');
+    });
+  });
+
+  test('JSON→CSV: 変換結果が role="status" で包まれ常時 aria-live="polite" で SR 通知可能（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/json-csv', async (page) => {
+      // OutputField は常時 role="status" aria-live="polite" を持つ
+      const statusEl = page.getByRole('status').first();
+      await expect(statusEl).toBeVisible();
+      await expect(statusEl).toHaveAttribute('aria-live', 'polite');
+
+      // JSON 入力後: status 領域内の textarea に CSV 結果が反映される
+      await page.getByLabel('入力').fill('[{"id":1,"name":"太郎"}]');
+      await expect(page.getByLabel('変換結果')).toHaveValue(/id,name/);
+      await expect(statusEl.locator('textarea')).toHaveValue(/id,name/);
+    });
+  });
 });
 
 test.describe('a11y aria-expanded (issue #163, production CSP 適用)', () => {


### PR DESCRIPTION
## リリース内容

`develop` → `main` マージ。以下 3件を本番反映。

### 変更一覧

| PR | 種別 | 内容 |
|----|------|------|
| #404 | fix | X (Twitter) 文字数カウント: 複合絵文字 (👋🏽 / ❤️ / 👨‍👩‍👧‍👦 / 1️⃣ / 🇯🇵) を grapheme cluster 単位で weight 2 に修正 |
| #402 | fix | a11y: OutputField に `aria-live` を追加しスクリーンリーダー通知を実現 |
| #401 | docs | agent-lessons: gh CLI TLS verification が PATCH で intermittent に失敗するケースを記録 |

### 確認済み事項

- [x] 全 PR で CI (test / e2e / VRT) 通過済み
- [x] develop ブランチは最新の main を取り込み済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
