### PR TITLE
fix(a11y): QrCode の aria-live 連呼問題を sr-only debounce 通知で解消 (#435)

### DIFF
--- a/src/components/tools/QrCode.tsx
+++ b/src/components/tools/QrCode.tsx
@@ -49,6 +49,10 @@ export function QrCodeGenerator() {
   const [errorLevel, setErrorLevel] = useState<ErrorLevel>('M');
   const [svgHtml, setSvgHtml] = useState<string | null>(null);
   const [error, setError] = useState('');
+  // sr-only live region 用の announcement テキスト。
+  // 視覚プレビュー側 (svgHtml) は即時更新するが、announcement は 300ms debounce 後に
+  // 1 度だけ更新することで SR の「QRコード QRコード ...」連呼を防ぐ (issue #435)。
+  const [announcement, setAnnouncement] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -66,6 +70,19 @@ export function QrCodeGenerator() {
       setError('QRコードを生成できませんでした。テキストが長すぎる可能性があります。');
     }
   }, [text, errorLevel]);
+
+  // svgHtml の変化を 300ms debounce して sr-only announcement を更新する。
+  // 連続入力中は cleanup で timer をキャンセル + announcement を空に戻すことで、
+  // 同一文言「QRコードを生成しました」でも入力 stable のたびに毎回 announce される。
+  useEffect(() => {
+    if (!svgHtml) {
+      setAnnouncement('');
+      return;
+    }
+    setAnnouncement('');
+    const t = setTimeout(() => setAnnouncement('QRコードを生成しました'), 300);
+    return () => clearTimeout(t);
+  }, [svgHtml]);
 
   const handleDownload = () => {
     if (!containerRef.current) return;
@@ -108,14 +125,22 @@ export function QrCodeGenerator() {
       {/* エラー */}
       {error && <ErrorMessage message={error} />}
 
-      {/* QRコード表示 */}
+      {/* sr-only live region: 視覚プレビューとは分離し、入力 stable 後にだけ
+          一度だけ announce する (issue #435)。SVG <title> を直接 live region に
+          含めると入力 1 文字ごとに「QRコード: h, QRコード: ht...」と連呼される
+          ため、視覚 div の role="status" は外し、短文だけここで通知する。 */}
+      <span role="status" aria-live="polite" className="sr-only" data-testid="qr-announcement">
+        {announcement}
+      </span>
+
+      {/* QRコード表示 (視覚プレビューは即時更新、live region は持たない) */}
       {svgHtml && (
         <div className="rounded-lg border border-default overflow-hidden">
           <div className="flex items-center justify-between gap-2 px-4 py-3 bg-subtle border-b border-default">
             <span className="body-emphasis text-default">プレビュー</span>
             <DownloadButton onClick={handleDownload} label="SVGダウンロード" variant="secondary" />
           </div>
-          <div className="flex justify-center p-8 bg-default" role="status" aria-live="polite">
+          <div className="flex justify-center p-8 bg-default">
             <div
               ref={containerRef}
               data-testid="qr-code-container"

--- a/tests/e2e/qr-code.spec.ts
+++ b/tests/e2e/qr-code.spec.ts
@@ -97,10 +97,12 @@ test.describe('QRコード生成（production CSP 適用）', () => {
     });
   });
 
-  // issue #435 陽性対照 A (debounce 機能): 入力直後 200ms 時点では announcement が
-  // まだ空で、合計 400ms 経過後に「QRコードを生成しました」が現れる。
-  // 旧実装 (debounce 無しの直貼り role="status") に当てれば 200ms 時点で既に
-  // announcement テキストが視覚 SVG 中に出ているため、`toHaveText('')` 段で fail する。
+  // issue #435 陽性対照 A (debounce 機能): 入力直後の早い段階では announcement が
+  // まだ空で、合計 600ms 経過後に「QRコードを生成しました」が現れる。
+  // 実装側の debounce は 300ms。100ms / 500ms の二段でサンプルし、CI runner の
+  // React commit ラグ (50-100ms) を吸収しても境界 (300ms) を確実に跨ぐマージンを取る。
+  // 旧実装 (debounce 無しの直貼り role="status") に当てれば `qr-announcement` testid
+  // 要素自体が無く `toHaveText` 段で fail する。
   test('aria-live announcement は 300ms debounce 後にだけ短文を出す（CSP 違反なし）', async ({
     browser,
   }) => {
@@ -113,12 +115,12 @@ test.describe('QRコード生成（production CSP 適用）', () => {
       // テキスト入力。fill は瞬時。announcement はまだ debounce 待ち中。
       await page.getByLabel('テキスト / URL').fill('https://example.com');
 
-      // 200ms 時点では debounce 待ち中で空のまま
-      await page.waitForTimeout(200);
+      // 100ms 時点では debounce 待ち中で空のまま (300ms 境界より十分手前)
+      await page.waitForTimeout(100);
       await expect(announcement).toHaveText('');
 
-      // さらに待つと 300ms 経過し announce される (合計 200 + 200 = 400ms > 300ms)
-      await page.waitForTimeout(200);
+      // さらに 500ms 待つと debounce 通過し announce される (合計 600ms > 300ms に余裕)
+      await page.waitForTimeout(500);
       await expect(announcement).toHaveText('QRコードを生成しました');
     });
   });

--- a/tests/e2e/qr-code.spec.ts
+++ b/tests/e2e/qr-code.spec.ts
@@ -67,26 +67,23 @@ test.describe('QRコード生成（production CSP 適用）', () => {
     });
   });
 
-  // issue #386: a11y。SR が生成完了と SVG の意味（URL 等の本文）を読み取れること。
-  // 修正前は role="status" / aria-live も <title> も無いため、この test は fail する。
-  // accessible name に URL の本文が含まれることを assert することで、aria-label で
-  // `<title>` が上書きされてしまう regression も検知できる (PR #434 レビュー指摘)。
-  test('生成結果が role="status" として読め、SVG の accessible name に URL 本文が含まれる（CSP 違反なし）', async ({
+  // issue #386 / #435: SVG の `<title>` は維持しつつ視覚プレビュー側の role="status" を
+  // 撤去 (連呼防止)。sr-only な debounce live region でだけ短文を announce する。
+  // accessible name の URL 本文 + aria-label 上書き防止 + <title> first child を assert する。
+  test('SVG の accessible name に URL 本文が含まれ、aria-label で上書きされない（CSP 違反なし）', async ({
     browser,
   }) => {
     await withProductionCsp(browser, '/tools/qr-code', async (page) => {
       await page.getByLabel('テキスト / URL').fill('https://example.com');
 
-      const status = page
-        .getByRole('status')
-        .filter({ has: page.getByTestId('qr-code-container') });
-      await expect(status).toBeVisible();
+      const container = page.getByTestId('qr-code-container');
+      await expect(container).toBeVisible();
 
       // SVG は role="img" を持ち、`<title>` が first child であることが accessible name の
       // 計算条件 (Accessible Name and Description Computation 4.3.1)。
-      // aria-label を併用すると <title> が無視されるため、本 PR では aria-label を
+      // aria-label を併用すると <title> が無視されるため、本コンポーネントは aria-label を
       // 付けない。属性として aria-label が無いことも陽性対照として確認する。
-      const svgImg = status.locator('svg[role="img"]');
+      const svgImg = container.locator('svg[role="img"]');
       await expect(svgImg).toHaveCount(1);
       await expect(svgImg).not.toHaveAttribute('aria-label', /.*/);
 
@@ -97,6 +94,53 @@ test.describe('QRコード生成（production CSP 適用）', () => {
       const titleText = await svgImg.locator('> title').textContent();
       expect(titleText).toContain('QRコード:');
       expect(titleText).toContain('https://example.com');
+    });
+  });
+
+  // issue #435 陽性対照 A (debounce 機能): 入力直後 200ms 時点では announcement が
+  // まだ空で、合計 400ms 経過後に「QRコードを生成しました」が現れる。
+  // 旧実装 (debounce 無しの直貼り role="status") に当てれば 200ms 時点で既に
+  // announcement テキストが視覚 SVG 中に出ているため、`toHaveText('')` 段で fail する。
+  test('aria-live announcement は 300ms debounce 後にだけ短文を出す（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      const announcement = page.getByTestId('qr-announcement');
+
+      // 初期状態は空
+      await expect(announcement).toHaveText('');
+
+      // テキスト入力。fill は瞬時。announcement はまだ debounce 待ち中。
+      await page.getByLabel('テキスト / URL').fill('https://example.com');
+
+      // 200ms 時点では debounce 待ち中で空のまま
+      await page.waitForTimeout(200);
+      await expect(announcement).toHaveText('');
+
+      // さらに待つと 300ms 経過し announce される (合計 200 + 200 = 400ms > 300ms)
+      await page.waitForTimeout(200);
+      await expect(announcement).toHaveText('QRコードを生成しました');
+    });
+  });
+
+  // issue #435 陽性対照 B (構造): 視覚プレビュー側 div は role="status" / aria-live を
+  // 持たない (持たせると入力 1 文字ごとに SVG title が連呼される旧実装に逆戻り)。
+  // sr-only 専用 span がただ 1 つの aria-live 領域である構造の回帰を検知する。
+  test('視覚プレビュー div は aria-live を持たず、sr-only span 1 つだけが live region である（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/qr-code', async (page) => {
+      await page.getByLabel('テキスト / URL').fill('https://example.com');
+
+      // 視覚プレビュー div の祖先に aria-live を持つ要素が無い
+      const container = page.getByTestId('qr-code-container');
+      const liveAncestors = container.locator('xpath=ancestor-or-self::*[@aria-live]');
+      await expect(liveAncestors).toHaveCount(0);
+
+      // aria-live="polite" を持つ要素は qr-announcement の sr-only span ただ 1 つ
+      const liveRegions = page.locator('[aria-live="polite"]');
+      await expect(liveRegions).toHaveCount(1);
+      await expect(liveRegions).toHaveAttribute('data-testid', 'qr-announcement');
     });
   });
 


### PR DESCRIPTION
## サマリー

**Closes #435** — `QrCode` の `aria-live` region が入力 1 文字ごとに発火して SR で「QRコード: h, QRコード: ht, ...」と連呼される問題を、視覚プレビューと SR 通知を分離する案 B で解消。

## 変更内容

- 視覚プレビュー div から `role="status" aria-live="polite"` を撤去（即時表示は維持）
- 新たに sr-only な `<span role="status" aria-live="polite" data-testid="qr-announcement">` を追加
- `svgHtml` の変化を 300ms debounce してから「QRコードを生成しました」を announce
- 連続入力中は `useEffect` cleanup で timer をキャンセル + announcement を空に戻すことで、同一文言でも入力 stable のたびに毎回 SR が変化検知できる設計

## test-gates 陽性対照

debounce 機能と構造的回帰の 2 軸を、それぞれ独立した `test()` に分離して追加:

| Test | 観測対象 | 旧実装に当てた場合 |
|------|----------|--------------------|
| A: debounce タイミング | 200ms 時点で `qr-announcement` が空、400ms 時点で「QRコードを生成しました」 | debounce 無し直貼り実装には `qr-announcement` testid 要素自体が無く `toHaveText` 段で timeout fail |
| B: 視覚プレビューに live region なし | `qr-code-container` の祖先に `aria-live` を持つ要素が無く、`[aria-live="polite"]` が `qr-announcement` ただ 1 つ | 旧実装は視覚 div に `aria-live` があるため `liveAncestors.toHaveCount(0)` で fail |

## 検証

- `node_modules/.bin/astro check` → 0 errors / 0 warnings / 0 hints
- `npm run test` → 1247 件 pass
- `npm run test:e2e -- qr-code.spec.ts a11y-live-region.spec.ts` → 17 件 pass
- `npm run format:check` → All files use Prettier code style

## Test plan

- [ ] CI green
- [ ] QR コードページで長い URL を入力中、SR が連呼しないこと（macOS VoiceOver 等で手動）
- [ ] 入力 stable から 300ms 後に「QRコードを生成しました」が 1 度だけ announce されること

Closes #435

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYLdSjS5aEzUErJ7E2JLAc)_