### PR TITLE
fix(gs1-databar): CC-A 上端 quiet zone (3X) を確保し印刷物 reader での AI 10/17 decode 失敗を解消

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3238,6 +3238,8 @@ PR #450 で行った decode 検証 3 種類:
 
 descender 仮説は本 PR で **明確に否定** された。GS1 仕様の「composite 周囲 1X quiet zone」要求自体は依然有効だが、image-based reader の binary threshold 動作には透明背景の方が遥かに支配的な影響を与えていた。
 
+> **訂正 ([084] 参照)**: 本「明確に否定」は **PNG ファイル → reader app 直入力経路に限定した結論**。後続の `[084]` で印刷物 + 業務 reader 経路では descender 侵入が独立した阻害要因として成立することが判明し、本 ADR は経路条件付きでのみ有効。
+
 ### 決定
 
 1. **`escapeHtml` / `injectCompositeText` を `src/utils/gs1-databar.ts` に復元**: PR #450 撤去時 (commit `c563cf5`) から geometry / 関数シグネチャ不変で復元。コメントブロックで「PR #450 撤去 → PR #458 真因判明 → 本 PR 復活」の時系列を明示
@@ -3314,7 +3316,8 @@ GS1 General Specifications 5.9.2.6 は composite component 上下に **≥1X (= 
 - ✅ 既存 unit 42 件 / 全体 unit 1310 件 pass + astro check 0 errors
 - ⚠️ 生成 SVG / PNG の **全高がさらに 9 svg-px 拡張** (旧 24 → 新 33 が barcode offset)。VRT baseline (`/tools/gs1-databar`) の composite シンボル表示は差分必須 → CI `workflow_dispatch` で再生成 (CLAUDE.md 6.8、mac local 生成不可)
 - ⚠️ 実機 decode 検証は user 環境 (印刷物 + 医薬品向け業務 reader) でのみ可能。エージェント側では unit / 型 / E2E (preview SVG) までで、最終 OK は user 実機確認
-- ⚠️ `[083]` の「descender 仮説は明確に否定された」記述は **PNG ファイル経路に限定した結論** として残置 (印刷物経路では成立しない旨を本 [084] で訂正)
+- ⚠️ `[083]` の「descender 仮説は明確に否定された」記述は **PNG ファイル経路に限定した結論** として残置 (印刷物経路では成立しない旨を本 [084] で訂正、`[083]` 側にも forward reference 注記)
+- ⚠️ **dark mode UI でも白背景 rect (`fill="white"`) を固定**: SVG は `dangerouslySetInnerHTML` でページに直接 embed されるため、dark theme 適用時に白い矩形がプレビュー領域に浮く可能性がある。decode 信頼性 (reader aggressive binarization 対策) > 視覚調和、を優先する判断 (現状の preview wrapper `.gs1-svg-container` は `bg-surface` で light のため顕在化していないが、将来 dark wrapper に変更しても rect は white 固定)
 
 ### 関連
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3266,3 +3266,57 @@ descender 仮説は本 PR で **明確に否定** された。GS1 仕様の「co
 - 関連 fix: PR #450 (撤去, decisions `[067]` update) / PR #458 (透明背景真因判明, decisions `[082]`)
 - 陽性対照 (unit): `src/utils/__tests__/gs1-databar.test.ts` の `escapeHtml` / `injectCompositeText` describe
 - 陽性対照 (E2E): `tests/e2e/gs1-databar.spec.ts` の `composite シンボルに AI テキスト ((17)... (10)...) が SVG 上部に注入される` / `non-composite (AI フィールド未入力) シンボルには AI テキスト注入されない`
+
+---
+
+## [084] 2026-05-21 — Gs1Databar `injectCompositeText` の text 描画領域と barcode offset を分離し CC-A 上端 quiet zone を 3X 確保
+
+### 背景
+
+`[083]` (PR #462) で復活させた `injectCompositeText` を user 実機で運用したところ、PNG ファイル単体を業務 reader に流す経路では decode 成功するが、**印刷物を医薬品向け業務 reader (CC-A 対応) で読ませると linear GTIN-14 (01) は読めるのに合成 CC-A 側の AI (17) 賞味期限 / (10) ロット番号だけが decode 不能**になることが判明 (2026-05-21 user 報告)。reader の対応可否ではない (他生成系の GS1 は同 reader で読める)。
+
+### 根本原因の再評価
+
+`[083]` で「descender 仮説は明確に否定された」と結論したが、これは **PNG ファイル → reader app という 1 経路のみ** での empirical 検証で、印刷物 → カメラ撮像 → reader 経路は対象外だった。後者は reader 側の前処理 (binarization threshold / contrast normalization) が画像直入力より弱く、わずかな noise が CC-A の row indicator pattern 検出を破綻させる。
+
+旧 geometry を実数で再検証:
+
+- `fontSize = 18`, `textRowH = fontSize + 6 = 24` を **text 描画領域と barcode translate offset の兼用** 変数として使用
+- text baseline `y = textRowH - 3 = 21`、Courier New descender ≈ 4-5px → descender 終端 `y ≈ 25-26`
+- barcode 上端 = `translate(_, textRowH=24)` → **descender 終端 (~25) > barcode 上端 (24) で実質 1-2px CC-A 上端を侵食**
+
+GS1 General Specifications 5.9.2.6 は composite component 上下に **≥1X (= 3px @ scale=3) の quiet zone 必須** と規定。旧 geometry はこの仕様要求を `gap = -1px` で違反していた。透明背景バグ (`[082]`) が解消した後も、印刷物 + 業務 reader 経路ではこの spec 違反が独立した阻害要因として残存していた。
+
+`[083]` の descender 仮説否定は **PNG ファイル経路に限定すれば正しい** が、印刷物経路では誤りだった。両仮説 (透明背景 / descender 侵入) はそれぞれ独立した CC-A decode 阻害要因。
+
+### 決定
+
+1. **`textRegionH` と `barcodeOffsetY` を変数として分離** (`src/utils/gs1-databar.ts:259` 周辺):
+   - `textRegionH = fontSize + 6 = 24` (text 描画専用)
+   - `quietZone = 9` (= 3X @ scale=3、spec ≥1X に対して 3X の安全マージン)
+   - `barcodeOffsetY = textRegionH + quietZone = 33` (barcode translate 専用)
+   - `newH = h + barcodeOffsetY` (旧: `h + textRowH`)
+2. **SVG 全域に白背景 `<rect fill="white">` を最背面挿入**: PR #458 が canvas2D 経路のみで対処していた領域を SVG 単体でも防ぐ defense in depth。dark UI embed / reader aggressive binarization 時の CC-A 透明 pixel 黒判定を SVG 自己完結で回避
+3. **陽性対照テスト追加** (`src/utils/__tests__/gs1-databar.test.ts`):
+   - `text descender 終端と barcode 上端の gap が GS1 spec ≥1X (3px @ scale=3) を満たす`: 旧 geometry (`barcodeOffsetY = textRegionH`) に戻すと gap = -2px で fail
+   - `白背景 rect が <svg> 開始タグ直後 (text / barcode より背面) に挿入される`: 白背景 rect 撤去で match 不能 fail
+
+### 検討した代替案
+
+- **AI text を撤去 (PR #450 状態に戻す)**: HRI が肉眼で読めなくなり UX 後退。decisions [083] の user 要求 (合成シンボル内容を人間可読で確認) を満たさない
+- **AI text を barcode の下に移動 (linear HRI のさらに下)**: CC-A 上端 quiet zone に一切触れない物理分離で堅牢だが、SVG geometry を大きく組み替える必要があり test/VRT diff が広範囲。最小変更の本案で spec 準拠 gap を確保できるため過剰
+- **`quietZone = 3` (= spec 最低値 1X)**: spec 上は十分だが reader 個体差 / 印刷品質劣化のマージンが薄い。`9` (3X) で堅牢化
+
+### 結果・トレードオフ
+
+- ✅ GS1 General Spec 5.9.2.6 の CC-A 上下 quiet zone 要求 (≥1X) を 3X で満たす geometry に修正
+- ✅ SVG 単体での透明背景問題も defense in depth で防止 (PR #458 の canvas2D fix と独立)
+- ✅ 既存 unit 42 件 / 全体 unit 1310 件 pass + astro check 0 errors
+- ⚠️ 生成 SVG / PNG の **全高がさらに 9 svg-px 拡張** (旧 24 → 新 33 が barcode offset)。VRT baseline (`/tools/gs1-databar`) の composite シンボル表示は差分必須 → CI `workflow_dispatch` で再生成 (CLAUDE.md 6.8、mac local 生成不可)
+- ⚠️ 実機 decode 検証は user 環境 (印刷物 + 医薬品向け業務 reader) でのみ可能。エージェント側では unit / 型 / E2E (preview SVG) までで、最終 OK は user 実機確認
+- ⚠️ `[083]` の「descender 仮説は明確に否定された」記述は **PNG ファイル経路に限定した結論** として残置 (印刷物経路では成立しない旨を本 [084] で訂正)
+
+### 関連
+
+- 関連 fix: PR #450 (旧 descender 仮説で撤去, `[067]` update) / PR #458 (透明背景真因判明, `[082]`) / PR #462 (AI text 復活, `[083]`)
+- 陽性対照 (unit): `src/utils/__tests__/gs1-databar.test.ts` の `injectCompositeText > 陽性対照: text descender 終端と barcode 上端の gap が GS1 spec ≥1X (3px @ scale=3) を満たす` / `陽性対照: 白背景 rect が <svg> 開始タグ直後 (text / barcode より背面) に挿入される`

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -129,12 +129,19 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
 
       // composite component 上に AI テキスト ((17)... 等) を SVG injection する。
       //
-      // 経緯: PR #450 (commit c563cf5) は「ディセンダーが composite 上端 1X quiet
-      // zone に侵入して Dynamsoft Reader が decode 不能」を理由に撤去したが、PR #458
-      // (commit 977f6b6) で真因は **Canvas2D の透明背景** (一部 reader が transparent
-      // pixel を黒判定) と判明。PR #450 の検証はすべて透明背景時だったため descender
-      // 仮説は red herring と判断、白背景 fix とセットで復活させ user 実機検証で
-      // decode 成功を確認した (decisions [083])。
+      // 経緯:
+      //  - PR #450 (commit c563cf5): 「ディセンダーが composite 上端 1X quiet zone を
+      //    侵入して Dynamsoft Reader decode 不能」を理由に撤去。
+      //  - PR #458 (commit 977f6b6): PNG decode 不能の独立要因として Canvas2D の透明
+      //    背景が判明、白背景 fix を入れた。
+      //  - PR #462: PR #458 と組合せれば PNG ファイル → reader app 経路で decode 成功
+      //    することを user 実機 (Dynamsoft) で確認し AI text を復活させた。
+      //  - 本修正: しかし PR #462 の検証は PNG ファイル単体経路のみで **印刷物 → 業務
+      //    reader 経路は検証されていなかった**。印刷物では reader の前処理が画像直入力
+      //    より弱く、descender 終端が CC-A 上端を侵食していた旧 geometry (gap -1px) で
+      //    AI 10/17 が decode 不能だった (linear GTIN は読める = CC-A 単独失敗)。
+      //    `injectCompositeText` の geometry を text 領域 + quiet zone (3X @ scale=3) に
+      //    分離して GS1 General Spec 5.9.2.6 準拠の gap を確保。詳細は同関数 JSDoc。
       const compositeText = aiFields
         .filter((f) => f.value.trim() !== '')
         .map((f) => `(${f.ai})${f.value.trim()}`)

--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -253,12 +253,14 @@ describe('escapeHtml', () => {
 // PR #458 (透明背景真因判明) を受けて復活させる際の geometry / XSS 安全性 / dimension
 // 拡張の回帰防止テスト一式。
 //
-// fix revert (関数削除 / dimension 拡張ロジック削除 / escape 削除) で必ず fail する
-// 設計。具体的には:
+// fix revert (関数削除 / dimension 拡張ロジック削除 / escape 削除 / quiet zone 撤去 /
+// 白背景 rect 撤去) で必ず fail する設計。具体的には:
 //   - 関数削除: import error → test ファイル全体 fail
-//   - dimension 拡張削除: newH = h + textRowH を確認する assert が fail
+//   - dimension 拡張削除: newH = h + barcodeOffsetY(33) を確認する assert が fail
 //   - text 配置 y 削除: `<text ... y="21" ...>` 文字列が存在しない fail
 //   - XSS escape 削除: raw `<script>` が SVG 文字列に残って escape 検証 fail
+//   - quiet zone 撤去 (barcodeOffsetY を textRegionH と同値に戻す): translate y=33 検証 fail
+//   - 白背景 rect 撤去: `<rect ... fill="white"/>` 検証 fail
 describe('injectCompositeText', () => {
   // bwip-js + addSvgDimensions の出力に近い fixture
   const baseSvg =
@@ -275,9 +277,9 @@ describe('injectCompositeText', () => {
     expect(injectCompositeText(noVb, '(17)231231')).toBe(noVb);
   });
 
-  it('text が injection され y=21 (textRowH - 3) に配置される', () => {
+  it('text が injection され y=21 (textRegionH - 3) に配置される', () => {
     const out = injectCompositeText(baseSvg, '(17)231231(10)ABC123');
-    // text element の baseline 位置 (textRowH=24 - 3 = 21)
+    // text element の baseline 位置 (textRegionH=24 - 3 = 21)
     expect(out).toMatch(/<text [^>]*y="21" /);
     // 中身は escape された AI 値
     expect(out).toContain('>(17)231231(10)ABC123</text>');
@@ -287,30 +289,30 @@ describe('injectCompositeText', () => {
     expect(out).toContain('font-family="\'Courier New\',Courier,monospace"');
   });
 
-  it('viewBox 高さは元の barcode 高さ + textRowH(24) に拡張される', () => {
+  it('viewBox 高さは元の barcode 高さ + barcodeOffsetY(33) に拡張される', () => {
     const out = injectCompositeText(baseSvg, '(17)231231');
-    // baseSvg height=75 + textRowH=24 = 99
-    expect(out).toMatch(/viewBox="0 0 \S+ 99\.0"/);
-    expect(out).toContain('height="99"');
+    // baseSvg height=75 + barcodeOffsetY=33 = 108
+    expect(out).toMatch(/viewBox="0 0 \S+ 108\.0"/);
+    expect(out).toContain('height="108"');
   });
 
-  it('barcode が text より広いときは barcode 幅を維持し translate は y=24 のみ (横 shift 0)', () => {
+  it('barcode が text より広いときは barcode 幅を維持し translate は y=33 のみ (横 shift 0)', () => {
     // baseSvg width=293、text 長 10 文字 + padding 16 → 推定幅 ~76px < 293
     const out = injectCompositeText(baseSvg, '(17)231231');
     expect(out).toContain('width="293"');
-    expect(out).toMatch(/viewBox="0 0 293\.0 99\.0"/);
-    // translate(0, 24) で barcode は下方向のみ shift
-    expect(out).toContain('transform="translate(0.0,24)"');
+    expect(out).toMatch(/viewBox="0 0 293\.0 108\.0"/);
+    // translate(0, 33) で barcode は下方向のみ shift (textRegionH 24 + quietZone 9)
+    expect(out).toContain('transform="translate(0.0,33)"');
   });
 
   it('text が barcode より広いときは SVG 幅を拡張し barcode を中央寄せする', () => {
     // 54 文字 ((17) + '1'×50) × charW=10.8 + padding=16 = 599.2 > 293
     const longText = '(17)' + '1'.repeat(50);
     const out = injectCompositeText(baseSvg, longText);
-    expect(out).toMatch(/viewBox="0 0 599\.2 99\.0"/);
+    expect(out).toMatch(/viewBox="0 0 599\.2 108\.0"/);
     expect(out).toContain('width="599"'); // Math.round(599.2)
     // (newW - barcodeW) / 2 = (599.2 - 293) / 2 = 153.1
-    expect(out).toContain('transform="translate(153.1,24)"');
+    expect(out).toContain('transform="translate(153.1,33)"');
   });
 
   it('XSS escape: <script> tag を含む text は &lt;script&gt; に escape される', () => {
@@ -322,10 +324,60 @@ describe('injectCompositeText', () => {
     expect(out).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
   });
 
-  it('barcode 部は <g transform="translate(_, 24)"> でラップされる (元 inner を保持)', () => {
+  it('barcode 部は <g transform="translate(_, 33)"> でラップされる (元 inner を保持)', () => {
     const out = injectCompositeText(baseSvg, '(17)231231');
     // 元 SVG の <path .../> が <g transform="..."> 内に残る
-    expect(out).toMatch(/<g transform="translate\([\d.]+,24\)">.*<path[^>]*\/>.*<\/g>/s);
+    expect(out).toMatch(/<g transform="translate\([\d.]+,33\)">.*<path[^>]*\/>.*<\/g>/s);
+  });
+
+  // 陽性対照 (本修正で導入): text descender 終端と barcode 上端の間に GS1 General Spec
+  // 5.9.2.6 が要求する ≥1X (= 3px @ scale=3) の quiet zone を確保していることを実観測する。
+  //
+  // 旧実装 (barcode translate y = textRegionH = 24) では:
+  //   - text baseline y=21 + Courier New descender ~4px → descender 終端 ~y=25
+  //   - barcode 上端 = y=24 → 実際は descender が CC-A 上端を **1px 侵食**
+  // → composite reader (Dynamsoft / 医薬品 reader) が CC-A の row indicator pattern を
+  //   誤検出して AI 10/17 が decode 不能になる回帰。PR #450 で同問題が「ディセンダー
+  //   侵入」として認知され撤去されたが、PR #458 で transparent 背景という独立要因が
+  //   見つかり PR #462 で AI text 復活時に descender 仮説が red herring 扱いされた。
+  //   実際は両方とも独立した decode 阻害要因で、印刷物 + 業務 reader 経路では
+  //   descender 侵入が再浮上していた。
+  //
+  // 本 assert が fail する revert pattern:
+  //   - `barcodeOffsetY = textRegionH + quietZone` を `= textRegionH` に戻す
+  //   - `quietZone = 9` を `= 0` にする
+  // → translate y が 24 に戻り `translate(0.0,33)` assert が fail。
+  it('陽性対照: text descender 終端と barcode 上端の gap が GS1 spec ≥1X (3px @ scale=3) を満たす', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    // baseline y=21 + Courier New descender ~4-5px → 描画 bottom y ≈ 25-26
+    // barcode top y = 33 (translate y)
+    // → gap = 33 - 26 = 7px = ~2.3X @ scale=3 ≥ 1X spec要求 ✓
+    const translateMatch = out.match(/<g transform="translate\([\d.]+,(\d+)\)">/);
+    expect(translateMatch, 'barcode translate y を抽出できない').not.toBeNull();
+    const barcodeTopY = Number(translateMatch![1]);
+    const baselineY = 21;
+    const descenderApprox = 5; // Courier New @ fontSize=18 の安全側見積もり
+    const gap = barcodeTopY - (baselineY + descenderApprox);
+    const oneXAtScale3 = 3;
+    expect(
+      gap,
+      `quiet zone gap (${gap}px) must be ≥ 1X (${oneXAtScale3}px)`
+    ).toBeGreaterThanOrEqual(oneXAtScale3);
+  });
+
+  // 陽性対照 (本修正で導入): SVG 全域に白背景 rect が **text / barcode より背面** に
+  // 挿入されていることを確認。SVG transparent な状態で dark UI に embed されたり
+  // reader が aggressive binarization する場合に CC-A 透明 pixel が黒判定されて decode
+  // 失敗する事象 (PR #458 が canvas2D 経由でのみ対処していた領域) を SVG 単体でも
+  // 防ぐ defense in depth。
+  //
+  // fail する revert pattern: `<rect ... fill="white"/>` の挿入を撤去 → 本 assert が fail。
+  it('陽性対照: 白背景 rect が <svg> 開始タグ直後 (text / barcode より背面) に挿入される', () => {
+    const out = injectCompositeText(baseSvg, '(17)231231');
+    // <svg ...><rect width="293.0" height="108.0" fill="white"/> の順
+    expect(out).toMatch(
+      /<svg[^>]*>\s*<rect width="293\.0" height="108\.0" fill="white"\/>\s*<text /
+    );
   });
 
   // 陽性対照 (#462 review A 対応): width / height 置換 regex は **<svg> 開始タグ内に
@@ -346,14 +398,16 @@ describe('injectCompositeText', () => {
       '<svg viewBox="0 0 100 50" xmlns="http://www.w3.org/2000/svg">' +
       '<rect width="10" height="20" fill="#000"/></svg>';
     // text 長さ 10 文字 → estimatedTextW = 10 * 10.8 + 16 = 124 → newW = max(100, 124) = 124
-    // newH = 50 + 24 = 74
+    // newH = 50 + barcodeOffsetY(33) = 83
     const out = injectCompositeText(svgNoRootWidth, '(17)231231');
-    // 子要素 <rect> の width / height は元のまま (10 / 20)。
+    // 子要素 <rect width="10" height="20" fill="#000"> は元のまま。
     // 旧 regex (anchor 無し) なら最初の `width="10"` が `width="124"` に誤置換されて
-    // `<rect width="124" height="74">` になり、本 assert が fail する。
-    expect(out).toMatch(/<rect width="10" height="20"/);
+    // `<rect width="124" height="83" fill="#000">` になり、本 assert が fail する。
+    // (注: SVG 全域に追加挿入される白背景 rect (`width="124.0" height="83.0" fill="white"`)
+    //  とは別物。子要素 rect のみを照合するため `fill="#000"` も含めて anchor する。)
+    expect(out).toMatch(/<rect width="10" height="20" fill="#000"/);
     // svg root には元々 width 属性が無いため anchor 付き regex は no-op (注入もしない)。
     // viewBox は別 regex で更新される (anchor 無関係)。
-    expect(out).toMatch(/viewBox="0 0 124\.0 74\.0"/);
+    expect(out).toMatch(/viewBox="0 0 124\.0 83\.0"/);
   });
 });

--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -333,30 +333,36 @@ describe('injectCompositeText', () => {
   // 陽性対照 (本修正で導入): text descender 終端と barcode 上端の間に GS1 General Spec
   // 5.9.2.6 が要求する ≥1X (= 3px @ scale=3) の quiet zone を確保していることを実観測する。
   //
+  // 本テストは既存の `transform="translate(0.0,33)"` 直接照合 (固定値 assert) と異なり、
+  // **「gap が spec 下限 ≥1X を満たす」という行動的不変条件** を検証する責務。fontSize
+  // が将来変更されて translate y が固定値から動いても、本テストは spec 下限制約のみを
+  // 評価するため引き続き正しく動作する (固定値レベルと spec レベルの assertion を
+  // 分離して提供する)。
+  //
   // 旧実装 (barcode translate y = textRegionH = 24) では:
-  //   - text baseline y=21 + Courier New descender ~4px → descender 終端 ~y=25
-  //   - barcode 上端 = y=24 → 実際は descender が CC-A 上端を **1px 侵食**
+  //   - text baseline y=21 + Courier New descender (fontSize×0.28 ≈ 5px) → descender 終端 ~y=26
+  //   - barcode 上端 = y=24 → 実際は descender が CC-A 上端を **1-2px 侵食**
   // → composite reader (Dynamsoft / 医薬品 reader) が CC-A の row indicator pattern を
-  //   誤検出して AI 10/17 が decode 不能になる回帰。PR #450 で同問題が「ディセンダー
-  //   侵入」として認知され撤去されたが、PR #458 で transparent 背景という独立要因が
-  //   見つかり PR #462 で AI text 復活時に descender 仮説が red herring 扱いされた。
-  //   実際は両方とも独立した decode 阻害要因で、印刷物 + 業務 reader 経路では
-  //   descender 侵入が再浮上していた。
+  //   誤検出して AI 10/17 が decode 不能になる回帰。
   //
   // 本 assert が fail する revert pattern:
   //   - `barcodeOffsetY = textRegionH + quietZone` を `= textRegionH` に戻す
-  //   - `quietZone = 9` を `= 0` にする
-  // → translate y が 24 に戻り `translate(0.0,33)` assert が fail。
+  //   - `quietZone` を 0 または `< descender approximation` に下げる
+  // → gap < 3px (= 1X) で本 assert が fail。
   it('陽性対照: text descender 終端と barcode 上端の gap が GS1 spec ≥1X (3px @ scale=3) を満たす', () => {
     const out = injectCompositeText(baseSvg, '(17)231231');
-    // baseline y=21 + Courier New descender ~4-5px → 描画 bottom y ≈ 25-26
-    // barcode top y = 33 (translate y)
-    // → gap = 33 - 26 = 7px = ~2.3X @ scale=3 ≥ 1X spec要求 ✓
     const translateMatch = out.match(/<g transform="translate\([\d.]+,(\d+)\)">/);
     expect(translateMatch, 'barcode translate y を抽出できない').not.toBeNull();
     const barcodeTopY = Number(translateMatch![1]);
-    const baselineY = 21;
-    const descenderApprox = 5; // Courier New @ fontSize=18 の安全側見積もり
+    // 実装の geometry 定数を陽性対照側でも再現する。fontSize / baselineY が将来変更
+    // されたら本テストの定数も連動して em 比で再計算されるため silent regression を
+    // 起こさない (review #465 should-fix #1 対応: 旧実装は `descenderApprox = 5` を
+    // hardcode していたため fontSize 変更時に追従破綻する穴があった)。
+    const fontSize = 18;
+    const baselineY = fontSize + 6 - 3; // = textRegionH - 3 = 21
+    // Courier New の descender は概ね fontSize の 0.28 倍。Math.ceil で安全側に
+    // 切り上げて gap 計算で過小評価しない。
+    const descenderApprox = Math.ceil(fontSize * 0.28);
     const gap = barcodeTopY - (baselineY + descenderApprox);
     const oneXAtScale3 = 3;
     expect(
@@ -372,11 +378,14 @@ describe('injectCompositeText', () => {
   // 防ぐ defense in depth。
   //
   // fail する revert pattern: `<rect ... fill="white"/>` の挿入を撤去 → 本 assert が fail。
-  it('陽性対照: 白背景 rect が <svg> 開始タグ直後 (text / barcode より背面) に挿入される', () => {
+  //
+  // `data-role="bg"` 属性は E2E paddingwidth 陽性対照との fragility 低減 identifier
+  // (review #465 nice #2 対応)。これも併せて assert する。
+  it('陽性対照: 白背景 rect が <svg> 開始タグ直後 (text / barcode より背面) に data-role="bg" 付きで挿入される', () => {
     const out = injectCompositeText(baseSvg, '(17)231231');
-    // <svg ...><rect width="293.0" height="108.0" fill="white"/> の順
+    // <svg ...><rect data-role="bg" width="293.0" height="108.0" fill="white"/> の順
     expect(out).toMatch(
-      /<svg[^>]*>\s*<rect width="293\.0" height="108\.0" fill="white"\/>\s*<text /
+      /<svg[^>]*>\s*<rect data-role="bg" width="293\.0" height="108\.0" fill="white"\/>\s*<text /
     );
   });
 

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -269,7 +269,11 @@ export function injectCompositeText(svg: string, text: string): string {
   const fontSize = 18;
   const textRegionH = fontSize + 6;
   // GS1 General Spec 5.9.2.6: composite component 上下に ≥1X (= 3px @ scale=3) の
-  // quiet zone 必須。安全マージン込みで 3X (= 9px) を確保する。
+  // quiet zone 必須。9px (= 3X) を選択した根拠:
+  //  - spec 下限 1X (= 3px) は reader 個体差 / 印刷品質劣化のマージンが薄い
+  //  - 12X 以上は visual gap が広く preview / PNG で text と barcode が分離して見える
+  //  - 3X は spec の 3 倍マージンで頑健、かつ視覚的にも text と barcode が
+  //    同じ symbol の一部として認知される距離 (経験則による選択)
   const quietZone = 9;
   const barcodeOffsetY = textRegionH + quietZone;
   const baselineY = textRegionH - 3;
@@ -293,7 +297,13 @@ export function injectCompositeText(svg: string, text: string): string {
     .replace(/(<svg\s[^>]*?)width="\d+"/, `$1width="${Math.round(newW)}"`)
     .replace(/(<svg\s[^>]*?)height="\d+"/, `$1height="${Math.round(newH)}"`);
 
-  const openEnd = result.indexOf('>') + 1;
+  // `<svg ...>` 開始タグ末尾を **regex で anchor** して抽出する。`indexOf('>')` 単純
+  // 切断は属性値内に `>` が含まれた場合 (例: `<svg data-foo="a>b">`) に誤切断する
+  // 潜在リスクがある。現状の bwip-js + `addSvgDimensions` 出力では発生しないが、
+  // 将来 attribute 追加で silent regression しないよう defensive に regex 化する。
+  const openTagMatch = result.match(/<svg[^>]*>/);
+  if (!openTagMatch) return svg;
+  const openEnd = (openTagMatch.index ?? 0) + openTagMatch[0].length;
   const closeStart = result.lastIndexOf('</svg>');
   const openTag = result.slice(0, openEnd);
   const inner = result.slice(openEnd, closeStart);
@@ -301,7 +311,11 @@ export function injectCompositeText(svg: string, text: string): string {
   // 白背景 rect は最背面 (text / barcode より前) に置く。SVG transparent な状態で
   // dark UI に embed されたり reader が aggressive binarization する場合に CC-A が
   // 黒判定されて decode 失敗するのを防ぐ defense in depth。
-  const bgRect = `<rect width="${newW.toFixed(1)}" height="${newH.toFixed(1)}" fill="white"/>`;
+  // `data-role="bg"` を付与: 将来 bwip-js が `fill="white"` の decorative rect を
+  // 出力するようになった場合に、E2E paddingwidth 陽性対照 (`fill === 'white'` で除外
+  // していた) との semantic 衝突を避ける identifier。E2E 側は `data-role="bg"` で
+  // 識別する。
+  const bgRect = `<rect data-role="bg" width="${newW.toFixed(1)}" height="${newH.toFixed(1)}" fill="white"/>`;
 
   const textEl =
     `<text x="${(newW / 2).toFixed(1)}" y="${baselineY}" ` +

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -228,10 +228,21 @@ export function escapeHtml(text: string): string {
  *   実機 Dynamsoft で empirical 検証 → 成功 → 復活。
  *
  * ## geometry
- * - `fontSize = 18`, `textRowH = fontSize + 6 = 24`
- * - text baseline `y = textRowH - 3 = 21` (Courier New descender ~4px 含む)
- * - barcode 全体を `translate(_, textRowH)` で下に 24px shift
+ * - `fontSize = 18`, `textRegionH = fontSize + 6 = 24` (text 描画領域)
+ * - text baseline `y = textRegionH - 3 = 21`、Courier New descender ~4px → 終端 ~y=25
+ * - **`quietZone = 9` (= 3X @ scale=3) を text 領域と barcode の間に確保**。
+ *   GS1 General Specifications 5.9.2.6 は composite component 上下に ≥1X (= 3px @
+ *   scale=3) の quiet zone を要求するため、descender 終端 ~y=25 が CC-A 上端
+ *   を侵食しないよう余裕を取る (旧実装 `textRowH=24` を barcode offset と兼用
+ *   していたため gap が -1px と CC-A 上端を侵食し、composite reader で AI 10/17
+ *   が decode 不能だった事象の再発防止: PR #450 で同問題を撤去 / PR #458 で
+ *   透明背景真因判明により復活 / 本修正で印刷物の医薬品 reader 失敗対応)。
+ * - barcode 全体を `translate(_, barcodeOffsetY = textRegionH + quietZone = 33)` で
+ *   下に 33px shift
  * - text が barcode より広いときは centering (`(newW - barcodeW) / 2`)
+ * - SVG 全域に `<rect fill="white">` を最背面に挿入。CC-A 透明背景による decode
+ *   失敗 (PR #458 で判明) を SVG 単体でも防ぐ defense in depth (canvas2D 経由の
+ *   白背景 fill は `svgContentToPngBlob` 側で別途実装済み)。
  *
  * ## 引数
  * @param svg - bwip-js が生成 + `addSvgDimensions` 済み SVG 文字列。viewBox / width /
@@ -256,7 +267,12 @@ export function injectCompositeText(svg: string, text: string): string {
   const h = parseFloat(vbMatch[2]);
 
   const fontSize = 18;
-  const textRowH = fontSize + 6;
+  const textRegionH = fontSize + 6;
+  // GS1 General Spec 5.9.2.6: composite component 上下に ≥1X (= 3px @ scale=3) の
+  // quiet zone 必須。安全マージン込みで 3X (= 9px) を確保する。
+  const quietZone = 9;
+  const barcodeOffsetY = textRegionH + quietZone;
+  const baselineY = textRegionH - 3;
 
   // Courier New monospace: 1 文字あたり約 0.6em。
   // 見積もりはエスケープ前の文字数で行う (ブラウザは実体参照を 1 文字分で描画するため)。
@@ -266,7 +282,7 @@ export function injectCompositeText(svg: string, text: string): string {
 
   // text が barcode より広い場合は SVG 全体を横に拡張し barcode を中央寄せする。
   const newW = Math.max(barcodeW, estimatedTextW);
-  const newH = h + textRowH;
+  const newH = h + barcodeOffsetY;
   const barcodeOffsetX = (newW - barcodeW) / 2;
 
   // 置換 regex は `<svg` 開始タグ内 (`<svg ... width="N" height="N" ...>`) に anchor する。
@@ -282,12 +298,17 @@ export function injectCompositeText(svg: string, text: string): string {
   const openTag = result.slice(0, openEnd);
   const inner = result.slice(openEnd, closeStart);
 
+  // 白背景 rect は最背面 (text / barcode より前) に置く。SVG transparent な状態で
+  // dark UI に embed されたり reader が aggressive binarization する場合に CC-A が
+  // 黒判定されて decode 失敗するのを防ぐ defense in depth。
+  const bgRect = `<rect width="${newW.toFixed(1)}" height="${newH.toFixed(1)}" fill="white"/>`;
+
   const textEl =
-    `<text x="${(newW / 2).toFixed(1)}" y="${textRowH - 3}" ` +
+    `<text x="${(newW / 2).toFixed(1)}" y="${baselineY}" ` +
     `text-anchor="middle" font-family="'Courier New',Courier,monospace" ` +
     `font-size="${fontSize}" fill="currentColor">${escapedText}</text>`;
 
-  const barcodeTranslate = `translate(${barcodeOffsetX.toFixed(1)},${textRowH})`;
+  const barcodeTranslate = `translate(${barcodeOffsetX.toFixed(1)},${barcodeOffsetY})`;
 
-  return `${openTag}${textEl}<g transform="${barcodeTranslate}">${inner}</g></svg>`;
+  return `${openTag}${bgRect}${textEl}<g transform="${barcodeTranslate}">${inner}</g></svg>`;
 }

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -185,9 +185,15 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
         if (!svg) return -1;
         // SVGGraphicsElement.getBBox() は viewBox 座標系で要素群の bounding box を返す。
         // viewBox 全体に対し描画要素群の x が paddingleft 分だけ右にオフセットされる。
+        //
+        // `injectCompositeText` (decisions [084]) が defense-in-depth で挿入する
+        // **白背景 `<rect width="W" height="H" fill="white"/>`** は SVG 全域を x=0 から
+        // 覆うため barcode quiet zone 計測対象から除外する。除外しないと minX=0 に
+        // 引きずられて本 assert (leftPaddingPx > 25) が誤 fail する。
         const items = svg.querySelectorAll('rect, path');
         let minX = Infinity;
         for (const it of items) {
+          if ((it as Element).getAttribute('fill') === 'white') continue;
           const bbox = (it as SVGGraphicsElement).getBBox();
           if (bbox.x < minX) minX = bbox.x;
         }

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -280,7 +280,9 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
       expect(inspection?.found, '<text> 要素が AI テキストを含んで存在する').toBe(true);
       // バー code text 表示 = "(17)YYMMDD(10)LOT" の compact 形式 (decisions [083] user 決定)
       expect(inspection?.content).toBe('(17)231231(10)ABC123');
-      // geometry: textRowH - 3 = 24 - 3 = 21 (Courier New baseline)
+      // geometry: textRegionH(24) - 3 = 21 (Courier New baseline)。barcode 全体は
+      // 別途 textRegionH + quietZone(9) = 33px 下に translate される (CC-A 上端の
+      // 1X quiet zone 確保。詳細は `gs1-databar.ts` の injectCompositeText JSDoc)。
       expect(inspection?.y).toBe('21');
       expect(inspection?.textAnchor).toBe('middle');
       expect(inspection?.fontSize).toBe('18');

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -187,13 +187,16 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
         // viewBox 全体に対し描画要素群の x が paddingleft 分だけ右にオフセットされる。
         //
         // `injectCompositeText` (decisions [084]) が defense-in-depth で挿入する
-        // **白背景 `<rect width="W" height="H" fill="white"/>`** は SVG 全域を x=0 から
-        // 覆うため barcode quiet zone 計測対象から除外する。除外しないと minX=0 に
-        // 引きずられて本 assert (leftPaddingPx > 25) が誤 fail する。
+        // **白背景 `<rect data-role="bg" width="W" height="H" fill="white"/>`** は
+        // SVG 全域を x=0 から覆うため barcode quiet zone 計測対象から除外する。
+        // 除外しないと minX=0 に引きずられて本 assert (leftPaddingPx > 25) が誤 fail する。
+        // 識別子は `data-role="bg"` (semantic 属性): `fill === 'white'` 識別では将来
+        // bwip-js が `fill="white"` の decorative rect を出すと誤除外する fragility が
+        // ある (review #465 nice #2 対応)。
         const items = svg.querySelectorAll('rect, path');
         let minX = Infinity;
         for (const it of items) {
-          if ((it as Element).getAttribute('fill') === 'white') continue;
+          if ((it as Element).getAttribute('data-role') === 'bg') continue;
           const bbox = (it as SVGGraphicsElement).getBBox();
           if (bbox.x < minX) minX = bbox.x;
         }


### PR DESCRIPTION
## 背景

PR #462 (decisions [083]) で復活させた `injectCompositeText` を user 実機で運用したところ、**印刷物を医薬品向け業務 reader (CC-A 対応) で読ませると linear GTIN-14 (01) は読めるのに合成 CC-A 側の AI (17) 賞味期限 / (10) ロット番号だけが decode 不能**になることが判明 (2026-05-21 user 報告)。

切り分け結果:

- ✅ reader 非対応ではない (他生成系の GS1 は同 reader で読める)
- ✅ camera 解像度問題ではない (印刷物 = 高解像度でも CC-A だけ読めない)
- ✅ linear GTIN-14 は読める = CC-A 単独失敗
- → CC-A の生成側に問題があると確定

## 根本原因

旧 geometry を実数で再検証:

| 項目 | 値 |
|:---|:---|
| `fontSize` | 18 |
| `textRowH` (= text 描画と barcode offset の兼用変数) | 24 |
| text baseline `y` | 21 |
| Courier New descender 終端 | ~y=25-26 |
| barcode 上端 (`translate(_, textRowH)`) | y=24 |
| **descender ↔ CC-A 上端 gap** | **実質 -1〜-2px (重なっている)** |
| GS1 General Spec 5.9.2.6 要求 quiet zone | ≥1X (= 3px @ scale=3) |

`[083]` で「descender 仮説は明確に否定された」と結論したが、これは **PNG ファイル → reader app という 1 経路のみ** での empirical 検証で、印刷物経路は対象外だった。後者は reader 側の前処理 (binarization threshold / contrast normalization) が画像直入力より弱く、わずかな noise が CC-A の row indicator pattern 検出を破綻させる。

両仮説 (透明背景 / descender 侵入) はそれぞれ独立した CC-A decode 阻害要因。`[083]` の descender 仮説否定は **PNG ファイル経路に限定すれば正しい** が、印刷物経路では誤りだった。

## 修正内容

### geometry の変数分離 (`src/utils/gs1-databar.ts:259` 周辺)

```diff
-  const fontSize = 18;
-  const textRowH = fontSize + 6;
+  const fontSize = 18;
+  const textRegionH = fontSize + 6;          // 24, text 描画専用
+  const quietZone = 9;                       // = 3X @ scale=3 (spec ≥1X の 3X 安全マージン)
+  const barcodeOffsetY = textRegionH + quietZone;  // 33, barcode translate 専用
+  const baselineY = textRegionH - 3;         // 21
```

- `newH = h + barcodeOffsetY` (旧: `h + textRowH`)
- `<text y="${baselineY}">` (= 21, 旧と同値で baseline 位置は不変)
- `translate(_, ${barcodeOffsetY})` (= 33, 旧は 24)

### 白背景 rect の最背面挿入

SVG 全域に `<rect width="W" height="H" fill="white"/>` を `<svg>` 開始タグ直後 (text / barcode より背面) に挿入。PR #458 が canvas2D 経路のみで対処していた領域を SVG 単体でも防ぐ defense in depth (dark UI embed / reader aggressive binarization 時の CC-A 透明 pixel 黒判定回避)。

### 検討した代替案

- **AI text を撤去 (PR #450 状態に戻す)**: HRI が肉眼で読めなくなり UX 後退。`[083]` の user 要求と不一致
- **AI text を barcode の下に移動**: CC-A 上端 quiet zone に一切触れない物理分離で堅牢だが、SVG geometry 再設計で test/VRT diff が広範囲。最小変更の本案で spec 準拠 gap を確保できるため過剰
- **`quietZone = 3` (spec 最低値 1X)**: spec 上は十分だが reader 個体差 / 印刷品質劣化のマージンが薄い

## 陽性対照テスト

`src/utils/__tests__/gs1-databar.test.ts` に 2 件追加 (両方とも対応する fix を revert すると必ず fail する設計):

1. `陽性対照: text descender 終端と barcode 上端の gap が GS1 spec ≥1X (3px @ scale=3) を満たす`
   - revert pattern: `barcodeOffsetY = textRegionH + quietZone` を `= textRegionH` に戻す → gap = -2px で fail
2. `陽性対照: 白背景 rect が <svg> 開始タグ直後 (text / barcode より背面) に挿入される`
   - revert pattern: `<rect fill="white">` 挿入を撤去 → match 不能で fail

## 検証

| 項目 | 結果 |
|:---|:---|
| unit `gs1-databar` (42 件、新陽性対照 2 件含む) | ✅ pass |
| unit 全体 1310 件 | ✅ pass |
| `node_modules/.bin/astro check` | ✅ 0 errors / 0 warnings |
| `npm run format:check` | ✅ clean |
| ローカル E2E (`npm run test:e2e -- gs1-databar.spec.ts`) | ⚠️ CSP `style-src` 違反で 14/14 fail。**develop baseline / 他 spec (base64) でも同症状 = 本 PR の修正と無関係なローカル env 既存問題**。別 issue で起票予定。CI 環境では production CSP hash と build 出力 inline style が一致しているため pass する見込み |
| user 実機検証 (印刷物 + 医薬品向け業務 reader) | ⏳ user 側で 2026-05-22 予定。decode 成功確認後 merge 判定 |
| VRT baseline 更新 | ⏳ SVG 全高が 9px 追加拡張 + 白背景 rect 挿入で `/tools/gs1-databar` baseline 差分必須。merge 後 CI `Update Visual Regression Baseline` workflow を `workflow_dispatch` trigger |

## Test plan

- [ ] CI で全 check (unit / type / E2E / VRT) が pass
- [ ] user 実機 (印刷物 + 医薬品向け業務 reader) で AI (17) / (10) decode 成功確認
- [ ] merge 後に VRT baseline を CI workflow_dispatch で再生成
- [ ] ローカル E2E CSP 違反の env 問題を別 issue で root cause 調査

## 関連

- 関連 fix: PR #450 (旧 descender 仮説で撤去, `[067]` update) / PR #458 (透明背景真因判明, `[082]`) / PR #462 (AI text 復活, `[083]`)
- decisions.md: `[084]` 新規 entry (本 PR で `[083]` の descender 仮説否定を「PNG 経路限定の結論」として訂正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
