### PR TITLE
fix: P1 issue 対応 (#392 PNG ダウンロード失敗の UI 通知 / #386 QrCode a11y)

### DIFF
--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -4,14 +4,17 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { InputField } from '@/components/ui/InputField';
 import { DownloadButtonGroup } from '@/components/ui/DownloadButtonGroup';
+import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { calcJan, generateJanSample, validateJanInput, type JanMode } from '@/utils/jan-code';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { downloadSvg as downloadSvgFile, downloadPngFromSvgElement } from '@/utils/download';
+import { getErrorMessage } from '@/utils/errors';
 
 export function JanCodeTool() {
   const [mode, setMode] = useState<JanMode>('jan13');
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
+  const [downloadError, setDownloadError] = useState('');
   const svgRef = useRef<SVGSVGElement>(null);
 
   const result =
@@ -51,12 +54,25 @@ export function JanCodeTool() {
 
   const downloadSvg = () => {
     if (!svgRef.current) return;
-    downloadSvgFile(svgRef.current.outerHTML, `jan-${result!.fullCode}.svg`);
+    setDownloadError('');
+    try {
+      downloadSvgFile(svgRef.current.outerHTML, `jan-${result!.fullCode}.svg`);
+    } catch (e) {
+      setDownloadError(getErrorMessage(e, 'SVG ダウンロードに失敗しました'));
+    }
   };
 
-  const downloadPng = () => {
+  // downloadPngFromSvgElement は img.onerror / canvas エラーで reject する。
+  // await + try/catch で例外を吸収し ErrorMessage 経由でユーザーに通知する
+  // (Gs1Databar の downloadPng と同じ pattern, issue #392)。
+  const downloadPng = async () => {
     if (!svgRef.current) return;
-    downloadPngFromSvgElement(svgRef.current, `jan-${result!.fullCode}.png`);
+    setDownloadError('');
+    try {
+      await downloadPngFromSvgElement(svgRef.current, `jan-${result!.fullCode}.png`);
+    } catch (e) {
+      setDownloadError(getErrorMessage(e, 'PNG ダウンロードに失敗しました'));
+    }
   };
 
   return (
@@ -159,6 +175,10 @@ export function JanCodeTool() {
             <svg ref={svgRef} aria-label={`JANコード ${result.fullCode} のバーコード`} />
             <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />
           </div>
+
+          {downloadError && (
+            <ErrorMessage message={`ダウンロードエラー: ${downloadError}`} variant="block" />
+          )}
         </div>
       )}
 

--- a/src/components/tools/QrCode.tsx
+++ b/src/components/tools/QrCode.tsx
@@ -33,11 +33,12 @@ function generateQrSvg(text: string, errorLevel: ErrorLevel): string | null {
     qr.addData(text);
     qr.make();
     const svg = qr.createSvgTag({ scalable: true });
-    // SR が SVG の意味を読み取れるよう `<title>` と role/aria-label を注入する
-    // (issue #386)。dangerouslySetInnerHTML 経由で挿入されるため、SVG 自身に
-    // a11y メタデータを持たせる必要がある。
+    // SR が SVG の意味を読み取れるよう role="img" + `<title>` を first child として
+    // 注入する (issue #386)。`aria-label` は意図的に付けない: ARIA Accessible Name
+    // and Description Computation 4.3.1 で aria-label があると `<title>` が name
+    // 計算から除外され、URL 等の本文が読まれなくなる (PR #434 レビュー指摘)。
     const title = `<title>QRコード: ${escapeXml(text)}</title>`;
-    return svg.replace(/<svg([^>]*)>/, `<svg$1 role="img" aria-label="QRコード">${title}`);
+    return svg.replace(/<svg([^>]*)>/, `<svg$1 role="img">${title}`);
   } catch {
     return null;
   }

--- a/src/components/tools/QrCode.tsx
+++ b/src/components/tools/QrCode.tsx
@@ -15,13 +15,29 @@ const ERROR_LEVELS: { value: ErrorLevel; label: string; desc: string }[] = [
   { value: 'H', label: 'H', desc: '30%' },
 ];
 
+// SVG `<title>` に埋め込む文字列は HTML 特殊文字を実体参照化する必要がある
+// (text が URL や `<` を含む可能性があるため XSS 二次防衛線も兼ねる)。
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 function generateQrSvg(text: string, errorLevel: ErrorLevel): string | null {
   if (!text) return null;
   try {
     const qr = qrcode(0, errorLevel);
     qr.addData(text);
     qr.make();
-    return qr.createSvgTag({ scalable: true });
+    const svg = qr.createSvgTag({ scalable: true });
+    // SR が SVG の意味を読み取れるよう `<title>` と role/aria-label を注入する
+    // (issue #386)。dangerouslySetInnerHTML 経由で挿入されるため、SVG 自身に
+    // a11y メタデータを持たせる必要がある。
+    const title = `<title>QRコード: ${escapeXml(text)}</title>`;
+    return svg.replace(/<svg([^>]*)>/, `<svg$1 role="img" aria-label="QRコード">${title}`);
   } catch {
     return null;
   }
@@ -98,7 +114,7 @@ export function QrCodeGenerator() {
             <span className="body-emphasis text-default">プレビュー</span>
             <DownloadButton onClick={handleDownload} label="SVGダウンロード" variant="secondary" />
           </div>
-          <div className="flex justify-center p-8 bg-default">
+          <div className="flex justify-center p-8 bg-default" role="status" aria-live="polite">
             <div
               ref={containerRef}
               data-testid="qr-code-container"

--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { downloadBlob } from '@/utils/download';
+import { downloadBlob, downloadPngFromSvgElement } from '@/utils/download';
 
 /**
  * downloadBlob のスモークテスト。
@@ -47,6 +47,101 @@ describe('downloadBlob', () => {
 
   it('生成した ObjectURL は revokeObjectURL で解放される', () => {
     downloadBlob(new Blob(['x']), 'a.txt');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});
+
+/**
+ * downloadPngFromSvgElement の Promise 化 (issue #392) 検証。
+ *
+ * 旧実装は戻り型 void で img.onerror 発生時に「何もしない」silent failure
+ * 経路を持っていた。Promise 化後は失敗を caller に伝播する必要がある。
+ *
+ * 陽性対照 (reject パス) と陰性対照 (resolve パス) を別 it() に分離。
+ * 旧実装 (void) に陽性対照を当てると Promise インターフェイス自体が
+ * 存在せず `await` できないため必ず fail する (test-gates 鉄則 1)。
+ */
+describe('downloadPngFromSvgElement', () => {
+  let createdElements: Array<{ tag: string; el: Record<string, unknown> }>;
+  let imgInstance: { onload: (() => void) | null; onerror: (() => void) | null; src: string };
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createdElements = [];
+    createObjectURL = vi.fn(() => 'blob:mock-url');
+    revokeObjectURL = vi.fn();
+
+    vi.stubGlobal('document', {
+      createElement: vi.fn((tag: string) => {
+        if (tag === 'canvas') {
+          const el = {
+            width: 0,
+            height: 0,
+            getContext: vi.fn(() => ({ scale: vi.fn(), drawImage: vi.fn() })),
+            toDataURL: vi.fn(() => 'data:image/png;base64,XXX'),
+          };
+          createdElements.push({ tag, el });
+          return el;
+        }
+        if (tag === 'a') {
+          const el = { href: '', download: '', click: vi.fn() };
+          createdElements.push({ tag, el });
+          return el;
+        }
+        return {};
+      }),
+    });
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+    vi.stubGlobal(
+      'Image',
+      class {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        _src = '';
+        get src() {
+          return this._src;
+        }
+        set src(v: string) {
+          this._src = v;
+          imgInstance = this;
+        }
+      }
+    );
+    imgInstance = { onload: null, onerror: null, src: '' };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // テスト用 SVGSVGElement のスタブ
+  const makeSvgStub = () =>
+    ({
+      getBoundingClientRect: () => ({ width: 100, height: 50 }),
+      outerHTML: '<svg width="100" height="50"></svg>',
+    }) as unknown as SVGSVGElement;
+
+  it('陰性対照: img.onload が発火すると Promise は resolve し anchor.click() が呼ばれる', async () => {
+    const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
+    // src setter で imgInstance が確定 → onload を発火
+    imgInstance.onload?.();
+    await expect(promise).resolves.toBeUndefined();
+
+    const anchor = createdElements.find((e) => e.tag === 'a')!.el as {
+      download: string;
+      click: ReturnType<typeof vi.fn>;
+    };
+    expect(anchor.download).toBe('jan-test.png');
+    expect(anchor.click).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('陽性対照: img.onerror が発火すると Promise は "PNG への変換に失敗しました" で reject する', async () => {
+    const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
+    imgInstance.onerror?.();
+    await expect(promise).rejects.toThrow('PNG への変換に失敗しました');
+    // 失敗経路でも ObjectURL は確実に解放される
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 });

--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -93,6 +93,9 @@ describe('downloadPngFromSvgElement', () => {
       }),
     });
     vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+    // imgInstance は Image の src setter で確定される。
+    // テスト本体は src 代入後 (= production code の img.src = url) に
+    // imgInstance.onload / onerror を発火させる。
     vi.stubGlobal(
       'Image',
       class {
@@ -108,7 +111,6 @@ describe('downloadPngFromSvgElement', () => {
         }
       }
     );
-    imgInstance = { onload: null, onerror: null, src: '' };
   });
 
   afterEach(() => {
@@ -142,6 +144,32 @@ describe('downloadPngFromSvgElement', () => {
     imgInstance.onerror?.();
     await expect(promise).rejects.toThrow('PNG への変換に失敗しました');
     // 失敗経路でも ObjectURL は確実に解放される
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('陽性対照: img.onload 内で canvas.toDataURL が throw した場合も Promise は reject する', async () => {
+    // canvas.toDataURL を throw する stub に差し替える (tainted canvas 等の SecurityError 相当)
+    vi.stubGlobal('document', {
+      createElement: vi.fn((tag: string) => {
+        if (tag === 'canvas') {
+          return {
+            width: 0,
+            height: 0,
+            getContext: () => ({ scale: vi.fn(), drawImage: vi.fn() }),
+            toDataURL: () => {
+              throw new Error('canvas is tainted');
+            },
+          };
+        }
+        if (tag === 'a') return { href: '', download: '', click: vi.fn() };
+        return {};
+      }),
+    });
+
+    const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
+    imgInstance.onload?.();
+    await expect(promise).rejects.toThrow('canvas is tainted');
+    // finally で ObjectURL は解放される
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 });

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -82,29 +82,35 @@ export async function downloadPngFromSvgContent(
 
 /**
  * SVG要素からPNGをダウンロードする（getBoundingClientRectで寸法取得、Retina x2倍）
- * 要素がDOMに描画されている必要がある
+ * 要素がDOMに描画されている必要がある。
+ * Image 読み込み失敗時は reject し、呼出側で UI 通知できるようにする
+ * (svgContentToPngBlob と同じ pattern)。
  */
-export function downloadPngFromSvgElement(svgEl: SVGSVGElement, filename: string): void {
-  const { width, height } = svgEl.getBoundingClientRect();
-  const scale = 2;
-  const canvas = document.createElement('canvas');
-  canvas.width = width * scale;
-  canvas.height = height * scale;
-  const ctx = canvas.getContext('2d')!;
-  ctx.scale(scale, scale);
-  const img = new Image();
-  const blob = new Blob([svgEl.outerHTML], { type: 'image/svg+xml' });
-  const url = URL.createObjectURL(blob);
-  img.onload = () => {
-    ctx.drawImage(img, 0, 0);
-    URL.revokeObjectURL(url);
-    const a = document.createElement('a');
-    a.href = canvas.toDataURL('image/png');
-    a.download = filename;
-    a.click();
-  };
-  img.onerror = () => {
-    URL.revokeObjectURL(url);
-  };
-  img.src = url;
+export function downloadPngFromSvgElement(svgEl: SVGSVGElement, filename: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const { width, height } = svgEl.getBoundingClientRect();
+    const scale = 2;
+    const canvas = document.createElement('canvas');
+    canvas.width = width * scale;
+    canvas.height = height * scale;
+    const ctx = canvas.getContext('2d')!;
+    ctx.scale(scale, scale);
+    const img = new Image();
+    const blob = new Blob([svgEl.outerHTML], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      const a = document.createElement('a');
+      a.href = canvas.toDataURL('image/png');
+      a.download = filename;
+      a.click();
+      resolve();
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('PNG への変換に失敗しました'));
+    };
+    img.src = url;
+  });
 }

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -99,13 +99,21 @@ export function downloadPngFromSvgElement(svgEl: SVGSVGElement, filename: string
     const blob = new Blob([svgEl.outerHTML], { type: 'image/svg+xml' });
     const url = URL.createObjectURL(blob);
     img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      URL.revokeObjectURL(url);
-      const a = document.createElement('a');
-      a.href = canvas.toDataURL('image/png');
-      a.download = filename;
-      a.click();
-      resolve();
+      try {
+        ctx.drawImage(img, 0, 0);
+        const a = document.createElement('a');
+        a.href = canvas.toDataURL('image/png');
+        a.download = filename;
+        a.click();
+        resolve();
+      } catch (e) {
+        // drawImage / toDataURL は canvas tainted 等で SecurityError を throw する。
+        // try/catch しないと unhandled error として外に逃げ、caller の Promise には
+        // reject されず silent failure 経路が残る (PR #434 レビュー指摘)。
+        reject(e instanceof Error ? e : new Error('PNG への変換に失敗しました'));
+      } finally {
+        URL.revokeObjectURL(url);
+      }
     };
     img.onerror = () => {
       URL.revokeObjectURL(url);

--- a/tests/e2e/jan-code.spec.ts
+++ b/tests/e2e/jan-code.spec.ts
@@ -64,4 +64,42 @@ test.describe('JANコード生成（production CSP 適用）', () => {
       ).toBeVisible();
     });
   });
+
+  // issue #392: downloadPngFromSvgElement Promise 化の陽性対照 E2E。
+  // Image 読み込みを強制 onerror させ、async downloadPng の catch 経路で
+  // ErrorMessage が表示されることを観測可能な振る舞いとして assert する
+  // (旧 void 実装ではこの ErrorMessage は絶対に出ない silent failure)。
+  test('JAN-13: PNG ダウンロード失敗時に role="alert" でエラー表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
+
+      // hydration 後・クリック前に Image を必ず onerror させる stub に差し替える。
+      // withProductionCsp は page.goto 後に fn が呼ばれるため addInitScript では
+      // 次回ナビゲーション分しか効かない。
+      await page.evaluate(() => {
+        class FailingImage {
+          onload: (() => void) | null = null;
+          onerror: (() => void) | null = null;
+          private _src = '';
+          get src() {
+            return this._src;
+          }
+          set src(v: string) {
+            this._src = v;
+            queueMicrotask(() => this.onerror?.());
+          }
+        }
+        (window as unknown as { Image: unknown }).Image = FailingImage;
+      });
+
+      await page.getByRole('button', { name: 'PNGダウンロード' }).click();
+
+      const alert = page.getByRole('alert').filter({ hasText: /PNG への変換に失敗しました/ });
+      await expect(alert).toBeVisible();
+      await expect(alert).toContainText('ダウンロードエラー');
+    });
+  });
 });

--- a/tests/e2e/qr-code.spec.ts
+++ b/tests/e2e/qr-code.spec.ts
@@ -67,9 +67,11 @@ test.describe('QRコード生成（production CSP 適用）', () => {
     });
   });
 
-  // issue #386: a11y。SR が生成完了と SVG の意味を読み取れること。
+  // issue #386: a11y。SR が生成完了と SVG の意味（URL 等の本文）を読み取れること。
   // 修正前は role="status" / aria-live も <title> も無いため、この test は fail する。
-  test('生成結果が role="status" として読め、SVG に <title> が含まれる（CSP 違反なし）', async ({
+  // accessible name に URL の本文が含まれることを assert することで、aria-label で
+  // `<title>` が上書きされてしまう regression も検知できる (PR #434 レビュー指摘)。
+  test('生成結果が role="status" として読め、SVG の accessible name に URL 本文が含まれる（CSP 違反なし）', async ({
     browser,
   }) => {
     await withProductionCsp(browser, '/tools/qr-code', async (page) => {
@@ -80,12 +82,20 @@ test.describe('QRコード生成（production CSP 適用）', () => {
         .filter({ has: page.getByTestId('qr-code-container') });
       await expect(status).toBeVisible();
 
-      // SVG が img role + aria-label でアクセシブル名を持つ
-      const svgImg = status.getByRole('img', { name: 'QRコード' });
-      await expect(svgImg).toBeVisible();
+      // SVG は role="img" を持ち、`<title>` が first child であることが accessible name の
+      // 計算条件 (Accessible Name and Description Computation 4.3.1)。
+      // aria-label を併用すると <title> が無視されるため、本 PR では aria-label を
+      // 付けない。属性として aria-label が無いことも陽性対照として確認する。
+      const svgImg = status.locator('svg[role="img"]');
+      await expect(svgImg).toHaveCount(1);
+      await expect(svgImg).not.toHaveAttribute('aria-label', /.*/);
 
-      // <title> 要素にテキスト内容が含まれる
-      const titleText = await status.locator('svg title').textContent();
+      // <title> が SVG の最初の子要素であり、URL 本文を含むこと
+      const firstChildTag = await svgImg.evaluate((el) => el.firstElementChild?.tagName);
+      expect(firstChildTag?.toLowerCase()).toBe('title');
+
+      const titleText = await svgImg.locator('> title').textContent();
+      expect(titleText).toContain('QRコード:');
       expect(titleText).toContain('https://example.com');
     });
   });

--- a/tests/e2e/qr-code.spec.ts
+++ b/tests/e2e/qr-code.spec.ts
@@ -66,4 +66,49 @@ test.describe('QRコード生成（production CSP 適用）', () => {
       await expect(downloadButton).toBeEnabled();
     });
   });
+
+  // issue #386: a11y。SR が生成完了と SVG の意味を読み取れること。
+  // 修正前は role="status" / aria-live も <title> も無いため、この test は fail する。
+  test('生成結果が role="status" として読め、SVG に <title> が含まれる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      await page.getByLabel('テキスト / URL').fill('https://example.com');
+
+      const status = page
+        .getByRole('status')
+        .filter({ has: page.getByTestId('qr-code-container') });
+      await expect(status).toBeVisible();
+
+      // SVG が img role + aria-label でアクセシブル名を持つ
+      const svgImg = status.getByRole('img', { name: 'QRコード' });
+      await expect(svgImg).toBeVisible();
+
+      // <title> 要素にテキスト内容が含まれる
+      const titleText = await status.locator('svg title').textContent();
+      expect(titleText).toContain('https://example.com');
+    });
+  });
+
+  // issue #386: XSS 二次防衛線。<title> 内に挿入される text は XML エスケープされる。
+  // 旧実装 (生 text 連結) ではこの test が <script> 文字列の生置換で fail する設計
+  // (test-gates 陽性対照: title 注入機構の escape が機能していないと検知)。
+  test('<title> 内のテキストは HTML 特殊文字がエスケープされる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      await page.getByLabel('テキスト / URL').fill('<script>alert(1)</script>');
+
+      const container = page.getByTestId('qr-code-container');
+      // textContent は DOM パース後の値なので元の文字列がそのまま見える
+      const titleText = await container.locator('svg title').textContent();
+      expect(titleText).toContain('<script>alert(1)</script>');
+
+      // 一方、生の HTML 文字列上では実体参照化されており、<script> タグとして
+      // パースされていない (XSS sink である dangerouslySetInnerHTML の前段で防御)。
+      const containerHtml = await container.innerHTML();
+      expect(containerHtml).toContain('&lt;script&gt;');
+      expect(await container.locator('script').count()).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## サマリー

P1 タグ open issue 7 件のうち、独立かつ単一 PR で完結できる以下 2 件をまとめて対応。

- **Closes #392** (fix + refactor): `downloadPngFromSvgElement` の silent failure を解消。Promise 化し `JanCode.downloadPng` の catch から `ErrorMessage` に接続。
- **Closes #386** (a11y): `QrCode` プレビューに `role="status" aria-live="polite"` と SVG `<title>` を付与。

## 変更内容

### #392: `downloadPngFromSvgElement` Promise 化

- `src/utils/download.ts` — 戻り型 `void` → `Promise<void>`、`img.onerror` で `reject(new Error('PNG への変換に失敗しました'))`、`img.onload` の末尾で `resolve()`。並列実装 `svgContentToPngBlob` と同じ pattern。
- `src/components/tools/JanCode.tsx` — `Gs1Databar.downloadPng` pattern を踏襲し `downloadError` state + `await/try-catch` + `<ErrorMessage variant="block">` を配置。SVG ダウンロードも try/catch で包む。

### #386: QrCode a11y

- `src/components/tools/QrCode.tsx` — プレビューコンテナに `role="status" aria-live="polite"`。`generateQrSvg` で生成 SVG に `<title>QRコード: <text></title>` と `role="img"` / `aria-label="QRコード"` を注入。`<title>` 内テキストは XML エスケープして XSS 二次防衛線も兼ねる。

## test-gates 陽性対照

両 issue ともガード/検知系として、旧実装に当てれば fail する設計のテストを併設:

| 対象 | 陽性対照 |
|------|----------|
| #392 unit | `Image.onerror` 強制発火で `Promise.reject('PNG への変換に失敗しました')` を assert (`src/utils/__tests__/download.test.ts`)。旧 `void` 実装には `await` できず必ず fail。 |
| #392 E2E | `page.evaluate` で `window.Image` を必ず `onerror` 発火する stub に差し替え、`role="alert"` の `ErrorMessage` 表示を assert (`tests/e2e/jan-code.spec.ts`)。旧実装は silent failure で alert 出ず。 |
| #386 E2E (title) | `<script>alert(1)</script>` を入力 → `containerHtml` に `&lt;script&gt;` が含まれ生 `<script>` タグが DOM に無いことを assert (`tests/e2e/qr-code.spec.ts`)。escape を外せば fail。 |

## 検証

- `node_modules/.bin/astro check` → 0 errors / 0 warnings / 0 hints
- `npm run test` → 1246 件 pass (build artifact 依存 meta テストのため事前に `npm run build` 実施)
- `npm run test:e2e -- jan-code.spec.ts qr-code.spec.ts a11y-live-region.spec.ts` → 22 件 pass
- `npm run format:check` → All files use Prettier code style

## Test plan

- [ ] CI green
- [ ] JAN-13 ページで PNG ダウンロード正常動作（手動）
- [ ] QR コードページで生成 SVG の `<title>` を DevTools で確認（手動）

Closes #392
Closes #386

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYLdSjS5aEzUErJ7E2JLAc)_