### PR TITLE
release: gs1-databar composite シンボル CC-A の quiet zone 修正を本番反映

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3113,3 +3113,61 @@ TypeScript 5.9.3 では `Uint8Array = Uint8Array<ArrayBufferLike>` だが、Web 
 - issue #352
 - meta test: `tests/meta/vrt-slider-report.test.ts` の `generateHTML (slider lib 参照経路)` describe (陰性対照: ローカル `lib/` 参照を assert) + `[陽性対照] CDN 参照検知 assertion が機能している` describe (`unpkg.com` / `cdn.jsdelivr.net` を含む synthetic HTML で検知 assertion 自体の機能を担保)
 - CI workflow: `.github/workflows/visual-regression.yml` (改修不要、`npm ci` step が既に存在)
+
+---
+
+## [081] 2026-05-20 — Gs1Databar Composite に `paddingwidth: 10` を追加 + PR #450 のコメント誤読を訂正
+
+**日付 2026-05-20 | ステータス: 採用**
+
+### 背景
+
+`databarlimitedcomposite` で生成した GS1 DataBar Limited 合成シンボルを PC スキャナで読み取ると、**GTIN-14 (AI 01) は decode されるがロット番号 (AI 10) など CC-A 部が一切返らない** 事象が報告された。他ツールで作成した同種シンボルは同じスキャナで読めており、当ツールの出力に GS1 仕様面の不足があると判明。
+
+PR #450 (`height` オプション削除) と PR #453 (`shape-rendering="crispEdges"` 注入) で 2 段階の修正を入れていたが、本症状は再発した。bwip-js v4.9.0 の内部構造を再調査した結果、以下 2 点が判明した。
+
+### bwip-js v4.9.0 内部構造の再整理
+
+1. **`databarlimitedcomposite` は linear と CC を別レンダラで描画する**
+   - linear 部: `bwipp_renlinear` (`bwipp.js` 周辺の renlinear 経路)。`borderleft: 10` / `borderright: 10` を default で持ち 10X quiet zone を確保
+   - CC 部 (CC-A/CC-B): `bwipp_renmatrix` 経由で `bwipp_micropdf417` が `borderleft: 1` / `borderright: 1` しか渡さない → **CC の左右 quiet zone が 1X (= 3 svg-px @ scale=3) しかない**
+2. **CC-A モジュールが 1X × 2X 長方形なのは ISO/IEC 24723 仕様準拠**
+   - `bwipp_micropdf417` は `rowmult: 2` を default に持ち、CC-A 各行の高さは 2X となる
+   - GS1 General Spec 5.9.2.2 が要求する「X-dim 一致」は **横方向のみ** で、CC モジュールが正方形である必要はない (= PR #450 のコメント「~1X×1X 正方形」は GS1 仕様の誤読だった)
+   - PR #450 が本当に解決したのは「`height: 6mm` 指定が renmatrix の processoptions で CC 行高も上書きしていた (cc module = 1X × 4X に潰れた)」点で、修正そのものは正しい
+
+### 決断
+
+1. **`bwipjs.toSVG()` に `paddingwidth: 10` を composite 時のみ条件付き適用** (`src/components/tools/Gs1Databar.tsx`)
+   - `FixupOptions` (`bwip-js` 公式 type 定義) で `paddingleft = paddingright = 10 * scale = 30 svg-px` が viewBox 左右に挿入される
+   - renlinear が linear 部に確保していた 10X とは別経路で、**CC 部含む symbol 外周** に GS1 推奨の 10X quiet zone を確実に確保
+   - 結果として CC 左右の quiet zone は実質 `1X (micropdf417 内側) + 10X (paddingwidth)` に拡張され、厳密実装のスキャナでも CC を分離検出できる
+   - **non-composite (`databarlimited` 単独) には適用しない**: renlinear が default で持つ `borderleft/right=10` で既に 10X quiet zone が確保されているため、`paddingwidth: 10` を追加すると実質 20X となり symbol 全幅が必要以上に拡大する (仕様違反ではないが過剰)。`isComposite = hasAnyAiValue` の判定で適用範囲を composite に限定し、レイアウト影響を最小化する (#456 レビュー指摘)
+2. **PR #450 のコメントを訂正**: `Gs1Databar.tsx` の `bwipjs.toSVG()` 上の説明を「~1X×1X 正方形モジュール」から「CC-A 1X × 2X (ISO/IEC 24723 準拠) + CC 部 quiet zone 不足の経緯」に書き直し、将来の誤解の温床を断つ
+3. **陽性対照テスト 2 件** (`tests/e2e/gs1-databar.spec.ts`):
+   - **composite 経路**: AI フィールド入力で composite シンボルを生成し SVG の最も左にある描画要素 (`<path>`) の `getBBox().x` が `> 25 svg-px` であることを assert。`paddingwidth` を削ると leftmost x が 4.01 → 削除時 fail、`paddingwidth: 10` 適用時は 34.01 → pass
+   - **non-composite 経路**: GTIN のみ入力 (AI フィールド未入力) で `databarlimited` 単独を生成し `getBBox().x` が `< 25 svg-px` であることを assert。条件分岐を削除して常時 `paddingwidth: 10` 適用する旧実装に戻すと leftmost x が 7 → 37 にシフトして fail することを実機検証済
+   - 両方とも test-gates skill 要件 (旧実装で fail することを実機検証) を満たす
+
+### 却下した選択肢
+
+- **`rowmult: 1` で CC 行高を 1X に強制**: ISO/IEC 24723 違反になり、厳密実装の物理スキャナで逆に decode 不能になる懸念。`paddingwidth` で解決しない場合のみ別タスクで段階的に検証する方針
+- **`parse: true` / `parsefnc: true` 追加**: 現コードの bracket syntax `(01)x|(10)y` は bwip-js の `gs1process` が既に自動処理しているため不要
+- **`scale` を 3 → 4/5 に増やす**: 横方向の X-dim は既に linear と CC で一致しており、scale 増加では quiet zone 不足の根本解決にならない
+- **`ccversion: 'b'` で CC-B 強制**: ユーザー要件 (CC-A 維持) に反する
+- **`paddingwidth: 10` を non-composite にも常時適用**: renlinear で既に 10X 確保されているため二重 padding (実質 20X) になり symbol 幅が必要以上に拡大。GS1 仕様違反ではないが過剰。条件分岐で composite のみに限定 (上記 1) する方針
+
+### 結果・トレードオフ
+
+- ✅ CC 部の左右 quiet zone が GS1 推奨の 10X (実質 11X) に拡張され、厳密実装スキャナでも CC-A を分離検出できる見込み
+- ✅ PR #450 の GS1 仕様誤読がコード comment 上から除去され、将来「~1X×1X」を根拠にした逆走 fix を防げる
+- ✅ non-composite (`databarlimited` 単独) は従来通りの symbol 幅を維持。VRT baseline 差分は composite 経路に限定される
+- ⚠️ composite シンボル (`databarlimitedcomposite`) の SVG / PNG 全幅は 60 svg-px 拡張される → composite ケースの VRT baseline 差分が発生する可能性がある。CLAUDE.md 6.8 に従い数値根拠で baseline 更新を recommend せず、user 目視確認後に CI `workflow_dispatch` で更新
+- ⚠️ 実機スキャナで decode 改善するかは user 検証次第。改善しない場合は `paddingheight: 2` (CC 上下 2X 追加) / `rowmult: 1` (spec 違反だが scanner 寛容性に賭ける) を段階的に試す別 issue を起票する
+
+### 関連
+
+- bwip-js 公式 type (`node_modules/bwip-js/dist/bwip-js.d.ts:79-85`): `paddingwidth` / `paddingleft` 等は公式 typed option
+- 過去 fix: PR #450 (`height` 削除), PR #453 (`shape-rendering` 注入)
+- 陽性対照 (composite): `tests/e2e/gs1-databar.spec.ts` の `composite シンボルに GS1 推奨の 10X quiet zone (paddingwidth) が確保されている`
+- 陽性対照 (non-composite): 同 spec の `non-composite シンボルには paddingwidth が適用されない`

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -95,16 +95,32 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
     );
 
     try {
-      const bcid = hasAnyAiValue ? 'databarlimitedcomposite' : 'databarlimited';
-      // bwip-js v4.9.0 は composite で `height` を指定すると linear 部だけでなく
-      // composite component (CC-A/CC-B) のモジュール縦サイズも一緒にスケールし、
-      // GS1 spec の ~1X×1X 正方形モジュールが ~1X×4X に潰れて scanner が decode
-      // 不能になる (scale=3 + height=6 で cc module = 3×12)。`height` を default
-      // に委ねる (linear 10.3X = GS1 最小値、bwip-js demo の default と同じ)。
+      const isComposite = hasAnyAiValue;
+      const bcid = isComposite ? 'databarlimitedcomposite' : 'databarlimited';
+      // bwip-js v4.9.0 メモ (composite component):
+      //  - `databarlimitedcomposite` は linear を `bwipp_renlinear`、CC を
+      //    `bwipp_renmatrix` で別経路描画する。`height` オプションは renmatrix の
+      //    processoptions で CC 行高も上書きしてしまうため指定不可 (PR #450)。
+      //  - CC-A 行高は ISO/IEC 24723 で 2X 最小と規定されており、bwip-js は
+      //    `bwipp_micropdf417` の `rowmult: 2` で実現する。GS1 General Spec
+      //    5.9.2.2 が要求する「X-dim 一致」は横方向のみで、CC モジュールが
+      //    1X × 2X 長方形なのは仕様準拠 (PR #450 のコメント記述は誤りだった)。
+      //  - linear 部は renlinear が `borderleft/right=10` を持つので 10X quiet
+      //    zone を確保するが、CC 部は micropdf417 が `borderleft/right=1` しか
+      //    渡さないため CC 左右の quiet zone が 1X しかない。GS1 推奨は 10X で、
+      //    1X だとスキャナの実装次第で CC を分離検出できず GTIN だけ返って CC-A
+      //    (AI 10 等) が decode 不能になる。`paddingwidth: 10` で symbol 外周に
+      //    GS1 推奨の 10X quiet zone を確実に確保する。
+      //  - **`paddingwidth` は composite 時のみ適用**: non-composite (databarlimited
+      //    単独) は renlinear が既に 10X quiet zone を確保しているため、追加すると
+      //    実質 20X となり symbol 全幅が必要以上に拡大する (仕様違反ではないが過剰)。
+      //    composite 経路の CC 部だけが quiet zone 不足の問題を持つので適用範囲を
+      //    限定する。
       const rawSvg = bwipjs.toSVG({
         bcid,
         text: bwipText,
         scale: 3,
+        ...(isComposite ? { paddingwidth: 10 } : {}),
         includetext: true,
         textxalign: 'center',
         textsize: 7,

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -151,4 +151,90 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
       expect(rendering).toBe('pixelated');
     });
   });
+
+  // 陽性対照: composite シンボルに GS1 推奨の 10X quiet zone (左右 padding) が
+  // 確保されていることを実出力 SVG で検証する。bwip-js v4.9.0 の renmatrix は
+  // micropdf417 経由で渡される `borderleft/right=1` しか CC 部に持たず、CC-A
+  // 周囲の quiet zone が 1X (= 3 svg-px @ scale=3) に縮退する。GS1 General Spec
+  // は CC component 周囲に 10X 推奨を要求し、PC スキャナの decode 失敗実例が
+  // あるため `paddingwidth: 10` を `bwipjs.toSVG` に明示している。
+  //
+  // 検証方法: AI フィールド入力で composite シンボルを生成 → SVG の最初の
+  // <rect/path> の x 座標が `scale × paddingwidth = 30` 以上であることを確認。
+  // `paddingwidth` を削ると 0〜数 svg-px (1X 相当) になるため必ず fail する。
+  test('composite シンボルに GS1 推奨の 10X quiet zone (paddingwidth) が確保されている（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // GTIN + ロット (10) を入力して databarlimitedcomposite を生成
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await page.getByLabel('AI フィールド値 2').fill('ABC123');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      const preview = page.getByLabel(/GS1 DataBar.*のバーコード/);
+      // SVG viewBox の min-x からシンボル左端までの padding を svg-px で取得。
+      // bwip-js は描画要素を <path>/<rect> で出力する。最も左にある描画要素の
+      // x 座標 (= 左端からの padding) を測定する。
+      // `<text>` (includetext: true の人間可読 GTIN) は textxalign='center' で
+      // symbol 中央配置されるため最左にならないが、stroke-width 計算で getBBox
+      // の挙動が path/rect と微妙に異なるため、quiet zone 計測対象から明示的に
+      // 除外する (rect, path のみを query)。
+      const leftPaddingPx = await preview.evaluate((el) => {
+        const svg = el.querySelector('svg');
+        if (!svg) return -1;
+        // SVGGraphicsElement.getBBox() は viewBox 座標系で要素群の bounding box を返す。
+        // viewBox 全体に対し描画要素群の x が paddingleft 分だけ右にオフセットされる。
+        const items = svg.querySelectorAll('rect, path');
+        let minX = Infinity;
+        for (const it of items) {
+          const bbox = (it as SVGGraphicsElement).getBBox();
+          if (bbox.x < minX) minX = bbox.x;
+        }
+        return Number.isFinite(minX) ? minX : -1;
+      });
+
+      // paddingwidth: 10 × scale: 3 = 30 svg-px。bwip-js の内部処理で多少の
+      // 浮動小数点誤差が乗る可能性があるため > 25 で判定する (paddingwidth 削除時は
+      // 0〜3 svg-px 程度になるため十分な余裕)。
+      expect(leftPaddingPx).toBeGreaterThan(25);
+    });
+  });
+
+  // 陽性対照 (補): non-composite (`databarlimited` 単独) には `paddingwidth` が
+  // **適用されない** ことを assert する。renlinear が default で持つ
+  // `borderleft: 10` (10X quiet zone) のみ反映され、symbol 全幅が必要以上に
+  // 拡大しない設計を回帰防止する。
+  //
+  // 検証方法: GTIN のみ入力 (AI フィールド未入力) → `hasAnyAiValue=false` →
+  // `databarlimited` 経路 + paddingwidth スキップ。最左描画要素の x が
+  // 25 svg-px 未満であることを assert。`paddingwidth: 10` を non-composite にも
+  // 誤って適用すると leftmost x が 37 svg-px 付近に shift して fail する。
+  test('non-composite シンボルには paddingwidth が適用されない（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // GTIN のみ入力 (AI フィールド未入力で composite 経路に入らない)
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      const preview = page.getByLabel(/GS1 DataBar.*のバーコード/);
+      const leftPaddingPx = await preview.evaluate((el) => {
+        const svg = el.querySelector('svg');
+        if (!svg) return -1;
+        const items = svg.querySelectorAll('rect, path');
+        let minX = Infinity;
+        for (const it of items) {
+          const bbox = (it as SVGGraphicsElement).getBBox();
+          if (bbox.x < minX) minX = bbox.x;
+        }
+        return Number.isFinite(minX) ? minX : -1;
+      });
+
+      // renlinear の borderleft=10 (X-dim) + scale=3 = 30 svg-px 内に最初のバーが
+      // 入る (実測 M.x=8.50 付近, stroke-width 込みで getBBox.x ≈ 7)。
+      // `paddingwidth: 10` が誤って適用された場合は 30 svg-px 更に右にシフト
+      // (≈ 37) するため、< 25 の閾値で確実に分離できる。
+      expect(leftPaddingPx).toBeLessThan(25);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`develop` に merge 済みの修正を `main` (本番) に反映する release PR。

### 含まれる変更

- **#456 fix(gs1-databar)**: composite シンボル CC-A の quiet zone 不足を `paddingwidth: 10` で解消
  - composite (`databarlimitedcomposite`) のみ `paddingwidth: 10` を条件付き適用し、CC 部の左右に GS1 推奨の 10X quiet zone を確保
  - non-composite (`databarlimited` 単独) は renlinear default の 10X を維持 (過剰な 20X を回避)
  - PR #450 のコード comment「CC-A モジュールは ~1X×1X 正方形」という GS1 仕様誤読を訂正
  - 陽性対照 E2E 2 件追加 (composite/non-composite 両経路)
  - `docs/decisions.md [081]` に設計判断・却下した選択肢を記録

## Test plan

- [x] develop ブランチで `test` / `e2e` / `visual-regression` 全 CI 通過
- [x] レビュー指摘 (3 件) 全て対応済 (PR #456 内で 2nd round LGTM 受領)
- [ ] release 後の本番環境で `/tools/gs1-databar` を実機スキャナで decode 確認 (PR #456 の最終ゲート)
- [ ] 必要なら composite シンボルの VRT baseline を本番反映後に更新 (`workflow_dispatch` trigger)

https://claude.ai/code/session_01MpDKxnBeXQVCDD1AoLKYcf

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpDKxnBeXQVCDD1AoLKYcf)_