### PR TITLE
docs(setup): Gemini policy セットアップ手順を git rev-parse 起点に変更

### DIFF
--- a/docs/setup/gemini-policy.md
+++ b/docs/setup/gemini-policy.md
@@ -12,8 +12,10 @@
 
 ```bash
 mkdir -p ~/.gemini/policies
-ln -sfn "$(pwd)/.gemini/policies/security.toml" ~/.gemini/policies/security.toml
+ln -sfn "$(git rev-parse --show-toplevel)/.gemini/policies/security.toml" ~/.gemini/policies/security.toml
 ```
+
+> `$(git rev-parse --show-toplevel)` でリポジトリルートを動的解決するため、コマンド実行時の cwd がリポジトリ内のどのサブディレクトリでも壊れた symlink にならない。
 
 ---
 


### PR DESCRIPTION
## 概要

`docs/setup/gemini-policy.md` の Gemini CLI セキュリティポリシー setup 手順で、`$(pwd)` を `$(git rev-parse --show-toplevel)` に置換。コマンド実行時の cwd 依存を排除し、リポジトリ内のどのサブディレクトリから実行しても壊れた symlink にならないようにする。

Closes #123

## 変更内容

```diff
 mkdir -p ~/.gemini/policies
-ln -sfn "$(pwd)/.gemini/policies/security.toml" ~/.gemini/policies/security.toml
+ln -sfn "$(git rev-parse --show-toplevel)/.gemini/policies/security.toml" ~/.gemini/policies/security.toml
```

理由の補足を 1 行 quote で追加。

## 背景

issue #123 (PR #122 の follow-up): リポジトリルート以外 (例: `docs/` 内) から実行すると `$(pwd)` がそのサブディレクトリを返してしまい、symlink が `~/.gemini/policies/security.toml -> /repo/docs/.gemini/policies/security.toml` のような壊れたパスを指してしまう。

なお、本 issue 起票時の `GEMINI.md` は既に `docs/setup/gemini-policy.md` へ詳細を委譲する形にリファクタ済みのため、修正対象は doc 側のみ。

## テスト計画

- [ ] CI green (docs only のため build / test に影響なし)


---
_Generated by [Claude Code](https://claude.ai/code/session_01H99qbsGpBnFxHiKB4Cx3M8)_