### PR TITLE
fix: P1 タグの Effort S issue 4 件を修正 (#391 / #389 / #388 / #387)

### DIFF
--- a/src/components/tools/DummyText.tsx
+++ b/src/components/tools/DummyText.tsx
@@ -166,6 +166,9 @@ export function DummyTextTool() {
       {/* 結果 */}
       {result && (
         <div className="rounded-lg border border-default overflow-hidden">
+          <span role="status" aria-live="polite" className="sr-only">
+            {`${result.length}文字のダミーテキストを生成しました`}
+          </span>
           <div className="flex items-center justify-between gap-2 px-4 py-3 bg-subtle border-b border-default">
             <span className="body-emphasis text-default">{result.length} 文字</span>
             <div className="flex items-center gap-2">

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -162,7 +162,7 @@ export function EncodingConverterTool() {
     }
   }
 
-  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     e.target.value = '';
     if (!file) return;
@@ -177,13 +177,16 @@ export function EncodingConverterTool() {
       return;
     }
 
-    file.arrayBuffer().then((buf) => {
+    try {
+      const buf = await file.arrayBuffer();
       setFileBytes(new Uint8Array(buf));
       setFileName(file.name);
       setError('');
       setOutputBytes(null);
       setOutputPreview('');
-    });
+    } catch (e) {
+      setError(getErrorMessage(e, 'ファイルの読み込みに失敗しました'));
+    }
   }
 
   function handleClear() {

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -2,35 +2,11 @@ import { useState, useMemo, useEffect } from 'react';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { InputField } from '@/components/ui/InputField';
-import {
-  parseJwt,
-  formatTimestamp,
-  formatRemaining,
-  base64UrlToBytes,
-  type ExpStatus,
-} from '@/utils/jwt';
+import { parseJwt, formatTimestamp, formatRemaining, type ExpStatus } from '@/utils/jwt';
 import { bytesToBase64Url } from '@/utils/base64url';
-import { pemBlockToBytes } from '@/utils/base64';
+import { verifySignature, type SigStatus } from '@/utils/jwt-verify';
 
 const SAMPLE_SECRET = 'your-256-bit-secret';
-
-type AlgParams =
-  | { name: 'HMAC'; hash: string }
-  | { name: 'RSASSA-PKCS1-v1_5'; hash: string }
-  | { name: 'ECDSA'; hash: string; namedCurve: string };
-
-/** アルゴリズム → WebCrypto パラメーターのマッピング（テスト用にエクスポート） */
-export const ALG_MAP: Record<string, AlgParams> = {
-  HS256: { name: 'HMAC', hash: 'SHA-256' },
-  HS384: { name: 'HMAC', hash: 'SHA-384' },
-  HS512: { name: 'HMAC', hash: 'SHA-512' },
-  RS256: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-  RS384: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' },
-  RS512: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-512' },
-  ES256: { name: 'ECDSA', hash: 'SHA-256', namedCurve: 'P-256' },
-  ES384: { name: 'ECDSA', hash: 'SHA-384', namedCurve: 'P-384' },
-  ES512: { name: 'ECDSA', hash: 'SHA-512', namedCurve: 'P-521' },
-};
 
 async function generateSampleJwt(secret: string): Promise<string> {
   const headerB64 = bytesToBase64Url(
@@ -58,75 +34,6 @@ async function generateSampleJwt(secret: string): Promise<string> {
   const sigBuffer = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(signingInput));
   const sigB64 = bytesToBase64Url(new Uint8Array(sigBuffer));
   return `${signingInput}.${sigB64}`;
-}
-
-export type SigStatus = 'unchecked' | 'verifying' | 'valid' | 'invalid' | 'unsupported' | 'error';
-
-export async function verifySignature(
-  rawHeader: string,
-  rawPayload: string,
-  signature: string,
-  header: Record<string, unknown>,
-  secretOrKey: string
-): Promise<SigStatus> {
-  const alg = typeof header.alg === 'string' ? header.alg : '';
-  const algParams = ALG_MAP[alg];
-  if (!algParams) return 'unsupported';
-
-  const signingInput = new TextEncoder().encode(`${rawHeader}.${rawPayload}`);
-  const sigBytes = base64UrlToBytes(signature);
-
-  try {
-    if (algParams.name === 'HMAC') {
-      const key = await crypto.subtle.importKey(
-        'raw',
-        new TextEncoder().encode(secretOrKey),
-        { name: 'HMAC', hash: algParams.hash },
-        false,
-        ['verify']
-      );
-      return (await crypto.subtle.verify('HMAC', key, sigBytes, signingInput))
-        ? 'valid'
-        : 'invalid';
-    }
-
-    // RS* / ES* は公開鍵 PEM を使用
-    const keyBytes = pemBlockToBytes(secretOrKey, 'PUBLIC KEY');
-    if (algParams.name === 'RSASSA-PKCS1-v1_5') {
-      const key = await crypto.subtle.importKey(
-        'spki',
-        keyBytes.buffer,
-        { name: 'RSASSA-PKCS1-v1_5', hash: algParams.hash },
-        false,
-        ['verify']
-      );
-      return (await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, sigBytes, signingInput))
-        ? 'valid'
-        : 'invalid';
-    }
-
-    // ECDSA
-    if (algParams.name === 'ECDSA') {
-      const key = await crypto.subtle.importKey(
-        'spki',
-        keyBytes.buffer,
-        { name: 'ECDSA', namedCurve: algParams.namedCurve },
-        false,
-        ['verify']
-      );
-      return (await crypto.subtle.verify(
-        { name: 'ECDSA', hash: algParams.hash },
-        key,
-        sigBytes,
-        signingInput
-      ))
-        ? 'valid'
-        : 'invalid';
-    }
-    return 'error';
-  } catch {
-    return 'error';
-  }
 }
 
 const TIMESTAMP_KEYS = ['iat', 'exp', 'nbf'];

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -218,13 +218,19 @@ export function JwtDecoderTool() {
       return;
     }
     setSigStatus('verifying');
+    let cancelled = false;
     verifySignature(
       parsed.rawHeader,
       parsed.rawPayload,
       parsed.signature,
       parsed.header,
       secretKey.trim()
-    ).then(setSigStatus);
+    ).then((result) => {
+      if (!cancelled) setSigStatus(result);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [parsed, secretKey]);
 
   const expBadge: Record<ExpStatus, { label: string; badgeClass: string }> = {

--- a/src/components/tools/__tests__/EncodingConverter.test.tsx
+++ b/src/components/tools/__tests__/EncodingConverter.test.tsx
@@ -147,9 +147,7 @@ describe('EncodingConverterTool — ファイル読込失敗時のエラー表�
       screen.getByRole('button', { name: 'ファイル' }).click();
     });
 
-    const input = container.querySelector(
-      'input[type="file"]'
-    ) as HTMLInputElement | null;
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement | null;
     expect(input).not.toBeNull();
 
     await act(async () => {

--- a/src/components/tools/__tests__/EncodingConverter.test.tsx
+++ b/src/components/tools/__tests__/EncodingConverter.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useState } from 'react';
-import { render, act, cleanup, fireEvent, screen } from '@testing-library/react';
+import { render, act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 
 // `EncodingConverterTool` 内で呼ばれる encoding ユーティリティを spy 化する。
 // 直接 `runDetect` / `runConvert` を spy する代わりに、内部から呼ばれる
@@ -124,6 +124,52 @@ describe('EncodingConverterTool — 入力非依存の再 render では detect �
 // ────────────────────────────────────────────
 // 変換モードでも debounce 中の連続入力は convert 1 回に集約される
 // ────────────────────────────────────────────
+// ────────────────────────────────────────────
+// #391: file.arrayBuffer() の reject 時に error 表示が出る
+// ────────────────────────────────────────────
+describe('EncodingConverterTool — ファイル読込失敗時のエラー表示 (issue #391)', () => {
+  it('file.arrayBuffer() が reject すると ErrorMessage に fallback が表示される', async () => {
+    // beforeEach の fakeTimers だと waitFor の内部 setTimeout が回らないため
+    // 本 test だけ real timer に戻す
+    vi.useRealTimers();
+
+    // jsdom は本物の File を返すが arrayBuffer は controllable ではないため
+    // Object.defineProperty で reject に差し替える
+    const file = new File(['dummy'], 'sample.txt', { type: 'text/plain' });
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: () => Promise.reject(new Error('read failed')),
+    });
+
+    const { container } = render(<EncodingConverterTool />);
+
+    // 入力方式を「ファイル」に切替
+    act(() => {
+      screen.getByRole('button', { name: 'ファイル' }).click();
+    });
+
+    const input = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.change(input!, { target: { files: [file] } });
+    });
+
+    // reject の microtask が flush されるのを待つ
+    await waitFor(() => {
+      const alerts = container.querySelectorAll('[role="alert"]');
+      expect(alerts.length).toBeGreaterThan(0);
+    });
+    const alertText = Array.from(container.querySelectorAll('[role="alert"]'))
+      .map((n) => n.textContent ?? '')
+      .join('');
+    // Error.message を優先するため "read failed" を含む。
+    // (旧実装は .catch なしのため unhandled rejection で alert が出ず本 test は fail する)
+    expect(alertText).toMatch(/read failed|ファイルの読み込みに失敗しました/);
+  });
+});
+
 describe('EncodingConverterTool — 変換モードでも debounce で convert は最終 1 回', () => {
   it('変換モードに切替後、連続入力中は convertBytes が 1 回のみ呼ばれる', () => {
     const { container } = render(<EncodingConverterTool />);

--- a/src/components/tools/__tests__/JwtDecoder.test.ts
+++ b/src/components/tools/__tests__/JwtDecoder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ALG_MAP, verifySignature } from '../JwtDecoder';
+import { ALG_MAP, verifySignature } from '@/utils/jwt-verify';
 import { bytesToBase64Url } from '@/utils/base64url';
 
 // ────────────────────────────────────────────

--- a/src/components/tools/__tests__/JwtDecoder.test.tsx
+++ b/src/components/tools/__tests__/JwtDecoder.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+
+// `@/utils/jwt-verify` を mock 化し、`verifySignature` を controllable promise に差し替える。
+// JwtDecoderTool は `verifySignature` を ESM import 経由で参照するため (本 PR で
+// `src/utils/jwt-verify.ts` に切り出し)、vi.mock で差し替えが効く。
+vi.mock('@/utils/jwt-verify', () => {
+  return {
+    ALG_MAP: {},
+    verifySignature: vi.fn(),
+  };
+});
+
+import { JwtDecoderTool } from '@/components/tools/JwtDecoder';
+import { verifySignature } from '@/utils/jwt-verify';
+
+// 構造的に valid (3 セグメント / 各セグメントが base64url な JSON) な HS256 JWT。
+// 署名検証は mock するため値は何でもよい。
+const VALID_JWT =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.dummy';
+
+beforeEach(() => {
+  vi.mocked(verifySignature).mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ────────────────────────────────────────────
+// #389: cancellation flag が stale promise の setSigStatus を抑止する
+// ────────────────────────────────────────────
+describe('JwtDecoderTool — verifySignature の stale promise race を cleanup で抑止する (issue #389)', () => {
+  it('古い verifySignature の resolve は新しい呼び出し後に届いても badge を上書きしない', async () => {
+    // 各 verify 呼び出しを controllable な promise に差し替える。
+    // call 1 (古い) は意図的に call 2 より後に resolve させる。
+    const resolvers: Array<(value: 'valid' | 'invalid') => void> = [];
+    vi.mocked(verifySignature).mockImplementation(() => {
+      return new Promise((resolve) => {
+        resolvers.push(resolve);
+      });
+    });
+
+    render(<JwtDecoderTool />);
+
+    // 1. valid な JWT を入力 → parsed != null になり secretKey 入力欄が表示される
+    const tokenInput = screen.getByLabelText('JWTトークンを貼り付け') as HTMLTextAreaElement;
+    act(() => {
+      fireEvent.change(tokenInput, { target: { value: VALID_JWT } });
+    });
+
+    // 2. secretKey を 'first' に設定 → useEffect が verify 呼び出し (call 1)
+    const secretInput = (await screen.findByLabelText(/シークレットキー/)) as HTMLTextAreaElement;
+    act(() => {
+      fireEvent.change(secretInput, { target: { value: 'first' } });
+    });
+    await waitFor(() => expect(resolvers.length).toBe(1));
+
+    // 3. secretKey を 'second' に変更 → cleanup が走り cancelled=true、続いて verify (call 2)
+    act(() => {
+      fireEvent.change(secretInput, { target: { value: 'second' } });
+    });
+    await waitFor(() => expect(resolvers.length).toBe(2));
+
+    // 4. 新しい呼び出し (call 2) を先に 'invalid' で resolve
+    await act(async () => {
+      resolvers[1]('invalid');
+    });
+
+    // この時点で badge は '署名: 無効'
+    expect(screen.getByText('署名: 無効')).toBeTruthy();
+
+    // 5. 遅れて古い呼び出し (call 1) が 'valid' で resolve。
+    //    cancellation flag が機能していれば setSigStatus は呼ばれず、badge は変化しない。
+    //    旧実装 (cleanup なし) ではここで '署名: 有効' に上書きされて test fail する。
+    await act(async () => {
+      resolvers[0]('valid');
+    });
+
+    expect(screen.getByText('署名: 無効')).toBeTruthy();
+    expect(screen.queryByText('署名: 有効')).toBeNull();
+  });
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -693,3 +693,17 @@
     -webkit-overflow-scrolling: touch;
   }
 }
+
+/* 前庭障害ユーザー向けに transition / animation を抑止する。
+   特定 selector のみで `transition` を上書きしても layer 順や specificity で
+   silent regression するため、`!important` でグローバル reset する。 */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/utils/jwt-verify.ts
+++ b/src/utils/jwt-verify.ts
@@ -1,0 +1,89 @@
+import { base64UrlToBytes } from '@/utils/jwt';
+import { pemBlockToBytes } from '@/utils/base64';
+
+type AlgParams =
+  | { name: 'HMAC'; hash: string }
+  | { name: 'RSASSA-PKCS1-v1_5'; hash: string }
+  | { name: 'ECDSA'; hash: string; namedCurve: string };
+
+/** アルゴリズム → WebCrypto パラメーターのマッピング（テスト用にエクスポート） */
+export const ALG_MAP: Record<string, AlgParams> = {
+  HS256: { name: 'HMAC', hash: 'SHA-256' },
+  HS384: { name: 'HMAC', hash: 'SHA-384' },
+  HS512: { name: 'HMAC', hash: 'SHA-512' },
+  RS256: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+  RS384: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' },
+  RS512: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-512' },
+  ES256: { name: 'ECDSA', hash: 'SHA-256', namedCurve: 'P-256' },
+  ES384: { name: 'ECDSA', hash: 'SHA-384', namedCurve: 'P-384' },
+  ES512: { name: 'ECDSA', hash: 'SHA-512', namedCurve: 'P-521' },
+};
+
+export type SigStatus = 'unchecked' | 'verifying' | 'valid' | 'invalid' | 'unsupported' | 'error';
+
+export async function verifySignature(
+  rawHeader: string,
+  rawPayload: string,
+  signature: string,
+  header: Record<string, unknown>,
+  secretOrKey: string
+): Promise<SigStatus> {
+  const alg = typeof header.alg === 'string' ? header.alg : '';
+  const algParams = ALG_MAP[alg];
+  if (!algParams) return 'unsupported';
+
+  const signingInput = new TextEncoder().encode(`${rawHeader}.${rawPayload}`);
+  const sigBytes = base64UrlToBytes(signature);
+
+  try {
+    if (algParams.name === 'HMAC') {
+      const key = await crypto.subtle.importKey(
+        'raw',
+        new TextEncoder().encode(secretOrKey),
+        { name: 'HMAC', hash: algParams.hash },
+        false,
+        ['verify']
+      );
+      return (await crypto.subtle.verify('HMAC', key, sigBytes, signingInput))
+        ? 'valid'
+        : 'invalid';
+    }
+
+    // RS* / ES* は公開鍵 PEM を使用
+    const keyBytes = pemBlockToBytes(secretOrKey, 'PUBLIC KEY');
+    if (algParams.name === 'RSASSA-PKCS1-v1_5') {
+      const key = await crypto.subtle.importKey(
+        'spki',
+        keyBytes.buffer,
+        { name: 'RSASSA-PKCS1-v1_5', hash: algParams.hash },
+        false,
+        ['verify']
+      );
+      return (await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, sigBytes, signingInput))
+        ? 'valid'
+        : 'invalid';
+    }
+
+    // ECDSA
+    if (algParams.name === 'ECDSA') {
+      const key = await crypto.subtle.importKey(
+        'spki',
+        keyBytes.buffer,
+        { name: 'ECDSA', namedCurve: algParams.namedCurve },
+        false,
+        ['verify']
+      );
+      return (await crypto.subtle.verify(
+        { name: 'ECDSA', hash: algParams.hash },
+        key,
+        sigBytes,
+        signingInput
+      ))
+        ? 'valid'
+        : 'invalid';
+    }
+    return 'error';
+  } catch {
+    return 'error';
+  }
+}

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -64,6 +64,21 @@ test.describe('a11y live region (issue #163, production CSP 適用)', () => {
     });
   });
 
+  test('ダミーテキスト: 生成完了が role="status" aria-live="polite" で SR 通知可能（CSP 違反なし、issue #388）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/dummy-text', async (page) => {
+      // ページ読込時に auto-generate されるため status は即時存在する
+      const status = page.getByRole('status').first();
+      await expect(status).toHaveAttribute('aria-live', 'polite');
+      await expect(status).toContainText('ダミーテキストを生成しました');
+
+      // 文字種を変えると result が再生成され、status の文言も更新される
+      await page.getByRole('button', { name: 'ひらがな' }).click();
+      await expect(status).toContainText('ダミーテキストを生成しました');
+    });
+  });
+
   test('JSON→CSV: 変換結果が role="status" で包まれ常時 aria-live="polite" で SR 通知可能（CSP 違反なし）', async ({
     browser,
   }) => {

--- a/tests/e2e/prefers-reduced-motion.spec.ts
+++ b/tests/e2e/prefers-reduced-motion.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * issue #387: prefers-reduced-motion グローバルリセットの E2E。
+ *
+ * `src/styles/global.css` の `@media (prefers-reduced-motion: reduce)` で
+ * すべての要素の transition-duration を 0.01ms に抑止していることを検証する。
+ *
+ * 陽性 / 陰性対照を **同一スペック内に併設** することで「セレクタが
+ * transition 持ちの要素を選べていない / CSS が無効化されていない」事故を防ぐ:
+ *  - 陽性対照: 通常モードでは btn-copy に transition-duration > 0 が残ること
+ *  - 検知側:   reduced-motion 強制時に transition-duration が 0.01ms 以下に抑止されること
+ *
+ * 旧 develop（@media ルール削除）にこのテストを当てると検知側が fail する想定。
+ */
+
+// .btn-toggle はページ初期描画時から visible で transition 持ち (0.15s)。
+// .btn-copy は value=空時に visibility:hidden になるため初期 visible で取得できない。
+const TARGET_SELECTOR = '.btn-toggle';
+// 0.15s = 150ms (btn-toggle の transition)。reset 適用後は 0.01ms。
+const REDUCED_THRESHOLD_MS = 1;
+
+function parseDurationToMs(value: string): number {
+  // computed style は "0.2s" / "200ms" / "0s, 0.2s, ..." 等を返す。
+  // transition プロパティは複数値の場合 comma 区切りで返るため、最初の値を採用する。
+  const first = value.split(',')[0]?.trim() ?? '';
+  if (first.endsWith('ms')) return parseFloat(first);
+  if (first.endsWith('s')) return parseFloat(first) * 1000;
+  return Number.NaN;
+}
+
+async function readTransitionDuration(page: import('@playwright/test').Page) {
+  const btn = page.locator(TARGET_SELECTOR).first();
+  await btn.waitFor({ state: 'visible' });
+  const duration = await btn.evaluate((el) => getComputedStyle(el).transitionDuration);
+  return parseDurationToMs(duration);
+}
+
+test.describe('prefers-reduced-motion (issue #387)', () => {
+  test('陽性対照: 通常モードでは btn-toggle に transition-duration が残る', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await page.goto('/tools/encoding-converter');
+    const ms = await readTransitionDuration(page);
+    expect(ms).toBeGreaterThan(REDUCED_THRESHOLD_MS);
+  });
+
+  test('reduced-motion 強制時は transition-duration がほぼ 0 に抑止される', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/tools/encoding-converter');
+    const ms = await readTransitionDuration(page);
+    expect(ms).toBeLessThanOrEqual(REDUCED_THRESHOLD_MS);
+  });
+});


### PR DESCRIPTION
## Summary

P1 タグの Effort S issue 4 件をまとめて修正。いずれも単独 PR で完結可能と issue 本文に明記されているもので、互いに干渉しないためコミットを issue 単位に分割している。

| # | 内容 | 種別 |
| :-- | :-- | :-- |
| #391 | encoding-converter: `file.arrayBuffer()` の unhandled rejection を try/catch 化 | bug |
| #389 | jwt: `verifySignature` の stale promise race を cancellation flag で解消 | bug |
| #388 | a11y: DummyText 自動再生成完了を aria-live で通知 | a11y |
| #387 | a11y: `prefers-reduced-motion` で transition/animation を抑止 | a11y |

加えてレビュー指摘対応として、`verifySignature` を `src/utils/jwt-verify.ts` に切り出し、#389 cancellation flag の component-level regression test を追加。

## 変更詳細

### #391: encoding-converter
`handleFileChange` を `async/await + try/catch` に変換。catch では既存の `getErrorMessage(e, 'ファイルの読み込みに失敗しました')` パターン（同コンポーネントの `runDetect` / `runConvert` と統一）で `error` state に書き込む。

### #389: jwt
`useEffect` cleanup に `cancelled` flag を導入。`verifySignature` の戻りが解決された時点で flag が立っていれば `setSigStatus` を skip する。`verifySignature` 内部で例外は `'error'` status に変換されて返るため `.catch` 追加は不要。

追加対応 (40eee97): `verifySignature` を `src/utils/jwt-verify.ts` に切り出し、`vi.mock` で controllable promise に差し替え可能にした上で、cancellation flag の regression test を `JwtDecoder.test.tsx` に新規追加。

### #388: DummyText
本体テキストは文量が多いため、別個 `sr-only` span に `role="status"` / `aria-live="polite"` を付与し「N 文字のダミーテキストを生成しました」を告知。本体 `<p>` には `aria-live` を付けず過剰読み上げを回避。

### #387: prefers-reduced-motion
`@media (prefers-reduced-motion: reduce)` で `*, *::before, *::after` 全体に `!important` でグローバルリセット。特定 selector のみで `transition` を上書きすると `@layer` 順や specificity で silent regression するため全体適用。

## Test plan

- [x] `node_modules/.bin/astro check` 0 errors / 0 warnings
- [x] `npm run test` 1244 passed (cancellation flag test 追加分含む)
- [x] `npm run test:e2e` 198 passed
  - #391: `src/components/tools/__tests__/EncodingConverter.test.tsx` に新規 unit test (file.arrayBuffer reject → ErrorMessage 表示)
  - #389: `src/components/tools/__tests__/JwtDecoder.test.tsx` (新規) に cancellation flag regression test (stale promise の遅延 resolve が新しい結果を上書きしないことを assert)。旧実装に当てて fail することをローカルで実機確認済み。
  - #388: `tests/e2e/a11y-live-region.spec.ts` に DummyText ケース追加 (status の aria-live=polite + 文字種切替時の更新を assert)
  - #387: `tests/e2e/prefers-reduced-motion.spec.ts` (新規) — 陽性対照 + 検知側を同一 spec に併設

## 陽性対照について

`test-gates` skill に従い regression test 全てに陽性対照を併設:

- **#387**: 通常モードで `btn-toggle` に `transition-duration > 1ms` (セレクタが transition 持ち要素を選べている証明)、reduced-motion 強制時に `≤ 1ms` (CSS reset が効いている証明)。`@media` ルール削除で検知側が必ず fail。
- **#389**: 旧実装 (cleanup なし) に test を当てて fail することを実機確認 (call 1 の stale resolve が '署名: 有効' に上書き)。restore 後 green。
- **#391**: 旧実装 (`.then` chain で `.catch` なし) では unhandled rejection で `setError` が呼ばれず alert 不出のため fail。

## 関連

- Refactor: `verifySignature` / `ALG_MAP` / `SigStatus` を `src/utils/jwt-verify.ts` に切り出し（テスト容易性のための最小 refactor）
- Follow-up issue #433: cancellation flag test 追加 — 本 PR 内で対応完了したため completed close

https://claude.ai/code/session_013TMdsT2aH1QKmFspnVbuM3