### PR TITLE
feat(totp): ランダム生成時に HOTP counter を 0 にリセット

### DIFF
--- a/src/components/tools/TotpHotpGenerator.tsx
+++ b/src/components/tools/TotpHotpGenerator.tsx
@@ -156,8 +156,9 @@ export function TotpHotpGeneratorTool() {
     setHotpCode('');
   };
 
-  // secret 差し替え時の派生 state リセットを 1 箇所に集約。
-  // 入力欄編集とランダム生成ボタンの両経路から呼ばれる single source of truth。
+  // secret 自体に紐づく派生 state リセットを 1 箇所に集約。
+  // 入力欄編集とランダム生成ボタンの両経路から呼ばれる。
+  // counter のリセットは「ランダム生成時のみ」という別軸の責務なので呼び出し側で行う。
   const replaceSecret = (next: string) => {
     setSecretBase32(next);
     setCurrentCode('');

--- a/src/components/tools/TotpHotpGenerator.tsx
+++ b/src/components/tools/TotpHotpGenerator.tsx
@@ -266,7 +266,10 @@ export function TotpHotpGeneratorTool() {
               <div className="flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() => replaceSecret(generateRandomBase32Secret())}
+                  onClick={() => {
+                    replaceSecret(generateRandomBase32Secret());
+                    setCounterStr('0');
+                  }}
                   className="caption text-link-color btn-link-plain"
                   aria-label="ランダム生成（新しいシークレット）"
                 >

--- a/tests/e2e/totp-hotp.spec.ts
+++ b/tests/e2e/totp-hotp.spec.ts
@@ -152,6 +152,22 @@ test.describe('TOTP/HOTP ジェネレータ（production CSP 適用）', () => {
     });
   });
 
+  test('HOTP モードでランダム生成すると counter が 0 にリセットされる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/totp-hotp', async (page) => {
+      await page.getByRole('button', { name: 'HOTP' }).click();
+
+      const counterInput = page.getByLabel('カウンタ');
+      await counterInput.fill('42');
+      await expect(counterInput).toHaveValue('42');
+
+      await page.getByRole('button', { name: /ランダム生成/ }).click();
+
+      await expect(counterInput).toHaveValue('0');
+    });
+  });
+
   test('検証モードで Cmd/Ctrl+Enter で検証が発火する（CSP 違反なし）', async ({ browser }) => {
     await withProductionCsp(browser, '/tools/totp-hotp', async (page) => {
       // TOTP モードで現在のコードを取得


### PR DESCRIPTION
## 概要

HOTP モードでランダム生成ボタンを押した時に `counterStr` を `'0'` にリセットする (本来の HOTP 用法に揃える)。

Closes #427

## 変更内容

`TotpHotpGenerator.tsx` のランダム生成ボタン onClick:

```diff
- onClick={() => replaceSecret(generateRandomBase32Secret())}
+ onClick={() => {
+   replaceSecret(generateRandomBase32Secret());
+   setCounterStr('0');
+ }}
```

入力欄編集経路 (`replaceSecret`) では counter を維持する (既存 secret を別の有効値に貼り替える操作で counter を残したいユースケースを尊重)。

## E2E (陽性対照)

`tests/e2e/totp-hotp.spec.ts` に以下のテストを追加:

1. HOTP モードへ切替
2. counter を `'42'` に設定
3. ランダム生成ボタンクリック
4. counter が `'0'` になっていることを assert

fix を revert すると counter が `'42'` のまま残るため、test-gates ルールの「旧実装で fail する陽性対照」要件を満たす。

## テスト計画

- [x] `node_modules/.bin/astro check` 0 errors
- [x] 追加 E2E (`HOTP モードでランダム生成すると counter が 0 にリセットされる`) local pass
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01H99qbsGpBnFxHiKB4Cx3M8)_