### PR TITLE
refactor: EncodingConverter の手書き debounce 2 系統を useDebouncedTransform に統合 (#394)

### DIFF
--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useRef, useMemo } from 'react';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { Select } from '@/components/ui/Select';
 import { InputField } from '@/components/ui/InputField';
@@ -28,6 +28,7 @@ import {
   type DetectionResult,
   type NewlineMode,
 } from '@/utils/encoding';
+import { useDebouncedTransform } from '@/hooks/useDebouncedTransform';
 
 type Mode = 'detect' | 'convert';
 type InputMethod = 'text' | 'file';
@@ -61,6 +62,64 @@ function hexPreview(bytes: Uint8Array, limit = 32): string {
   return parts.join(' ') + (bytes.length > limit ? ' ...' : '');
 }
 
+// ──────────────────────────────────────────────
+// タスク 2-B: pure function 抽出（モジュールスコープ）
+//
+// EncodingConverter.tsx のモジュールスコープに置くことで、
+// テストの vi.mock('@/utils/encoding', ...) による
+// detectEncoding / convertBytes の mock が正常に効く。
+// （utils/encoding 内部に置くと intra-module call となり mock が無効になる）
+// ──────────────────────────────────────────────
+
+interface DetectResult {
+  detection: DetectionResult | null;
+  decodedPreview: string;
+}
+
+interface ConvertResult {
+  outputBytes: Uint8Array | null;
+  outputPreview: string;
+}
+
+/** detectEncoding + デコードプレビュー生成の純粋変換。throw はそのまま伝播させ hook の catch で拾う。 */
+function detectFromBytes(bytes: Uint8Array): DetectResult {
+  const result = detectEncoding(bytes);
+  let decodedPreview = '';
+  if (result.encoding !== 'UNKNOWN') {
+    const preview = decodeToText(bytes, result.encoding);
+    decodedPreview = preview.slice(0, 500);
+  }
+  return { detection: result, decodedPreview };
+}
+
+/** convertBytes + 改行正規化 + プレビュー生成の純粋変換。throw はそのまま伝播させ hook の catch で拾う。 */
+function convertFromBytes(
+  bytes: Uint8Array,
+  sourceEnc: SourceEncoding,
+  targetEnc: EncodingName,
+  withBom: boolean,
+  newlineMode: NewlineMode
+): ConvertResult {
+  const converted = convertBytes(bytes, sourceEnc, targetEnc, withBom);
+  const effectiveMode: NewlineMode = UTF16_ENCODINGS.has(targetEnc) ? 'keep' : newlineMode;
+  const normalized = normalizeNewlines(converted, effectiveMode);
+  // プレビューは変換後バイトを UTF-8 デコード (SJIS/EUC-JP → UNICODE 経由)
+  let outputPreview: string;
+  if (targetEnc === 'UTF8') {
+    outputPreview = new TextDecoder('utf-8').decode(normalized).slice(0, 500);
+  } else {
+    const preview = decodeToText(normalized, targetEnc);
+    outputPreview = preview.slice(0, 500);
+  }
+  return { outputBytes: normalized, outputPreview };
+}
+
+// ──────────────────────────────────────────────
+// emptyResult 定数（安定参照。useDebouncedTransform の要件）
+// ──────────────────────────────────────────────
+const EMPTY_DETECT: DetectResult = { detection: null, decodedPreview: '' };
+const EMPTY_CONVERT: ConvertResult = { outputBytes: null, outputPreview: '' };
+
 export function EncodingConverterTool() {
   const [mode, setMode] = useState<Mode>('detect');
   const [inputMethod, setInputMethod] = useState<InputMethod>('text');
@@ -68,17 +127,13 @@ export function EncodingConverterTool() {
   const [fileBytes, setFileBytes] = useState<Uint8Array | null>(null);
   const [fileName, setFileName] = useState('');
 
-  const [detection, setDetection] = useState<DetectionResult | null>(null);
-  const [decodedPreview, setDecodedPreview] = useState('');
-
   const [sourceEnc, setSourceEnc] = useState<SourceEncoding>('AUTO');
   const [targetEnc, setTargetEnc] = useState<EncodingName>('UTF8');
   const [withBom, setWithBom] = useState(false);
   const [newlineMode, setNewlineMode] = useState<NewlineMode>('keep');
 
-  const [outputBytes, setOutputBytes] = useState<Uint8Array | null>(null);
-  const [outputPreview, setOutputPreview] = useState('');
-  const [error, setError] = useState('');
+  // file I/O 用エラー（handleFileChange の validation 失敗 / arrayBuffer reject で使用）
+  const [fileError, setFileError] = useState('');
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -90,77 +145,26 @@ export function EncodingConverterTool() {
     return null;
   }, [inputMethod, fileBytes, textInput]);
 
-  // 判定処理
-  // activeBytes は useMemo で参照が安定化済みのため、依存配列にそのまま含めて
-  // react-hooks/exhaustive-deps の保護を残す。
-  useEffect(() => {
-    if (!activeBytes) {
-      setDetection(null);
-      setDecodedPreview('');
-      setError('');
-      return;
-    }
-    if (inputMethod === 'file') {
-      runDetect(activeBytes);
-      return;
-    }
-    const timer = setTimeout(() => runDetect(activeBytes), 300);
-    return () => clearTimeout(timer);
-  }, [activeBytes, inputMethod]);
+  // 判定処理（file 入力は即時、text 入力は 300ms debounce）
+  const { result: detectResult, error: detectError } = useDebouncedTransform(
+    activeBytes,
+    detectFromBytes,
+    EMPTY_DETECT,
+    [],
+    { immediate: inputMethod === 'file' }
+  );
 
-  function runDetect(bytes: Uint8Array) {
-    try {
-      const result = detectEncoding(bytes);
-      setDetection(result);
-      setError('');
-      if (result.encoding !== 'UNKNOWN') {
-        const preview = decodeToText(bytes, result.encoding);
-        setDecodedPreview(preview.slice(0, 500));
-      } else {
-        setDecodedPreview('');
-      }
-    } catch (e) {
-      setDetection(null);
-      setDecodedPreview('');
-      setError(getErrorMessage(e, '判定に失敗しました'));
-    }
-  }
+  // 変換処理（convert モード以外は source を null にして結果をクリア）
+  const { result: convertResult, error: convertError } = useDebouncedTransform(
+    mode === 'convert' ? activeBytes : null,
+    (b) => convertFromBytes(b, sourceEnc, targetEnc, withBom, newlineMode),
+    EMPTY_CONVERT,
+    [mode, sourceEnc, targetEnc, withBom, newlineMode],
+    { immediate: inputMethod === 'file' }
+  );
 
-  // 変換処理
-  useEffect(() => {
-    if (mode !== 'convert' || !activeBytes) {
-      setOutputBytes(null);
-      setOutputPreview('');
-      return;
-    }
-    if (inputMethod === 'file') {
-      runConvert(activeBytes);
-      return;
-    }
-    const timer = setTimeout(() => runConvert(activeBytes), 300);
-    return () => clearTimeout(timer);
-  }, [activeBytes, inputMethod, mode, sourceEnc, targetEnc, withBom, newlineMode]);
-
-  function runConvert(bytes: Uint8Array) {
-    try {
-      const converted = convertBytes(bytes, sourceEnc, targetEnc, withBom);
-      const effectiveMode: NewlineMode = UTF16_ENCODINGS.has(targetEnc) ? 'keep' : newlineMode;
-      const normalized = normalizeNewlines(converted, effectiveMode);
-      setOutputBytes(normalized);
-      setError('');
-      // プレビューは変換後バイトを UTF-8 デコード (SJIS/EUC-JP → UNICODE 経由)
-      if (targetEnc === 'UTF8') {
-        setOutputPreview(new TextDecoder('utf-8').decode(normalized).slice(0, 500));
-      } else {
-        const preview = decodeToText(normalized, targetEnc);
-        setOutputPreview(preview.slice(0, 500));
-      }
-    } catch (e) {
-      setOutputBytes(null);
-      setOutputPreview('');
-      setError(getErrorMessage(e, '変換に失敗しました'));
-    }
-  }
+  // エラーの合流: file I/O を最優先、次に detect、convert の順
+  const error = fileError || detectError || convertError;
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -173,7 +177,7 @@ export function EncodingConverterTool() {
       acceptExtensions: ACCEPTED_EXTENSIONS,
     });
     if (!validation.ok) {
-      setError(validation.message);
+      setFileError(validation.message);
       return;
     }
 
@@ -181,11 +185,9 @@ export function EncodingConverterTool() {
       const buf = await file.arrayBuffer();
       setFileBytes(new Uint8Array(buf));
       setFileName(file.name);
-      setError('');
-      setOutputBytes(null);
-      setOutputPreview('');
+      setFileError('');
     } catch (e) {
-      setError(getErrorMessage(e, 'ファイルの読み込みに失敗しました'));
+      setFileError(getErrorMessage(e, 'ファイルの読み込みに失敗しました'));
     }
   }
 
@@ -193,18 +195,15 @@ export function EncodingConverterTool() {
     setTextInput('');
     setFileBytes(null);
     setFileName('');
-    setDetection(null);
-    setDecodedPreview('');
-    setOutputBytes(null);
-    setOutputPreview('');
-    setError('');
+    setFileError('');
+    // hook が管理する detection/decodedPreview/outputBytes/outputPreview は
+    // source が null になることで自動リセットされる
   }
 
   function handleModeChange(next: Mode) {
     setMode(next);
-    setOutputBytes(null);
-    setOutputPreview('');
-    setError('');
+    // hook が管理する outputBytes/outputPreview は mode === 'convert' ? activeBytes : null
+    // という source 制御により自動リセットされる
   }
 
   function handleInputMethodChange(next: InputMethod) {
@@ -213,7 +212,7 @@ export function EncodingConverterTool() {
   }
 
   function handleDownload() {
-    if (!outputBytes) return;
+    if (!convertResult.outputBytes) return;
     // OS 由来のファイル名は信頼できないため、許可拡張子のホワイトリストで
     // サニタイズする。拡張子が不正・欠落した場合は txt にフォールバック。
     const safeSource = sanitizeFilename(fileName || 'converted.txt', ACCEPTED_EXTENSIONS);
@@ -222,7 +221,7 @@ export function EncodingConverterTool() {
     const baseName = safeSource.replace(/\.[^.]+$/, '');
     const composed = `${baseName}_${targetEnc.toLowerCase()}.${ext}`;
     // 念のため再度サニタイズ（baseName 末尾連結の安全保証）
-    downloadBytes(outputBytes, sanitizeFilename(composed, ACCEPTED_EXTENSIONS));
+    downloadBytes(convertResult.outputBytes, sanitizeFilename(composed, ACCEPTED_EXTENSIONS));
   }
 
   const bomActive = BOM_ENCODINGS.has(targetEnc);
@@ -317,7 +316,7 @@ export function EncodingConverterTool() {
       {error && <ErrorMessage message={error} />}
 
       {/* 判定結果カード */}
-      {detection && (
+      {detectResult.detection && (
         <div
           data-testid="detection-result"
           className="rounded-lg px-4 py-3 space-y-1 border border-default bg-subtle"
@@ -325,18 +324,26 @@ export function EncodingConverterTool() {
           <div className="flex flex-wrap gap-x-6 gap-y-1">
             <span data-testid="detection-encoding" className="caption text-muted">
               文字コード:{' '}
-              <strong className="text-default">{ENCODING_LABELS[detection.encoding]}</strong>
+              <strong className="text-default">
+                {ENCODING_LABELS[detectResult.detection.encoding]}
+              </strong>
             </span>
             <span data-testid="detection-bom" className="caption text-muted">
-              BOM: <strong className="text-default">{detection.hasBom ? 'あり' : 'なし'}</strong>
+              BOM:{' '}
+              <strong className="text-default">
+                {detectResult.detection.hasBom ? 'あり' : 'なし'}
+              </strong>
             </span>
             <span className="caption text-muted">
-              サイズ: <strong className="text-default">{formatBytes(detection.byteLength)}</strong>
+              サイズ:{' '}
+              <strong className="text-default">
+                {formatBytes(detectResult.detection.byteLength)}
+              </strong>
             </span>
           </div>
-          {decodedPreview && (
+          {detectResult.decodedPreview && (
             <div className="mt-2 font-mono rounded px-2 py-1.5 overflow-auto caption text-default bg-default border border-default max-h-24 whitespace-pre-wrap break-all">
-              {decodedPreview}
+              {detectResult.decodedPreview}
             </div>
           )}
         </div>
@@ -405,7 +412,7 @@ export function EncodingConverterTool() {
           <OutputField
             id="enc-output"
             label="変換結果プレビュー"
-            value={outputPreview}
+            value={convertResult.outputPreview}
             rows={8}
             // クリップボードは Unicode テキストのみ保持できるため UTF-8 変換時のみ表示
             showCopy={targetEnc === 'UTF8'}
@@ -418,9 +425,10 @@ export function EncodingConverterTool() {
               />
             }
           />
-          {outputBytes && (
+          {convertResult.outputBytes && (
             <div data-testid="output-hex-preview" className="caption text-muted mt-1">
-              {formatBytes(outputBytes.length)}　先頭: {hexPreview(outputBytes, 16)}
+              {formatBytes(convertResult.outputBytes.length)}　先頭:{' '}
+              {hexPreview(convertResult.outputBytes, 16)}
             </div>
           )}
         </div>

--- a/src/components/tools/__tests__/EncodingConverter.test.tsx
+++ b/src/components/tools/__tests__/EncodingConverter.test.tsx
@@ -209,3 +209,44 @@ describe('EncodingConverterTool — 変換モードでも debounce で convert �
     expect(vi.mocked(convertBytes)).toHaveBeenCalledTimes(1);
   });
 });
+
+// ────────────────────────────────────────────
+// error 合流の優先順位（#394: 旧実装の error 相互上書き解消の回帰ガード）
+//
+// 旧実装は detect / convert effect が単一 error state を実行順で上書きしており、
+// convert モードで detect が throw しても convert 成功が error を空に握り潰し得た。
+// 新実装は error = fileError || detectError || convertError で合流し detect を優先する。
+// 本テストは detect だけ throw・convert 成功という構成で detect error が表示される
+// ことを assert する。error を convertError 優先（または detect を落とす）に戻すと
+// fail する = 陽性対照。
+// ────────────────────────────────────────────
+describe('EncodingConverterTool — convert モードで detect error が convert 成功に握り潰されない', () => {
+  it('detect throw・convert 成功時に detect の error が表示される（陽性対照）', () => {
+    const { container } = render(<EncodingConverterTool />);
+
+    // 変換モードに切替
+    act(() => {
+      screen.getByRole('button', { name: '変換' }).click();
+    });
+
+    // detect だけ throw させる（convert は actual 実装で成功する）
+    vi.mocked(detectEncoding).mockImplementationOnce(() => {
+      throw new Error('判定失敗テスト');
+    });
+
+    const textarea = container.querySelector(
+      'textarea#enc-text-input'
+    ) as HTMLTextAreaElement | null;
+    expect(textarea).not.toBeNull();
+
+    act(() => {
+      fireEvent.change(textarea!, { target: { value: 'hello' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    // 合流 error に detectError が出る（convert 成功で握り潰されない）
+    expect(screen.queryByText('判定失敗テスト')).not.toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useDebouncedTransform.test.ts
+++ b/src/hooks/__tests__/useDebouncedTransform.test.ts
@@ -53,6 +53,33 @@ describe('useDebouncedTransform — immediate: true で setTimeout なしに同�
     expect(result.current.result).toBe('WORLD');
     expect(transform).toHaveBeenCalledTimes(2);
   });
+
+  it('[陽性] debounce パス(isPending=true)から immediate へ遷移すると isPending が false に正規化される', () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result, rerender } = renderHook(
+      ({ src, immediate }: { src: string; immediate: boolean }) =>
+        useDebouncedTransform(src, transform, EMPTY_STRING, [], {
+          immediate,
+          debounceMs: DEBOUNCE_MS,
+        }),
+      { initialProps: { src: 'hello', immediate: false } }
+    );
+
+    // debounce パスでは isPending が true
+    expect(result.current.isPending).toBe(true);
+
+    // immediate へ遷移（前 effect の cleanup は clearTimeout のみで isPending を触らない）
+    act(() => {
+      rerender({ src: 'hello2', immediate: true });
+    });
+
+    // immediate パスでも isPending が false に正規化される。
+    // fix 前（immediate ブランチに setIsPending(false) が無い）実装に当てると
+    // isPending が true のまま stuck し本 assert が fail する = 陽性対照。
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.result).toBe('HELLO2');
+  });
 });
 
 // ────────────────────────────────────────────

--- a/src/hooks/__tests__/useDebouncedTransform.test.ts
+++ b/src/hooks/__tests__/useDebouncedTransform.test.ts
@@ -1,0 +1,306 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedTransform } from '@/hooks/useDebouncedTransform';
+
+const DEBOUNCE_MS = 300;
+
+// 安定参照の emptyResult 定数（モジュールスコープ）
+const EMPTY_STRING = '';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ────────────────────────────────────────────
+// ① immediate: true で同期実行される
+// ────────────────────────────────────────────
+describe('useDebouncedTransform — immediate: true で setTimeout なしに同期実行される', () => {
+  it('source が非 null で immediate: true のとき debounce 待ちなしに result が反映される', () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result } = renderHook(() =>
+      useDebouncedTransform('hello', transform, EMPTY_STRING, [], { immediate: true })
+    );
+
+    // advanceTimers を呼ばずとも即時に result が反映されている
+    expect(result.current.result).toBe('HELLO');
+    expect(result.current.error).toBe('');
+    expect(result.current.isPending).toBe(false);
+    expect(transform).toHaveBeenCalledTimes(1);
+  });
+
+  it('source が更新されると再び同期実行される', () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result, rerender } = renderHook(
+      ({ src }: { src: string }) =>
+        useDebouncedTransform(src, transform, EMPTY_STRING, [], { immediate: true }),
+      { initialProps: { src: 'hello' } }
+    );
+
+    expect(result.current.result).toBe('HELLO');
+    expect(transform).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rerender({ src: 'world' });
+    });
+
+    expect(result.current.result).toBe('WORLD');
+    expect(transform).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ────────────────────────────────────────────
+// ② debounce（300ms 後に反映）
+// ────────────────────────────────────────────
+describe('useDebouncedTransform — debounce 後に result が反映される', () => {
+  it('source を渡した直後は result が emptyResult のまま、300ms 後に反映される', async () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result } = renderHook(() =>
+      useDebouncedTransform('hello', transform, EMPTY_STRING, [], { debounceMs: DEBOUNCE_MS })
+    );
+
+    // debounce 前は emptyResult のまま
+    expect(result.current.result).toBe(EMPTY_STRING);
+    expect(result.current.isPending).toBe(true);
+    expect(transform).not.toHaveBeenCalled();
+
+    // debounce 完了
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(result.current.result).toBe('HELLO');
+    expect(result.current.isPending).toBe(false);
+    expect(transform).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ────────────────────────────────────────────
+// ③ debounce 中の再入力で前回キャンセル（最後の 1 回だけ transform）
+//
+// test-gates 鉄則:
+//   陰性対照（debounce 中は呼ばれない）と
+//   陽性対照（clearTimeout を削除した実装に当てると fail する = 1回超呼ばれる）を分離。
+// ────────────────────────────────────────────
+describe('useDebouncedTransform — debounce 中の再入力で前回がキャンセルされる', () => {
+  // 陰性対照: debounce 完了前は transform が呼ばれないことを確認
+  it('[陰性] debounce 完了前は再入力後も transform が呼ばれていない', () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { rerender } = renderHook(
+      ({ src }: { src: string }) =>
+        useDebouncedTransform(src, transform, EMPTY_STRING, [], { debounceMs: DEBOUNCE_MS }),
+      { initialProps: { src: 'first' } }
+    );
+
+    // debounce 半分だけ進める
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS / 2);
+    });
+    expect(transform).not.toHaveBeenCalled();
+
+    // 2 回目の入力 → 前回タイマーをキャンセルして新しいタイマーをセット
+    act(() => {
+      rerender({ src: 'second' });
+    });
+
+    // 新しいタイマーの半分しか進めていない → まだ呼ばれない
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS / 2);
+    });
+    expect(transform).not.toHaveBeenCalled();
+  });
+
+  // 陽性対照: clearTimeout を削除した実装（キャンセルなし）に当てると
+  // 'first' でも transform が呼ばれ toHaveBeenCalledTimes(1) が失敗する
+  it('[陽性] debounce 完了後は最後の source に対して 1 回だけ transform が呼ばれる', async () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result, rerender } = renderHook(
+      ({ src }: { src: string }) =>
+        useDebouncedTransform(src, transform, EMPTY_STRING, [], { debounceMs: DEBOUNCE_MS }),
+      { initialProps: { src: 'first' } }
+    );
+
+    // debounce 半分 → 再入力 → 残り全部進める
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS / 2);
+    });
+    act(() => {
+      rerender({ src: 'second' });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    // キャンセル機構が正常なら 'second' の 1 回だけ
+    // キャンセルなし実装なら 'first' + 'second' の 2 回になり fail する
+    expect(transform).toHaveBeenCalledTimes(1);
+    expect(transform).toHaveBeenCalledWith('second');
+    expect(result.current.result).toBe('SECOND');
+  });
+
+  it('連続して 3 回 source を変えても transform は最後の入力にだけ 1 回だけ走る', async () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result, rerender } = renderHook(
+      ({ src }: { src: string }) =>
+        useDebouncedTransform(src, transform, EMPTY_STRING, [], { debounceMs: DEBOUNCE_MS }),
+      { initialProps: { src: 'a' } }
+    );
+
+    act(() => {
+      rerender({ src: 'ab' });
+    });
+    act(() => {
+      rerender({ src: 'abc' });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(transform).toHaveBeenCalledTimes(1);
+    expect(transform).toHaveBeenCalledWith('abc');
+    expect(result.current.result).toBe('ABC');
+  });
+});
+
+// ────────────────────────────────────────────
+// ④ source = null で emptyResult / error クリア
+// ────────────────────────────────────────────
+describe('useDebouncedTransform — source = null で emptyResult / error がクリアされる', () => {
+  it('source が null のとき result = emptyResult / error = "" / isPending = false が即時反映される', () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result } = renderHook(() =>
+      useDebouncedTransform<string, string>(null, transform, EMPTY_STRING, [], {
+        debounceMs: DEBOUNCE_MS,
+      })
+    );
+
+    expect(result.current.result).toBe(EMPTY_STRING);
+    expect(result.current.error).toBe('');
+    expect(result.current.isPending).toBe(false);
+    expect(transform).not.toHaveBeenCalled();
+  });
+
+  it('変換完了後に source を null に戻すと result / error が即時クリアされ debounce 待ちにならない', async () => {
+    const transform = vi.fn((s: string) => s.toUpperCase());
+
+    const { result, rerender } = renderHook(
+      ({ src }: { src: string | null }) =>
+        useDebouncedTransform(src, transform, EMPTY_STRING, [], { debounceMs: DEBOUNCE_MS }),
+      { initialProps: { src: 'hello' as string | null } }
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    expect(result.current.result).toBe('HELLO');
+
+    // null に戻す → debounce を進めなくても即時クリア
+    act(() => {
+      rerender({ src: null });
+    });
+
+    expect(result.current.result).toBe(EMPTY_STRING);
+    expect(result.current.error).toBe('');
+    expect(result.current.isPending).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────
+// ⑤ transform が throw したときに error セット・result = emptyResult
+// ────────────────────────────────────────────
+describe('useDebouncedTransform — transform が throw したとき error がセットされ result = emptyResult になる', () => {
+  it('debounce パスで transform が throw すると error が設定され result = emptyResult になる', async () => {
+    const transform = vi.fn((_s: string): string => {
+      throw new Error('変換エラー');
+    });
+
+    const { result } = renderHook(() =>
+      useDebouncedTransform('bad input', transform, EMPTY_STRING, [], { debounceMs: DEBOUNCE_MS })
+    );
+
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBe('変換エラー');
+    expect(result.current.result).toBe(EMPTY_STRING);
+  });
+
+  it('immediate パスで transform が throw すると error が設定され result = emptyResult になる', () => {
+    const transform = vi.fn((_s: string): string => {
+      throw new Error('即時エラー');
+    });
+
+    const { result } = renderHook(() =>
+      useDebouncedTransform('bad input', transform, EMPTY_STRING, [], { immediate: true })
+    );
+
+    expect(result.current.error).toBe('即時エラー');
+    expect(result.current.result).toBe(EMPTY_STRING);
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('fallbackError が設定されているとき、非 Error の throw に対して fallbackError が使われる', async () => {
+    const transform = vi.fn((_s: string): string => {
+      throw 'string error';
+    });
+
+    const { result } = renderHook(() =>
+      useDebouncedTransform('bad', transform, EMPTY_STRING, [], {
+        debounceMs: DEBOUNCE_MS,
+        fallbackError: 'フォールバックエラー',
+      })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(result.current.error).toBe('フォールバックエラー');
+    expect(result.current.result).toBe(EMPTY_STRING);
+  });
+
+  it('throw 後に正常な source を渡すと error がクリアされ result が更新される', async () => {
+    const transform = vi.fn((s: string): string => {
+      if (s === 'bad') throw new Error('変換エラー');
+      return s.toUpperCase();
+    });
+
+    const { result, rerender } = renderHook(
+      ({ src }: { src: string }) =>
+        useDebouncedTransform(src, transform, EMPTY_STRING, [], { debounceMs: DEBOUNCE_MS }),
+      { initialProps: { src: 'bad' } }
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    expect(result.current.error).toBe('変換エラー');
+
+    act(() => {
+      rerender({ src: 'good' });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(result.current.error).toBe('');
+    expect(result.current.result).toBe('GOOD');
+  });
+});

--- a/src/hooks/useDebouncedTransform.ts
+++ b/src/hooks/useDebouncedTransform.ts
@@ -56,7 +56,9 @@ export function useDebouncedTransform<I, R>(
         setResult(emptyResult);
         setError(getErrorMessage(e, fallbackError));
       }
-      // isPending は false のまま（setIsPending 不要）
+      // debounce パスから immediate へ遷移したときに isPending が true で
+      // stuck しないよう、即時パスでも明示的に false へ正規化する。
+      setIsPending(false);
       return;
     }
 

--- a/src/hooks/useDebouncedTransform.ts
+++ b/src/hooks/useDebouncedTransform.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import type { DependencyList } from 'react';
+import { getErrorMessage } from '@/utils/errors';
+
+interface UseDebouncedTransformOptions {
+  /** デバウンス（ms）。既定 300。`immediate` が true の場合は無視される。 */
+  debounceMs?: number;
+  /** true のとき setTimeout を使わず effect 内で同期実行する（ファイル入力の即時パス用）。 */
+  immediate?: boolean;
+  /** transform が Error 以外を throw した場合のフォールバックメッセージ。 */
+  fallbackError?: string;
+}
+
+/**
+ * source → debounce（または即時） → transform → result ＋ error ＋ isPending をひとまとめにするフック。
+ *
+ * - `source === null` → result = emptyResult / error = '' / isPending = false（debounce を待たず即時）。
+ * - `options.immediate === true` → setTimeout を使わず effect 内で同期実行。isPending は false のまま。
+ * - それ以外 → setTimeout(debounceMs ?? 300)。debounce 中は isPending = true。
+ * - `transform` throw → error に getErrorMessage(e, fallbackError)、result = emptyResult、isPending = false。
+ *
+ * `emptyResult` は安定参照前提（呼び出し側がモジュールスコープ定数か useMemo で渡すこと）。
+ * `transform` は deps を介して追跡する設計（exhaustive-deps を意図的に無効化）。
+ */
+export function useDebouncedTransform<I, R>(
+  source: I | null,
+  transform: (input: I) => R,
+  emptyResult: R,
+  deps: DependencyList,
+  options?: UseDebouncedTransformOptions
+): { result: R; error: string; isPending: boolean } {
+  const {
+    debounceMs = 300,
+    immediate = false,
+    fallbackError = '変換に失敗しました',
+  } = options ?? {};
+
+  const [result, setResult] = useState<R>(emptyResult);
+  const [error, setError] = useState('');
+  const [isPending, setIsPending] = useState(false);
+
+  useEffect(() => {
+    if (source === null) {
+      setResult(emptyResult);
+      setError('');
+      setIsPending(false);
+      return;
+    }
+
+    if (immediate) {
+      // ファイル入力の即時パス: setTimeout を使わず同期実行
+      try {
+        setResult(transform(source));
+        setError('');
+      } catch (e) {
+        setResult(emptyResult);
+        setError(getErrorMessage(e, fallbackError));
+      }
+      // isPending は false のまま（setIsPending 不要）
+      return;
+    }
+
+    // テキスト入力の debounce パス
+    setIsPending(true);
+    const timer = setTimeout(() => {
+      try {
+        setResult(transform(source));
+        setError('');
+      } catch (e) {
+        setResult(emptyResult);
+        setError(getErrorMessage(e, fallbackError));
+      } finally {
+        setIsPending(false);
+      }
+    }, debounceMs);
+    return () => clearTimeout(timer);
+    // transform は deps を介して追跡する設計（exhaustive-deps を意図的に無効化）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [source, immediate, debounceMs, fallbackError, ...deps]);
+
+  return { result, error, isPending };
+}


### PR DESCRIPTION
## 概要

リファクタ監査 (2026-05-11) finding L-7 への対応。`EncodingConverter` が持つ手書き debounce pipeline 2 系統（detect / convert）を汎用フックに統合し、debounce plumbing と state reset の散逸を解消する。

Closes #394

## 設計判断（issue 記載との差分）

issue は「`useCodec` をそのまま使う」想定だったが、`EncodingConverter` は `useCodec` のモデルと乖離している:

- 入力が `Uint8Array | null`（`activeBytes`、コンポーネントが `useMemo` で所有）で `string` でない
- 出力が `string` でない（detect→`DetectionResult`+preview / convert→`Uint8Array`+preview）
- **条件付き debounce**（file 入力は即時、text 入力のみ 300ms）
- 2 系統が同一 source を共有

`useCodec` を bytes / 非 string / 条件付き debounce 対応まで一般化すると 4 消費者（ConfigConverter / JsonXml / JsonCsv / Base64Codec）に波及するため、**`useCodec` は無変更**とし、汎用フック `useDebouncedTransform<I, R>` を新設した。

## 変更内容

- **`src/hooks/useDebouncedTransform.ts`**（新規）: `source` / `transform` / `emptyResult` / `deps` / `{ debounceMs, immediate, fallbackError }` を受け、`source === null` で即時クリア、`immediate` で同期実行（file パス）、それ以外は debounce（再入力で前回キャンセル）、`transform` throw を error 化。ジェネリックで入出力型に依存しない。
- **`src/components/tools/EncodingConverter.tsx`**:
  - 手書き detect / convert effect（`setTimeout`/`clearTimeout`）と `runDetect`/`runConvert` の setState 群を削除し、`useDebouncedTransform` 2 回呼び出しに置換。
  - 変換ロジックを pure function `detectFromBytes` / `convertFromBytes` としてモジュールスコープに抽出（既存テストの `vi.mock('@/utils/encoding')` を維持するため utils 側ではなくコンポーネント側に配置）。
  - error 表示を `fileError || detectError || convertError` に合流。旧実装で detect/convert effect が単一 `error` を相互上書きしていた latent な問題も解消。
  - `activeBytes`（useMemo）と `inputMethod` 分岐はオーケストレーション役としてコンポーネント側に残置。
- **`src/hooks/__tests__/useDebouncedTransform.test.ts`**（新規）: immediate 同期実行 / debounce / 再入力キャンセル / `source=null` クリア / throw 時 error の各ケース。

## 検証

- `npm run test`: **1358 passed**（新規フックテスト + 既存 `EncodingConverter.test.tsx` の debounce 集約・useMemo 安定・file reject エラー表示・convert debounce の 4 ケース全 green）
- `node_modules/.bin/astro check`: **0 errors / 0 warnings**
- `npm run test:e2e -- encoding-converter a11y-live-region filename-sanitize`: **29 passed**
- pre-commit: Prettier OK / TypeScript OK

## 補足

- 内部リファクタのためツール追加/削除なし。`README.md` / `SPEC.md` 更新は不要。
- aria 属性の削除なし。Tailwind primitive scale 直書きの新規追加なし（既存 className 維持）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
