### PR TITLE
release: develop → main (#453 GS1 DataBar scanner 認識失敗修正)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -207,6 +207,10 @@ JANコードで使用した JsBarcode は EAN/UPC 系のみ対応で、GS1 DataB
 また、`includetext: true` で合成部の上に AI テキストが描画されない bwip-js のバージョン挙動の問題は、
 SVG 文字列を後処理してテキスト要素を直接注入することで解決した。
 
+加えて、bwip-js の default 出力には `shape-rendering` 指定がないため、ブラウザ表示 / SVG→`<img>`→Canvas 経路の両方で bar/space edge が sub-pixel anti-alias で滲み、scanner が黒/白二値閾値で bar 幅を誤判定する事象が発生していた（特に composite CC-A の 1X 矩形 module でロット (10) が decode 不能）。`addSvgDimensions()` で `shape-rendering="crispEdges"` を同時注入し、PNG 変換側 (`svgContentToPngBlob` / `downloadPngFromSvgElement`) では `ctx.imageSmoothingEnabled = false` を設定し、表示プレビュー側は `.barcode-preview { image-rendering: pixelated }` で crisp edge を強制することで全経路の anti-aliasing を抑止した。
+
+この 3 層のうち **真の砦は L1 = SVG `shape-rendering="crispEdges"`** で、ブラウザの vector rasterize 全経路 (preview / Image rasterization) に効く。L2 = Canvas `imageSmoothingEnabled = false` は `ctx.scale(2,2)` + `drawImage` の 2x upscale 段階の re-smoothing を抑止する念押し、L3 = CSS `image-rendering: pixelated` は inline SVG (vector) には UA 依存で effectively no-op が多く、raster cache 経由で SVG が bitmap 化される極端ケースのみで効く保険、という位置づけ。将来この fix の一部を revert する判断が必要になった際は **L1 を最優先で残す** こと（L1 を消すと L2/L3 はほぼ無力）。bwip-js は半画素座標 + `stroke-width="3"` で bar を描く構造のため、整数 DPR では `shape-rendering` 無しでも crisp だが非整数 DPR (モバイル 2.625x/3x 等) では anti-alias の灰色 sub-pixel ringing で decode 失敗する。L1 の `crispEdges` は SVG spec 上 stroke geometry にも適用されるため全 DPR で binary thresholding を強制でき、これが root fix となる。
+
 ### 却下した選択肢
 
 - **JsBarcode**: GS1 DataBar 非対応のため却下。

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -6,6 +6,7 @@ import {
   calcGtin14CheckDigit,
   validateGtin14Input,
   buildBwipText,
+  addSvgDimensions,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
@@ -38,21 +39,6 @@ const DEFAULT_AI_FIELDS: AiFieldState[] = [
 const SAMPLE_GTINS = ['0498700000001', '0498700000018', '0498700000025'];
 
 const MAX_CARDS = 10;
-
-/**
- * bwip-js の toSVG は viewBox のみで width/height を持たない SVG を返す。
- * width/height がないと:
- *   - flex コンテナでの描画が不安定になる
- *   - Image 要素の natural size が 0x0 になり PNG が空になる
- * viewBox から pixel 寸法を取り出して属性として追加する。
- */
-function addSvgDimensions(svg: string): string {
-  const m = svg.match(/viewBox="0 0 ([\d.]+) ([\d.]+)"/);
-  if (!m) return svg;
-  const w = Math.round(parseFloat(m[1]));
-  const h = Math.round(parseFloat(m[2]));
-  return svg.replace('<svg viewBox=', `<svg width="${w}" height="${h}" viewBox=`);
-}
 
 // ─────────────────────────────────────────────
 // BarcodeCard
@@ -339,6 +325,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
           >
             <div
               aria-label={`GS1 DataBar ${gtinResult?.fullGtin} のバーコード`}
+              className="barcode-preview"
               dangerouslySetInnerHTML={{ __html: svgContent }}
             />
             <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -557,6 +557,18 @@
     opacity: 0.7;
   }
 
+  /* === Gs1Databar: バーコードプレビューの sub-pixel anti-alias 抑止 ===
+     bwip-js は bar を <path stroke="#000000" stroke-width="N" d="..."> で描く。
+     vector だがブラウザは high-DPR / 非整数 scaling 時に raster cache を介して
+     anti-alias し、bar/space edge が灰色に滲むと scanner の黒/白二値閾値で
+     bar 幅判定が失敗する (特に composite CC-A の 1X 矩形 module でロット (10)
+     decode 失敗)。`pixelated` を指定して raster cache 経路への保険とする。
+     edge crisp 化の本体は SVG 自身に付与する shape-rendering="crispEdges"
+     (utils/gs1-databar.ts) が担い、本 class はその backstop という位置づけ。 */
+  .barcode-preview {
+    image-rendering: pixelated;
+  }
+
   /* === PR 4: Gs1Databar <details>/<summary> marker hide === */
   .summary-no-marker {
     list-style: none;

--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { downloadBlob, downloadPngFromSvgElement } from '@/utils/download';
+import { downloadBlob, downloadPngFromSvgElement, svgContentToPngBlob } from '@/utils/download';
 
 /**
  * downloadBlob のスモークテスト。
@@ -147,6 +147,36 @@ describe('downloadPngFromSvgElement', () => {
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 
+  it('陽性対照: Canvas context の imageSmoothingEnabled が false に設定される (バーコード edge anti-alias 抑止)', async () => {
+    // fix を revert (imageSmoothingEnabled = false 行を消す) すると context は
+    // mock default の true のままで本テストが fail する設計 (test-gates 鉄則 1)。
+    let capturedCtx: { imageSmoothingEnabled: boolean; scale: unknown; drawImage: unknown } | null =
+      null;
+    vi.stubGlobal('document', {
+      createElement: vi.fn((tag: string) => {
+        if (tag === 'canvas') {
+          return {
+            width: 0,
+            height: 0,
+            getContext: () => {
+              capturedCtx = { imageSmoothingEnabled: true, scale: vi.fn(), drawImage: vi.fn() };
+              return capturedCtx;
+            },
+            toDataURL: vi.fn(() => 'data:image/png;base64,XXX'),
+          };
+        }
+        if (tag === 'a') return { href: '', download: '', click: vi.fn() };
+        return {};
+      }),
+    });
+
+    const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
+    imgInstance.onload?.();
+    await promise;
+    expect(capturedCtx).not.toBeNull();
+    expect(capturedCtx!.imageSmoothingEnabled).toBe(false);
+  });
+
   it('陽性対照: img.onload 内で canvas.toDataURL が throw した場合も Promise は reject する', async () => {
     // canvas.toDataURL を throw する stub に差し替える (tainted canvas 等の SecurityError 相当)
     vi.stubGlobal('document', {
@@ -171,5 +201,77 @@ describe('downloadPngFromSvgElement', () => {
     await expect(promise).rejects.toThrow('canvas is tainted');
     // finally で ObjectURL は解放される
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});
+
+/**
+ * svgContentToPngBlob: PNG 変換時の anti-aliasing 抑止 (GS1 DataBar 認識失敗修正)。
+ *
+ * fix を revert (download.ts:55 付近の `ctx.imageSmoothingEnabled = false` を削る)
+ * と本テストが必ず fail する陽性対照 (test-gates 鉄則 1)。
+ *
+ * 旧実装は ctx.drawImage(img, 0, 0) を smoothing 有効 default のまま呼んでおり、
+ * scanner が黒/白二値閾値で bar 幅を取り違える事象を起こしていた。
+ */
+describe('svgContentToPngBlob', () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let imgInstance: { onload: (() => void) | null; onerror: (() => void) | null; src: string };
+  let capturedCtx: { imageSmoothingEnabled: boolean; scale: unknown; drawImage: unknown } | null;
+
+  beforeEach(() => {
+    capturedCtx = null;
+    createObjectURL = vi.fn(() => 'blob:mock-url');
+    revokeObjectURL = vi.fn();
+    vi.stubGlobal('document', {
+      createElement: vi.fn((tag: string) => {
+        if (tag === 'canvas') {
+          return {
+            width: 0,
+            height: 0,
+            getContext: () => {
+              capturedCtx = { imageSmoothingEnabled: true, scale: vi.fn(), drawImage: vi.fn() };
+              return capturedCtx;
+            },
+            toBlob: (cb: (b: Blob | null) => void) => cb(new Blob(['png'], { type: 'image/png' })),
+          };
+        }
+        return {};
+      }),
+    });
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+    vi.stubGlobal(
+      'Image',
+      class {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        _src = '';
+        get src() {
+          return this._src;
+        }
+        set src(v: string) {
+          this._src = v;
+          imgInstance = this;
+        }
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('陽性対照: Canvas context の imageSmoothingEnabled が false に設定される', async () => {
+    const svg = '<svg width="100" height="50" viewBox="0 0 100 50"></svg>';
+    const promise = svgContentToPngBlob(svg);
+    imgInstance.onload?.();
+    await promise;
+    expect(capturedCtx).not.toBeNull();
+    expect(capturedCtx!.imageSmoothingEnabled).toBe(false);
+  });
+
+  it('width/height が無い SVG は reject される (既存契約)', async () => {
+    const svg = '<svg viewBox="0 0 100 50"></svg>';
+    await expect(svgContentToPngBlob(svg)).rejects.toThrow('width/height');
   });
 });

--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -3,6 +3,7 @@ import {
   calcGtin14CheckDigit,
   validateGtin14Input,
   buildBwipText,
+  addSvgDimensions,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
@@ -135,5 +136,73 @@ describe('buildBwipText', () => {
   it('値の前後スペースはトリムされる', () => {
     const result = buildBwipText('04987000000017', [{ ai: '10' as AiCode, value: '  ABC  ' }]);
     expect(result).toBe('(01)04987000000017|(10)ABC');
+  });
+});
+
+// ────────────────────────────────────────────
+// addSvgDimensions
+// ────────────────────────────────────────────
+//
+// 陽性対照: fix を revert (shape-rendering 注入や width/height 注入を削る) と
+// 該当 it() が必ず fail する設計。bwip-js の SVG が anti-alias で滲んで scanner
+// decode 失敗した事象 (composite CC-A 部のロット (10) が読めない) を再発防止する
+// regression test 一式。
+describe('addSvgDimensions', () => {
+  it('viewBox から width / height 属性を注入する (PNG 変換時の natural size 0x0 回避)', () => {
+    const input = '<svg viewBox="0 0 96 50" xmlns="http://www.w3.org/2000/svg"></svg>';
+    const out = addSvgDimensions(input);
+    expect(out).toContain('width="96"');
+    expect(out).toContain('height="50"');
+  });
+
+  it('shape-rendering="crispEdges" を注入する (bar/space edge の anti-alias 抑止)', () => {
+    const input = '<svg viewBox="0 0 96 50" xmlns="http://www.w3.org/2000/svg"></svg>';
+    const out = addSvgDimensions(input);
+    expect(out).toContain('shape-rendering="crispEdges"');
+  });
+
+  it('注入された属性は <svg> 開始タグ内に存在する (子要素ではなく root への適用)', () => {
+    const input = '<svg viewBox="0 0 100 40"><rect width="10" height="40"/></svg>';
+    const out = addSvgDimensions(input);
+    const openTag = out.match(/<svg[^>]*>/);
+    expect(openTag).not.toBeNull();
+    expect(openTag![0]).toContain('shape-rendering="crispEdges"');
+    expect(openTag![0]).toContain('width="100"');
+    expect(openTag![0]).toContain('height="40"');
+  });
+
+  it('小数 viewBox は四捨五入される (整数 pixel 寸法)', () => {
+    const input = '<svg viewBox="0 0 95.6 49.4"></svg>';
+    const out = addSvgDimensions(input);
+    expect(out).toContain('width="96"');
+    expect(out).toContain('height="49"');
+  });
+
+  it('viewBox を持たない入力は変更せず返す (想定外フォーマットを破壊しない)', () => {
+    const input = '<svg width="100" height="50"></svg>';
+    expect(addSvgDimensions(input)).toBe(input);
+  });
+
+  // 陽性対照 (silent regression 防止): bwip-js が将来 `<svg xmlns="..." viewBox=...>`
+  // の属性順で出力するように変わった場合でも fix が動き続けることを保証する。
+  // 旧実装 (literal `<svg viewBox=` で String.prototype.replace) ではここで no-op
+  // になり width/height/shape-rendering が一切注入されない silent regression を
+  // 起こしていた。
+  it('viewBox の前に xmlns 属性があっても寸法と crispEdges を注入する', () => {
+    const input = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 50"></svg>';
+    const out = addSvgDimensions(input);
+    expect(out).toContain('width="96"');
+    expect(out).toContain('height="50"');
+    expect(out).toContain('shape-rendering="crispEdges"');
+    expect(out).toContain('xmlns="http://www.w3.org/2000/svg"');
+  });
+
+  it('viewBox の後に追加属性 (xmlns, class) があっても注入する', () => {
+    const input = '<svg viewBox="0 0 80 40" xmlns="http://www.w3.org/2000/svg" class="foo"></svg>';
+    const out = addSvgDimensions(input);
+    expect(out).toContain('width="80"');
+    expect(out).toContain('height="40"');
+    expect(out).toContain('shape-rendering="crispEdges"');
+    expect(out).toContain('class="foo"');
   });
 });

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -53,6 +53,11 @@ export function svgContentToPngBlob(svgContent: string): Promise<Blob> {
     canvas.width = parseInt(m[1], 10) * RETINA_SCALE;
     canvas.height = parseInt(m[2], 10) * RETINA_SCALE;
     const ctx = canvas.getContext('2d')!;
+    // バーコード/QR の bar/space edge を sharp に保つため smoothing 無効化。
+    // 有効のままだと SVG → Image → Canvas 経路で edge が灰色に滲み、scanner が
+    // 黒/白の二値閾値で bar 幅を取り違えて decode 失敗する（GS1 DataBar の
+    // composite CC-A 1X 矩形 module が読めなくなる原因）。
+    ctx.imageSmoothingEnabled = false;
     ctx.scale(RETINA_SCALE, RETINA_SCALE);
     const img = new Image();
     const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
@@ -95,6 +100,8 @@ export function downloadPngFromSvgElement(svgEl: SVGSVGElement, filename: string
     canvas.width = width * RETINA_SCALE;
     canvas.height = height * RETINA_SCALE;
     const ctx = canvas.getContext('2d')!;
+    // bar/space の edge anti-aliasing を抑止 (svgContentToPngBlob と同じ理由)。
+    ctx.imageSmoothingEnabled = false;
     ctx.scale(RETINA_SCALE, RETINA_SCALE);
     const img = new Image();
     const blob = new Blob([svgEl.outerHTML], { type: 'image/svg+xml' });

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -166,3 +166,33 @@ export function buildBwipText(
   const composite = filledFields.map((f) => `(${f.ai})${f.value.trim()}`).join('');
   return `${linear}|${composite}`;
 }
+
+/**
+ * bwip-js の toSVG 出力は viewBox のみで width/height を持たない。
+ * (1) flex コンテナでの寸法不定 / Image の natural size = 0x0 → PNG 空回避のため
+ *     viewBox から pixel 寸法を取り出して width/height 属性を注入する。
+ * (2) shape-rendering="crispEdges" を同時に注入する。bwip-js default では未指定で、
+ *     付けないとブラウザ表示・Image→Canvas 経路の両方で bar/space edge が
+ *     sub-pixel anti-alias で滲み、scanner が黒/白二値閾値で bar 幅を誤判定する
+ *     (特に composite CC-A の 1X 矩形 module でロット (10) が読めない事象の原因)。
+ *
+ * 属性順依存を避けるため <svg> 開始タグ全体を regex で捕捉し、`viewBox` の
+ * 前後どちらに `xmlns` 等が来ても動くようにする (bwip-js upgrade で属性順が
+ * 変わっても silent regression しないようにするため)。
+ *
+ * 出力契約 (downstream dependency): 注入する `width=...` と `height=...` は
+ * 連続して並べる。これは `utils/download.ts` の `svgContentToPngBlob` が
+ * `match(/width="(\d+)" height="(\d+)"/)` で canvas サイズを抽出するため
+ * (隣接していないと match 失敗 → reject)。間に他属性を挟まないこと。
+ */
+export function addSvgDimensions(svg: string): string {
+  const openTagMatch = svg.match(/<svg(\s[^>]*?)?\s+viewBox="0 0 ([\d.]+) ([\d.]+)"([^>]*)>/);
+  if (!openTagMatch) return svg;
+  const [originalTag, beforeViewBox = '', wStr, hStr, afterViewBox = ''] = openTagMatch;
+  const w = Math.round(parseFloat(wStr));
+  const h = Math.round(parseFloat(hStr));
+  const newTag =
+    `<svg width="${w}" height="${h}" shape-rendering="crispEdges"` +
+    `${beforeViewBox} viewBox="0 0 ${wStr} ${hStr}"${afterViewBox}>`;
+  return svg.replace(originalTag, newTag);
+}

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -112,4 +112,43 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
       await expect(page.getByRole('alert').filter({ hasText: /ダウンロードエラー/ })).toBeVisible();
     });
   });
+
+  // ─────────────────────────────────────────────
+  // バーコード認識安定化 (anti-aliasing 抑止) のブラウザ実測検証
+  //
+  // 旧実装は (a) bwip-js SVG に shape-rendering 未指定、(b) Canvas→PNG 時に
+  // imageSmoothingEnabled = true (default) のため、bar/space edge が灰色に滲み
+  // scanner が黒/白二値閾値で decode 失敗する事象を起こしていた (composite CC-A
+  // のロット (10) が読めない事象)。fix を revert すると以下 2 ケースは必ず fail
+  // する陽性対照。
+  // ─────────────────────────────────────────────
+  test('生成 SVG に shape-rendering="crispEdges" が付与されている（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      const preview = page.getByLabel(/GS1 DataBar.*のバーコード/);
+      const innerHtml = await preview.evaluate((el) => el.innerHTML);
+      expect(innerHtml).toContain('shape-rendering="crispEdges"');
+    });
+  });
+
+  test('バーコードプレビューの image-rendering が pixelated（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      const preview = page.getByLabel(/GS1 DataBar.*のバーコード/);
+      await expect(preview).toBeVisible();
+
+      const rendering = await preview.evaluate((el) => getComputedStyle(el).imageRendering);
+      // Chromium (本リポジトリ playwright.config.ts の唯一の project) は
+      // 'pixelated' をそのまま正規化して返す。本 assertion はあくまで CSS class が
+      // 適用されたことの観測であり、実際の raster cache 経路でのピクセル化挙動は
+      // ブラウザ実装依存のため別途実機検証が必要。
+      expect(rendering).toBe('pixelated');
+    });
+  });
 });


### PR DESCRIPTION
## リリース内容

develop の以下 1 件を main に反映します。前回リリース (#451) 以降のユーザー報告由来の bug fix を取り込むリリースです。

| PR | 種別 | 概要 |
|---|---|---|
| #453 | fix | GS1 DataBar 生成ツールでダウンロードした PNG / モバイル表示の DataBar が scanner で認識されない問題を修正。bwip-js 出力 SVG が `shape-rendering` 未指定 + Canvas 経由 PNG 生成時の `imageSmoothingEnabled` が default `true` のままで bar/space edge が anti-alias で滲み、scanner が黒/白二値閾値で bar 幅を誤判定していた（特に composite CC-A の 1X 矩形 module でロット (10) 等の AI 情報が decode 不能）。3 層 (L1: SVG `shape-rendering="crispEdges"` / L2: Canvas `imageSmoothingEnabled=false` / L3: CSS `image-rendering: pixelated`) で抑止。L1 が真の砦、L2/L3 は upscale / raster cache 経路への保険。陽性対照テスト (unit 8 件 / e2e 2 件) を `test-gates` 鉄則に沿って追加。`addSvgDimensions` は寛容 regex 化して bwip-js upgrade 時の silent regression を防止。 |

## 本番への影響

### バグ修正

- **`/tools/gs1-databar`** で生成した PNG を scanner サイトにアップロードした際 / モバイル画面に表示して別端末カメラで読んだ際の **誤認識・decode 不能** を解消。特に composite barcode のロット (10) など 2D CC-A 部分の AI 情報が読めなかった事象を修正。
- 「screenshot で縮小すると読める / 生 PNG は読めない」という症状は解像度ではなく **非整数 DPR (モバイル 2.625x / 3x) での sub-pixel ringing** が root cause。bwip-js が半画素座標 + `stroke-width="3"` で bar を描く構造に対し SVG attribute / Canvas API / CSS の各 path で anti-aliasing を抑止することで全 DPR で binary thresholding を強制する。

### 互換性

- 既存ツールへの影響なし。`download.ts` の `imageSmoothingEnabled = false` は JsBarcode (JAN code) など他バーコード PNG 出力経路にも一律で効くが、JsBarcode は整数座標の `<rect>` で描画するため元々 anti-alias 起因問題が顕在化しにくく、副作用として **小さな改善** が乗るだけで regression リスクは実質ゼロ。
- 依存ライブラリ追加なし。CSP 影響なし。
- VRT baseline 影響なし (CI 上で全 40 件 pass 確認済み)。
- 関数名 `addSvgDimensions` は意味拡大 (shape-rendering も注入) しているが downstream API 影響なし、JSDoc に明記。

### 検証状況

PR #453 は develop merge 時に CI 全 green を確認済み (test / e2e / visual-regression)。レビューでは以下が本 PR 内で対応されています:

- 3 層 anti-alias 抑止の設計妥当性 (`test-gates` 鉄則準拠の陽性対照テスト)
- `addSvgDimensions` の literal `replace` fragility (bwip-js upgrade 時 silent regression リスク) を寛容 regex + xmlns 順入れ替え陽性対照テストで解消
- L1 = SVG `shape-rendering` が真の砦であることを `docs/decisions.md` に明記 (将来 partial revert 判断時のため)
- `width/height` 隣接前提を JSDoc に明記 (`svgContentToPngBlob` regex の暗黙 dependency)
- CSS コメント `<rect>` → `<path>` 訂正 (bwip-js 実態に整合)
- 副作用範囲 (JsBarcode への波及) の精査と妥当性確認

### 残課題

- **実機 scanner での PNG / モバイル decode 成功確認**: 技術的根拠は bwip-js の出力構造 (半画素 stroke) と SVG/Canvas spec から演繹的に裏付けられているが、最終 closure には実機 scanner サイトでの decode 成功確認をユーザー側で実施することを推奨。本リリース merge 自体は CI green で blocker なし。


---
_Generated by [Claude Code](https://claude.ai/code/session_01UV1Hi7SxjUDz6LUxjz1bCk)_