### PR TITLE
refactor(config-converter): Cmd/Ctrl+Enter ハンドラの preventDefault を guard 前に移動

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -233,8 +233,8 @@ export function ConfigConverterTool() {
               onKeyDown={(e) => {
                 if (e.nativeEvent.isComposing) return;
                 if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                  if (!output || !schemaText || isValidating) return;
                   e.preventDefault();
+                  if (!output || !schemaText || isValidating) return;
                   handleValidate();
                 }
               }}

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -295,4 +295,30 @@ test.describe('設定ファイル相互変換', () => {
     // 検証成功メッセージが表示されること
     await expect(page.getByText('スキーマ検証成功')).toBeVisible();
   });
+
+  test('JSON Schema 検証パネル: スキーマ未入力で Cmd/Ctrl+Enter は検証を発火しない（陽性対照）', async ({
+    page,
+  }) => {
+    // from=JSON, to=JSON にセットして output を発生させる
+    const toGroup = page.getByRole('group', { name: '変換先フォーマット' });
+    await toGroup.getByRole('button', { name: 'JSON' }).click();
+
+    const inputTextarea = page.getByLabel('JSON (整形)');
+    await inputTextarea.fill('{"name":"Alice"}');
+    await expect(page.getByLabel('JSON', { exact: true })).toHaveValue(/"name"/);
+
+    // スキーマパネルを開くが、スキーマは未入力のまま
+    await page.getByRole('button', { name: /json schema/i }).click();
+    const schemaTextarea = page.getByLabel(/json schema/i);
+    await schemaTextarea.focus();
+
+    // 空のまま Cmd/Ctrl+Enter を押下
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+Enter`);
+
+    // guard が効いて検証結果（成功/失敗いずれの message も）が表示されないこと
+    await page.waitForTimeout(300);
+    await expect(page.getByText('スキーマ検証成功')).toHaveCount(0);
+    await expect(page.getByText('スキーマ検証失敗')).toHaveCount(0);
+  });
 });

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -317,8 +317,7 @@ test.describe('設定ファイル相互変換', () => {
     await page.keyboard.press(`${modifier}+Enter`);
 
     // guard が効いて検証結果（成功/失敗いずれの message も）が表示されないこと
-    await page.waitForTimeout(300);
-    await expect(page.getByText('スキーマ検証成功')).toHaveCount(0);
-    await expect(page.getByText('スキーマ検証失敗')).toHaveCount(0);
+    // toHaveCount の timeout で「現れないこと」を確認 (固定 wait より auto-wait が確実)
+    await expect(page.getByText(/スキーマ検証(成功|失敗)/)).toHaveCount(0, { timeout: 500 });
   });
 });


### PR DESCRIPTION
## 概要

`ConfigConverter` の Cmd/Ctrl+Enter ハンドラで `e.preventDefault()` を guard より前に移動。将来 `<form>` で包まれた場合に「未入力 Cmd+Enter で form submit に流れる」silent regression を予防する (PR #423 の TOTP 側と同等のパターン)。

Closes #424

## 変更内容

```diff
 onKeyDown={(e) => {
   if (e.nativeEvent.isComposing) return;
   if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-    if (!output || !schemaText || isValidating) return;
     e.preventDefault();
+    if (!output || !schemaText || isValidating) return;
     handleValidate();
   }
 }}
```

## E2E (陽性対照)

`tests/e2e/config-converter.spec.ts` に以下のテストを追加:

「JSON Schema 検証パネル: スキーマ未入力で Cmd/Ctrl+Enter は検証を発火しない（陽性対照）」

- スキーマパネルを開き、スキーマ未入力のまま Cmd/Ctrl+Enter 押下
- `スキーマ検証成功` / `スキーマ検証失敗` のいずれも表示されないことを assert (guard が効くことを確認)

## test-gates 補足

本 fix の `preventDefault` 順序入れ替えは **現状 `<form>` で包まれていないため観測可能な振る舞い差分なし**。追加した test は guard 自体の陽性対照であり、preventDefault 順序の陽性対照ではない。

PR #423 (TOTP 側の同等修正) も guard 陽性対照のみ追加して `<form>` シナリオの synthetic test は書いていない先例に揃えた。issue #424 自体も「現状 `<form>` で包まれておらず実害なし。将来の form 化時の予防策」と低優先度判定。

## テスト計画

- [x] `node_modules/.bin/astro check` 0 errors
- [x] 追加 E2E + 既存 Cmd/Ctrl+Enter E2E 2 件 local pass
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01H99qbsGpBnFxHiKB4Cx3M8)_