### PR TITLE
fix(a11y): ToggleGroup に hover / focus-visible フィードバックを追加 (#385)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -369,6 +369,16 @@
     color: var(--color-text);
     box-shadow: var(--elevation-2);
   }
+  /* hover / :focus-visible: 未選択ボタンへの a11y / UX フィードバック (issue #385)。
+     コンテナ自体が --color-bg-subtle で塗られているため、hover に同色は使えず
+     --color-bg-active (blue-50) を採用 (btn-action--secondary:hover と統一)。
+     focus-visible の outline は global :where(button, ...):focus-visible で適用済み。
+     §7.1 の variant 非対応制約により :hover / :focus-visible 擬似クラスを直接定義する。 */
+  .btn-toggle:hover:not([aria-pressed='true']):not(:disabled),
+  .btn-toggle:focus-visible:not([aria-pressed='true']):not(:disabled) {
+    background: var(--color-bg-active);
+    color: var(--color-text);
+  }
 
   /* === PR 1.5: Surface bg (used by table thead row & InputField readOnly) === */
   .bg-surface {

--- a/tests/e2e/toggle-group.spec.ts
+++ b/tests/e2e/toggle-group.spec.ts
@@ -4,6 +4,8 @@ import { withProductionCsp } from './helpers';
 const BG_ACTIVE = 'rgb(239, 246, 255)'; // --color-bg-active (blue-50)
 const BG_TRANSPARENT = 'rgba(0, 0, 0, 0)';
 const BG_PRESSED = 'rgb(255, 255, 255)'; // --color-bg (white)
+const COLOR_TEXT = 'rgb(17, 24, 39)'; // --color-text (neutral-900)
+const COLOR_MUTED = 'rgb(107, 114, 128)'; // --color-muted (neutral-500)
 
 test.describe('ToggleGroup hover / focus-visible フィードバック（issue #385）', () => {
   test('未選択ボタンを hover すると背景が --color-bg-active になる（CSP 違反なし）', async ({
@@ -14,9 +16,11 @@ test.describe('ToggleGroup hover / focus-visible フィードバック（issue #
       await expect(decodeBtn).toBeVisible();
       await expect(decodeBtn).toHaveAttribute('aria-pressed', 'false');
       await expect(decodeBtn).toHaveCSS('background-color', BG_TRANSPARENT);
+      await expect(decodeBtn).toHaveCSS('color', COLOR_MUTED);
 
       await decodeBtn.hover();
       await expect(decodeBtn).toHaveCSS('background-color', BG_ACTIVE);
+      await expect(decodeBtn).toHaveCSS('color', COLOR_TEXT);
     });
   });
 
@@ -28,9 +32,11 @@ test.describe('ToggleGroup hover / focus-visible フィードバック（issue #
       await expect(encodeBtn).toBeVisible();
       await expect(encodeBtn).toHaveAttribute('aria-pressed', 'true');
       await expect(encodeBtn).toHaveCSS('background-color', BG_PRESSED);
+      await expect(encodeBtn).toHaveCSS('color', COLOR_TEXT);
 
       await encodeBtn.hover();
       await expect(encodeBtn).toHaveCSS('background-color', BG_PRESSED);
+      await expect(encodeBtn).toHaveCSS('color', COLOR_TEXT);
     });
   });
 
@@ -47,8 +53,9 @@ test.describe('ToggleGroup hover / focus-visible フィードバック（issue #
       await page.keyboard.press('Tab');
       await expect(decodeBtn).toBeFocused();
 
-      // 背景が hover と同じ blue-50 になる
+      // 背景・文字色が hover と同じ blue-50 / --color-text になる
       await expect(decodeBtn).toHaveCSS('background-color', BG_ACTIVE);
+      await expect(decodeBtn).toHaveCSS('color', COLOR_TEXT);
       // global :where(button, ...):focus-visible で適用される outline ring
       await expect(decodeBtn).toHaveCSS('outline-color', 'rgb(37, 99, 235)');
       await expect(decodeBtn).toHaveCSS('outline-style', 'solid');

--- a/tests/e2e/toggle-group.spec.ts
+++ b/tests/e2e/toggle-group.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { withProductionCsp } from './helpers';
+
+const BG_ACTIVE = 'rgb(239, 246, 255)'; // --color-bg-active (blue-50)
+const BG_TRANSPARENT = 'rgba(0, 0, 0, 0)';
+const BG_PRESSED = 'rgb(255, 255, 255)'; // --color-bg (white)
+
+test.describe('ToggleGroup hover / focus-visible フィードバック（issue #385）', () => {
+  test('未選択ボタンを hover すると背景が --color-bg-active になる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      const decodeBtn = page.getByRole('button', { name: 'デコード' });
+      await expect(decodeBtn).toBeVisible();
+      await expect(decodeBtn).toHaveAttribute('aria-pressed', 'false');
+      await expect(decodeBtn).toHaveCSS('background-color', BG_TRANSPARENT);
+
+      await decodeBtn.hover();
+      await expect(decodeBtn).toHaveCSS('background-color', BG_ACTIVE);
+    });
+  });
+
+  test('選択中ボタン（aria-pressed=true）は hover しても背景が変わらない（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      const encodeBtn = page.getByRole('button', { name: 'エンコード' });
+      await expect(encodeBtn).toBeVisible();
+      await expect(encodeBtn).toHaveAttribute('aria-pressed', 'true');
+      await expect(encodeBtn).toHaveCSS('background-color', BG_PRESSED);
+
+      await encodeBtn.hover();
+      await expect(encodeBtn).toHaveCSS('background-color', BG_PRESSED);
+    });
+  });
+
+  test('未選択ボタンを Tab focus すると背景が --color-bg-active になり outline ring が出る（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/base64', async (page) => {
+      const encodeBtn = page.getByRole('button', { name: 'エンコード' });
+      const decodeBtn = page.getByRole('button', { name: 'デコード' });
+      await expect(encodeBtn).toBeVisible();
+
+      // エンコード（pressed）に focus → Tab で隣の未選択ボタン（デコード）へ移動
+      await encodeBtn.focus();
+      await page.keyboard.press('Tab');
+      await expect(decodeBtn).toBeFocused();
+
+      // 背景が hover と同じ blue-50 になる
+      await expect(decodeBtn).toHaveCSS('background-color', BG_ACTIVE);
+      // global :where(button, ...):focus-visible で適用される outline ring
+      await expect(decodeBtn).toHaveCSS('outline-color', 'rgb(37, 99, 235)');
+      await expect(decodeBtn).toHaveCSS('outline-style', 'solid');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

`.btn-toggle` は `[aria-pressed='true']` の選択状態スタイルしか持たず、未選択ボタンに対する hover / focus 視覚フィードバックが無いため、マウスでもキーボードでも操作可能性が伝わらず、`btn-clear` / `btn-action--*` との一貫性を欠いていた。`ToggleGroup` は 10+ ツールで多用される共通コンポーネントのため影響範囲が大きい。

closes #385

## 変更内容

`src/styles/global.css` の `@layer components` 内、既存 `.btn-toggle` 定義の直後に未選択ボタン向け hover / focus-visible ルールを追加:

```css
.btn-toggle:hover:not([aria-pressed='true']):not(:disabled),
.btn-toggle:focus-visible:not([aria-pressed='true']):not(:disabled) {
  background: var(--color-bg-active);
  color: var(--color-text);
}
```

### issue 提案からの調整点

1. **背景色を `--color-bg-subtle` → `--color-bg-active` (blue-50) に変更**: `ToggleGroup` コンテナ自体が `bg-subtle` のため、未選択ボタン hover に同色を指定すると視覚的に何も変化しない。`btn-action--secondary:hover` と同じ `--color-bg-active` に統一。
2. **`outline` / `outline-offset` を別途書かない**: `global.css` の `:where(button, ...):focus-visible` が全 button に既に `outline: var(--focus-ring)` を適用済み。重複定義は specificity 衝突リスクを生む。issue 提案の `var(--color-focus-ring)` という変数は未定義（実在するのは `--color-focus` と `--focus-ring` 短縮形）。
3. **`:not(:disabled)` を併記**: `btn-action--*` の hover ルールと整合。
4. **Tailwind v4 variant 非対応制約 (§7.1)**: `hover:bg-...` ではなく `:hover` 擬似クラスを直接定義。build 後の `dist/_astro/BaseLayout.*.css` に CSS rule が生成されていることを確認済み。

## テスト

`tests/e2e/toggle-group.spec.ts` を新規追加（`download-button.spec.ts` の hover フィードバック検証パターンを踏襲）:

- 未選択ボタンを hover すると `background-color` が `--color-bg-active` (rgb(239, 246, 255)) になる
- 選択中ボタン (aria-pressed=true) は hover しても背景が変わらない（white のまま）
- Tab focus で未選択ボタンに移動すると背景が `--color-bg-active`、`outline-color: rgb(37, 99, 235)`, `outline-style: solid` が適用される

## 検証

- [x] `npm run format:check`
- [x] `node_modules/.bin/astro check` (0 errors)
- [x] `npm run test` (1240 passed)
- [x] `npm run test:e2e` (195 passed) — 新規 3 ケース含む
- [x] `npm run build` 後 `dist/_astro/BaseLayout.*.css` に hover / focus-visible 両ルールの CSS 出力を確認

## スコープ外

- ToggleGroup 以外の hover 不足コンポーネント調査
- VRT baseline 再生成 — hover/focus-visible は idle screenshot に影響しないため不要。万一 diff が出ればユーザ目視確認を依頼（§6.8 によりエージェントから baseline 更新は推奨しない）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Se4L8M6PB9hXKkakhnfmnK)_