### PR TITLE
release: develop → main (#458 PNG 背景透明 fix + #462 合成シンボル AI テキスト復活)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3215,3 +3215,54 @@ PR #450 (`height` オプション削除) と PR #453 (`shape-rendering="crispEdg
 - 関連 fix: PR #456 (`paddingwidth: 10` for composite, decisions `[081]`)
 - 陽性対照 (unit): `src/utils/__tests__/download.test.ts` の `svgContentToPngBlob: PNG 背景白塗り (transparent decode 失敗修正)` describe / `downloadPngFromSvgElement` の `陽性対照: fillStyle が white にセットされて fillRect が canvas 全面で呼ばれる` / `陽性対照: 呼び出し順序は fillRect → scale → drawImage`
 - 陽性対照 (E2E): `tests/e2e/gs1-databar.spec.ts` の `生成 PNG の quiet zone が透明ではなく白 (α=255) で塗られている`
+
+## [083] 2026-05-21 — Gs1Databar 合成シンボル上部の AI テキスト injection を `injectCompositeText` 復活で再導入
+
+### 背景
+
+`[067]` update / PR #450 (commit `c563cf5`, 2026-05-19) は、合成シンボル (`databarlimitedcomposite`) 上部に AI テキスト ((17)YYMMDD / (10)LOT 等) を SVG `<text>` で注入する `injectCompositeText` 関数を撤去した。撤去理由として「テキストのディセンダー (paren `( )` の下端カーブ ~4px) が composite 上端の 1X quiet zone に侵入し Dynamsoft Barcode Reader が decode 不能 (0 件)」「textRowH を 3X gap (= 9px) に広げる代替案も decode 不能で撤回」と記録されていた。
+
+しかし `[082]` / PR #458 で composite PNG decode 不能の真因が **Canvas2D の透明背景** (`svgContentToPngBlob` が `fillStyle = 'white'` 未設定で α=0 のまま) と判明。PR #450 当時の実機検証はすべて透明背景時に行われており、descender 仮説は **transparent 背景という別バグに巻き込まれた red herring** だった可能性が極めて高いと user が指摘した。
+
+### 根本原因の再評価
+
+PR #450 で行った decode 検証 3 種類:
+
+1. `injectCompositeText` 有効、1X gap → Dynamsoft 0 件
+2. `injectCompositeText` 有効、3X gap (textRowH 拡大) → Dynamsoft 0 件
+3. `injectCompositeText` 撤去 → Dynamsoft 100% 認識
+
+3 検証はすべて PNG 背景が transparent のまま実施。reader が transparent pixel を黒判定するため、quiet zone の幅に関わらず全面ノイズ → decode 不能になっていた。撤去ケース (3) で decode 成功した理由は、SVG 出力が小さく screenshot 経由などで再ラスタライズされる経路を含んだ可能性がある (詳細は当時のテスト手順が残っていない)。
+
+実機 user 検証 (本 PR 2026-05-20): PR #458 の白背景 fix を merge した状態で `injectCompositeText` を旧 geometry (textRowH = fontSize + 6 = 24px、text baseline y=21、barcode translate y=24) でそのまま復活 → Dynamsoft online reader (https://demo.dynamsoft.com/barcode-reader-js/) で `Found 1 barcode + GS1_COMPOSITE + confidence: 100` の decode 成功を確認。
+
+descender 仮説は本 PR で **明確に否定** された。GS1 仕様の「composite 周囲 1X quiet zone」要求自体は依然有効だが、image-based reader の binary threshold 動作には透明背景の方が遥かに支配的な影響を与えていた。
+
+### 決定
+
+1. **`escapeHtml` / `injectCompositeText` を `src/utils/gs1-databar.ts` に復元**: PR #450 撤去時 (commit `c563cf5`) から geometry / 関数シグネチャ不変で復元。コメントブロックで「PR #450 撤去 → PR #458 真因判明 → 本 PR 復活」の時系列を明示
+2. **`src/components/tools/Gs1Databar.tsx` の wiring を復元**: `addSvgDimensions(rawSvg)` 後に `compositeText` (非空時) を `injectCompositeText` に通す
+3. **`.gs1-svg-container` クラスを `src/styles/global.css` に復元**: `<text fill="currentColor">` が `color: var(--color-text)` を継承するための container 色設定。preview wrapper (`Gs1Databar.tsx:352`) に `barcode-preview gs1-svg-container` 併用
+4. **陽性対照テスト**:
+   - unit (`src/utils/__tests__/gs1-databar.test.ts`): `escapeHtml` 6 件 + `injectCompositeText` 8 件。geometry (y=21, height +=24, translate y=24)、XSS escape (`<script>` → `&lt;script&gt;`)、text < barcode width / text > barcode width の centering 両条件
+   - E2E (`tests/e2e/gs1-databar.spec.ts`): composite 入力時に `<text>` 要素 + `(17)...(10)...` 内容 + y="21" / text-anchor="middle" / fill="currentColor" を assert。non-composite (AI 未入力) では `<text>` 要素に AI 文字列が含まれないことも別 case で assert (常時 injection regression 検知)
+
+### 検討した代替案
+
+- **`textRowH` を旧 3X gap (= 34px) で安全側に**: GS1 spec 推奨に厳密に揃える案。だが旧 geometry (textRowH=24) で実機 decode 成功を確認できたため YAGNI で見送り。後続 reader 互換性問題が出たら拡張する
+- **AI テキストを SVG 外 (HTML レベル) で render**: preview には表示できるが downloaded PNG に反映されないため、印刷用バーコードとしての利用 (一般的な GS1 ラベル慣習) を満たさない。user 要求と不一致
+- **TEC-IT 等 reference 実装相当の独自 layout を組む**: 既存 `injectCompositeText` 復元で要件を満たすため過剰
+
+### 結果・トレードオフ
+
+- ✅ user 要求「合成シンボル内容を人間可読で確認」を満たす ((17)YYMMDD / (10)LOT 等を visual に確認可能)
+- ✅ Dynamsoft Barcode Reader (online) で `confidence: 100` decode 成功 (実機検証済 / 2026-05-20)
+- ✅ PR #458 白背景 fix と組み合わせで symbol 構造に影響なし
+- ⚠️ 生成 SVG / PNG の **全高が 24 svg-px 拡張** される (textRowH = fontSize + 6)。VRT baseline (`/tools/gs1-databar`) は composite シンボル表示時の差分が出る可能性 → CI `workflow_dispatch` で生成 → user 目視確認後に commit (CLAUDE.md 6.8)
+- ⚠️ AI 値が長い (例: lot 20 文字) と SVG 全幅が barcode より広がり centering される (旧実装の挙動と同じ)。preview / PNG の見た目は受け入れ可能だが、将来 layout 上の問題が出たら multi-line 対応も検討
+
+### 関連
+
+- 関連 fix: PR #450 (撤去, decisions `[067]` update) / PR #458 (透明背景真因判明, decisions `[082]`)
+- 陽性対照 (unit): `src/utils/__tests__/gs1-databar.test.ts` の `escapeHtml` / `injectCompositeText` describe
+- 陽性対照 (E2E): `tests/e2e/gs1-databar.spec.ts` の `composite シンボルに AI テキスト ((17)... (10)...) が SVG 上部に注入される` / `non-composite (AI フィールド未入力) シンボルには AI テキスト注入されない`

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3171,3 +3171,47 @@ PR #450 (`height` オプション削除) と PR #453 (`shape-rendering="crispEdg
 - 過去 fix: PR #450 (`height` 削除), PR #453 (`shape-rendering` 注入)
 - 陽性対照 (composite): `tests/e2e/gs1-databar.spec.ts` の `composite シンボルに GS1 推奨の 10X quiet zone (paddingwidth) が確保されている`
 - 陽性対照 (non-composite): 同 spec の `non-composite シンボルには paddingwidth が適用されない`
+
+## [082] 2026-05-20 — PNG 変換 Canvas2D の透明背景が原因の reader decode 失敗を白塗りで解消
+
+### 背景
+
+`[081]` の `paddingwidth: 10` で composite の左右 quiet zone を GS1 推奨 10X に拡張したが、ユーザーから「ツールで生成した PNG (`gs1-databar-04987000000017.png`) が読取サイト (Dynamsoft Barcode Reader online) で `Found 0 barcodes` になるが、同 PNG を画面 screenshot 経由で再ラスタライズしたものは confidence=100 で decode 成功する」という事象が報告された。
+
+### 根本原因（仮説の差し替え経緯）
+
+**初期仮説 (誤り)**: 垂直 quiet zone (上下余白) の不足。bwip-js の `bordertop/borderbottom` が default 0 のため bars / CC-A 上端が image 上端に密着しており、image-based scanner が symbol 境界を検出できないと推定し、`paddingheight: 10` の追加を試した。
+
+しかし `paddingheight: 10` で上下 30 svg-px の quiet zone を確保しても、Dynamsoft は依然 `Found 0 barcodes` を返した。一方、同じ PNG の screenshot は依然 decode 成功する。垂直 quiet zone は decode 成立条件ではなかったため `paddingheight` 案は revert した。
+
+**真因 (実機 pixel 計測で確定)**: `src/utils/download.ts` の `svgContentToPngBlob` / `downloadPngFromSvgElement` が **Canvas2D default の透明背景** (RGBA=0,0,0,0) のまま `drawImage(svg)` を呼んでいた。bwip-js / JsBarcode の SVG は黒バーのみ `<path>` で描画し背景 `<rect>` を持たないため、生成 PNG の **quiet zone / バー間 pixel が完全 transparent** になっていた (Playwright で `getImageData` 計測: 4 隅すべて α=0, RGB=(0,0,0))。
+
+ブラウザ表示時はページ白背景が透過するため視覚上は白だが、image-based barcode reader (Dynamsoft 等) は **transparent pixel を「黒」と解釈** する実装があり、quiet zone が黒判定 → 全面ノイズ → decode 不能になっていた。screenshot 経由で読めるのは、ブラウザが PNG を白ページ上に rendering した結果を screen capture すると実 RGB 値が白になり、再生成 PNG が通常の white-background 画像になるためである。
+
+### 決定
+
+1. **PNG 変換 Canvas の背景を白で塗る** (`src/utils/download.ts`)
+   - `svgContentToPngBlob` / `downloadPngFromSvgElement` 両方で `ctx.scale()` 前に `ctx.fillStyle = 'white'` + `ctx.fillRect(0, 0, canvas.width, canvas.height)` を呼ぶ
+   - 順序は **fillRect (device px 単位) → ctx.scale (retina 変換) → drawImage (bars を overdraw)**。scale 後だと rect 寸法が CSS px 扱いになり半分しか塗れない
+   - 影響範囲: GS1 DataBar (`svgContentToPngBlob` 経由) と JAN コード (`downloadPngFromSvgElement` 経由) の両 PNG ダウンロード
+2. **陽性対照テスト** (`src/utils/__tests__/download.test.ts` + `tests/e2e/gs1-databar.spec.ts`):
+   - unit: `svgContentToPngBlob` / `downloadPngFromSvgElement` の `fillStyle === 'white'`, `fillRect` の引数 (canvas 全面 device px), 呼び出し順序 (fillRect → scale → drawImage) を assert (各経路 3 件 × 2 経路 = 6 件)
+   - E2E: composite 生成 PNG を Canvas で実生成し 4 隅の quiet zone pixel が `α=255 / RGB=(255,255,255)` であることを `getImageData` で assert。fix を revert すると α=0 (transparent) に戻り全件 fail する設計
+
+### 検討した代替案
+
+- **垂直 quiet zone (paddingheight) のみで解決を目指す**: 当初の仮説。実機検証で否定 (Dynamsoft 依然 `Found 0`)。screenshot 経由が読める真因は余白ではなく **再ラスタライズで透明→白に変換される** ことだった。誤仮説で追加した `paddingheight: 10` と陽性対照 2 件 (`non-composite シンボルに垂直 quiet zone` / `composite シンボルに垂直 quiet zone`) は user 判断で revert した (YAGNI: scope discipline 優先)
+- **SVG 側に背景 `<rect width="100%" height="100%" fill="white"/>` を注入**: bwip-js 出力の SVG を post-process することで Image→Canvas 経路に依存せず白背景を持たせる選択肢。だが SVG 内に rect を入れると `addSvgDimensions` の regex match 経路に影響し、preview 表示時の image-rendering: pixelated との相互作用も発生するため副作用が大きい。**Canvas 側で fill する方が影響範囲が局所的** (`svgContentToPngBlob` / `downloadPngFromSvgElement` の 2 関数のみ) で安全
+- **`canvas.getContext('2d', { alpha: false })`**: alpha チャネルを完全に無効化する選択肢。canvas の background が黒になる仕様で、`fillRect` で白塗りする必要があるため結局同じ工程になる。明示的な `fillStyle = 'white' + fillRect` のほうが意図が読みやすい
+
+### 結果・トレードオフ
+
+- ✅ Dynamsoft Barcode Reader (online) で composite シンボルが `Found 1 barcode (confidence: 100)` で decode 成功することを実機検証 (user 環境で確認)
+- ✅ JAN コード (`downloadPngFromSvgElement`) も同じ修正の恩恵を受け、同様の reader 互換性向上が見込まれる
+- ✅ SVG viewBox / preview の見た目は変更なし。PNG 画素値のみ「quiet zone を透明から白に変える」局所修正なので VRT baseline (`/tools/gs1-databar`) への影響は preview 経路では無し
+
+### 関連
+
+- 関連 fix: PR #456 (`paddingwidth: 10` for composite, decisions `[081]`)
+- 陽性対照 (unit): `src/utils/__tests__/download.test.ts` の `svgContentToPngBlob: PNG 背景白塗り (transparent decode 失敗修正)` describe / `downloadPngFromSvgElement` の `陽性対照: fillStyle が white にセットされて fillRect が canvas 全面で呼ばれる` / `陽性対照: 呼び出し順序は fillRect → scale → drawImage`
+- 陽性対照 (E2E): `tests/e2e/gs1-databar.spec.ts` の `生成 PNG の quiet zone が透明ではなく白 (α=255) で塗られている`

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -7,6 +7,7 @@ import {
   validateGtin14Input,
   buildBwipText,
   addSvgDimensions,
+  injectCompositeText,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
@@ -126,13 +127,20 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
         textsize: 7,
       });
 
-      // composite component 上に AI テキスト ((17)... 等) を SVG injection する
-      // 旧実装は、テキストのディセンダーが composite 上端の quiet zone (1X) に
-      // 侵入してスキャナが decode 不能になる問題があった (Dynamsoft Reader 0 件 →
-      // injection 撤去で `GS1_COMPOSITE` 100% 認識を確認)。textRowH を広げて
-      // quiet zone を 3X 確保する案も検証したが decode 不能のため撤回し撤去で確定。
-      // 合成シンボル内の AI 値は下部の「GS1文字列を見る」セクションで人間可読として確認できる。
-      const finalSvg = addSvgDimensions(rawSvg);
+      // composite component 上に AI テキスト ((17)... 等) を SVG injection する。
+      //
+      // 経緯: PR #450 (commit c563cf5) は「ディセンダーが composite 上端 1X quiet
+      // zone に侵入して Dynamsoft Reader が decode 不能」を理由に撤去したが、PR #458
+      // (commit 977f6b6) で真因は **Canvas2D の透明背景** (一部 reader が transparent
+      // pixel を黒判定) と判明。PR #450 の検証はすべて透明背景時だったため descender
+      // 仮説は red herring と判断、白背景 fix とセットで復活させ user 実機検証で
+      // decode 成功を確認した (decisions [083])。
+      const compositeText = aiFields
+        .filter((f) => f.value.trim() !== '')
+        .map((f) => `(${f.ai})${f.value.trim()}`)
+        .join('');
+      const sizedSvg = addSvgDimensions(rawSvg);
+      const finalSvg = compositeText ? injectCompositeText(sizedSvg, compositeText) : sizedSvg;
       setSvgContent(finalSvg);
       setBwipError('');
       onSvgChangeRef.current(finalSvg, gtinResult.fullGtin);
@@ -341,7 +349,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
           >
             <div
               aria-label={`GS1 DataBar ${gtinResult?.fullGtin} のバーコード`}
-              className="barcode-preview"
+              className="barcode-preview gs1-svg-container"
               dangerouslySetInnerHTML={{ __html: svgContent }}
             />
             <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -569,6 +569,16 @@
     image-rendering: pixelated;
   }
 
+  /* === Gs1Databar: composite シンボル上部 AI テキスト (injectCompositeText) 色継承 ===
+     `injectCompositeText` (utils/gs1-databar.ts) が SVG に注入する <text> は
+     `fill="currentColor"` で親要素の color を継承する。本 class が container 側で
+     `color: var(--color-text)` を確定させることで、theme (light/dark) に追従した
+     text 色を実現する。class が外れると text の塗り色が UA default (通常 black)
+     にフォールバックして dark theme で読みにくくなるため削除しないこと。 */
+  .gs1-svg-container {
+    color: var(--color-text);
+  }
+
   /* === PR 4: Gs1Databar <details>/<summary> marker hide === */
   .summary-no-marker {
     list-style: none;

--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -2,10 +2,159 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { downloadBlob, downloadPngFromSvgElement, svgContentToPngBlob } from '@/utils/download';
 
 /**
+ * `src/utils/download.ts` の private const `RETINA_SCALE` の mirror。
+ * canvas 寸法計算 (canvas.width = SVG.width * RETINA_SCALE) を test 側で再現する際に、
+ * `200` / `100` 等の生数値ではなくこの定数を経由することで、将来 RETINA_SCALE を変更
+ * した場合の link を明示する (#458 review B 対応)。
+ */
+const RETINA_SCALE = 2;
+
+// ─────────────────────────────────────────────
+// 共通 mock setup (#458 review A 対応)
+//
+// `downloadPngFromSvgElement` (`toDataURL` 出力) と `svgContentToPngBlob` (`toBlob` 出力)
+// で重複していた canvas / Image / URL / anchor の stubGlobal 構築を `setupBrowserMocks()`
+// に集約。観測対象 (call log / fillStyle / ctx / image / anchor) を MockHandles で返す。
+//
+// design 方針:
+// - call log / capturedFillStyle / capturedCtx は **常に観測** (test 側で assert する/しないを選択)。
+//   overhead は無視できる (vi.fn の wrapper のみ)。
+// - 出力 API は `output: 'toBlob' | 'toDataURL'` で切替。`toDataURL` 時は `throwsOnInvoke`
+//   で SecurityError 相当を強制可能 (tainted canvas 経路の陽性対照用)。
+// - imgInstance / anchors は getter 経由 (closure 安定化、test 内で時間差発火可能)。
+// ─────────────────────────────────────────────
+
+type CallLog = { method: string; args: unknown[] };
+
+interface MockedCtx {
+  imageSmoothingEnabled: boolean;
+  fillStyle: string;
+  fillRect: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+}
+
+interface AnchorStub {
+  href: string;
+  download: string;
+  click: ReturnType<typeof vi.fn>;
+}
+
+interface ImgInstance {
+  onload: (() => void) | null;
+  onerror: (() => void) | null;
+  src: string;
+}
+
+interface MockHandles {
+  callLog: CallLog[];
+  capturedCtx: { value: MockedCtx | null };
+  getCapturedFillStyle: () => string | undefined;
+  getImgInstance: () => ImgInstance | undefined;
+  getCreatedAnchors: () => AnchorStub[];
+  createObjectURL: ReturnType<typeof vi.fn>;
+  revokeObjectURL: ReturnType<typeof vi.fn>;
+}
+
+type SetupOptions = { output: 'toBlob' } | { output: 'toDataURL'; throwsOnInvoke?: Error };
+
+function setupBrowserMocks(opts: SetupOptions): MockHandles {
+  const callLog: CallLog[] = [];
+  let capturedFillStyle: string | undefined;
+  const capturedCtx: { value: MockedCtx | null } = { value: null };
+  let imgInstance: ImgInstance | undefined;
+  const createdAnchors: AnchorStub[] = [];
+
+  const createObjectURL = vi.fn(() => 'blob:mock-url');
+  const revokeObjectURL = vi.fn();
+
+  vi.stubGlobal('document', {
+    createElement: vi.fn((tag: string) => {
+      if (tag === 'canvas') {
+        const ctxStub = {
+          imageSmoothingEnabled: true,
+          set fillStyle(v: string) {
+            capturedFillStyle = v;
+            callLog.push({ method: 'set fillStyle', args: [v] });
+          },
+          get fillStyle() {
+            return capturedFillStyle ?? '';
+          },
+          fillRect: vi.fn((...args: number[]) => callLog.push({ method: 'fillRect', args })),
+          scale: vi.fn((...args: number[]) => callLog.push({ method: 'scale', args })),
+          drawImage: vi.fn((...args: unknown[]) => callLog.push({ method: 'drawImage', args })),
+        } as MockedCtx;
+        const canvasEl: Record<string, unknown> = {
+          width: 0,
+          height: 0,
+          getContext: () => {
+            capturedCtx.value = ctxStub;
+            return ctxStub;
+          },
+        };
+        if (opts.output === 'toBlob') {
+          canvasEl.toBlob = (cb: (b: Blob | null) => void) =>
+            cb(new Blob(['png'], { type: 'image/png' }));
+        } else {
+          canvasEl.toDataURL = vi.fn(() => {
+            if (opts.throwsOnInvoke) throw opts.throwsOnInvoke;
+            return 'data:image/png;base64,XXX';
+          });
+        }
+        return canvasEl;
+      }
+      if (tag === 'a') {
+        const el: AnchorStub = { href: '', download: '', click: vi.fn() };
+        createdAnchors.push(el);
+        return el;
+      }
+      return {};
+    }),
+  });
+
+  vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+
+  vi.stubGlobal(
+    'Image',
+    class {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      _src = '';
+      get src() {
+        return this._src;
+      }
+      set src(v: string) {
+        this._src = v;
+        imgInstance = this as unknown as ImgInstance;
+      }
+    }
+  );
+
+  return {
+    callLog,
+    capturedCtx,
+    getCapturedFillStyle: () => capturedFillStyle,
+    getImgInstance: () => imgInstance,
+    getCreatedAnchors: () => createdAnchors,
+    createObjectURL,
+    revokeObjectURL,
+  };
+}
+
+// テスト用 SVGSVGElement のスタブ (downloadPngFromSvgElement 用)
+const makeSvgStub = () =>
+  ({
+    getBoundingClientRect: () => ({ width: 100, height: 50 }),
+    outerHTML: '<svg width="100" height="50"></svg>',
+  }) as unknown as SVGSVGElement;
+
+/**
  * downloadBlob のスモークテスト。
  * vitest の environment は node なので DOM API は存在しない。
  * テストごとに必要な API（document, URL.createObjectURL/revokeObjectURL）を
  * vi.stubGlobal でモックし、終了後にリセットする。
+ *
+ * 注: canvas を使わないため `setupBrowserMocks` は経由せず、anchor のみ stub する。
  */
 describe('downloadBlob', () => {
   let createdAnchor: { href: string; download: string; click: ReturnType<typeof vi.fn> };
@@ -62,199 +211,111 @@ describe('downloadBlob', () => {
  * 存在せず `await` できないため必ず fail する (test-gates 鉄則 1)。
  */
 describe('downloadPngFromSvgElement', () => {
-  let createdElements: Array<{ tag: string; el: Record<string, unknown> }>;
-  let imgInstance: { onload: (() => void) | null; onerror: (() => void) | null; src: string };
-  let createObjectURL: ReturnType<typeof vi.fn>;
-  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let m: MockHandles;
 
   beforeEach(() => {
-    createdElements = [];
-    createObjectURL = vi.fn(() => 'blob:mock-url');
-    revokeObjectURL = vi.fn();
-
-    vi.stubGlobal('document', {
-      createElement: vi.fn((tag: string) => {
-        if (tag === 'canvas') {
-          const el = {
-            width: 0,
-            height: 0,
-            getContext: vi.fn(() => ({ scale: vi.fn(), drawImage: vi.fn() })),
-            toDataURL: vi.fn(() => 'data:image/png;base64,XXX'),
-          };
-          createdElements.push({ tag, el });
-          return el;
-        }
-        if (tag === 'a') {
-          const el = { href: '', download: '', click: vi.fn() };
-          createdElements.push({ tag, el });
-          return el;
-        }
-        return {};
-      }),
-    });
-    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
-    // imgInstance は Image の src setter で確定される。
-    // テスト本体は src 代入後 (= production code の img.src = url) に
-    // imgInstance.onload / onerror を発火させる。
-    vi.stubGlobal(
-      'Image',
-      class {
-        onload: (() => void) | null = null;
-        onerror: (() => void) | null = null;
-        _src = '';
-        get src() {
-          return this._src;
-        }
-        set src(v: string) {
-          this._src = v;
-          imgInstance = this;
-        }
-      }
-    );
+    m = setupBrowserMocks({ output: 'toDataURL' });
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  // テスト用 SVGSVGElement のスタブ
-  const makeSvgStub = () =>
-    ({
-      getBoundingClientRect: () => ({ width: 100, height: 50 }),
-      outerHTML: '<svg width="100" height="50"></svg>',
-    }) as unknown as SVGSVGElement;
-
   it('陰性対照: img.onload が発火すると Promise は resolve し anchor.click() が呼ばれる', async () => {
     const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
     // src setter で imgInstance が確定 → onload を発火
-    imgInstance.onload?.();
+    m.getImgInstance()?.onload?.();
     await expect(promise).resolves.toBeUndefined();
 
-    const anchor = createdElements.find((e) => e.tag === 'a')!.el as {
-      download: string;
-      click: ReturnType<typeof vi.fn>;
-    };
-    expect(anchor.download).toBe('jan-test.png');
-    expect(anchor.click).toHaveBeenCalledTimes(1);
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    const anchors = m.getCreatedAnchors();
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0].download).toBe('jan-test.png');
+    expect(anchors[0].click).toHaveBeenCalledTimes(1);
+    expect(m.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 
   it('陽性対照: img.onerror が発火すると Promise は "PNG への変換に失敗しました" で reject する', async () => {
     const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
-    imgInstance.onerror?.();
+    m.getImgInstance()?.onerror?.();
     await expect(promise).rejects.toThrow('PNG への変換に失敗しました');
     // 失敗経路でも ObjectURL は確実に解放される
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    expect(m.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 
   it('陽性対照: Canvas context の imageSmoothingEnabled が false に設定される (バーコード edge anti-alias 抑止)', async () => {
     // fix を revert (imageSmoothingEnabled = false 行を消す) すると context は
     // mock default の true のままで本テストが fail する設計 (test-gates 鉄則 1)。
-    let capturedCtx: { imageSmoothingEnabled: boolean; scale: unknown; drawImage: unknown } | null =
-      null;
-    vi.stubGlobal('document', {
-      createElement: vi.fn((tag: string) => {
-        if (tag === 'canvas') {
-          return {
-            width: 0,
-            height: 0,
-            getContext: () => {
-              capturedCtx = { imageSmoothingEnabled: true, scale: vi.fn(), drawImage: vi.fn() };
-              return capturedCtx;
-            },
-            toDataURL: vi.fn(() => 'data:image/png;base64,XXX'),
-          };
-        }
-        if (tag === 'a') return { href: '', download: '', click: vi.fn() };
-        return {};
-      }),
-    });
-
     const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
-    imgInstance.onload?.();
+    m.getImgInstance()?.onload?.();
     await promise;
-    expect(capturedCtx).not.toBeNull();
-    expect(capturedCtx!.imageSmoothingEnabled).toBe(false);
+    expect(m.capturedCtx.value).not.toBeNull();
+    expect(m.capturedCtx.value!.imageSmoothingEnabled).toBe(false);
+  });
+
+  // ─────────────────────────────────────────────
+  // 陽性対照: PNG 背景白塗り (transparent decode 失敗修正)
+  //
+  // downloadPngFromSvgElement (JAN コード経路) も svgContentToPngBlob と同じく
+  // Canvas2D default transparent 背景のまま drawImage していた。fix を revert
+  // (`ctx.fillStyle = 'white'` / `ctx.fillRect(...)` を削る) と本テスト 2 件が
+  // fail する設計 (call ログから fillRect が消える / fillStyle が undefined のまま)。
+  // ─────────────────────────────────────────────
+  it('陽性対照: fillStyle が white にセットされて fillRect が canvas 全面で呼ばれる (背景透明 → 白)', async () => {
+    const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
+    m.getImgInstance()?.onload?.();
+    await promise;
+    expect(m.getCapturedFillStyle()).toBe('white');
+    const fillRectCalls = m.callLog.filter((c) => c.method === 'fillRect');
+    expect(fillRectCalls).toHaveLength(1);
+    // getBoundingClientRect = { width: 100, height: 50 } → canvas は scale 前 device px 単位
+    expect(fillRectCalls[0].args).toEqual([0, 0, 100 * RETINA_SCALE, 50 * RETINA_SCALE]);
+  });
+
+  it('陽性対照: 呼び出し順序は fillRect → scale → drawImage (背景 → retina 変換 → bars)', async () => {
+    const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
+    m.getImgInstance()?.onload?.();
+    await promise;
+    const fillRectIdx = m.callLog.findIndex((c) => c.method === 'fillRect');
+    const scaleIdx = m.callLog.findIndex((c) => c.method === 'scale');
+    const drawImageIdx = m.callLog.findIndex((c) => c.method === 'drawImage');
+    expect(fillRectIdx).toBeGreaterThanOrEqual(0);
+    expect(scaleIdx).toBeGreaterThan(fillRectIdx);
+    expect(drawImageIdx).toBeGreaterThan(scaleIdx);
   });
 
   it('陽性対照: img.onload 内で canvas.toDataURL が throw した場合も Promise は reject する', async () => {
-    // canvas.toDataURL を throw する stub に差し替える (tainted canvas 等の SecurityError 相当)
-    vi.stubGlobal('document', {
-      createElement: vi.fn((tag: string) => {
-        if (tag === 'canvas') {
-          return {
-            width: 0,
-            height: 0,
-            getContext: () => ({ scale: vi.fn(), drawImage: vi.fn() }),
-            toDataURL: () => {
-              throw new Error('canvas is tainted');
-            },
-          };
-        }
-        if (tag === 'a') return { href: '', download: '', click: vi.fn() };
-        return {};
-      }),
+    // canvas.toDataURL を throw する mock に差し替える (tainted canvas 等の SecurityError 相当)
+    vi.unstubAllGlobals();
+    const m2 = setupBrowserMocks({
+      output: 'toDataURL',
+      throwsOnInvoke: new Error('canvas is tainted'),
     });
-
     const promise = downloadPngFromSvgElement(makeSvgStub(), 'jan-test.png');
-    imgInstance.onload?.();
+    m2.getImgInstance()?.onload?.();
     await expect(promise).rejects.toThrow('canvas is tainted');
     // finally で ObjectURL は解放される
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    expect(m2.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 });
 
 /**
- * svgContentToPngBlob: PNG 変換時の anti-aliasing 抑止 (GS1 DataBar 認識失敗修正)。
+ * svgContentToPngBlob: PNG 変換時の anti-aliasing 抑止 (GS1 DataBar 認識失敗修正) +
+ * PNG 背景白塗り (transparent decode 失敗修正)。
  *
- * fix を revert (download.ts:55 付近の `ctx.imageSmoothingEnabled = false` を削る)
- * と本テストが必ず fail する陽性対照 (test-gates 鉄則 1)。
+ * fix を revert (`imageSmoothingEnabled = false` / `fillStyle = 'white'` /
+ * `fillRect(...)` を削る) と各陽性対照テストが必ず fail する設計 (test-gates 鉄則 1)。
  *
  * 旧実装は ctx.drawImage(img, 0, 0) を smoothing 有効 default のまま呼んでおり、
- * scanner が黒/白二値閾値で bar 幅を取り違える事象を起こしていた。
+ * scanner が黒/白二値閾値で bar 幅を取り違える事象を起こしていた。さらに Canvas2D
+ * default の transparent 背景のまま drawImage していたため、生成 PNG の quiet zone /
+ * バー間 pixel が RGBA=0,0,0,0 になり image-based barcode reader (Dynamsoft 等) が
+ * transparent を「黒」と解釈して decode 失敗する事象も併発していた。
  */
 describe('svgContentToPngBlob', () => {
-  let createObjectURL: ReturnType<typeof vi.fn>;
-  let revokeObjectURL: ReturnType<typeof vi.fn>;
-  let imgInstance: { onload: (() => void) | null; onerror: (() => void) | null; src: string };
-  let capturedCtx: { imageSmoothingEnabled: boolean; scale: unknown; drawImage: unknown } | null;
+  let m: MockHandles;
 
   beforeEach(() => {
-    capturedCtx = null;
-    createObjectURL = vi.fn(() => 'blob:mock-url');
-    revokeObjectURL = vi.fn();
-    vi.stubGlobal('document', {
-      createElement: vi.fn((tag: string) => {
-        if (tag === 'canvas') {
-          return {
-            width: 0,
-            height: 0,
-            getContext: () => {
-              capturedCtx = { imageSmoothingEnabled: true, scale: vi.fn(), drawImage: vi.fn() };
-              return capturedCtx;
-            },
-            toBlob: (cb: (b: Blob | null) => void) => cb(new Blob(['png'], { type: 'image/png' })),
-          };
-        }
-        return {};
-      }),
-    });
-    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
-    vi.stubGlobal(
-      'Image',
-      class {
-        onload: (() => void) | null = null;
-        onerror: (() => void) | null = null;
-        _src = '';
-        get src() {
-          return this._src;
-        }
-        set src(v: string) {
-          this._src = v;
-          imgInstance = this;
-        }
-      }
-    );
+    m = setupBrowserMocks({ output: 'toBlob' });
   });
 
   afterEach(() => {
@@ -264,14 +325,47 @@ describe('svgContentToPngBlob', () => {
   it('陽性対照: Canvas context の imageSmoothingEnabled が false に設定される', async () => {
     const svg = '<svg width="100" height="50" viewBox="0 0 100 50"></svg>';
     const promise = svgContentToPngBlob(svg);
-    imgInstance.onload?.();
+    m.getImgInstance()?.onload?.();
     await promise;
-    expect(capturedCtx).not.toBeNull();
-    expect(capturedCtx!.imageSmoothingEnabled).toBe(false);
+    expect(m.capturedCtx.value).not.toBeNull();
+    expect(m.capturedCtx.value!.imageSmoothingEnabled).toBe(false);
   });
 
   it('width/height が無い SVG は reject される (既存契約)', async () => {
     const svg = '<svg viewBox="0 0 100 50"></svg>';
     await expect(svgContentToPngBlob(svg)).rejects.toThrow('width/height');
+  });
+
+  it('陽性対照: fillStyle が white にセットされる', async () => {
+    const svg = '<svg width="100" height="50" viewBox="0 0 100 50"></svg>';
+    const promise = svgContentToPngBlob(svg);
+    m.getImgInstance()?.onload?.();
+    await promise;
+    expect(m.getCapturedFillStyle()).toBe('white');
+  });
+
+  it('陽性対照: fillRect が canvas 全面 (device px, scale 前) で呼ばれる', async () => {
+    const svg = '<svg width="100" height="50" viewBox="0 0 100 50"></svg>';
+    const promise = svgContentToPngBlob(svg);
+    m.getImgInstance()?.onload?.();
+    await promise;
+    const fillRectCalls = m.callLog.filter((c) => c.method === 'fillRect');
+    expect(fillRectCalls).toHaveLength(1);
+    // canvas は scale 前 device px 単位 (SVG width/height × RETINA_SCALE)
+    expect(fillRectCalls[0].args).toEqual([0, 0, 100 * RETINA_SCALE, 50 * RETINA_SCALE]);
+  });
+
+  it('陽性対照: 呼び出し順序は fillRect → scale → drawImage (背景 → retina 変換 → bars)', async () => {
+    const svg = '<svg width="100" height="50" viewBox="0 0 100 50"></svg>';
+    const promise = svgContentToPngBlob(svg);
+    m.getImgInstance()?.onload?.();
+    await promise;
+    // fillRect は scale より先 (scale 前 device px 単位での塗り潰しが必須)
+    const fillRectIdx = m.callLog.findIndex((c) => c.method === 'fillRect');
+    const scaleIdx = m.callLog.findIndex((c) => c.method === 'scale');
+    const drawImageIdx = m.callLog.findIndex((c) => c.method === 'drawImage');
+    expect(fillRectIdx).toBeGreaterThanOrEqual(0);
+    expect(scaleIdx).toBeGreaterThan(fillRectIdx);
+    expect(drawImageIdx).toBeGreaterThan(scaleIdx);
   });
 });

--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -4,6 +4,8 @@ import {
   validateGtin14Input,
   buildBwipText,
   addSvgDimensions,
+  escapeHtml,
+  injectCompositeText,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
@@ -204,5 +206,154 @@ describe('addSvgDimensions', () => {
     expect(out).toContain('height="40"');
     expect(out).toContain('shape-rendering="crispEdges"');
     expect(out).toContain('class="foo"');
+  });
+});
+
+// ────────────────────────────────────────────
+// escapeHtml
+// ────────────────────────────────────────────
+//
+// 陽性対照: `injectCompositeText` が AI 値を SVG <text> として埋め込む際の XSS 対策。
+// fix を revert (関数削除 / `replace(/</g, ...)` 等の置換を削除) すると raw `<` `>`
+// `"` が SVG に流れて XSS / SVG 破損が起き、本 describe の expected/actual 比較で
+// 必ず差分が出て fail する設計。
+describe('escapeHtml', () => {
+  it('& は &amp; に変換される (最初に処理しないと連鎖 escape の事故になる)', () => {
+    expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+  });
+
+  it('< と > はタグ injection 防止のため変換される', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('" は属性 injection 防止のため &quot; に変換される', () => {
+    expect(escapeHtml('say "hi"')).toBe('say &quot;hi&quot;');
+  });
+
+  it("' は属性 injection 防止のため &#039; に変換される", () => {
+    expect(escapeHtml("it's")).toBe('it&#039;s');
+  });
+
+  it('複数文字が混在しても順序通り escape される (& 先頭で連鎖 escape を防ぐ)', () => {
+    // `&` が `&amp;` に展開された後に再度 escape されると `&amp;amp;` になる事故を防ぐ。
+    expect(escapeHtml('a & b < c')).toBe('a &amp; b &lt; c');
+  });
+
+  it('escape 不要な文字 (英数記号 / 日本語) はそのまま', () => {
+    expect(escapeHtml('(17)231231(10)ABC123')).toBe('(17)231231(10)ABC123');
+    expect(escapeHtml('賞味期限')).toBe('賞味期限');
+  });
+});
+
+// ────────────────────────────────────────────
+// injectCompositeText
+// ────────────────────────────────────────────
+//
+// 陽性対照: PR #450 (commit c563cf5) で撤去された AI テキスト SVG injection を
+// PR #458 (透明背景真因判明) を受けて復活させる際の geometry / XSS 安全性 / dimension
+// 拡張の回帰防止テスト一式。
+//
+// fix revert (関数削除 / dimension 拡張ロジック削除 / escape 削除) で必ず fail する
+// 設計。具体的には:
+//   - 関数削除: import error → test ファイル全体 fail
+//   - dimension 拡張削除: newH = h + textRowH を確認する assert が fail
+//   - text 配置 y 削除: `<text ... y="21" ...>` 文字列が存在しない fail
+//   - XSS escape 削除: raw `<script>` が SVG 文字列に残って escape 検証 fail
+describe('injectCompositeText', () => {
+  // bwip-js + addSvgDimensions の出力に近い fixture
+  const baseSvg =
+    '<svg width="293" height="75" shape-rendering="crispEdges" viewBox="0 0 293 75"' +
+    ' xmlns="http://www.w3.org/2000/svg">' +
+    '<path stroke="#000000" stroke-width="3" d="M0 0L293 0"/></svg>';
+
+  it('空 text は SVG をそのまま返す (early return)', () => {
+    expect(injectCompositeText(baseSvg, '')).toBe(baseSvg);
+  });
+
+  it('viewBox を持たない SVG は変更せず返す (想定外 fixture 破壊防止)', () => {
+    const noVb = '<svg width="100" height="50"><path/></svg>';
+    expect(injectCompositeText(noVb, '(17)231231')).toBe(noVb);
+  });
+
+  it('text が injection され y=21 (textRowH - 3) に配置される', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231(10)ABC123');
+    // text element の baseline 位置 (textRowH=24 - 3 = 21)
+    expect(out).toMatch(/<text [^>]*y="21" /);
+    // 中身は escape された AI 値
+    expect(out).toContain('>(17)231231(10)ABC123</text>');
+    expect(out).toContain('font-size="18"');
+    expect(out).toContain('text-anchor="middle"');
+    expect(out).toContain('fill="currentColor"');
+    expect(out).toContain('font-family="\'Courier New\',Courier,monospace"');
+  });
+
+  it('viewBox 高さは元の barcode 高さ + textRowH(24) に拡張される', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    // baseSvg height=75 + textRowH=24 = 99
+    expect(out).toMatch(/viewBox="0 0 \S+ 99\.0"/);
+    expect(out).toContain('height="99"');
+  });
+
+  it('barcode が text より広いときは barcode 幅を維持し translate は y=24 のみ (横 shift 0)', () => {
+    // baseSvg width=293、text 長 10 文字 + padding 16 → 推定幅 ~76px < 293
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    expect(out).toContain('width="293"');
+    expect(out).toMatch(/viewBox="0 0 293\.0 99\.0"/);
+    // translate(0, 24) で barcode は下方向のみ shift
+    expect(out).toContain('transform="translate(0.0,24)"');
+  });
+
+  it('text が barcode より広いときは SVG 幅を拡張し barcode を中央寄せする', () => {
+    // 54 文字 ((17) + '1'×50) × charW=10.8 + padding=16 = 599.2 > 293
+    const longText = '(17)' + '1'.repeat(50);
+    const out = injectCompositeText(baseSvg, longText);
+    expect(out).toMatch(/viewBox="0 0 599\.2 99\.0"/);
+    expect(out).toContain('width="599"'); // Math.round(599.2)
+    // (newW - barcodeW) / 2 = (599.2 - 293) / 2 = 153.1
+    expect(out).toContain('transform="translate(153.1,24)"');
+  });
+
+  it('XSS escape: <script> tag を含む text は &lt;script&gt; に escape される', () => {
+    const out = injectCompositeText(baseSvg, '<script>alert(1)</script>');
+    // raw `<script>` は SVG に出ない
+    expect(out).not.toContain('<script>');
+    expect(out).not.toContain('</script>');
+    // escape 後の文字列が text element 内に含まれる
+    expect(out).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('barcode 部は <g transform="translate(_, 24)"> でラップされる (元 inner を保持)', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    // 元 SVG の <path .../> が <g transform="..."> 内に残る
+    expect(out).toMatch(/<g transform="translate\([\d.]+,24\)">.*<path[^>]*\/>.*<\/g>/s);
+  });
+
+  // 陽性対照 (#462 review A 対応): width / height 置換 regex は **<svg> 開始タグ内に
+  // anchor** されており、`<svg>` に width/height 属性が無く子要素にだけ `width="N"`
+  // がある場合に **子要素を wrong match して破壊しない** ことを実観測する。
+  //
+  // anchor を外して旧形 (`/width="\d+"/`) に戻すと、最初の match が子要素
+  // `<rect width="10">` になり `<rect width="76">` (newW=76) に誤置換されて
+  // 子要素 width assertion が必ず fail する設計 (test-gates 鉄則 1)。
+  //
+  // 実運用では `addSvgDimensions` が `<svg>` に width/height を必ず注入するため
+  // anchor の差は顕在化しないが、bwip-js / addSvgDimensions の将来変更で svg root
+  // から width/height が外れた場合の silent regression を防ぐ防御ガード。
+  it('<svg> ルートに width 属性無し + 子要素 <rect width="N"> ありの場合に子要素を破壊しない (anchor 検証)', () => {
+    // svg root に width/height 属性なし、viewBox のみ。子要素 <rect width="10">。
+    // injectCompositeText は viewBox から barcodeW=100 / h=50 を取得して動作する。
+    const svgNoRootWidth =
+      '<svg viewBox="0 0 100 50" xmlns="http://www.w3.org/2000/svg">' +
+      '<rect width="10" height="20" fill="#000"/></svg>';
+    // text 長さ 10 文字 → estimatedTextW = 10 * 10.8 + 16 = 124 → newW = max(100, 124) = 124
+    // newH = 50 + 24 = 74
+    const out = injectCompositeText(svgNoRootWidth, '(17)231231');
+    // 子要素 <rect> の width / height は元のまま (10 / 20)。
+    // 旧 regex (anchor 無し) なら最初の `width="10"` が `width="124"` に誤置換されて
+    // `<rect width="124" height="74">` になり、本 assert が fail する。
+    expect(out).toMatch(/<rect width="10" height="20"/);
+    // svg root には元々 width 属性が無いため anchor 付き regex は no-op (注入もしない)。
+    // viewBox は別 regex で更新される (anchor 無関係)。
+    expect(out).toMatch(/viewBox="0 0 124\.0 74\.0"/);
   });
 });

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -53,6 +53,11 @@ export function svgContentToPngBlob(svgContent: string): Promise<Blob> {
     canvas.width = parseInt(m[1], 10) * RETINA_SCALE;
     canvas.height = parseInt(m[2], 10) * RETINA_SCALE;
     const ctx = canvas.getContext('2d')!;
+    // Canvas2D default は transparent。bwip-js / JsBarcode の SVG は背景 rect を持たない
+    // ため、一部 reader (Dynamsoft 等) が transparent を「黒」と解釈して decode 失敗する。
+    // scale 前に device px 単位で全面白塗り。詳細経緯 / 代替案: docs/decisions.md [082]。
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
     // バーコード/QR の bar/space edge を sharp に保つため smoothing 無効化。
     // 有効のままだと SVG → Image → Canvas 経路で edge が灰色に滲み、scanner が
     // 黒/白の二値閾値で bar 幅を取り違えて decode 失敗する（GS1 DataBar の
@@ -100,6 +105,10 @@ export function downloadPngFromSvgElement(svgEl: SVGSVGElement, filename: string
     canvas.width = width * RETINA_SCALE;
     canvas.height = height * RETINA_SCALE;
     const ctx = canvas.getContext('2d')!;
+    // 背景を白で fill (svgContentToPngBlob と同じ理由: transparent 背景は reader が
+    // 黒 pixel と解釈して decode 失敗するため、scale 前の device px 単位で全面塗り)。
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
     // bar/space の edge anti-aliasing を抑止 (svgContentToPngBlob と同じ理由)。
     ctx.imageSmoothingEnabled = false;
     ctx.scale(RETINA_SCALE, RETINA_SCALE);

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -196,3 +196,98 @@ export function addSvgDimensions(svg: string): string {
     `${beforeViewBox} viewBox="0 0 ${wStr} ${hStr}"${afterViewBox}>`;
   return svg.replace(originalTag, newTag);
 }
+
+/**
+ * HTML/XML 特殊文字をエスケープする (`injectCompositeText` の安全な text 注入用)。
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * 合成シンボル (`databarlimitedcomposite`) の上に AI テキストを SVG `<text>` で注入する。
+ *
+ * bwip-js の `includetext: true` は linear 部の `(01)GTIN` のみ render するため、
+ * AI 値 ((17)YYMMDD / (10)LOT 等) は barcode binary に encode されるだけで visual には
+ * 出ない。本関数は SVG 文字列を直接操作して composite 上に AI テキスト行を 1 行追加する。
+ *
+ * ## 復活の経緯 (PR #450 → PR #458 → 本 PR)
+ * - PR #450 (commit `c563cf5`): 「テキストのディセンダーが composite 上端 1X quiet
+ *   zone に侵入して Dynamsoft Reader decode 不能」を根拠に撤去 (decisions [067] update)。
+ *   `textRowH` を 3X gap (= 9px) に広げる alternative も decode 不能で撤回。
+ * - PR #458 (commit `977f6b6`): composite PNG decode 不能の真因が **Canvas2D の透明
+ *   背景** (`svgContentToPngBlob` で `fillStyle = 'white'` 未設定) だったと判明。
+ *   PR #450 の検証はすべて透明背景時に行われたため、descender 仮説は red herring
+ *   だった可能性が高い (decisions [082])。
+ * - 本 PR (decisions [083]): 白背景 fix とセットなら decode 成功するという user 仮説を
+ *   実機 Dynamsoft で empirical 検証 → 成功 → 復活。
+ *
+ * ## geometry
+ * - `fontSize = 18`, `textRowH = fontSize + 6 = 24`
+ * - text baseline `y = textRowH - 3 = 21` (Courier New descender ~4px 含む)
+ * - barcode 全体を `translate(_, textRowH)` で下に 24px shift
+ * - text が barcode より広いときは centering (`(newW - barcodeW) / 2`)
+ *
+ * ## 引数
+ * @param svg - bwip-js が生成 + `addSvgDimensions` 済み SVG 文字列。viewBox / width /
+ *   height 属性が必須 (regex で抽出するため)。
+ * @param text - 注入する **raw** 文字列 (例: `(17)231231(10)ABC123`)。内部で
+ *   `escapeHtml` を適用するため、呼出側で escape してはならない (二重 escape で `&amp;`
+ *   が文字として表示される事故になる)。
+ * @returns text を注入した SVG 文字列。`text` が空なら入力 SVG をそのまま返す。
+ *
+ * ## 色
+ * `<text>` の `fill="currentColor"` で親要素の `color` を継承する。`Gs1Databar.tsx`
+ * の preview wrapper は `.gs1-svg-container` クラスで `color: var(--color-text)` を
+ * 設定する前提 (`global.css`)。親 className を変更する際は color 設定を維持すること。
+ */
+export function injectCompositeText(svg: string, text: string): string {
+  if (!text) return svg;
+
+  const escapedText = escapeHtml(text);
+  const vbMatch = svg.match(/viewBox="0 0 ([\d.]+) ([\d.]+)"/);
+  if (!vbMatch) return svg;
+  const barcodeW = parseFloat(vbMatch[1]);
+  const h = parseFloat(vbMatch[2]);
+
+  const fontSize = 18;
+  const textRowH = fontSize + 6;
+
+  // Courier New monospace: 1 文字あたり約 0.6em。
+  // 見積もりはエスケープ前の文字数で行う (ブラウザは実体参照を 1 文字分で描画するため)。
+  const charW = fontSize * 0.6;
+  const padding = 16;
+  const estimatedTextW = text.length * charW + padding;
+
+  // text が barcode より広い場合は SVG 全体を横に拡張し barcode を中央寄せする。
+  const newW = Math.max(barcodeW, estimatedTextW);
+  const newH = h + textRowH;
+  const barcodeOffsetX = (newW - barcodeW) / 2;
+
+  // 置換 regex は `<svg` 開始タグ内 (`<svg ... width="N" height="N" ...>`) に anchor する。
+  // 将来 bwip-js が SVG 内に `<rect width="N">` 等の子要素を含むようになった場合に
+  // **最初の match が子要素になって wrong match する** silent regression を防ぐ (#462 review A)。
+  const result = svg
+    .replace(/viewBox="0 0 [\d.]+ [\d.]+"/, `viewBox="0 0 ${newW.toFixed(1)} ${newH.toFixed(1)}"`)
+    .replace(/(<svg\s[^>]*?)width="\d+"/, `$1width="${Math.round(newW)}"`)
+    .replace(/(<svg\s[^>]*?)height="\d+"/, `$1height="${Math.round(newH)}"`);
+
+  const openEnd = result.indexOf('>') + 1;
+  const closeStart = result.lastIndexOf('</svg>');
+  const openTag = result.slice(0, openEnd);
+  const inner = result.slice(openEnd, closeStart);
+
+  const textEl =
+    `<text x="${(newW / 2).toFixed(1)}" y="${textRowH - 3}" ` +
+    `text-anchor="middle" font-family="'Courier New',Courier,monospace" ` +
+    `font-size="${fontSize}" fill="currentColor">${escapedText}</text>`;
+
+  const barcodeTranslate = `translate(${barcodeOffsetX.toFixed(1)},${textRowH})`;
+
+  return `${openTag}${textEl}<g transform="${barcodeTranslate}">${inner}</g></svg>`;
+}

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
 import { withProductionCsp } from './helpers';
 
 test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
@@ -235,6 +236,85 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
       // `paddingwidth: 10` が誤って適用された場合は 30 svg-px 更に右にシフト
       // (≈ 37) するため、< 25 の閾値で確実に分離できる。
       expect(leftPaddingPx).toBeLessThan(25);
+    });
+  });
+
+  // 陽性対照: 生成 PNG の **背景が transparent ではなく白 (RGBA=255,255,255,255)**
+  // であることを **実 download click 経路** で検証する。
+  //
+  // 旧実装は Canvas2D default の transparent 背景 (RGBA=0,0,0,0) のまま drawImage
+  // していたため、quiet zone / バー間 pixel が完全 transparent になり、image-based
+  // barcode reader (Dynamsoft Barcode Reader 等) が transparent pixel を「黒」と
+  // 解釈して decode 失敗していた (実例: dev server 生成 PNG → Dynamsoft 0 件、
+  // 同 PNG を画面 screenshot → 同 reader で confidence=100 で decode 成功)。
+  //
+  // `src/utils/download.ts` の svgContentToPngBlob で `ctx.fillStyle = 'white'` +
+  // `ctx.fillRect(0, 0, canvas.width, canvas.height)` を scale 前に呼ぶことで
+  // PNG 背景を実 RGB 白として記録する。
+  //
+  // 検証方法 (#458 review C 対応):
+  //  - PNG ダウンロードボタン click → page.waitForEvent('download') で実 blob を受け取る
+  //  - download.path() で OS 一時 file に書き出された実 PNG を Node fs で読み込む
+  //  - その PNG を base64 化して page.evaluate 内に渡し、<img> → canvas drawImage 経由で
+  //    pixel を decode → 4 隅 quiet zone の RGBA を sampling
+  //  - 本物の svgContentToPngBlob (download.ts) の出力 PNG を assert する経路なので、
+  //    fix を revert すると α=0 (transparent) に戻り全件 fail する設計を維持
+  //  - 旧版 (test 内で svgContentToPngBlob を再実装) は本実装を bypass する false
+  //    negative リスクがあったため、実 production code 経由に置換
+  test('生成 PNG の quiet zone が透明ではなく白 (α=255) で塗られている（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // composite を生成 (PNG dimensions: 293 × 75 @ scale=3, paddingwidth=10)
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await page.getByLabel('AI フィールド値 2').fill('ABC123');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      // 実 download click → OS 一時 file 取得
+      const downloadPromise = page.waitForEvent('download');
+      await page.getByRole('button', { name: 'PNGダウンロード' }).click();
+      const download = await downloadPromise;
+      const path = await download.path();
+      expect(path, 'download path should be defined').toBeTruthy();
+
+      // 実 PNG を読み込み base64 化して browser に転送 → <img> 経由で pixel decode
+      const pngBase64 = (await readFile(path!)).toString('base64');
+      const samples = await page.evaluate(async (b64) => {
+        const img = new Image();
+        img.src = 'data:image/png;base64,' + b64;
+        await img.decode();
+        const canvas = document.createElement('canvas');
+        canvas.width = img.naturalWidth;
+        canvas.height = img.naturalHeight;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return null;
+        ctx.drawImage(img, 0, 0);
+        // quiet zone 4 隅で sampling (image-based reader が境界検出に使う領域)
+        const points = [
+          { name: 'top-left', x: 5, y: 5 },
+          { name: 'top-right', x: canvas.width - 5, y: 5 },
+          { name: 'bottom-left', x: 5, y: canvas.height - 5 },
+          { name: 'bottom-right', x: canvas.width - 5, y: canvas.height - 5 },
+        ];
+        return {
+          width: canvas.width,
+          height: canvas.height,
+          pixels: points.map((p) => {
+            const d = ctx.getImageData(p.x, p.y, 1, 1).data;
+            return { name: p.name, r: d[0], g: d[1], b: d[2], a: d[3] };
+          }),
+        };
+      }, pngBase64);
+
+      expect(samples).not.toBeNull();
+      // 全 quiet zone 4 隅で α=255 / RGB=(255,255,255) (transparent 0 ではなく白)
+      // fix revert 時は α=0, RGB=(0,0,0) になり全件 fail する。
+      for (const s of samples!.pixels) {
+        expect.soft(s.a, `${s.name} alpha`).toBe(255);
+        expect.soft(s.r, `${s.name} red`).toBe(255);
+        expect.soft(s.g, `${s.name} green`).toBe(255);
+        expect.soft(s.b, `${s.name} blue`).toBe(255);
+      }
     });
   });
 });

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -239,6 +239,77 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
     });
   });
 
+  // 陽性対照: composite シンボル上部に `injectCompositeText` で AI テキストが注入
+  // されることを実 preview SVG で検証する。
+  //
+  // PR #450 で撤去された関数を PR #458 (透明背景真因判明) を受けて復活させた経緯
+  // (decisions [083])。`src/utils/gs1-databar.ts` の `injectCompositeText` を削除
+  // または `Gs1Databar.tsx` の wiring (`compositeText ? injectCompositeText(...) : sizedSvg`)
+  // を削ると本 test の text 要素 / 文字列 / y=21 配置 assert が全て fail する。
+  //
+  // non-composite (AI フィールド未入力) では injection されない (`compositeText` が
+  // 空文字で early return) ことも別 case で確認し、誤って常時注入する regression
+  // を捕捉する。
+  test('composite シンボルに AI テキスト ((17)... (10)...) が SVG 上部に注入される（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await page.getByLabel('AI フィールド値 1').fill('231231');
+      await page.getByLabel('AI フィールド値 2').fill('ABC123');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      const inspection = await page.getByLabel(/GS1 DataBar.*のバーコード/).evaluate((el) => {
+        const svg = el.querySelector('svg');
+        if (!svg) return null;
+        const textEls = Array.from(svg.querySelectorAll('text'));
+        const compositeText = textEls.find((t) => /\(17\).*\(10\)/.test(t.textContent ?? ''));
+        if (!compositeText) {
+          return { found: false, textContents: textEls.map((t) => t.textContent) };
+        }
+        return {
+          found: true,
+          content: compositeText.textContent,
+          y: compositeText.getAttribute('y'),
+          textAnchor: compositeText.getAttribute('text-anchor'),
+          fontSize: compositeText.getAttribute('font-size'),
+          fill: compositeText.getAttribute('fill'),
+        };
+      });
+
+      expect(inspection?.found, '<text> 要素が AI テキストを含んで存在する').toBe(true);
+      // バー code text 表示 = "(17)YYMMDD(10)LOT" の compact 形式 (decisions [083] user 決定)
+      expect(inspection?.content).toBe('(17)231231(10)ABC123');
+      // geometry: textRowH - 3 = 24 - 3 = 21 (Courier New baseline)
+      expect(inspection?.y).toBe('21');
+      expect(inspection?.textAnchor).toBe('middle');
+      expect(inspection?.fontSize).toBe('18');
+      // <text> の塗り色は `.gs1-svg-container` の color から継承 (global.css)
+      expect(inspection?.fill).toBe('currentColor');
+    });
+  });
+
+  test('non-composite (AI フィールド未入力) シンボルには AI テキスト注入されない（陽性対照 / CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+      // GTIN のみ入力 (`compositeText` が空文字 → injectCompositeText は early return)
+      await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+      await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+      const aiTextPresent = await page.getByLabel(/GS1 DataBar.*のバーコード/).evaluate((el) => {
+        const svg = el.querySelector('svg');
+        if (!svg) return false;
+        // bwip-js の `includetext: true` で linear 部 "(01)GTIN" は出るが
+        // それは <text> ではなく <path> として描画される。AI テキスト形式
+        // `(17)` / `(10)` の <text> 要素は injection されないはず。
+        const textEls = Array.from(svg.querySelectorAll('text'));
+        return textEls.some((t) => /\(17\)|\(10\)|\(11\)|\(15\)|\(21\)/.test(t.textContent ?? ''));
+      });
+      expect(aiTextPresent).toBe(false);
+    });
+  });
+
   // 陽性対照: 生成 PNG の **背景が transparent ではなく白 (RGBA=255,255,255,255)**
   // であることを **実 download click 経路** で検証する。
   //


### PR DESCRIPTION
## 含まれる変更

### #458 PNG 背景の透明状態が原因の barcode reader decode 失敗を白塗りで解消 (fix)

`svgContentToPngBlob` / `downloadPngFromSvgElement` の Canvas2D に `fillStyle = 'white' + fillRect` を `ctx.scale()` 前に追加し、生成 PNG の quiet zone を透明 (α=0) から実 RGB 白に変更。一部 image-based barcode reader (Dynamsoft 等) が transparent pixel を「黒」と解釈して decode 失敗していた事象を解消。GS1 DataBar / JAN コードの両 PNG ダウンロードが恩恵。詳細: decisions.md [082]

### #462 合成シンボル上部に AI テキスト ((17)... 等) 表示を復活 (feat)

PR #450 で「ディセンダーが quiet zone を侵入して decode 不能」を根拠に撤去していた `injectCompositeText` を、#458 で真因が透明背景と判明したのを受けて復活。旧 geometry (textRowH=24, text baseline y=21) のまま白背景 fix とセットで再導入し、実機 Dynamsoft で decode 成功確認。合成シンボル内の AI 値 ((17)YYMMDD / (10)LOT 等) が visual に表示されるように。詳細: decisions.md [083]

## ユーザー影響

- GS1 DataBar 生成ツールで composite シンボル PNG を読取アプリ / オンライン reader に upload した場合の **decode 成功率向上**
- 合成シンボル上部に AI フィールド値が **視覚表示** され、生成内容の人間可読確認が可能に
- JAN コード生成ツールも同じ PNG 変換経路で白背景化の恩恵

## CI 結果

- #458: test / e2e / visual-regression 全 pass、code review approved
- #462: test / e2e / visual-regression 全 pass、code review approved + review A 対応 commit (`e7a6c4b`) も CI 全 pass

## Test plan

- [x] develop 上で全 unit 1307+ / type / E2E / VRT pass
- [x] user 実機 Dynamsoft Barcode Reader online で composite シンボル decode 成功 (#458, #462 両方)
- [ ] main 反映後の本番 (https://devtools-d9w.pages.dev/tools/gs1-databar) で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
