### PR TITLE
refactor(download): Retina スケール係数を RETINA_SCALE 定数に集約

### DIFF
--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -2,6 +2,9 @@
  * ファイルダウンロードユーティリティ
  */
 
+/** Retina 表示向けに canvas を 2 倍解像度で描画するためのスケール係数。 */
+const RETINA_SCALE = 2;
+
 /**
  * Blob を `<a download>` 経由でダウンロードする共通処理。
  * テキスト・バイナリ・SVG・PNG・ZIP すべての出口で利用される。
@@ -46,12 +49,11 @@ export function svgContentToPngBlob(svgContent: string): Promise<Blob> {
       reject(new Error('SVG に width/height がありません'));
       return;
     }
-    const scale = 2;
     const canvas = document.createElement('canvas');
-    canvas.width = parseInt(m[1], 10) * scale;
-    canvas.height = parseInt(m[2], 10) * scale;
+    canvas.width = parseInt(m[1], 10) * RETINA_SCALE;
+    canvas.height = parseInt(m[2], 10) * RETINA_SCALE;
     const ctx = canvas.getContext('2d')!;
-    ctx.scale(scale, scale);
+    ctx.scale(RETINA_SCALE, RETINA_SCALE);
     const img = new Image();
     const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
     const url = URL.createObjectURL(blob);
@@ -89,12 +91,11 @@ export async function downloadPngFromSvgContent(
 export function downloadPngFromSvgElement(svgEl: SVGSVGElement, filename: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const { width, height } = svgEl.getBoundingClientRect();
-    const scale = 2;
     const canvas = document.createElement('canvas');
-    canvas.width = width * scale;
-    canvas.height = height * scale;
+    canvas.width = width * RETINA_SCALE;
+    canvas.height = height * RETINA_SCALE;
     const ctx = canvas.getContext('2d')!;
-    ctx.scale(scale, scale);
+    ctx.scale(RETINA_SCALE, RETINA_SCALE);
     const img = new Image();
     const blob = new Blob([svgEl.outerHTML], { type: 'image/svg+xml' });
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## 目的

`src/utils/download.ts` 内で 2 箇所複製されていた `const scale = 2;` を module-level の `RETINA_SCALE` 定数に集約する軽微な refactor。挙動変化なし。

## 副次的目的（本 PR で重要なもの）

Cloudflare Pages の develop 環境 (`https://develop.devtools-d9w.pages.dev`) で発生中の **特定ファイルが `500 + content-length: 0 + etag 無し` で配信される問題** の解消トリガーを兼ねる。

直前の deploy log で

```
Uploading... (599/599)
✨ Success! Uploaded 1 files (598 already uploaded) (1.06 sec)
```

が観測され、Cloudflare がコンテンツハッシュベースで upload を deduplicate しており、過去デプロイで edge が壊れた状態で「アップロード済み」と記録された hash をそのまま使い回していることが判明（[#437](https://github.com/fumtas1k/devtools/pull/437) の空コミット fresh build でも byte-identical だったため改善せず）。

本 refactor は `download.ts` のバイト列を変えるため、これを動的 import する 6 ページ (`gs1-databar` / `config-converter` / `json-csv` / `qr-code` / `encoding-converter` / `jan-code`) の bundle chunk 名と HTML 内の `<script src=...>` も差し替わり、Cloudflare 側で「新規 upload」として処理される → 壊れた edge キャッシュをバイパスできる、という仕掛け。

## 影響範囲

- `RETINA_SCALE` は private const なので外部 API 変化なし
- `svgContentToPngBlob` / `downloadPngFromSvgElement` の振る舞いは完全に同じ
- 既存 1247 テスト全通過確認済み

## Test plan

- [ ] merge 後、Cloudflare Pages の build が成功すること
- [ ] 下記 URL が全て `HTTP/2 200` を返すこと
  ```bash
  curl -sI https://develop.devtools-d9w.pages.dev/tools/gs1-databar/
  curl -sI https://develop.devtools-d9w.pages.dev/tools/config-converter/
  curl -sI https://develop.devtools-d9w.pages.dev/tools/json-csv/
  ```
- [ ] `/tools/qr-code/` で ToggleGroup が横並びで描画され、「サンプルを入力」ボタンが動作すること
