### PR TITLE
refactor: 方針確定済み refactor issue 2 件を対応 (#393, #400)

### DIFF
--- a/src/components/tools/QrTicket.tsx
+++ b/src/components/tools/QrTicket.tsx
@@ -44,17 +44,13 @@ export function QrTicketTool() {
     generation.setExpiry(getDefaultExpiry());
   }, []);
 
-  // モード切替時にカメラを停止する
+  // モード切替時 / アンマウント時にカメラを停止する
   useAbortableEffect(() => {
     if (mode !== 'verify') verification.camera.stopCamera();
-  }, [mode, verification.camera.stopCamera]);
-
-  // アンマウント時にカメラを停止する
-  useAbortableEffect(() => {
     return () => {
       verification.camera.stopCamera();
     };
-  }, [verification.camera.stopCamera]);
+  }, [mode, verification.camera.stopCamera]);
 
   return (
     <div className="space-y-6">

--- a/src/components/tools/UlidGenerator.tsx
+++ b/src/components/tools/UlidGenerator.tsx
@@ -6,6 +6,7 @@ import { CountInput } from '@/components/ui/CountInput';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ResultTable } from '@/components/ui/ResultTable';
 import type { TableColumn } from '@/components/ui/ResultTable';
+import { useQuoteStyle, QUOTE_OPTIONS, type QuoteStyle } from '@/hooks/useQuoteStyle';
 
 interface UlidRow {
   id: string;
@@ -20,26 +21,11 @@ function generateRows(count: number): UlidRow[] {
   });
 }
 
-type QuoteStyle = 'none' | 'single' | 'double';
-
 export function UlidGeneratorTool() {
   const [rows, setRows] = useState<UlidRow[]>([]);
-  const [quoteStyle, setQuoteStyle] = useState<QuoteStyle>('none');
+  const { quoteStyle, setQuoteStyle, formatId, formatAll } = useQuoteStyle();
 
-  const formatId = (id: string) => {
-    if (quoteStyle === 'double') return `"${id}"`;
-    if (quoteStyle === 'single') return `'${id}'`;
-    return id;
-  };
-
-  const allUlids = rows
-    .map((r, i) => {
-      const isLast = i === rows.length - 1;
-      if (quoteStyle === 'double') return `"${r.id}"${isLast ? '' : ','}`;
-      if (quoteStyle === 'single') return `'${r.id}'${isLast ? '' : ','}`;
-      return r.id;
-    })
-    .join('\n');
+  const allUlids = formatAll(rows.map((r) => r.id));
 
   const columns: TableColumn<UlidRow>[] = [
     {
@@ -101,11 +87,7 @@ export function UlidGeneratorTool() {
                 <div className="flex flex-wrap items-center gap-2">
                   <div className="shrink-0">
                     <ToggleGroup<QuoteStyle>
-                      options={[
-                        { value: 'none', label: 'なし' },
-                        { value: 'double', label: '"..."' },
-                        { value: 'single', label: "'...'" },
-                      ]}
+                      options={QUOTE_OPTIONS}
                       value={quoteStyle}
                       onChange={setQuoteStyle}
                       ariaLabel="クォートスタイル"

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -7,6 +7,7 @@ import { ClearButton } from '@/components/ui/ClearButton';
 import { ResultTable } from '@/components/ui/ResultTable';
 import type { TableColumn } from '@/components/ui/ResultTable';
 import { parseUuidV7Fields, extractUuidV7Timestamp } from '@/utils/uuid-v7';
+import { useQuoteStyle, QUOTE_OPTIONS, type QuoteStyle } from '@/hooks/useQuoteStyle';
 
 interface UuidRow {
   id: string;
@@ -28,8 +29,6 @@ function generateRows(count: number): UuidRow[] {
     return { id, timestamp: extractUuidV7Timestamp(id) };
   });
 }
-
-type QuoteStyle = 'none' | 'single' | 'double';
 
 /** UUID 文字列を色分けして表示する */
 function ColoredUuid({ uuid, quoteStyle }: { uuid: string; quoteStyle: QuoteStyle }) {
@@ -92,17 +91,9 @@ function FieldBreakdownPanel({ uuid }: { uuid: string }) {
 export function UuidV7GeneratorTool() {
   const [rows, setRows] = useState<UuidRow[]>([]);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [quoteStyle, setQuoteStyle] = useState<QuoteStyle>('none');
+  const { quoteStyle, setQuoteStyle, formatId, formatAll } = useQuoteStyle();
 
-  const quote = quoteStyle === 'double' ? '"' : quoteStyle === 'single' ? "'" : '';
-  const formatId = (id: string) => `${quote}${id}${quote}`;
-
-  const allUuids = rows
-    .map((r, i) => {
-      const isLast = i === rows.length - 1;
-      return `${quote}${r.id}${quote}${isLast ? '' : ','}`;
-    })
-    .join('\n');
+  const allUuids = formatAll(rows.map((r) => r.id));
 
   const columns: TableColumn<UuidRow>[] = [
     {
@@ -164,11 +155,7 @@ export function UuidV7GeneratorTool() {
                 <div className="flex flex-wrap items-center gap-2">
                   <div className="shrink-0">
                     <ToggleGroup<QuoteStyle>
-                      options={[
-                        { value: 'none', label: 'なし' },
-                        { value: 'double', label: '"..."' },
-                        { value: 'single', label: "'...'" },
-                      ]}
+                      options={QUOTE_OPTIONS}
                       value={quoteStyle}
                       onChange={setQuoteStyle}
                       ariaLabel="クォートスタイル"

--- a/src/hooks/__tests__/useQuoteStyle.test.ts
+++ b/src/hooks/__tests__/useQuoteStyle.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useQuoteStyle, QUOTE_OPTIONS } from '@/hooks/useQuoteStyle';
+
+describe('useQuoteStyle', () => {
+  describe('初期値', () => {
+    it('引数なしの場合 none で初期化される', () => {
+      const { result } = renderHook(() => useQuoteStyle());
+      expect(result.current.quoteStyle).toBe('none');
+    });
+
+    it('initial 引数で初期スタイルを指定できる', () => {
+      const { result } = renderHook(() => useQuoteStyle('double'));
+      expect(result.current.quoteStyle).toBe('double');
+    });
+  });
+
+  describe('formatId', () => {
+    it('none では ID をそのまま返す', () => {
+      const { result } = renderHook(() => useQuoteStyle('none'));
+      expect(result.current.formatId('abc')).toBe('abc');
+    });
+
+    it('double では ID をダブルクォートで囲む', () => {
+      const { result } = renderHook(() => useQuoteStyle('double'));
+      expect(result.current.formatId('abc')).toBe('"abc"');
+    });
+
+    it('single では ID をシングルクォートで囲む', () => {
+      const { result } = renderHook(() => useQuoteStyle('single'));
+      expect(result.current.formatId('abc')).toBe("'abc'");
+    });
+  });
+
+  describe('formatAll', () => {
+    it('none では改行区切りで結合し comma を付けない', () => {
+      const { result } = renderHook(() => useQuoteStyle('none'));
+      expect(result.current.formatAll(['a', 'b', 'c'])).toBe('a\nb\nc');
+    });
+
+    it('double では各 ID をダブルクォートで囲み trailing comma を付ける（最終行を除く）', () => {
+      const { result } = renderHook(() => useQuoteStyle('double'));
+      expect(result.current.formatAll(['a', 'b', 'c'])).toBe('"a",\n"b",\n"c"');
+    });
+
+    it('single では各 ID をシングルクォートで囲み trailing comma を付ける（最終行を除く）', () => {
+      const { result } = renderHook(() => useQuoteStyle('single'));
+      expect(result.current.formatAll(['a', 'b', 'c'])).toBe("'a',\n'b',\n'c'");
+    });
+
+    it('空配列では空文字列を返す', () => {
+      const { result } = renderHook(() => useQuoteStyle('double'));
+      expect(result.current.formatAll([])).toBe('');
+    });
+
+    it('単一要素では comma を付けない', () => {
+      const { result } = renderHook(() => useQuoteStyle('double'));
+      expect(result.current.formatAll(['x'])).toBe('"x"');
+    });
+  });
+
+  describe('setQuoteStyle', () => {
+    it('setQuoteStyle で style を切り替えられる', () => {
+      const { result } = renderHook(() => useQuoteStyle('none'));
+      act(() => result.current.setQuoteStyle('single'));
+      expect(result.current.quoteStyle).toBe('single');
+      expect(result.current.formatId('x')).toBe("'x'");
+    });
+  });
+
+  describe('QUOTE_OPTIONS', () => {
+    it('none / double / single の 3 種類が定義されている', () => {
+      expect(QUOTE_OPTIONS.map((o) => o.value)).toEqual(['none', 'double', 'single']);
+    });
+
+    it('日本語ラベルが定義されている', () => {
+      const noneOption = QUOTE_OPTIONS.find((o) => o.value === 'none');
+      expect(noneOption?.label).toBe('なし');
+    });
+  });
+});

--- a/src/hooks/useQuoteStyle.ts
+++ b/src/hooks/useQuoteStyle.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+
+/** ID 文字列のクォートスタイル。none / single / double のいずれか。 */
+export type QuoteStyle = 'none' | 'single' | 'double';
+
+/** ToggleGroup<QuoteStyle> 用の選択肢定数。Ulid / UuidV7 など複数 generator で共有する。 */
+export const QUOTE_OPTIONS: { value: QuoteStyle; label: string }[] = [
+  { value: 'none', label: 'なし' },
+  { value: 'double', label: '"..."' },
+  { value: 'single', label: "'...'" },
+];
+
+/**
+ * ID 列のクォートスタイル管理フック。
+ *
+ * - `formatId(id)`: 単一 ID をクォートで囲む
+ * - `formatAll(ids)`: 配列を改行区切りで結合（クォートあり時は array-like に trailing comma 付与）
+ */
+export function useQuoteStyle(initial: QuoteStyle = 'none') {
+  const [quoteStyle, setQuoteStyle] = useState<QuoteStyle>(initial);
+
+  const formatId = useCallback(
+    (id: string) => {
+      if (quoteStyle === 'double') return `"${id}"`;
+      if (quoteStyle === 'single') return `'${id}'`;
+      return id;
+    },
+    [quoteStyle]
+  );
+
+  const formatAll = useCallback(
+    (ids: string[]) =>
+      ids
+        .map((id, i) => {
+          const formatted = formatId(id);
+          if (quoteStyle === 'none') return formatted;
+          const isLast = i === ids.length - 1;
+          return `${formatted}${isLast ? '' : ','}`;
+        })
+        .join('\n'),
+    [formatId, quoteStyle]
+  );
+
+  return { quoteStyle, setQuoteStyle, formatId, formatAll };
+}

--- a/tests/e2e/uuid-v7.spec.ts
+++ b/tests/e2e/uuid-v7.spec.ts
@@ -130,6 +130,35 @@ test.describe('UUID v7 生成（production CSP 適用）', () => {
     });
   });
 
+  test('「すべてコピー」: none では改行のみ・quoted では trailing comma 付き array-like で出力する（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/uuid-v7', async (page) => {
+      await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+      await page.getByRole('button', { name: '生成' }).click();
+      await expect(page.getByText('10 件生成')).toBeVisible();
+
+      // none では comma が付かず改行のみで結合される
+      await page.getByRole('button', { name: 'すべてコピー' }).click();
+      const noneCopied = await page.evaluate(() => navigator.clipboard.readText());
+      expect(noneCopied).not.toContain(',');
+      expect(noneCopied.split('\n')).toHaveLength(10);
+
+      // double では各行にダブルクォート + trailing comma（最終行を除く）
+      await page.getByRole('button', { name: '"..."' }).click();
+      await page.getByRole('button', { name: 'すべてコピー' }).click();
+      const doubleCopied = await page.evaluate(() => navigator.clipboard.readText());
+      const doubleLines = doubleCopied.split('\n');
+      expect(doubleLines).toHaveLength(10);
+      // 最終行以外は `"...",` で終わる
+      for (const line of doubleLines.slice(0, -1)) {
+        expect(line).toMatch(/^".+",$/);
+      }
+      // 最終行は trailing comma 無し
+      expect(doubleLines[doubleLines.length - 1]).toMatch(/^".+"$/);
+    });
+  });
+
   test('クリアボタンでリストをリセットできる（CSP 違反なし）', async ({ browser }) => {
     await withProductionCsp(browser, '/tools/uuid-v7', async (page) => {
       await page.getByRole('button', { name: '生成' }).click();


### PR DESCRIPTION
## サマリ

`refactor` タグ open issue から **方針が確定済みかつ単独 PR で完結可能** な 2 件を選定して対応。両者とも対応案コードが issue 本文に明示されており、判断分岐が不要な低リスク refactor。

## 対応 issue

### refactor(generator): QuoteStyle / formatId を `useQuoteStyle` で共通化 (#393)

UlidGenerator / UuidV7Generator の `QuoteStyle` 型 / `formatId` / `allXxx` build / ToggleGroup options が完全重複していた DRY 違反を解消。

- `src/hooks/useQuoteStyle.ts` を新設し `QuoteStyle` 型 / `QUOTE_OPTIONS` / `useQuoteStyle()` を集約
- 両 generator から重複ロジックを削除しフックに委譲
- フック単体テスト 13 ケース (`src/hooks/__tests__/useQuoteStyle.test.ts`) で parity 保証

**挙動変更点（軽微）**: `formatAll` を「none では comma 無し / quoted では trailing comma 付き」に統一。UuidV7 側で従来発生していた「`none` でも `id,id,id` のように comma が付く」という不自然な挙動を解消（quote 無しに comma だけ付くのは UX 上ノイズ。Ulid 側は元から無かった）。

### refactor(qr-ticket): camera lifecycle Effect を 1 系統に統合 (#400)

`QrTicket.tsx` の camera lifecycle を管理する `useAbortableEffect` が 3 系統存在し、Effect 2 (mode change) と Effect 3 (unmount cleanup) を分離する根拠が薄かった。`useQrCamera.stopCamera` は `useCallback(..., [])` で stable のため、Effect 2 の cleanup として `stopCamera` を返せば teardown / unmount の両方をカバーできる。

- Effect 3 を削除し Effect 2 に cleanup 関数を付与
- 認知負荷削減（3 effect → 2 effect）、副作用は等価

## 検証

- ✅ `node_modules/.bin/astro check` (0 errors / 0 warnings / 0 hints)
- ✅ `npm run test` (1142 passed, ビルド未実行起因の `sw-cache-version` 2 件 fail は pre-existing で本 PR と無関係)
- ✅ `npm run build` (22 pages, success)
- ✅ `npm run test:e2e -- ulid-generator uuid-v7 qr-ticket` (24/24 pass、`クォートスタイルを切り替えられる` test も含む)

## Test plan

- [ ] CI で全 E2E / unit / type / VRT が通る
- [ ] `/tools/ulid-generator` と `/tools/uuid-v7` でクォートスタイル切替 (`なし` / `"..."` / `'...'`) → コピー結果が想定通り
- [ ] `/tools/qr-ticket` で生成 ⇄ 検証タブ切替で camera が確実に停止することを目視確認

Closes #393
Closes #400

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv85vj4W81NkyzN7W4guzh)_