### PR TITLE
fix: ConfigConverter の警告ブロックに live region を付与 (#479)

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -199,7 +199,11 @@ export function ConfigConverterTool() {
       </div>
 
       {warnings.length > 0 && (
-        <div className="rounded-lg p-3 border border-warning bg-warning-tint">
+        <div
+          className="rounded-lg p-3 border border-warning bg-warning-tint"
+          role="status"
+          aria-live="polite"
+        >
           <ul className="caption text-default m-0 pl-5">
             {warnings.map((w, i) => (
               <li key={i}>{w}</li>

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -94,6 +94,26 @@ test.describe('a11y live region (issue #163, production CSP 適用)', () => {
       await expect(statusEl.locator('textarea')).toHaveValue(/id,name/);
     });
   });
+
+  test('ConfigConverter: 変換警告が role="status" aria-live="polite" で SR 通知可能（CSP 違反なし、issue #479）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/config-converter', async (page) => {
+      // 変換先を .env にすると「値はすべて文字列に変換されます」警告が出る
+      await page
+        .getByRole('group', { name: '変換先フォーマット' })
+        .getByRole('button', { name: '.env' })
+        .click();
+      await page.locator('#config-converter-input').fill('{"KEY":"val"}');
+
+      // OutputField も常時 role="status" を持つため、警告テキストで絞り込む（陽性対照の肝）
+      const warningStatus = page
+        .getByRole('status')
+        .filter({ hasText: '値はすべて文字列に変換されます' });
+      await expect(warningStatus).toBeVisible();
+      await expect(warningStatus).toHaveAttribute('aria-live', 'polite');
+    });
+  });
 });
 
 test.describe('a11y aria-expanded (issue #163, production CSP 適用)', () => {


### PR DESCRIPTION
## 概要

`ConfigConverter` の warnings ブロックは入力に応じて動的に出現/消滅するにもかかわらず live region 指定（`role` / `aria-live`）が無く、スクリーンリーダー利用者には変換警告（例「値はすべて文字列に変換されます」）が読み上げられなかった。隣接する `validationResult` ブロックや `OutputField` が `role="status"` + `aria-live="polite"` を持つのと対照的な既存挙動の a11y ギャップ（PR #477 / #390 レビュー指摘）。

closes #479

## 変更内容

- `src/components/tools/ConfigConverter.tsx`: warnings `<div>` に `role="status"` + `aria-live="polite"` を付与（警告は致命的でないため assertive ではなく polite）。
- `tests/e2e/a11y-live-region.spec.ts`: live region が機能することを検証する陽性対照 E2E を 1 ケース追加。

### 陽性対照の設計（test-gates 準拠）

`OutputField` が常時 `role="status"` を持つため、素の `getByRole('status')` では旧実装でも pass してしまう。**警告テキスト（`値はすべて文字列に変換されます`）で `filter` する**ことで warnings ブロック自身を特定し、旧実装（`role` 無しの素の `<div>`）では `count = 0` → fail することをローカルで実機確認済み（変更を一時 revert して fail を確認 → 復元して green）。

## テスト

- [x] `node_modules/.bin/astro check`（型チェック）: 0 errors
- [x] `npm run test`（ユニット）: 1361 passed
- [x] `npm run test:e2e -- a11y-live-region.spec.ts`: 9 passed（新規ケース含む）
- [x] 陽性対照: 修正を一時 revert した状態で新規 E2E が fail することを確認

## 補足

属性追加のみで視覚表現は不変のため VRT baseline 更新は不要。ツール追加/削除・ライブラリ変更ではないため README/SPEC/decisions の更新も不要。

---
_Generated by [Claude Code](https://claude.ai/code/session_0139nsdjS7mQAbbPCk2hgGm5)_