### PR TITLE
docs: dads-design-system スキルを #176 完了後の現状に同期

### DIFF
--- a/.claude/skills/dads-design-system/SKILL.md
+++ b/.claude/skills/dads-design-system/SKILL.md
@@ -1,13 +1,7 @@
 ---
 name: dads-design-system
-description: デジタル庁デザインシステム（DADS）準拠でウェブサイトやウェブアプリを作成するスキル。青基調のカラー、Noto Sans JP、アクセシビリティ対応コンポーネントを含む。サイト作成、ランディングページ、ダッシュボード、フォーム画面などを作る際に使用すること。「デジタル庁」「DADS」「青基調」「日本語サイト」等でもトリガーする。
+description: このプロジェクト（devtools）のフロントエンド UI を作成・変更する際に参照する、デジタル庁デザインシステム（DADS）ベースのデザイン規約。青基調カラー・Noto Sans JP・余白/角丸スケール・アクセシビリティ対応コンポーネント（ボタン/入力/テーブル/通知バナー等）の実装パターンを含む。新しいツールの追加、既存ツール画面の UI 変更、入力欄・ボタン・フォームのスタイル実装、配色・タイポグラフィの判断が必要なときに使うこと。DADS / 青基調 等でもトリガー。
 ---
-
-> ⚠️ **移行中**: issue [#176](https://github.com/fumtas1k/devtools/issues/176) B 案で `colors.* + style={{}}` パターン → `@layer components` semantic class へ移行中。
->
-> - **新規 component**: class-based パターン（`src/styles/global.css` に semantic class を追加 + className で参照）を使う
-> - **既存 component**: PR 番号順に migration（progress: PR 1 = `ui/*` simple 11、PR 1.5 = `ResultTable` + `InputField`、PR 2 = `qr-ticket/*`、PR 3-5 = tools、PR 6 = CSP flip + `colors.*` 撤去）
-> - 本 SKILL.md / references/components.md の inline-style 例は **移行中の暫定パターン**。PR 6 で全例を class-based に rewrite 予定
 
 # デジタル庁デザインシステム（DADS）スキル
 
@@ -360,7 +354,7 @@ DADS標準のフォーカスリングは **黒アウトライン4px＋黄色リ�
 }
 ```
 
-> このプロジェクト固有の実装（青フォーカスリング）については「11. このプロジェクト固有の実装パターン」を参照。
+> このリポジトリ（devtools）の focus 実装は `:focus-visible` に CSS で一括適用されている（`var(--focus-ring)`、JS ハンドラ不要）。プロジェクト固有の規約は「11. このプロジェクト（devtools）で実装する場合」を参照。
 
 ---
 
@@ -438,118 +432,20 @@ import {
 
 ---
 
-## 11. このプロジェクト固有の実装パターン
+## 11. このプロジェクト（devtools）で実装する場合
 
-### カラー管理の構造
+DADS の汎用仕様（1〜10章）に加えて devtools 固有のスタイリング規約があるが、**本スキルでは重複管理しない**。以前はここに旧実装（`src/utils/styles.ts` の `colors.*` + inline `style`）を記載していたが、issue #176 B 案で全廃され `styles.ts` も削除されたのに記述が残って陳腐化した。正本を一本化してドリフトを防ぐため、以下を直接参照すること:
 
-色の実値は `src/styles/global.css` の CSS 変数で一元管理。
-`src/utils/styles.ts` の `colors` オブジェクトは `var(--color-*)` の参照のみを持つ。
+| 知りたいこと | 正本 |
+|---|---|
+| 色・スタイリング規約（`@layer components` semantic class 経由、primitive scale 直書き禁止、HTML inline `style` 禁止） | `CLAUDE.md` §7 |
+| 共通 UI コンポーネント（`InputField` / `CopyButton` / `DownloadButtonGroup` / `ToggleGroup` / `ErrorMessage` 等）と共通フック（`useClampedInput` 等） | `docs/ui-conventions.md`、`CLAUDE.md` §5・§8 |
+| ツール追加の実装フロー | `CLAUDE.md` §5 |
+| `style-src` strict 化（`unsafe-inline` 撤去）の経緯と CSP 制約 | `docs/projects/issue-176-b-plan-progress.md`、`docs/decisions.md [064][067][068]` |
 
-```
-global.css (@theme / :root) ← 実際の色値はここだけ
-    ↑
-styles.ts (colors.*)        ← var(--color-*) 参照
-    ↑
-各コンポーネント             ← colors.* を import して使う
-```
-
-**ダークモード追加時は `global.css` に `.dark { }` を追加するだけでよい。コンポーネントは変更不要。**
-
-### カラー・タイポグラフィの参照方法
-
-```tsx
-// ✅ 正しい: styles.ts のトークンを使う
-import { colors, caption, bodyEmphasis } from '../../utils/styles';
-
-<p style={{ ...caption, color: colors.muted }}>ヒントテキスト</p>
-<span style={{ ...bodyEmphasis, color: colors.primary }}>強調テキスト</span>
-<input style={{ border: `1px solid ${colors.borderInput}` }} />
-```
-
-```tsx
-// ❌ 誤り: 生のhex値を直書きしない
-<p style={{ color: '#6B7280' }}>ヒントテキスト</p>
-```
-
-> **注意**: JsBarcode・bwip-js 等のサードパーティレンダラーに渡す色は CSS 変数を解釈できないため hex で直書きする（例: `background: '#ffffff'`）。
-
-### styles.ts のトークン一覧
-
-| トークン | CSS 変数 | 用途 |
-|---|---|---|
-| `colors.text` | `--color-text` | 本文テキスト |
-| `colors.muted` | `--color-muted` | ヒント・補足テキスト |
-| `colors.primary` | `--color-primary` | CTA・強調 |
-| `colors.primaryBg` | `--color-background` | セクション背景（blue-50相当） |
-| `colors.link` | `--color-link` | リンク・このプロジェクトの青フォーカスリング |
-| `colors.bg` | `--color-bg` | 基本背景 |
-| `colors.bgSurface` | `--color-bg-surface` | カード・パネル背景 |
-| `colors.bgSubtle` | `--color-bg-subtle` | ヘッダー・subtle背景 |
-| `colors.border` | `--color-border` | 区切り線・カード枠 |
-| `colors.borderInput` | `--color-border-input` | 入力欄の枠線 |
-| `colors.error` | `--color-error` | エラー枠線 |
-| `colors.errorText` | `--color-error-text` | エラーテキスト |
-| `colors.errorBg` | `--color-error-bg` | エラー背景 |
-| `colors.warning` | `--color-warning` | 警告テキスト（amber-800、WCAG AA 確保） |
-| `colors.warningBg` | `--color-warning-bg` | 警告背景 |
-| `colors.success` | `--color-success` | 成功テキスト |
-| `colors.successBg` | `--color-success-bg` | 成功背景 |
-
-### タイポグラフィスタイル
-
-| 定数 | サイズ | weight | 用途 |
-|---|---|---|---|
-| `bodyEmphasis` | 17px | 700 | 強調本文・ラベル見出し |
-| `caption` | 14px | 400 | UI制約のある小テキスト |
-| `micro` | `caption` のエイリアス | — | ヒント・補足テキスト |
-
-### Tailwind との使い分け
-
-- **Tailwind**: レイアウト・余白・フレックス・グリッド（`flex`, `gap-4`, `rounded`, `space-y-4` 等）
-- **`colors.*` インラインスタイル**: 色（Tailwindのカラークラスは使わない）
-
-### フォーカスリング（このプロジェクト固有）
-
-> ⚠️ **DADS標準との差分**: DADS本来は「黒アウトライン4px＋黄色リング」だが、このプロジェクトは採用前に青フォーカスリングを実装済みのため変更していない。
-
-このプロジェクトでは `onFocusRing` / `onBlurRing` を `src/utils/styles.ts` からインポートして使う。`InputField` コンポーネントを使う場合は内部で処理されるため不要。
-
-```tsx
-import { onFocusRing, onBlurRing } from '../../utils/styles';
-
-// InputField を使わない生の <input> にのみ付与する
-<input onFocus={onFocusRing} onBlur={onBlurRing} />
-```
-
-### 共通 UI コンポーネント（`src/components/ui/`）
-
-新規ツール作成時はこれらを使うこと。生の `<input>` / `<textarea>` / エラー `<p>` は原則使わない。
-
-| コンポーネント | ファイル | 用途 |
-|---|---|---|
-| `InputField` | `ui/InputField.tsx` | label・input または textarea・error/hint・サンプルボタンを統合。`multiline` `mono` `resize` `readOnly` 等のプロパティあり |
-| `ErrorMessage` | `ui/ErrorMessage.tsx` | `role="alert"` 付きエラー表示。`id` を渡すと `aria-describedby` と連動 |
-| `DownloadButtonGroup` | `ui/DownloadButtonGroup.tsx` | SVG/PNGダウンロードボタンペア。`onDownloadPng` は省略可 |
-| `CopyButton` | `ui/CopyButton.tsx` | クリップボードコピー。`compact` プロパティでアイコンのみ表示（テーブル行内用） |
-| `ToggleGroup<T>` | `ui/ToggleGroup.tsx` | モード切替タブ UI。`options`・`value`・`onChange`・`ariaLabel` を受け取るジェネリックコンポーネント |
-
-```tsx
-import { InputField } from '../ui/InputField';
-import { DownloadButtonGroup } from '../ui/DownloadButtonGroup';
-import { ErrorMessage } from '../ui/ErrorMessage';
-import { CopyButton } from '../ui/CopyButton';
-import { ToggleGroup } from '../ui/ToggleGroup';
-```
-
-### 共通フック（`src/hooks/`）
-
-| フック | ファイル | 用途 |
-|---|---|---|
-| `useClampedInput` | `hooks/useClampedInput.ts` | 数値入力の min/max クランプ処理。`{ value, inputStr, handleChange, handleBlur }` を返す |
-
-```tsx
-import { useClampedInput } from '../../hooks/useClampedInput';
-
-const { value: count, inputStr: countInput, handleChange, handleBlur } = useClampedInput(10, 1, 100);
-```
+> ⚠️ **使ってはいけない旧パターン**:
+> - `import { colors, onFocusRing, onBlurRing } from '../../utils/styles'` — `styles.ts` は削除済みでビルドエラーになる。
+> - `style={{ color: ... }}` 等の HTML inline `style` — `style-src` が strict（`public/_headers`）なため**適用されず CSP 違反**になる。
+>
+> 色は `global.css` の semantic class（`text-muted` / `alert-error` / `bg-subtle` 等）か `@theme` auto-utility（`text-primary` 等）で指定する。focus は `:focus-visible` に CSS 一括適用済み（`var(--focus-ring)`）で JS ハンドラ不要。
 

--- a/.claude/skills/dads-design-system/SKILL.md
+++ b/.claude/skills/dads-design-system/SKILL.md
@@ -439,7 +439,7 @@ DADS の汎用仕様（1〜10章）に加えて devtools 固有のスタイリ�
 | 知りたいこと | 正本 |
 |---|---|
 | 色・スタイリング規約（`@layer components` semantic class 経由、primitive scale 直書き禁止、HTML inline `style` 禁止） | `CLAUDE.md` §7 |
-| 共通 UI コンポーネント（`InputField` / `CopyButton` / `DownloadButtonGroup` / `ToggleGroup` / `ErrorMessage` 等）と共通フック（`useClampedInput` 等） | `docs/ui-conventions.md`、`CLAUDE.md` §5・§8 |
+| 共通 UI コンポーネント（`InputField` / `CopyButton` / `DownloadButtonGroup` / `ToggleGroup` / `ErrorMessage` 等） | `docs/ui-conventions.md` §1、`CLAUDE.md` §5・§8 |
 | ツール追加の実装フロー | `CLAUDE.md` §5 |
 | `style-src` strict 化（`unsafe-inline` 撤去）の経緯と CSP 制約 | `docs/projects/issue-176-b-plan-progress.md`、`docs/decisions.md [064][067][068]` |
 

--- a/.claude/skills/dads-design-system/references/components.md
+++ b/.claude/skills/dads-design-system/references/components.md
@@ -1,9 +1,3 @@
-> ⚠️ **移行中**: issue [#176](https://github.com/fumtas1k/devtools/issues/176) B 案で `colors.* + style={{}}` パターン → `@layer components` semantic class へ移行中。
->
-> - **新規 component**: class-based パターン（`src/styles/global.css` に semantic class を追加 + className で参照）を使う
-> - **既存 component**: PR 番号順に migration（progress: PR 1 = `ui/*` simple 11、PR 1.5 = `ResultTable` + `InputField`、PR 2 = `qr-ticket/*`、PR 3-5 = tools、PR 6 = CSP flip + `colors.*` 撤去）
-> - 本 SKILL.md / references/components.md の inline-style 例は **移行中の暫定パターン**。PR 6 で全例を class-based に rewrite 予定
-
 # コンポーネント実装リファレンス
 
 デジタル庁デザインシステム（DADS）のコンポーネント実装パターン集。
@@ -532,35 +526,25 @@ npm install @digital-go-jp/design-system-example-components-react
 - `@digital-go-jp/tailwind-theme-plugin` が必要（Tailwind前提）
 - コンポーネント一覧・使い方はSKILL.mdのSection 10を参照
 
-### 方針2: CSS変数 + インラインスタイル（Tailwindなし）
+### 方針2: CSS class で実装する
 
-`src/utils/styles.ts` の `colors.*` を使い、インラインスタイルで色を指定する。  
-このファイルのCSSパターンを参考に独自コンポーネントを実装する。
+このファイルの CSS をプロジェクトのスタイルシート（例: `@layer components`）に取り込み、`className` で参照する。色は CSS 変数（`var(--color-*)`）経由で指定し、**HTML 属性の inline `style` は避ける**（`style-src` を strict 化した環境では適用されず CSP 違反になる）。
 
 ```tsx
-// 例: このファイルのボタンCSSを参考にReactコンポーネント化
-import { colors, caption } from '../../utils/styles';
-
+// このファイルの .btn / .btn-primary CSS をスタイルシートに定義し、className で参照
 const Button = ({ children, variant = 'primary', onClick }: Props) => (
   <button
     onClick={onClick}
-    style={{
-      background: variant === 'primary' ? colors.primary : 'transparent',
-      color: variant === 'primary' ? '#fff' : colors.primary,
-      border: `2px solid ${variant === 'primary' ? 'transparent' : colors.primary}`,
-      padding: '12px 24px',
-      fontWeight: 700,
-      borderRadius: '4px',
-      cursor: 'pointer',
-    }}
+    className={`btn ${variant === 'primary' ? 'btn-primary' : 'btn-outline'}`}
   >
     {children}
   </button>
 );
 ```
 
-**フォーカスリング（DADS標準）**: `outline: 4px solid #000; box-shadow: 0 0 0 2px #FDE047`  
-**このプロジェクトの実装**: `onFocusRing` / `onBlurRing`（SKILL.md Section 11参照）
+**フォーカスリング（DADS標準）**: `outline: 4px solid #000; box-shadow: 0 0 0 2px #FDE047`（CSS の `:focus-visible` に適用する）
+
+> このリポジトリ（devtools）で実装する場合のスタイリング規約・共通コンポーネント・focus 実装は、SKILL.md「11. このプロジェクト（devtools）で実装する場合」を参照（正本は `CLAUDE.md` §7 / `docs/ui-conventions.md`）。
 
 ---
 


### PR DESCRIPTION
## 概要

`dads-design-system` スキルを評価したところ、issue #176（B 案: `style-src` strict 化）の完了後に追従できておらず、**従うとビルドが壊れ、かつ達成済みの CSP strict 化を逆戻りさせる**状態だったため修正した。あわせてスキルの想定用途を実態（devtools フロントエンド作成）に再定義した。

## 背景（何が陳腐化していたか）

スキルの最終更新は #176 PR 1 時点（2026-05-04）で止まっていた。その後:

- `src/utils/styles.ts` は **PR 6 (#290) で削除**
- `style-src` は **PR 10 (#315) で両層 strict 化**（`public/_headers` から `unsafe-inline` 撤去、#176 close）

にもかかわらずスキル §11 は以下を案内し続けていた:

- `import { colors, onFocusRing, onBlurRing } from '../../utils/styles'` → 削除済みでビルドエラー
- `style={{ color: ... }}` の inline-style パターン → `style-src` strict 下では適用されず CSP 違反
- 冒頭バナーは「⚠️ 移行中… PR 6 で rewrite 予定」と**完了済みの移行を未完と表示**

## 変更内容

- **誤った「移行中」バナーを削除**（SKILL.md / components.md 両方）
- **§11 を撤去し正本へ委譲**: 削除済みコード前提の旧実装記述・トークン表を撤去し、`CLAUDE.md §7` / `docs/ui-conventions.md` / `docs/projects/issue-176-b-plan-progress.md` / `docs/decisions.md [064][067][068]` へのポインタに置換。「使ってはいけない旧パターン」警告のみ残置
- **§9 の宙吊りポインタを修正**: 現状の `:focus-visible` CSS 一括適用（`var(--focus-ring)`）に追従
- **components.md の「方針2」を inline-style → CSS class 方式に書き換え**
- **description を再定義**: 行政/LP 寄りの的外れな枠組みを捨て、「devtools のフロント UI を作成・変更する際に使う DADS ベース規約」に変更

## 設計判断

- 削除した §11 の内容は 2 種類: ①削除済みコードの説明（保全不要、消して正しい）②生きているコードへの索引。①は対象が存在せず、②の共通 UI コンポーネント一覧は `docs/ui-conventions.md §1` に全件存在を確認済み。`useClampedInput`（DADS 無関係の汎用フック・索引のみ）だけは正本がないが、scope creep につき意図的にドロップ（`src/hooks/` で発見可能）
- 正本を一本化してドリフト源を断つ方針（スキルと CLAUDE.md の二重管理が今回の陳腐化の原因）

## 確認

- pre-commit hook（Prettier / TypeScript）通過
- SKILL.md frontmatter の YAML パース確認済み
- ポインタ先 4 件すべて実在を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
