### PR TITLE
refactor(e2e): applyCspOverride に transformBody hook を追加し route handler 重複を解消 (#442)

### DIFF
--- a/tests/e2e/csp-and-evaluation.spec.ts
+++ b/tests/e2e/csp-and-evaluation.spec.ts
@@ -35,7 +35,6 @@
 
 import { test, expect } from '@playwright/test';
 import { applyProductionCsp, waitForReactHydration } from './helpers';
-import { PRODUCTION_CSP } from '../../src/utils/csp';
 
 /**
  * inline script 注入プローブ:
@@ -114,44 +113,19 @@ test.describe('CSP AND 評価 runtime 検証', () => {
     try {
       const page = await context.newPage();
 
-      // CSP 違反を収集するリスナーを手動設置 (applyProductionCsp は使わず
-      // 独自の route handler で <meta> を除去した上で permissive ヘッダを注入する)
-      const violations: string[] = [];
-      page.on('console', (msg) => {
-        if (msg.type() === 'error' && /Content Security Policy/i.test(msg.text())) {
-          violations.push(msg.text());
-        }
-      });
-      page.on('pageerror', (err) => {
-        if (/Content Security Policy/i.test(err.message)) {
-          violations.push(err.message);
-        }
-      });
-
-      // route handler: document リクエストのみ介入し
-      //   1. <meta http-equiv="content-security-policy" ...> タグを正規表現で除去
-      //   2. permissive HTTP CSP ヘッダ (PRODUCTION_CSP) を付与して返す
-      // JS/CSS/画像 等は素通し
-      await page.route('**/*', async (route) => {
-        if (route.request().resourceType() !== 'document') {
-          await route.continue();
-          return;
-        }
-        const response = await route.fetch();
-        const bodyText = await response.text();
-        // <meta http-equiv="content-security-policy" ...> タグを除去
-        const strippedBody = bodyText.replace(
-          /<meta\s+http-equiv=["']content-security-policy["'][^>]*>/gi,
-          ''
-        );
-        await route.fulfill({
-          status: response.status(),
-          headers: {
-            ...response.headers(),
-            'content-security-policy': PRODUCTION_CSP,
-          },
-          body: strippedBody,
-        });
+      // applyProductionCsp の transformBody hook で <meta> CSP を除去しつつ
+      // permissive HTTP ヘッダ (PRODUCTION_CSP) を注入する (#442)。
+      //
+      // meta タグ抽出は 2-pass で attribute 順非依存:
+      //   1. <meta ...> タグ全体を捕捉
+      //   2. その attribute 群に http-equiv="content-security-policy" があれば削除
+      // これにより Astro が将来 <meta content="..." http-equiv="..."> 形式で
+      // 出力した場合でも regex 空振りせず対応できる (PR #441 review nit 3)。
+      const guard = await applyProductionCsp(page, {
+        transformBody: (body) =>
+          body.replace(/<meta\s+[^>]*>/gi, (match) =>
+            /http-equiv\s*=\s*["']content-security-policy["']/i.test(match) ? '' : match
+          ),
       });
 
       await page.goto('/tools/uuid-v7');
@@ -171,7 +145,7 @@ test.describe('CSP AND 評価 runtime 検証', () => {
       // (permissive ヘッダが standalone で 'unsafe-inline' を許可するため)
       // page.on('console') は別 tick 配送のため短い grace を与えてから sanity check。
       // 陽性検証は直前の title assert が担っており、本 assert は環境健全性のみ。
-      await expect.poll(() => violations.length, { timeout: 1_000 }).toBe(0);
+      await expect.poll(() => guard.violations.length, { timeout: 1_000 }).toBe(0);
     } finally {
       await context.close();
     }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -102,7 +102,23 @@ export interface CspGuard {
   dispose(): Promise<void>;
 }
 
-async function applyCspOverride(page: Page, csp: string): Promise<CspGuard> {
+/**
+ * `applyCspOverride` / `applyProductionCsp` のオプション。
+ *
+ * `transformBody` を指定すると document レスポンスの body 文字列に対して変換を
+ * 適用してから `route.fulfill` する。`<meta http-equiv="content-security-policy">`
+ * を除去して header 単独で動かしたい陽性対照メタテスト等で利用する
+ * (`tests/e2e/csp-and-evaluation.spec.ts` 参照)。
+ */
+export interface ApplyCspOptions {
+  transformBody?: (body: string) => string;
+}
+
+async function applyCspOverride(
+  page: Page,
+  csp: string,
+  options?: ApplyCspOptions
+): Promise<CspGuard> {
   const violations: string[] = [];
 
   const routeHandler = async (route: Route): Promise<void> => {
@@ -114,10 +130,14 @@ async function applyCspOverride(page: Page, csp: string): Promise<CspGuard> {
     // route.fulfill に { response, headers } 並列指定すると Playwright 1.59 では
     // headers の上書きが反映されない事象を確認したため、status / headers / body を
     // 個別に組み立てて確実に CSP が乗るようにする。
+    // transformBody 指定時は body 文字列に対して変換を適用する (meta strip 等)。
+    const body = options?.transformBody
+      ? options.transformBody(await response.text())
+      : await response.body();
     await route.fulfill({
       status: response.status(),
       headers: { ...response.headers(), 'content-security-policy': csp },
-      body: await response.body(),
+      body,
     });
   };
 
@@ -158,8 +178,8 @@ async function applyCspOverride(page: Page, csp: string): Promise<CspGuard> {
   };
 }
 
-export async function applyProductionCsp(page: Page): Promise<CspGuard> {
-  return applyCspOverride(page, PRODUCTION_CSP);
+export async function applyProductionCsp(page: Page, options?: ApplyCspOptions): Promise<CspGuard> {
+  return applyCspOverride(page, PRODUCTION_CSP, options);
 }
 
 /**


### PR DESCRIPTION
## 背景

PR #441 のレビューで挙がった 2 つの nit を解消する refactor:

- **nit 2**: `tests/e2e/csp-and-evaluation.spec.ts` (B) の route handler が `helpers.ts` の `applyCspOverride` 内部実装と大部分重複。将来 `applyCspOverride` 側に fix が入った時に silent 追従漏れする懸念
- **nit 3**: `<meta>` strip regex が attribute 順 (`<meta http-equiv="..." content="..."`) に依存。Astro が将来 `<meta content="..." http-equiv="..."` 形式で出力すると regex 空振り。silent regression にはならない (`expect(metaEl).toBeNull()` の前提検証で fail) が attribute 順非依存にしたい

Closes #442

## 変更内容

### `tests/e2e/helpers.ts`
- `ApplyCspOptions { transformBody?: (body: string) => string }` を新規 export
- `applyCspOverride` / `applyProductionCsp` で options を受け、`transformBody` 指定時は document body 文字列に変換を適用してから `route.fulfill`
- 既存呼び出し (オプション無し) は無変更 — 通常テストへの影響なし

### `tests/e2e/csp-and-evaluation.spec.ts` (B ケース)
- 独自 route handler + 手書き console / pageerror リスナー一式を撤去
- `applyProductionCsp(page, { transformBody })` 一本化で route handler 重複解消
- `<meta>` strip regex を 2-pass 化:
  ```ts
  body.replace(/<meta\s+[^>]*>/gi, (match) =>
    /http-equiv\s*=\s*["']content-security-policy["']/i.test(match) ? '' : match
  );
  ```
  タグ全体を捕捉して attribute 内に `http-equiv="content-security-policy"` があれば削除する 2-pass パターンで attribute 順非依存に。

### 検知能力の保持

陽性対照 (B ケース) の構造は不変:
- `<meta>` を剥がすと standalone `'unsafe-inline'` で inline script が実行される (`document.title === 'XSS_OK'`)
- gate 自体の検知能力ゼロ化リスクを runtime で証明

route handler 実装が helper 共通化したことで、`applyCspOverride` の `fulfill` 詳細 (Playwright 1.59 ヘッダ上書きワークアラウンド等) が今後 fix された時に自動追従するようになった。

## 検証結果

- [x] `node_modules/.bin/astro check` — 0 errors / 0 warnings / 0 hints
- [x] `npm run test:e2e -- csp-and-evaluation` — 2 件 pass (陰性 2.0s / 陽性 389ms)

## 関連

- 派生元 review: PR #441 の review 「## レビュー総評」 nit 2, nit 3
- 関連 ADR: `docs/decisions.md [064]`

---
_Generated by [Claude Code](https://claude.ai/code/session_0149PteQz4AyxeHkYD9mrPVd)_