### PR TITLE
chore(ci): サードパーティ action を SHA pinning に移行

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -28,13 +28,13 @@ jobs:
           echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
       - name: Run issue-metrics tool
-        uses: github/issue-metrics@v3
+        uses: github/issue-metrics@6fa9041b3ea7b6a9dafbdc388d25d86d06b2b6af # v3.23.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:${{ github.repository }} is:issue created:${{ env.last_month }} -reason:"not planned"'
 
       - name: Create issue
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Monthly issue metrics report
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: カバレッジバッジ用 Gist を更新
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 69f5d57c79b9b687f7c2ef61dcda57e5


### PR DESCRIPTION
## 概要

mutable tag 参照のままになっていたサードパーティ action 3 件を commit SHA pinning に移行し、サプライチェーン攻撃リスクを低減します。

Closes #174

## 変更内容

| ファイル | Action | Before | After |
| --- | --- | --- | --- |
| `.github/workflows/metrics.yml` | `github/issue-metrics` | `@v3` | `@6fa9041b3ea7b6a9dafbdc388d25d86d06b2b6af # v3.23.1` |
| `.github/workflows/metrics.yml` | `peter-evans/create-issue-from-file` | `@v6` | `@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0` |
| `.github/workflows/test.yml` | `schneegans/dynamic-badges-action` | `@v1.7.0` | `@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0` |

既存 `visual-regression.yml` の pin パターン (`<sha> # vX.Y.Z`) と統一しています。

SHA は `git ls-remote --tags` で各 upstream リポジトリから取得した、現状のタグ参照先と同一のものを使用 (挙動の変更なし)。

## 背景

#174 の追加スコープコメント (リファクタ監査 S-4) に従い、metrics.yml 内 2 件 + test.yml の `schneegans/dynamic-badges-action` (同 job 内で `secrets.GIST_TOKEN` を保持しており脅威が大) を一括対応。

## テスト計画

- [ ] CI green
- [ ] workflow syntax の妥当性は GitHub Actions parser に委ねる (YAML 構文のみの変更のためローカル検証不要)

実行系の挙動変更は無いため (SHA は現行 tag と同一参照先)、metrics workflow / coverage badge update workflow は次回 schedule / push trigger で従来どおり動作する想定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01H99qbsGpBnFxHiKB4Cx3M8)_