### PR TITLE
feat: JANコードのサンプルをクリックする度にランダム生成

### DIFF
--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -4,7 +4,7 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { InputField } from '@/components/ui/InputField';
 import { DownloadButtonGroup } from '@/components/ui/DownloadButtonGroup';
-import { calcJan, validateJanInput, type JanMode } from '@/utils/jan-code';
+import { calcJan, generateJanSample, validateJanInput, type JanMode } from '@/utils/jan-code';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { downloadSvg as downloadSvgFile, downloadPngFromSvgElement } from '@/utils/download';
 
@@ -59,16 +59,6 @@ export function JanCodeTool() {
     downloadPngFromSvgElement(svgRef.current, `jan-${result!.fullCode}.png`);
   };
 
-  const generateSample = (m: JanMode): string => {
-    const restLength = m === 'jan13' ? 10 : 5;
-    return (
-      '49' +
-      Math.floor(Math.random() * 10 ** restLength)
-        .toString()
-        .padStart(restLength, '0')
-    );
-  };
-
   return (
     <div className="space-y-6">
       {/* モード切替 */}
@@ -93,7 +83,7 @@ export function JanCodeTool() {
         maxLength={mode === 'jan13' ? 12 : 7}
         error={error || undefined}
         hint={`${input.length} / ${mode === 'jan13' ? 12 : 7} 桁`}
-        onSampleClick={() => handleInput(generateSample(mode))}
+        onSampleClick={() => handleInput(generateJanSample(mode))}
         mono
       />
 

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -59,9 +59,13 @@ export function JanCodeTool() {
     downloadPngFromSvgElement(svgRef.current, `jan-${result!.fullCode}.png`);
   };
 
-  const SAMPLE: Record<JanMode, string> = {
-    jan13: '490123456789',
-    jan8: '4901234',
+  const generateSample = (m: JanMode): string => {
+    const restLength = m === 'jan13' ? 10 : 5;
+    let rest = '';
+    for (let i = 0; i < restLength; i++) {
+      rest += Math.floor(Math.random() * 10).toString();
+    }
+    return '49' + rest;
   };
 
   return (
@@ -88,7 +92,7 @@ export function JanCodeTool() {
         maxLength={mode === 'jan13' ? 12 : 7}
         error={error || undefined}
         hint={`${input.length} / ${mode === 'jan13' ? 12 : 7} 桁`}
-        onSampleClick={() => handleInput(SAMPLE[mode])}
+        onSampleClick={() => handleInput(generateSample(mode))}
         mono
       />
 

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -61,11 +61,12 @@ export function JanCodeTool() {
 
   const generateSample = (m: JanMode): string => {
     const restLength = m === 'jan13' ? 10 : 5;
-    let rest = '';
-    for (let i = 0; i < restLength; i++) {
-      rest += Math.floor(Math.random() * 10).toString();
-    }
-    return '49' + rest;
+    return (
+      '49' +
+      Math.floor(Math.random() * 10 ** restLength)
+        .toString()
+        .padStart(restLength, '0')
+    );
   };
 
   return (

--- a/src/utils/__tests__/jan-code.test.ts
+++ b/src/utils/__tests__/jan-code.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calcJan, validateJanInput } from '@/utils/jan-code';
+import { calcJan, generateJanSample, validateJanInput } from '@/utils/jan-code';
 
 // ────────────────────────────────────────────
 // calcJan — JAN-13
@@ -99,5 +99,36 @@ describe('validateJanInput', () => {
   it('桁数超過はエラー', () => {
     expect(validateJanInput('4901234567890', 'jan13')).toContain('現在13桁');
     expect(validateJanInput('49012345', 'jan8')).toContain('現在8桁');
+  });
+});
+
+// ────────────────────────────────────────────
+// generateJanSample — サンプル入力値生成
+// ────────────────────────────────────────────
+describe('generateJanSample', () => {
+  it('JAN-13: 12桁の数字列を "49" 始まりで返す（先頭 0 落ち無し）', () => {
+    for (let i = 0; i < 100; i++) {
+      const s = generateJanSample('jan13');
+      expect(s).toMatch(/^49\d{10}$/);
+    }
+  });
+
+  it('JAN-8: 7桁の数字列を "49" 始まりで返す（先頭 0 落ち無し）', () => {
+    for (let i = 0; i < 100; i++) {
+      const s = generateJanSample('jan8');
+      expect(s).toMatch(/^49\d{5}$/);
+    }
+  });
+
+  it('複数回呼ぶと異なる値が出る（毎回ランダム化されている）', () => {
+    // 10^10 通りから 30 個取って衝突する確率は無視できるレベル
+    const samples = new Set<string>();
+    for (let i = 0; i < 30; i++) samples.add(generateJanSample('jan13'));
+    expect(samples.size).toBeGreaterThanOrEqual(28);
+  });
+
+  it('生成したサンプルは validateJanInput で正常入力と判定される', () => {
+    expect(validateJanInput(generateJanSample('jan13'), 'jan13')).toBe('');
+    expect(validateJanInput(generateJanSample('jan8'), 'jan8')).toBe('');
   });
 });

--- a/src/utils/jan-code.ts
+++ b/src/utils/jan-code.ts
@@ -54,6 +54,21 @@ export function calcJan(input: string, mode: JanMode): JanResult {
   };
 }
 
+/**
+ * サンプル入力値を生成する。先頭2桁は日本国コード「49」固定、残り桁はランダム。
+ * JAN-13: 12桁（"49" + 10桁ランダム）、JAN-8: 7桁（"49" + 5桁ランダム）。
+ * Math.floor 後の数値文字列は padStart で 0 埋めし、先頭 0 が落ちないようにする。
+ */
+export function generateJanSample(mode: JanMode): string {
+  const restLength = mode === 'jan13' ? 10 : 5;
+  return (
+    '49' +
+    Math.floor(Math.random() * 10 ** restLength)
+      .toString()
+      .padStart(restLength, '0')
+  );
+}
+
 /** 入力バリデーション。エラーメッセージを返す（正常時は空文字） */
 export function validateJanInput(input: string, mode: JanMode): string {
   if (!input) return '';


### PR DESCRIPTION
## 概要

JANコード生成ツールのサンプルボタンが固定値だったのを、クリックする度にランダムな入力値を生成するように変更。

## 変更点

- `src/components/tools/JanCode.tsx`: `SAMPLE` Record を `generateSample(mode)` 関数に置き換え
- 先頭「49」（日本国コード）は固定し、残り桁を `Math.random()` で生成
  - JAN-13: `49` + ランダム10桁 = 12桁入力
  - JAN-8: `49` + ランダム5桁 = 7桁入力
- サンプルボタンを押す度に別パターンが入る

## 動作確認

- `node_modules/.bin/astro check`: 0 errors
- `npm run test`: 1147 passed
- `npm run test:e2e -- tests/e2e/jan-code.spec.ts`: 6 passed
  - E2E は桁数のみ assert しており固定値非依存のためサンプル変更の影響なし

## スコープ外（先送りなし）

- placeholder 文字列（`490123456789（12桁）` 等）は固定のまま。入力例として常時表示する性質上、毎回変えると混乱を招くため意図的に据え置き。
