### PR TITLE
refactor: useCodecWithMeta 導入で ConfigConverter の warningsRef 側流路を解消 (#390)

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -51,6 +51,10 @@ const FORMAT_OPTIONS: { value: ConfigFormat; label: string }[] = [
   { value: 'dotenv', label: '.env' },
 ];
 
+// useCodecWithMeta の initialMeta に安定参照を渡す。毎レンダー新規配列だと
+// 空入力分岐・catch・reset() で setMeta が参照差により不要な再描画を起こすため。
+const EMPTY_WARNINGS: string[] = [];
+
 export function ConfigConverterTool() {
   const [from, setFrom] = useState<ConfigFormat>('json');
   const [to, setTo] = useState<ConfigFormat>('yaml');
@@ -72,7 +76,7 @@ export function ConfigConverterTool() {
       const result = convert(text, from, to);
       return { output: result.output, meta: result.warnings };
     },
-    [] as string[],
+    EMPTY_WARNINGS,
     [from, to]
   );
 

--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { InputField } from '@/components/ui/InputField';
 import { OutputField } from '@/components/ui/OutputField';
@@ -6,7 +6,7 @@ import { DownloadButton } from '@/components/ui/DownloadButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { StatusIcon } from '@/components/ui/StatusIcon';
-import { useCodec } from '@/hooks/useCodec';
+import { useCodecWithMeta } from '@/hooks/useCodec';
 import { convert } from '@/utils/config-converter';
 import type { ConfigFormat } from '@/utils/config-converter';
 import type { ValidationResult } from '@/utils/config-converter/schema-validator';
@@ -54,41 +54,43 @@ const FORMAT_OPTIONS: { value: ConfigFormat; label: string }[] = [
 export function ConfigConverterTool() {
   const [from, setFrom] = useState<ConfigFormat>('json');
   const [to, setTo] = useState<ConfigFormat>('yaml');
-  const [warnings, setWarnings] = useState<string[]>([]);
   const [schemaOpen, setSchemaOpen] = useState(false);
   const [schemaText, setSchemaText] = useState('');
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
   const [isValidating, setIsValidating] = useState(false);
 
-  const warningsRef = useRef<string[]>([]);
-  const { input, setInput, output, error, isPending, reset } = useCodec(
+  const {
+    input,
+    setInput,
+    output,
+    error,
+    isPending,
+    reset,
+    meta: warnings,
+  } = useCodecWithMeta(
     (text) => {
       const result = convert(text, from, to);
-      warningsRef.current = result.warnings;
-      return result.output;
+      return { output: result.output, meta: result.warnings };
     },
+    [] as string[],
     [from, to]
   );
 
+  // output / error 変化時に validationResult をリセットする（UI リセット目的、side-channel ではない）
   useEffect(() => {
-    if (!output && !error) {
-      setWarnings([]);
-      return;
-    }
-    setWarnings(error ? [] : warningsRef.current);
     setValidationResult(null);
   }, [output, error]);
 
   const handleFromChange = (next: ConfigFormat) => {
     setFrom(next);
+    // reset() が meta（warnings）を initialMeta（[]）にリセットする
     reset();
-    setWarnings([]);
     setValidationResult(null);
   };
 
   const handleToChange = (next: ConfigFormat) => {
     setTo(next);
-    setWarnings([]);
+    // to は deps に含まれるため、変更で transform が再走し meta（warnings）が更新される
     setValidationResult(null);
   };
 
@@ -284,8 +286,8 @@ export function ConfigConverterTool() {
       <div className="flex justify-end gap-2">
         <ClearButton
           onClick={() => {
+            // reset() が meta（warnings）も initialMeta（[]）にリセットする
             reset();
-            setWarnings([]);
             setValidationResult(null);
             setSchemaText('');
           }}

--- a/src/hooks/__tests__/useCodec.test.ts
+++ b/src/hooks/__tests__/useCodec.test.ts
@@ -285,3 +285,114 @@ describe('useCodec — transform が throw した後でも後続の入力で rec
     expect(result.current.output).toBe('GOOD');
   });
 });
+
+// ────────────────────────────────────────────
+// useCodecWithMeta
+// ────────────────────────────────────────────
+import { useCodecWithMeta } from '@/hooks/useCodec';
+
+describe('useCodecWithMeta — デバウンス完了後に output と meta が同時に反映される', () => {
+  it('debounce 完了後に output と meta が両方更新される', async () => {
+    const transform = vi.fn((s: string) => ({ output: s.toUpperCase(), meta: [s.length] }));
+    const { result } = renderHook(() =>
+      useCodecWithMeta(transform, [] as number[], [], { debounceMs: DEBOUNCE_MS })
+    );
+
+    act(() => {
+      result.current.setInput('hello');
+    });
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.output).toBe('HELLO');
+    expect(result.current.meta).toEqual([5]);
+  });
+});
+
+describe('useCodecWithMeta — 空入力で meta が initialMeta にリセットされる', () => {
+  it('一度変換後に空入力を渡すと output・meta・error が即時クリアされる', async () => {
+    const transform = vi.fn((s: string) => ({ output: s.toUpperCase(), meta: [s.length] }));
+    const { result } = renderHook(() =>
+      useCodecWithMeta(transform, [] as number[], [], { debounceMs: DEBOUNCE_MS })
+    );
+
+    // 一度変換を完了させる
+    act(() => {
+      result.current.setInput('hello');
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    expect(result.current.output).toBe('HELLO');
+    expect(result.current.meta).toEqual([5]);
+
+    // 空入力 → debounce を進めなくても即時クリアされる（リグレッション保護: PR #149）
+    act(() => {
+      result.current.setInput('');
+    });
+
+    expect(result.current.output).toBe('');
+    expect(result.current.error).toBe('');
+    expect(result.current.meta).toEqual([]);
+    expect(result.current.isPending).toBe(false);
+  });
+});
+
+describe('useCodecWithMeta — transform が throw したとき error が設定され meta が initialMeta になる', () => {
+  it('transform が throw すると error がセットされ output・meta がリセットされる', async () => {
+    const transform = vi.fn((_s: string): { output: string; meta: string[] } => {
+      throw new Error('変換エラー');
+    });
+    const { result } = renderHook(() =>
+      useCodecWithMeta(transform, [] as string[], [], { debounceMs: DEBOUNCE_MS })
+    );
+
+    act(() => {
+      result.current.setInput('bad input');
+    });
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBe('変換エラー');
+    expect(result.current.output).toBe('');
+    expect(result.current.meta).toEqual([]);
+  });
+});
+
+describe('useCodecWithMeta — reset() で input・output・meta が全リセットされる', () => {
+  it('reset() を呼ぶと全状態が初期値に戻る', async () => {
+    const transform = vi.fn((s: string) => ({ output: s.toUpperCase(), meta: [s.length] }));
+    const { result } = renderHook(() =>
+      useCodecWithMeta(transform, [] as number[], [], { debounceMs: DEBOUNCE_MS })
+    );
+
+    // 変換を完了させる
+    act(() => {
+      result.current.setInput('hello');
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    expect(result.current.output).toBe('HELLO');
+    expect(result.current.meta).toEqual([5]);
+
+    // reset() で全リセット
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.input).toBe('');
+    expect(result.current.output).toBe('');
+    expect(result.current.error).toBe('');
+    expect(result.current.meta).toEqual([]);
+    expect(result.current.isPending).toBe(false);
+  });
+});

--- a/src/hooks/useCodec.ts
+++ b/src/hooks/useCodec.ts
@@ -35,6 +35,7 @@ export function useCodec(
 
   useEffect(() => {
     if (!input) {
+      // 空入力で debounce を待たず即時クリア（リグレッション保護: PR #149）
       setOutput('');
       setError('');
       setIsPending(false);
@@ -42,6 +43,7 @@ export function useCodec(
     }
     // deps 変化直後からデバウンス完了まで pending 状態にする
     setIsPending(true);
+    // debounce 中の再入力で前回 schedule をキャンセル（リグレッション保護: PR #149）
     const timer = setTimeout(() => {
       try {
         setOutput(transform(input));
@@ -66,4 +68,72 @@ export function useCodec(
   };
 
   return { input, setInput, output, setOutput, error, setError, isPending, reset };
+}
+
+/**
+ * useCodec の拡張版。変換結果に加えてメタデータ（warnings 等）を同時に setState するフック。
+ *
+ * `transform` は `{ output: string; meta: M }` を返す。
+ * `output` と `meta` を同一 setTimeout コールバック内で同時に setState するため、
+ * warningsRef のような side-channel を必要とせず、将来の React batching/deferral にも安全。
+ *
+ * 既存 `useCodec` と同じ debounce 挙動を厳守:
+ * ①空入力で debounce を待たず即時クリア（リグレッション保護: PR #149）
+ * ②debounce 中の再入力で前回 schedule をキャンセル（cleanup の clearTimeout）
+ * ③`isPending` は input/deps 変化〜debounce 完了まで true
+ */
+export function useCodecWithMeta<M>(
+  transform: (input: string) => { output: string; meta: M },
+  initialMeta: M,
+  deps: DependencyList,
+  options: UseCodecOptions = {}
+) {
+  const { debounceMs = 300, fallbackError = '変換に失敗しました' } = options;
+  const [input, setInput] = useState('');
+  const [output, setOutput] = useState('');
+  const [error, setError] = useState('');
+  const [isPending, setIsPending] = useState(false);
+  const [meta, setMeta] = useState<M>(initialMeta);
+
+  useEffect(() => {
+    if (!input) {
+      // 空入力で debounce を待たず即時クリア（リグレッション保護: PR #149）
+      setOutput('');
+      setError('');
+      setMeta(initialMeta);
+      setIsPending(false);
+      return;
+    }
+    // deps 変化直後からデバウンス完了まで pending 状態にする
+    setIsPending(true);
+    // debounce 中の再入力で前回 schedule をキャンセル（リグレッション保護: PR #149）
+    const timer = setTimeout(() => {
+      try {
+        const result = transform(input);
+        // output と meta を同一コールバック内で同時に setState（side-channel 不要）
+        setOutput(result.output);
+        setMeta(result.meta);
+        setError('');
+      } catch (e) {
+        setOutput('');
+        setMeta(initialMeta);
+        setError(getErrorMessage(e, fallbackError));
+      } finally {
+        setIsPending(false);
+      }
+    }, debounceMs);
+    return () => clearTimeout(timer);
+    // transform は deps を介して追跡する設計（exhaustive-deps を意図的に無効化）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [input, debounceMs, fallbackError, ...deps]);
+
+  const reset = () => {
+    setInput('');
+    setOutput('');
+    setError('');
+    setMeta(initialMeta);
+    setIsPending(false);
+  };
+
+  return { input, setInput, output, setOutput, error, setError, isPending, reset, meta };
 }

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -320,4 +320,38 @@ test.describe('設定ファイル相互変換', () => {
     // toHaveCount の timeout で「現れないこと」を確認 (固定 wait より auto-wait が確実)
     await expect(page.getByText(/スキーマ検証(成功|失敗)/)).toHaveCount(0, { timeout: 500 });
   });
+
+  // ────────────────────────────────────────────
+  // warnings 表示の回帰ガード (#390: meta → warnings UI 結線の陽性対照)
+  // useCodecWithMeta の meta が ConfigConverter の warnings UI へ正しく結線され、
+  // convert() の warnings が画面に描画されることを保証する。meta の取り違えや
+  // warnings ブロックの描画欠落（= finding L-2 が懸念する silent breakage）が
+  // 起きると本テストが fail する。
+  // ────────────────────────────────────────────
+  test('JSON→.env変換: 値の文字列化 warning が表示される（陽性対照）', async ({ page }) => {
+    // 変換先を .env に変更（from=JSON のまま）
+    await page
+      .getByRole('group', { name: '変換先フォーマット' })
+      .getByRole('button', { name: '.env' })
+      .click();
+
+    // フラットな JSON を入力（ネストなしなので変換は成功し warning のみ出る）
+    await page.getByLabel('JSON').fill('{"host": "localhost", "port": 8080}');
+
+    // convert() が push する warning が画面に描画される
+    await expect(page.getByText('値はすべて文字列に変換されます')).toBeVisible();
+  });
+
+  test('warning の出ないフォーマットへ切替えると warning が消える', async ({ page }) => {
+    const toGroup = page.getByRole('group', { name: '変換先フォーマット' });
+
+    // まず JSON→.env で warning を出す
+    await toGroup.getByRole('button', { name: '.env' }).click();
+    await page.getByLabel('JSON').fill('{"host": "localhost", "port": 8080}');
+    await expect(page.getByText('値はすべて文字列に変換されます')).toBeVisible();
+
+    // 変換先を YAML に切替（JSON→YAML は warning なし）→ debounce 完了後 warning が消える
+    await toGroup.getByRole('button', { name: 'YAML' }).click();
+    await expect(page.getByText('値はすべて文字列に変換されます')).toBeHidden();
+  });
 });


### PR DESCRIPTION
## 概要

リファクタ監査 (2026-05-11) finding L-2 への対応。`ConfigConverter` が `useCodec` の `transform: (input) => string` シグネチャ制約を回避するために構築していた **side-channel**（`warningsRef` (`useRef`) に warnings を書き込み別 `useEffect` で読む）を撤廃する。

この side-channel は「`useCodec` が `transform` を同期実行してから `setOutput` する」実装に暗黙依存しており、将来 `useCodec` に batching / microtask deferral / double-buffered output などが入ると ref と output の順序がずれて warnings 表示が silent に壊れる latent bug だった。

Closes #390

## 変更内容

- **`src/hooks/useCodec.ts`**: 新規 hook `useCodecWithMeta<M>` を追加。`transform` が `{ output: string; meta: M }` を返し、`output` と `meta` を**同一 `setTimeout` コールバック内で同時に setState** するため side-channel が不要になる。既存 `useCodec` の public API・実装・テストは無変更（debounce ロジックは複製。PR #149 のリグレッション保護コメントを両方に明記）。
- **`src/components/tools/ConfigConverter.tsx`**: `warningsRef` と side-channel `useEffect` を撤廃し、`useCodecWithMeta` の `meta` で warnings を受ける。`warnings` の `useState` も撤廃して hook 由来に一本化。`validationResult` リセットは UI リセット目的の最小 `useEffect`（`[output, error]`）として残置。
- **`src/hooks/__tests__/useCodec.test.ts`**: `useCodecWithMeta` のテスト 4 ケース追加（output/meta 同時反映 / 空入力リセット / throw 時リセット / reset()）。

## 検証

- `npm run test`: **1346 passed**（既存 `useCodec` 11 ケース含め全 green）
- `node_modules/.bin/astro check`: **0 errors / 0 warnings**
- `npm run test:e2e -- config-converter`: **14 passed**
- pre-commit: Prettier OK / TypeScript OK

## 補足

- 内部リファクタのためツール追加/削除なし。`README.md` / `SPEC.md` 更新は不要。
- 本 PR は #394（EncodingConverter の手書き debounce 統合）の前提。#394 は本 PR merge 後に着手する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
