### PR TITLE
feat: TOTP/HOTP 検証モードに Cmd/Ctrl+Enter ショートカットを追加

### DIFF
--- a/src/components/tools/TotpHotpGenerator.tsx
+++ b/src/components/tools/TotpHotpGenerator.tsx
@@ -388,12 +388,21 @@ export function TotpHotpGeneratorTool() {
                 placeholder={'0'.repeat(digits)}
                 inputMode="numeric"
                 mono
+                onKeyDown={(e) => {
+                  if (e.nativeEvent.isComposing) return;
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    if (!verificationInput.trim() || verifying || !secretBytes) return;
+                    e.preventDefault();
+                    handleVerify();
+                  }
+                }}
               />
               <ActionButton
                 onClick={handleVerify}
                 variant="primary"
                 loading={verifying}
                 disabled={!verificationInput.trim()}
+                aria-keyshortcuts="Meta+Enter Control+Enter"
               >
                 {verifying ? '検証中…' : '検証する'}
               </ActionButton>

--- a/src/components/tools/TotpHotpGenerator.tsx
+++ b/src/components/tools/TotpHotpGenerator.tsx
@@ -391,21 +391,28 @@ export function TotpHotpGeneratorTool() {
                 onKeyDown={(e) => {
                   if (e.nativeEvent.isComposing) return;
                   if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                    if (!verificationInput.trim() || verifying || !secretBytes) return;
+                    // 将来 <form> 化したとき空入力 Cmd+Enter が submit に流れる silent regression を
+                    // 防ぐため guard より前に preventDefault する。
                     e.preventDefault();
+                    if (!verificationInput.trim() || verifying || !secretBytes) return;
                     handleVerify();
                   }
                 }}
               />
-              <ActionButton
-                onClick={handleVerify}
-                variant="primary"
-                loading={verifying}
-                disabled={!verificationInput.trim()}
-                aria-keyshortcuts="Meta+Enter Control+Enter"
-              >
-                {verifying ? '検証中…' : '検証する'}
-              </ActionButton>
+              <div className="flex items-center gap-3">
+                <ActionButton
+                  onClick={handleVerify}
+                  variant="primary"
+                  loading={verifying}
+                  disabled={!verificationInput.trim()}
+                  aria-keyshortcuts="Meta+Enter Control+Enter"
+                >
+                  {verifying ? '検証中…' : '検証する'}
+                </ActionButton>
+                <kbd className="caption text-muted font-mono" aria-hidden="true">
+                  Cmd/Ctrl+Enter
+                </kbd>
+              </div>
               {verificationResult !== null && (
                 <div aria-live="assertive">
                   {verificationResult.valid ? (

--- a/tests/e2e/totp-hotp.spec.ts
+++ b/tests/e2e/totp-hotp.spec.ts
@@ -112,6 +112,46 @@ test.describe('TOTP/HOTP ジェネレータ（production CSP 適用）', () => {
     });
   });
 
+  test('検証モードで Cmd/Ctrl+Enter で検証が発火する（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/totp-hotp', async (page) => {
+      // TOTP モードで現在のコードを取得
+      await page.getByLabel('Base32 シークレット').fill(RFC_SECRET_BASE32);
+      const codeSpan = page.getByRole('status').locator('span[aria-label*="現在のコード"]');
+      await expect(codeSpan).not.toHaveText(/^[─\s]+$/, { timeout: 5000 });
+      const labelText = await codeSpan.getAttribute('aria-label');
+      const currentCode = labelText?.split(': ')[1] ?? '';
+
+      // 検証モードへ切替 → input にコード入力 → Enter ボタンを押さずキーボードショートカットで発火
+      await page.getByRole('button', { name: '検証' }).click();
+      const verifyInput = page.getByLabel('検証するコードを入力');
+      await verifyInput.fill(currentCode);
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+      await verifyInput.press(`${modifier}+Enter`);
+
+      const verifyResult = page.locator('[aria-live="assertive"]');
+      await expect(verifyResult).toContainText(/有効|無効/, { timeout: 5000 });
+    });
+  });
+
+  test('検証モードで input が空の状態の Cmd/Ctrl+Enter は検証を発火しない（陽性対照・CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/totp-hotp', async (page) => {
+      await page.getByLabel('Base32 シークレット').fill(RFC_SECRET_BASE32);
+      await page.getByRole('button', { name: '検証' }).click();
+
+      // 空のまま Cmd/Ctrl+Enter を押下
+      const verifyInput = page.getByLabel('検証するコードを入力');
+      await verifyInput.focus();
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+      await verifyInput.press(`${modifier}+Enter`);
+
+      // 結果が表示されないこと（disabled guard が効いている）
+      const verifyResult = page.locator('[aria-live="assertive"]');
+      await expect(verifyResult).toHaveCount(0);
+    });
+  });
+
   test('otpauth URI が生成されコピーできる（CSP 違反なし）', async ({ browser }) => {
     await withProductionCsp(browser, '/tools/totp-hotp', async (page) => {
       // URI 出力欄に otpauth:// の文字列が含まれる

--- a/tests/e2e/totp-hotp.spec.ts
+++ b/tests/e2e/totp-hotp.spec.ts
@@ -146,7 +146,10 @@ test.describe('TOTP/HOTP ジェネレータ（production CSP 適用）', () => {
       const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
       await verifyInput.press(`${modifier}+Enter`);
 
-      // 結果が表示されないこと（disabled guard が効いている）
+      // 結果が表示されないこと（disabled guard が効いている）。
+      // `toHaveCount(0)` は要素「存在しない」を即時評価するため、guard を外した場合の
+      // `setVerificationResult` async 反映を確実に観測できるよう待機してから assert する。
+      await page.waitForTimeout(300);
       const verifyResult = page.locator('[aria-live="assertive"]');
       await expect(verifyResult).toHaveCount(0);
     });


### PR DESCRIPTION
## 概要

TOTP/HOTP ジェネレータの検証モードで、検証コード入力中に **Cmd/Ctrl + Enter** で「検証する」ボタンを発火できるようにします。

設定ファイル相互変換 (`ConfigConverter.tsx:233-240`) と同じパターンで実装。

## 変更

- `verify-code-input` の `InputField` に `onKeyDown` を追加
  - `e.nativeEvent.isComposing` 中は IME 確定 Enter を誤検知しないため skip
  - `disabled` と同条件 guard（input 空 / verifying 中 / secret 無効）
- 「検証する」`ActionButton` に `aria-keyshortcuts="Meta+Enter Control+Enter"` を付与
- E2E 2 件追加:
  - 陰性対照: 入力済 + Cmd+Enter → 検証結果が表示される
  - 陽性対照: 空入力 + Cmd+Enter → 結果が表示されない（disabled guard 検証）

## テスト

- [x] `node_modules/.bin/astro check` — 0 errors
- [x] `npm run test:e2e --grep TOTP` — 12 passed (元 10 + 新 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
