### PR TITLE
docs: test-gates スキルに陽性対照の具体コード例を追加

### DIFF
--- a/.claude/skills/test-gates/SKILL.md
+++ b/.claude/skills/test-gates/SKILL.md
@@ -32,7 +32,32 @@ description: ガード / バリデータ / 違反検知機構 / リグレッシ�
 3. 内部実装ではなく **観測可能な振る舞い** (UI 表示 / 戻り値 / log / state) を assert
 4. fixture / mock 経路は production code path を **確実に通る** こと (mock しすぎて gate を bypass してないか確認)
 
+## 具体例: 陰性対照と陽性対照を別 test に分ける
+
+CSP 違反検知ゲートを例にした最小形。**陰性対照だけでは「検知が空回りしていても green」になる** ので、故意に違反を起こす陽性対照を別 test として併設する。
+
+```ts
+// 陰性対照: 正常系では違反ゼロ。これ単体では検知能力を証明できない。
+it("正規 script のみなら CSP 違反は発生しない", async () => {
+  const violations = collectCspViolations();
+  await renderWithProductionCsp();
+  expect(violations).toHaveLength(0);
+});
+
+// 陽性対照（別 test に分離）: 故意の違反を必ず捕捉する。
+// → 検知が空回りしている旧実装に当てると fail する = 検知能力そのものの証明。
+it("外部 origin の script 注入を CSP 違反として検知する", async () => {
+  const violations = collectCspViolations();
+  injectExternalScript("https://evil.example.com/x.js"); // 意図的な違反
+  await waitFor(() => expect(violations.length).toBeGreaterThan(0));
+});
+```
+
+観測しているのは内部 state ではなく `violations` という **観測可能な振る舞い**（鉄則 3）であり、2 つを別 test に分けることで陽性側だけ消えても気付ける（鉄則 2）。リポジトリ内の実例は `src/utils/__tests__/headers.test.ts`（`'unsafe-inline'` 不在を陽性 assert）や `tests/e2e/csp-and-evaluation.spec.ts` を参照。
+
 ## チェックリスト (ガード追加 / 修正 PR で必ず触る)
+
+設計の鉄則を「PR 提出前に手で確認する項目」へ落とし込んだもの。TodoWrite 化して 1 項目ずつ潰す。
 
 - [ ] 陽性対照テストを **同じ PR に** 含めたか
 - [ ] そのテストは **fix 前 (旧実装) に当てると fail** することをローカルで実機確認したか
@@ -43,5 +68,5 @@ description: ガード / バリデータ / 違反検知機構 / リグレッシ�
 ## 参考
 
 - 個人 memory: `feedback_positive_control_for_gates.md`
-- 過去判断ログ: `docs/decisions.md` の「陽性対照」検索 (4 箇所)
+- 過去判断ログ: `docs/decisions.md` を「陽性対照」で検索
 - 過去事故: PR #233 (`applyProductionCsp` 空回り事故)

--- a/.claude/skills/test-gates/SKILL.md
+++ b/.claude/skills/test-gates/SKILL.md
@@ -34,26 +34,28 @@ description: ガード / バリデータ / 違反検知機構 / リグレッシ�
 
 ## 具体例: 陰性対照と陽性対照を別 test に分ける
 
-CSP 違反検知ゲートを例にした最小形。**陰性対照だけでは「検知が空回りしていても green」になる** ので、故意に違反を起こす陽性対照を別 test として併設する。
+CSP 違反検知ゲートを例にした最小形。**陰性対照だけでは「検知が空回りしていても green」になる** ので、故意に違反を起こす陽性対照を別 test として併設する。下記はパターンを示す擬似コードで、実ヘルパは `tests/e2e/helpers.ts` の `applyProductionCsp(page)`（戻り値 `guard.violations` に違反が溜まる）を使う。
 
 ```ts
 // 陰性対照: 正常系では違反ゼロ。これ単体では検知能力を証明できない。
-it("正規 script のみなら CSP 違反は発生しない", async () => {
-  const violations = collectCspViolations();
-  await renderWithProductionCsp();
-  expect(violations).toHaveLength(0);
+test("正規 script のみなら CSP 違反は発生しない", async ({ page }) => {
+  const guard = await applyProductionCsp(page);
+  await page.goto("/");
+  expect(guard.violations).toHaveLength(0);
 });
 
 // 陽性対照（別 test に分離）: 故意の違反を必ず捕捉する。
 // → 検知が空回りしている旧実装に当てると fail する = 検知能力そのものの証明。
-it("外部 origin の script 注入を CSP 違反として検知する", async () => {
-  const violations = collectCspViolations();
-  injectExternalScript("https://evil.example.com/x.js"); // 意図的な違反
-  await waitFor(() => expect(violations.length).toBeGreaterThan(0));
+test("外部 origin の script 注入を CSP 違反として検知する", async ({ page }) => {
+  const guard = await applyProductionCsp(page);
+  await injectExternalScript(page, "https://evil.example.com/x.js"); // 意図的な違反
+  await expect.poll(() => guard.violations.length).toBeGreaterThan(0);
 });
 ```
 
-観測しているのは内部 state ではなく `violations` という **観測可能な振る舞い**（鉄則 3）であり、2 つを別 test に分けることで陽性側だけ消えても気付ける（鉄則 2）。リポジトリ内の実例は `src/utils/__tests__/headers.test.ts`（`'unsafe-inline'` 不在を陽性 assert）や `tests/e2e/csp-and-evaluation.spec.ts` を参照。
+観測しているのは内部 state ではなく `guard.violations` という **観測可能な振る舞い**（鉄則 3）であり、2 つを別 test に分けることで陽性側だけ消えても気付ける（鉄則 2）。
+
+リポジトリ内の実例 `tests/e2e/csp-and-evaluation.spec.ts` は `<meta>` CSP を剥がすと inline script が実行されることを `expect.poll` で捕捉する **違反注入型の陽性対照**。なお `src/utils/__tests__/headers.test.ts` の `'unsafe-inline'` 不在 assert は **静的出力のリグレッションガード** であり、注入型の陽性対照とは性質が異なる（混同しないこと）。
 
 ## チェックリスト (ガード追加 / 修正 PR で必ず触る)
 


### PR DESCRIPTION
## 概要

`/skill-creator` で `test-gates` スキルを評価し、指摘事項を反映した。スキル本体（`.claude/skills/test-gates/SKILL.md`）のみの docs 変更。

## 変更内容

| 指摘 | 対応 |
| :--- | :--- |
| 参照件数 `(4 箇所)` が陳腐化 (実測 21 行ヒット) | 固定値を撤去し「`docs/decisions.md` を『陽性対照』で検索」に変更 |
| 具体コード例が無く鉄則が抽象的 | 陰性/陽性対照を別 test に分ける最小 Vitest 例を追加。鉄則 1（旧実装で fail）・2（別 test 分離）・3（観測可能な振る舞い）をコードで体現し、リポジトリ実例 (`headers.test.ts` / `csp-and-evaluation.spec.ts`) へ誘導 |
| 鉄則とチェックリストが重複 | チェックリスト冒頭に「鉄則を提出前確認項目へ落とし込んだもの」と役割を明示し、二層（理解 / 確認）に整理 |

## 評価で手を入れなかった点

- `description` の keyword 厚盛りは undertrigger 対策として妥当なため維持
- `applyProductionCsp` / 個人 memory file の参照は実在を確認済み

## 検証

- markdown のみの変更（`src/` / `tests/` 非該当）のため build / E2E は対象外
- `npx prettier --check` green / pre-commit hook の format・型チェック green
