### PR TITLE
feat(gs1-databar): 合成シンボル上部に AI テキスト ((17)... 等) 表示を復活

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3215,3 +3215,54 @@ PR #450 (`height` オプション削除) と PR #453 (`shape-rendering="crispEdg
 - 関連 fix: PR #456 (`paddingwidth: 10` for composite, decisions `[081]`)
 - 陽性対照 (unit): `src/utils/__tests__/download.test.ts` の `svgContentToPngBlob: PNG 背景白塗り (transparent decode 失敗修正)` describe / `downloadPngFromSvgElement` の `陽性対照: fillStyle が white にセットされて fillRect が canvas 全面で呼ばれる` / `陽性対照: 呼び出し順序は fillRect → scale → drawImage`
 - 陽性対照 (E2E): `tests/e2e/gs1-databar.spec.ts` の `生成 PNG の quiet zone が透明ではなく白 (α=255) で塗られている`
+
+## [083] 2026-05-21 — Gs1Databar 合成シンボル上部の AI テキスト injection を `injectCompositeText` 復活で再導入
+
+### 背景
+
+`[067]` update / PR #450 (commit `c563cf5`, 2026-05-19) は、合成シンボル (`databarlimitedcomposite`) 上部に AI テキスト ((17)YYMMDD / (10)LOT 等) を SVG `<text>` で注入する `injectCompositeText` 関数を撤去した。撤去理由として「テキストのディセンダー (paren `( )` の下端カーブ ~4px) が composite 上端の 1X quiet zone に侵入し Dynamsoft Barcode Reader が decode 不能 (0 件)」「textRowH を 3X gap (= 9px) に広げる代替案も decode 不能で撤回」と記録されていた。
+
+しかし `[082]` / PR #458 で composite PNG decode 不能の真因が **Canvas2D の透明背景** (`svgContentToPngBlob` が `fillStyle = 'white'` 未設定で α=0 のまま) と判明。PR #450 当時の実機検証はすべて透明背景時に行われており、descender 仮説は **transparent 背景という別バグに巻き込まれた red herring** だった可能性が極めて高いと user が指摘した。
+
+### 根本原因の再評価
+
+PR #450 で行った decode 検証 3 種類:
+
+1. `injectCompositeText` 有効、1X gap → Dynamsoft 0 件
+2. `injectCompositeText` 有効、3X gap (textRowH 拡大) → Dynamsoft 0 件
+3. `injectCompositeText` 撤去 → Dynamsoft 100% 認識
+
+3 検証はすべて PNG 背景が transparent のまま実施。reader が transparent pixel を黒判定するため、quiet zone の幅に関わらず全面ノイズ → decode 不能になっていた。撤去ケース (3) で decode 成功した理由は、SVG 出力が小さく screenshot 経由などで再ラスタライズされる経路を含んだ可能性がある (詳細は当時のテスト手順が残っていない)。
+
+実機 user 検証 (本 PR 2026-05-20): PR #458 の白背景 fix を merge した状態で `injectCompositeText` を旧 geometry (textRowH = fontSize + 6 = 24px、text baseline y=21、barcode translate y=24) でそのまま復活 → Dynamsoft online reader (https://demo.dynamsoft.com/barcode-reader-js/) で `Found 1 barcode + GS1_COMPOSITE + confidence: 100` の decode 成功を確認。
+
+descender 仮説は本 PR で **明確に否定** された。GS1 仕様の「composite 周囲 1X quiet zone」要求自体は依然有効だが、image-based reader の binary threshold 動作には透明背景の方が遥かに支配的な影響を与えていた。
+
+### 決定
+
+1. **`escapeHtml` / `injectCompositeText` を `src/utils/gs1-databar.ts` に復元**: PR #450 撤去時 (commit `c563cf5`) から geometry / 関数シグネチャ不変で復元。コメントブロックで「PR #450 撤去 → PR #458 真因判明 → 本 PR 復活」の時系列を明示
+2. **`src/components/tools/Gs1Databar.tsx` の wiring を復元**: `addSvgDimensions(rawSvg)` 後に `compositeText` (非空時) を `injectCompositeText` に通す
+3. **`.gs1-svg-container` クラスを `src/styles/global.css` に復元**: `<text fill="currentColor">` が `color: var(--color-text)` を継承するための container 色設定。preview wrapper (`Gs1Databar.tsx:352`) に `barcode-preview gs1-svg-container` 併用
+4. **陽性対照テスト**:
+   - unit (`src/utils/__tests__/gs1-databar.test.ts`): `escapeHtml` 6 件 + `injectCompositeText` 8 件。geometry (y=21, height +=24, translate y=24)、XSS escape (`<script>` → `&lt;script&gt;`)、text < barcode width / text > barcode width の centering 両条件
+   - E2E (`tests/e2e/gs1-databar.spec.ts`): composite 入力時に `<text>` 要素 + `(17)...(10)...` 内容 + y="21" / text-anchor="middle" / fill="currentColor" を assert。non-composite (AI 未入力) では `<text>` 要素に AI 文字列が含まれないことも別 case で assert (常時 injection regression 検知)
+
+### 検討した代替案
+
+- **`textRowH` を旧 3X gap (= 34px) で安全側に**: GS1 spec 推奨に厳密に揃える案。だが旧 geometry (textRowH=24) で実機 decode 成功を確認できたため YAGNI で見送り。後続 reader 互換性問題が出たら拡張する
+- **AI テキストを SVG 外 (HTML レベル) で render**: preview には表示できるが downloaded PNG に反映されないため、印刷用バーコードとしての利用 (一般的な GS1 ラベル慣習) を満たさない。user 要求と不一致
+- **TEC-IT 等 reference 実装相当の独自 layout を組む**: 既存 `injectCompositeText` 復元で要件を満たすため過剰
+
+### 結果・トレードオフ
+
+- ✅ user 要求「合成シンボル内容を人間可読で確認」を満たす ((17)YYMMDD / (10)LOT 等を visual に確認可能)
+- ✅ Dynamsoft Barcode Reader (online) で `confidence: 100` decode 成功 (実機検証済 / 2026-05-20)
+- ✅ PR #458 白背景 fix と組み合わせで symbol 構造に影響なし
+- ⚠️ 生成 SVG / PNG の **全高が 24 svg-px 拡張** される (textRowH = fontSize + 6)。VRT baseline (`/tools/gs1-databar`) は composite シンボル表示時の差分が出る可能性 → CI `workflow_dispatch` で生成 → user 目視確認後に commit (CLAUDE.md 6.8)
+- ⚠️ AI 値が長い (例: lot 20 文字) と SVG 全幅が barcode より広がり centering される (旧実装の挙動と同じ)。preview / PNG の見た目は受け入れ可能だが、将来 layout 上の問題が出たら multi-line 対応も検討
+
+### 関連
+
+- 関連 fix: PR #450 (撤去, decisions `[067]` update) / PR #458 (透明背景真因判明, decisions `[082]`)
+- 陽性対照 (unit): `src/utils/__tests__/gs1-databar.test.ts` の `escapeHtml` / `injectCompositeText` describe
+- 陽性対照 (E2E): `tests/e2e/gs1-databar.spec.ts` の `composite シンボルに AI テキスト ((17)... (10)...) が SVG 上部に注入される` / `non-composite (AI フィールド未入力) シンボルには AI テキスト注入されない`

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -7,6 +7,7 @@ import {
   validateGtin14Input,
   buildBwipText,
   addSvgDimensions,
+  injectCompositeText,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
@@ -126,13 +127,20 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
         textsize: 7,
       });
 
-      // composite component 上に AI テキスト ((17)... 等) を SVG injection する
-      // 旧実装は、テキストのディセンダーが composite 上端の quiet zone (1X) に
-      // 侵入してスキャナが decode 不能になる問題があった (Dynamsoft Reader 0 件 →
-      // injection 撤去で `GS1_COMPOSITE` 100% 認識を確認)。textRowH を広げて
-      // quiet zone を 3X 確保する案も検証したが decode 不能のため撤回し撤去で確定。
-      // 合成シンボル内の AI 値は下部の「GS1文字列を見る」セクションで人間可読として確認できる。
-      const finalSvg = addSvgDimensions(rawSvg);
+      // composite component 上に AI テキスト ((17)... 等) を SVG injection する。
+      //
+      // 経緯: PR #450 (commit c563cf5) は「ディセンダーが composite 上端 1X quiet
+      // zone に侵入して Dynamsoft Reader が decode 不能」を理由に撤去したが、PR #458
+      // (commit 977f6b6) で真因は **Canvas2D の透明背景** (一部 reader が transparent
+      // pixel を黒判定) と判明。PR #450 の検証はすべて透明背景時だったため descender
+      // 仮説は red herring と判断、白背景 fix とセットで復活させ user 実機検証で
+      // decode 成功を確認した (decisions [083])。
+      const compositeText = aiFields
+        .filter((f) => f.value.trim() !== '')
+        .map((f) => `(${f.ai})${f.value.trim()}`)
+        .join('');
+      const sizedSvg = addSvgDimensions(rawSvg);
+      const finalSvg = compositeText ? injectCompositeText(sizedSvg, compositeText) : sizedSvg;
       setSvgContent(finalSvg);
       setBwipError('');
       onSvgChangeRef.current(finalSvg, gtinResult.fullGtin);
@@ -341,7 +349,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
           >
             <div
               aria-label={`GS1 DataBar ${gtinResult?.fullGtin} のバーコード`}
-              className="barcode-preview"
+              className="barcode-preview gs1-svg-container"
               dangerouslySetInnerHTML={{ __html: svgContent }}
             />
             <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -569,6 +569,16 @@
     image-rendering: pixelated;
   }
 
+  /* === Gs1Databar: composite シンボル上部 AI テキスト (injectCompositeText) 色継承 ===
+     `injectCompositeText` (utils/gs1-databar.ts) が SVG に注入する <text> は
+     `fill="currentColor"` で親要素の color を継承する。本 class が container 側で
+     `color: var(--color-text)` を確定させることで、theme (light/dark) に追従した
+     text 色を実現する。class が外れると text の塗り色が UA default (通常 black)
+     にフォールバックして dark theme で読みにくくなるため削除しないこと。 */
+  .gs1-svg-container {
+    color: var(--color-text);
+  }
+
   /* === PR 4: Gs1Databar <details>/<summary> marker hide === */
   .summary-no-marker {
     list-style: none;

--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -327,4 +327,33 @@ describe('injectCompositeText', () => {
     // 元 SVG の <path .../> が <g transform="..."> 内に残る
     expect(out).toMatch(/<g transform="translate\([\d.]+,24\)">.*<path[^>]*\/>.*<\/g>/s);
   });
+
+  // 陽性対照 (#462 review A 対応): width / height 置換 regex は **<svg> 開始タグ内に
+  // anchor** されており、`<svg>` に width/height 属性が無く子要素にだけ `width="N"`
+  // がある場合に **子要素を wrong match して破壊しない** ことを実観測する。
+  //
+  // anchor を外して旧形 (`/width="\d+"/`) に戻すと、最初の match が子要素
+  // `<rect width="10">` になり `<rect width="76">` (newW=76) に誤置換されて
+  // 子要素 width assertion が必ず fail する設計 (test-gates 鉄則 1)。
+  //
+  // 実運用では `addSvgDimensions` が `<svg>` に width/height を必ず注入するため
+  // anchor の差は顕在化しないが、bwip-js / addSvgDimensions の将来変更で svg root
+  // から width/height が外れた場合の silent regression を防ぐ防御ガード。
+  it('<svg> ルートに width 属性無し + 子要素 <rect width="N"> ありの場合に子要素を破壊しない (anchor 検証)', () => {
+    // svg root に width/height 属性なし、viewBox のみ。子要素 <rect width="10">。
+    // injectCompositeText は viewBox から barcodeW=100 / h=50 を取得して動作する。
+    const svgNoRootWidth =
+      '<svg viewBox="0 0 100 50" xmlns="http://www.w3.org/2000/svg">' +
+      '<rect width="10" height="20" fill="#000"/></svg>';
+    // text 長さ 10 文字 → estimatedTextW = 10 * 10.8 + 16 = 124 → newW = max(100, 124) = 124
+    // newH = 50 + 24 = 74
+    const out = injectCompositeText(svgNoRootWidth, '(17)231231');
+    // 子要素 <rect> の width / height は元のまま (10 / 20)。
+    // 旧 regex (anchor 無し) なら最初の `width="10"` が `width="124"` に誤置換されて
+    // `<rect width="124" height="74">` になり、本 assert が fail する。
+    expect(out).toMatch(/<rect width="10" height="20"/);
+    // svg root には元々 width 属性が無いため anchor 付き regex は no-op (注入もしない)。
+    // viewBox は別 regex で更新される (anchor 無関係)。
+    expect(out).toMatch(/viewBox="0 0 124\.0 74\.0"/);
+  });
 });

--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -4,6 +4,8 @@ import {
   validateGtin14Input,
   buildBwipText,
   addSvgDimensions,
+  escapeHtml,
+  injectCompositeText,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
@@ -204,5 +206,125 @@ describe('addSvgDimensions', () => {
     expect(out).toContain('height="40"');
     expect(out).toContain('shape-rendering="crispEdges"');
     expect(out).toContain('class="foo"');
+  });
+});
+
+// ────────────────────────────────────────────
+// escapeHtml
+// ────────────────────────────────────────────
+//
+// 陽性対照: `injectCompositeText` が AI 値を SVG <text> として埋め込む際の XSS 対策。
+// fix を revert (関数削除 / `replace(/</g, ...)` 等の置換を削除) すると raw `<` `>`
+// `"` が SVG に流れて XSS / SVG 破損が起き、本 describe の expected/actual 比較で
+// 必ず差分が出て fail する設計。
+describe('escapeHtml', () => {
+  it('& は &amp; に変換される (最初に処理しないと連鎖 escape の事故になる)', () => {
+    expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+  });
+
+  it('< と > はタグ injection 防止のため変換される', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('" は属性 injection 防止のため &quot; に変換される', () => {
+    expect(escapeHtml('say "hi"')).toBe('say &quot;hi&quot;');
+  });
+
+  it("' は属性 injection 防止のため &#039; に変換される", () => {
+    expect(escapeHtml("it's")).toBe('it&#039;s');
+  });
+
+  it('複数文字が混在しても順序通り escape される (& 先頭で連鎖 escape を防ぐ)', () => {
+    // `&` が `&amp;` に展開された後に再度 escape されると `&amp;amp;` になる事故を防ぐ。
+    expect(escapeHtml('a & b < c')).toBe('a &amp; b &lt; c');
+  });
+
+  it('escape 不要な文字 (英数記号 / 日本語) はそのまま', () => {
+    expect(escapeHtml('(17)231231(10)ABC123')).toBe('(17)231231(10)ABC123');
+    expect(escapeHtml('賞味期限')).toBe('賞味期限');
+  });
+});
+
+// ────────────────────────────────────────────
+// injectCompositeText
+// ────────────────────────────────────────────
+//
+// 陽性対照: PR #450 (commit c563cf5) で撤去された AI テキスト SVG injection を
+// PR #458 (透明背景真因判明) を受けて復活させる際の geometry / XSS 安全性 / dimension
+// 拡張の回帰防止テスト一式。
+//
+// fix revert (関数削除 / dimension 拡張ロジック削除 / escape 削除) で必ず fail する
+// 設計。具体的には:
+//   - 関数削除: import error → test ファイル全体 fail
+//   - dimension 拡張削除: newH = h + textRowH を確認する assert が fail
+//   - text 配置 y 削除: `<text ... y="21" ...>` 文字列が存在しない fail
+//   - XSS escape 削除: raw `<script>` が SVG 文字列に残って escape 検証 fail
+describe('injectCompositeText', () => {
+  // bwip-js + addSvgDimensions の出力に近い fixture
+  const baseSvg =
+    '<svg width="293" height="75" shape-rendering="crispEdges" viewBox="0 0 293 75"' +
+    ' xmlns="http://www.w3.org/2000/svg">' +
+    '<path stroke="#000000" stroke-width="3" d="M0 0L293 0"/></svg>';
+
+  it('空 text は SVG をそのまま返す (early return)', () => {
+    expect(injectCompositeText(baseSvg, '')).toBe(baseSvg);
+  });
+
+  it('viewBox を持たない SVG は変更せず返す (想定外 fixture 破壊防止)', () => {
+    const noVb = '<svg width="100" height="50"><path/></svg>';
+    expect(injectCompositeText(noVb, '(17)231231')).toBe(noVb);
+  });
+
+  it('text が injection され y=21 (textRowH - 3) に配置される', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231(10)ABC123');
+    // text element の baseline 位置 (textRowH=24 - 3 = 21)
+    expect(out).toMatch(/<text [^>]*y="21" /);
+    // 中身は escape された AI 値
+    expect(out).toContain('>(17)231231(10)ABC123</text>');
+    expect(out).toContain('font-size="18"');
+    expect(out).toContain('text-anchor="middle"');
+    expect(out).toContain('fill="currentColor"');
+    expect(out).toContain('font-family="\'Courier New\',Courier,monospace"');
+  });
+
+  it('viewBox 高さは元の barcode 高さ + textRowH(24) に拡張される', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    // baseSvg height=75 + textRowH=24 = 99
+    expect(out).toMatch(/viewBox="0 0 \S+ 99\.0"/);
+    expect(out).toContain('height="99"');
+  });
+
+  it('barcode が text より広いときは barcode 幅を維持し translate は y=24 のみ (横 shift 0)', () => {
+    // baseSvg width=293、text 長 10 文字 + padding 16 → 推定幅 ~76px < 293
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    expect(out).toContain('width="293"');
+    expect(out).toMatch(/viewBox="0 0 293\.0 99\.0"/);
+    // translate(0, 24) で barcode は下方向のみ shift
+    expect(out).toContain('transform="translate(0.0,24)"');
+  });
+
+  it('text が barcode より広いときは SVG 幅を拡張し barcode を中央寄せする', () => {
+    // 54 文字 ((17) + '1'×50) × charW=10.8 + padding=16 = 599.2 > 293
+    const longText = '(17)' + '1'.repeat(50);
+    const out = injectCompositeText(baseSvg, longText);
+    expect(out).toMatch(/viewBox="0 0 599\.2 99\.0"/);
+    expect(out).toContain('width="599"'); // Math.round(599.2)
+    // (newW - barcodeW) / 2 = (599.2 - 293) / 2 = 153.1
+    expect(out).toContain('transform="translate(153.1,24)"');
+  });
+
+  it('XSS escape: <script> tag を含む text は &lt;script&gt; に escape される', () => {
+    const out = injectCompositeText(baseSvg, '<script>alert(1)</script>');
+    // raw `<script>` は SVG に出ない
+    expect(out).not.toContain('<script>');
+    expect(out).not.toContain('</script>');
+    // escape 後の文字列が text element 内に含まれる
+    expect(out).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('barcode 部は <g transform="translate(_, 24)"> でラップされる (元 inner を保持)', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    // 元 SVG の <path .../> が <g transform="..."> 内に残る
+    expect(out).toMatch(/<g transform="translate\([\d.]+,24\)">.*<path[^>]*\/>.*<\/g>/s);
   });
 });

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -269,10 +269,13 @@ export function injectCompositeText(svg: string, text: string): string {
   const newH = h + textRowH;
   const barcodeOffsetX = (newW - barcodeW) / 2;
 
+  // 置換 regex は `<svg` 開始タグ内 (`<svg ... width="N" height="N" ...>`) に anchor する。
+  // 将来 bwip-js が SVG 内に `<rect width="N">` 等の子要素を含むようになった場合に
+  // **最初の match が子要素になって wrong match する** silent regression を防ぐ (#462 review A)。
   const result = svg
     .replace(/viewBox="0 0 [\d.]+ [\d.]+"/, `viewBox="0 0 ${newW.toFixed(1)} ${newH.toFixed(1)}"`)
-    .replace(/width="\d+"/, `width="${Math.round(newW)}"`)
-    .replace(/height="\d+"/, `height="${Math.round(newH)}"`);
+    .replace(/(<svg\s[^>]*?)width="\d+"/, `$1width="${Math.round(newW)}"`)
+    .replace(/(<svg\s[^>]*?)height="\d+"/, `$1height="${Math.round(newH)}"`);
 
   const openEnd = result.indexOf('>') + 1;
   const closeStart = result.lastIndexOf('</svg>');

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -196,3 +196,95 @@ export function addSvgDimensions(svg: string): string {
     `${beforeViewBox} viewBox="0 0 ${wStr} ${hStr}"${afterViewBox}>`;
   return svg.replace(originalTag, newTag);
 }
+
+/**
+ * HTML/XML 特殊文字をエスケープする (`injectCompositeText` の安全な text 注入用)。
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * 合成シンボル (`databarlimitedcomposite`) の上に AI テキストを SVG `<text>` で注入する。
+ *
+ * bwip-js の `includetext: true` は linear 部の `(01)GTIN` のみ render するため、
+ * AI 値 ((17)YYMMDD / (10)LOT 等) は barcode binary に encode されるだけで visual には
+ * 出ない。本関数は SVG 文字列を直接操作して composite 上に AI テキスト行を 1 行追加する。
+ *
+ * ## 復活の経緯 (PR #450 → PR #458 → 本 PR)
+ * - PR #450 (commit `c563cf5`): 「テキストのディセンダーが composite 上端 1X quiet
+ *   zone に侵入して Dynamsoft Reader decode 不能」を根拠に撤去 (decisions [067] update)。
+ *   `textRowH` を 3X gap (= 9px) に広げる alternative も decode 不能で撤回。
+ * - PR #458 (commit `977f6b6`): composite PNG decode 不能の真因が **Canvas2D の透明
+ *   背景** (`svgContentToPngBlob` で `fillStyle = 'white'` 未設定) だったと判明。
+ *   PR #450 の検証はすべて透明背景時に行われたため、descender 仮説は red herring
+ *   だった可能性が高い (decisions [082])。
+ * - 本 PR (decisions [083]): 白背景 fix とセットなら decode 成功するという user 仮説を
+ *   実機 Dynamsoft で empirical 検証 → 成功 → 復活。
+ *
+ * ## geometry
+ * - `fontSize = 18`, `textRowH = fontSize + 6 = 24`
+ * - text baseline `y = textRowH - 3 = 21` (Courier New descender ~4px 含む)
+ * - barcode 全体を `translate(_, textRowH)` で下に 24px shift
+ * - text が barcode より広いときは centering (`(newW - barcodeW) / 2`)
+ *
+ * ## 引数
+ * @param svg - bwip-js が生成 + `addSvgDimensions` 済み SVG 文字列。viewBox / width /
+ *   height 属性が必須 (regex で抽出するため)。
+ * @param text - 注入する **raw** 文字列 (例: `(17)231231(10)ABC123`)。内部で
+ *   `escapeHtml` を適用するため、呼出側で escape してはならない (二重 escape で `&amp;`
+ *   が文字として表示される事故になる)。
+ * @returns text を注入した SVG 文字列。`text` が空なら入力 SVG をそのまま返す。
+ *
+ * ## 色
+ * `<text>` の `fill="currentColor"` で親要素の `color` を継承する。`Gs1Databar.tsx`
+ * の preview wrapper は `.gs1-svg-container` クラスで `color: var(--color-text)` を
+ * 設定する前提 (`global.css`)。親 className を変更する際は color 設定を維持すること。
+ */
+export function injectCompositeText(svg: string, text: string): string {
+  if (!text) return svg;
+
+  const escapedText = escapeHtml(text);
+  const vbMatch = svg.match(/viewBox="0 0 ([\d.]+) ([\d.]+)"/);
+  if (!vbMatch) return svg;
+  const barcodeW = parseFloat(vbMatch[1]);
+  const h = parseFloat(vbMatch[2]);
+
+  const fontSize = 18;
+  const textRowH = fontSize + 6;
+
+  // Courier New monospace: 1 文字あたり約 0.6em。
+  // 見積もりはエスケープ前の文字数で行う (ブラウザは実体参照を 1 文字分で描画するため)。
+  const charW = fontSize * 0.6;
+  const padding = 16;
+  const estimatedTextW = text.length * charW + padding;
+
+  // text が barcode より広い場合は SVG 全体を横に拡張し barcode を中央寄せする。
+  const newW = Math.max(barcodeW, estimatedTextW);
+  const newH = h + textRowH;
+  const barcodeOffsetX = (newW - barcodeW) / 2;
+
+  const result = svg
+    .replace(/viewBox="0 0 [\d.]+ [\d.]+"/, `viewBox="0 0 ${newW.toFixed(1)} ${newH.toFixed(1)}"`)
+    .replace(/width="\d+"/, `width="${Math.round(newW)}"`)
+    .replace(/height="\d+"/, `height="${Math.round(newH)}"`);
+
+  const openEnd = result.indexOf('>') + 1;
+  const closeStart = result.lastIndexOf('</svg>');
+  const openTag = result.slice(0, openEnd);
+  const inner = result.slice(openEnd, closeStart);
+
+  const textEl =
+    `<text x="${(newW / 2).toFixed(1)}" y="${textRowH - 3}" ` +
+    `text-anchor="middle" font-family="'Courier New',Courier,monospace" ` +
+    `font-size="${fontSize}" fill="currentColor">${escapedText}</text>`;
+
+  const barcodeTranslate = `translate(${barcodeOffsetX.toFixed(1)},${textRowH})`;
+
+  return `${openTag}${textEl}<g transform="${barcodeTranslate}">${inner}</g></svg>`;
+}

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -239,6 +239,77 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
     });
   });
 
+  // 陽性対照: composite シンボル上部に `injectCompositeText` で AI テキストが注入
+  // されることを実 preview SVG で検証する。
+  //
+  // PR #450 で撤去された関数を PR #458 (透明背景真因判明) を受けて復活させた経緯
+  // (decisions [083])。`src/utils/gs1-databar.ts` の `injectCompositeText` を削除
+  // または `Gs1Databar.tsx` の wiring (`compositeText ? injectCompositeText(...) : sizedSvg`)
+  // を削ると本 test の text 要素 / 文字列 / y=21 配置 assert が全て fail する。
+  //
+  // non-composite (AI フィールド未入力) では injection されない (`compositeText` が
+  // 空文字で early return) ことも別 case で確認し、誤って常時注入する regression
+  // を捕捉する。
+  test('composite シンボルに AI テキスト ((17)... (10)...) が SVG 上部に注入される（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await page.getByLabel('AI フィールド値 1').fill('231231');
+      await page.getByLabel('AI フィールド値 2').fill('ABC123');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      const inspection = await page.getByLabel(/GS1 DataBar.*のバーコード/).evaluate((el) => {
+        const svg = el.querySelector('svg');
+        if (!svg) return null;
+        const textEls = Array.from(svg.querySelectorAll('text'));
+        const compositeText = textEls.find((t) => /\(17\).*\(10\)/.test(t.textContent ?? ''));
+        if (!compositeText) {
+          return { found: false, textContents: textEls.map((t) => t.textContent) };
+        }
+        return {
+          found: true,
+          content: compositeText.textContent,
+          y: compositeText.getAttribute('y'),
+          textAnchor: compositeText.getAttribute('text-anchor'),
+          fontSize: compositeText.getAttribute('font-size'),
+          fill: compositeText.getAttribute('fill'),
+        };
+      });
+
+      expect(inspection?.found, '<text> 要素が AI テキストを含んで存在する').toBe(true);
+      // バー code text 表示 = "(17)YYMMDD(10)LOT" の compact 形式 (decisions [083] user 決定)
+      expect(inspection?.content).toBe('(17)231231(10)ABC123');
+      // geometry: textRowH - 3 = 24 - 3 = 21 (Courier New baseline)
+      expect(inspection?.y).toBe('21');
+      expect(inspection?.textAnchor).toBe('middle');
+      expect(inspection?.fontSize).toBe('18');
+      // <text> の塗り色は `.gs1-svg-container` の color から継承 (global.css)
+      expect(inspection?.fill).toBe('currentColor');
+    });
+  });
+
+  test('non-composite (AI フィールド未入力) シンボルには AI テキスト注入されない（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // GTIN のみ入力 (`compositeText` が空文字 → injectCompositeText は early return)
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      const aiTextPresent = await page.getByLabel(/GS1 DataBar.*のバーコード/).evaluate((el) => {
+        const svg = el.querySelector('svg');
+        if (!svg) return false;
+        // bwip-js の `includetext: true` で linear 部 "(01)GTIN" は出るが
+        // それは <text> ではなく <path> として描画される。AI テキスト形式
+        // `(17)` / `(10)` の <text> 要素は injection されないはず。
+        const textEls = Array.from(svg.querySelectorAll('text'));
+        return textEls.some((t) => /\(17\)|\(10\)|\(11\)|\(15\)|\(21\)/.test(t.textContent ?? ''));
+      });
+      expect(aiTextPresent).toBe(false);
+    });
+  });
+
   // 陽性対照: 生成 PNG の **背景が transparent ではなく白 (RGBA=255,255,255,255)**
   // であることを **実 download click 経路** で検証する。
   //


### PR DESCRIPTION
## Summary

- 合成シンボル ((17)YYMMDD / (10)LOT 等の AI 値が含まれる `databarlimitedcomposite`) の **上部に AI テキストを表示** する `injectCompositeText` 関数を、PR #450 で撤去した状態から復活
- 復活の根拠は PR #458 (commit `977f6b6`) で **真因は Canvas2D 透明背景** だったと判明したこと。PR #450 当時の「descender 仮説」は透明背景に巻き込まれた red herring の可能性が高いと user が指摘し、empirical 検証で確定
- 実機 user 検証 (Dynamsoft Barcode Reader online): 白背景 fix + AI テキスト注入で **decode 成功 (confidence > 0)** を確認

## Why now

| PR | 観察 | 当時の判断 | 真因 |
| :- | :- | :- | :- |
| #450 (撤去) | injection 有り → Dynamsoft 0 件、injection 無し → 100% | descender 1X quiet zone 侵入が原因と仮説 | **透明背景 PNG** (PR #458 で判明) |
| #458 (透明背景 fix) | 白背景塗りで Dynamsoft decode 成功 | Canvas2D default alpha=0 が真因 | ✓ |
| #459 (本 PR) | 白背景 fix + AI テキスト復活で decode 維持 | descender 仮説否定、復活妥当 | ✓ |

## 影響範囲

- `src/utils/gs1-databar.ts`: `escapeHtml` / `injectCompositeText` 復元 (PR #450 撤去時 commit `c563cf5^` と geometry 不変)
- `src/components/tools/Gs1Databar.tsx`: wiring 復元 (`compositeText` 非空時のみ `injectCompositeText(sizedSvg, ...)` を `addSvgDimensions` 後に通す)
- `src/styles/global.css`: `.gs1-svg-container { color: var(--color-text); }` 復元 (`<text fill="currentColor">` の色継承用)
- preview / 生成 PNG / ZIP 一括 DL すべて AI テキスト表示が反映される (path 経由・SVG 経由いずれも同 SVG を使うため)

## 陽性対照テスト (旧コードに当てて必ず fail する設計)

### unit (`src/utils/__tests__/gs1-databar.test.ts`, +14 件)

- **`escapeHtml`** (6 件): `<` `>` `"` `'` `&` の XSS 経路 + 連鎖 escape 防止 + 影響なし日本語/英数
- **`injectCompositeText`** (8 件):
  - 空 text early return / viewBox 不在時 no-op (想定外 fixture 破壊防止)
  - text 注入位置 (`y="21"` = `textRowH - 3`), `font-size="18"`, `text-anchor="middle"`, `fill="currentColor"`, `font-family="'Courier New',Courier,monospace"`
  - viewBox 高さ `h + textRowH(24)` 拡張、`width`/`height` 属性も同期
  - barcode < text 時の SVG 横拡張 + centering (`translate(163.9, 24)`)
  - XSS escape: `<script>alert(1)</script>` → `&lt;script&gt;alert(1)&lt;/script&gt;`
  - inner content (`<path>`) が `<g transform="translate(_, 24)">` 内に保持される

### E2E (`tests/e2e/gs1-databar.spec.ts`, +2 件)

- **composite 注入検証**: AI 17 + AI 10 入力 → preview SVG の `<text>` 要素に `(17)231231(10)ABC123` 内容 + `y="21"` / `text-anchor="middle"` / `fontSize="18"` / `fill="currentColor"` を assert
- **non-composite 排除検証**: GTIN のみ → SVG の `<text>` 要素に AI 文字列が含まれないことを assert (誤って常時 injection する regression 検知)

## Test plan

- [x] unit 1307 passed (+14 new) / type check 0 errors / prettier clean
- [x] E2E 14/14 passed (新規 injection 陽性対照 2 件 + 既存 12 件)
- [x] Playwright 実機 preview 目視: AI テキスト「(17)231231(10)ABC123」が composite 上部に表示
- [x] Canvas pixel 検証: 5 サンプル箇所すべて RGB(255,255,255) α=255 (白背景 fix と共存)
- [x] user 実機 Dynamsoft 検証: decode 成功 (descender 仮説否定確定)
- [ ] CI: unit + type check + E2E
- [ ] CI: VRT (`/tools/gs1-databar` の composite 表示時 baseline 差分が出る可能性 → user 目視確認後 `workflow_dispatch` で baseline 更新)

## 経緯詳細

`docs/decisions.md [083]` に「descender 仮説の再評価 → 真因は透明背景 (PR #458 で解消済) → `injectCompositeText` を白背景 fix とセットで復活」を記録。[067] update / [082] への refback を含む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
