### PR TITLE
fix: ConfigConverter の live region を常設化 (#483)

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -199,11 +199,7 @@ export function ConfigConverterTool() {
       </div>
 
       {warnings.length > 0 && (
-        <div
-          className="rounded-lg p-3 border border-warning bg-warning-tint"
-          role="status"
-          aria-live="polite"
-        >
+        <div className="rounded-lg p-3 border border-warning bg-warning-tint">
           <ul className="caption text-default m-0 pl-5">
             {warnings.map((w, i) => (
               <li key={i}>{w}</li>
@@ -266,8 +262,6 @@ export function ConfigConverterTool() {
             {validationResult && (
               <div
                 className={`rounded-lg p-3 border ${validationResult.valid ? 'alert-success' : 'alert-error'}`}
-                role={validationResult.valid ? 'status' : 'alert'}
-                aria-live={validationResult.valid ? 'polite' : 'assertive'}
               >
                 {validationResult.valid ? (
                   <p className="caption text-default inline-flex items-center gap-1">
@@ -300,6 +294,34 @@ export function ConfigConverterTool() {
             setSchemaText('');
           }}
         />
+      </div>
+
+      {/*
+       * SR 用の常設 live region。可視ボックス（warnings / validationResult）は条件付き
+       * マウントのままだが、live region 要素自体はページ読込時から常設し、中身（要約文言）
+       * だけを後から変化させることで挿入が確実に読み上げられるようにする（issue #483）。
+       * sr-only は margin:-1px / position:absolute でレイアウトに影響しない。
+       * 文言は可視テキストの逐語複製ではなく要約（CopyButton / DummyText と同方式）。
+       */}
+      <div
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+        data-testid="config-converter-warning-announcement"
+      >
+        {warnings.length > 0 ? `変換に関する警告が${warnings.length}件あります` : ''}
+      </div>
+      <div
+        role="status"
+        aria-live={validationResult && !validationResult.valid ? 'assertive' : 'polite'}
+        className="sr-only"
+        data-testid="config-converter-validation-announcement"
+      >
+        {validationResult
+          ? validationResult.valid
+            ? 'スキーマ検証に成功しました'
+            : `スキーマ検証で${validationResult.errors.length}件のエラーが見つかりました`
+          : ''}
       </div>
     </div>
   );

--- a/src/components/tools/__tests__/ConfigConverter.test.tsx
+++ b/src/components/tools/__tests__/ConfigConverter.test.tsx
@@ -13,9 +13,7 @@ afterEach(() => {
 describe('ConfigConverter a11y live region 常設 (issue #483)', () => {
   it('warnings 用 sr-only live region が入力前から role="status" aria-live="polite" で常設される', () => {
     const { container } = render(<ConfigConverterTool />);
-    const el = container.querySelector(
-      '[data-testid="config-converter-warning-announcement"]'
-    );
+    const el = container.querySelector('[data-testid="config-converter-warning-announcement"]');
     expect(el).not.toBeNull();
     expect(el!.getAttribute('role')).toBe('status');
     expect(el!.getAttribute('aria-live')).toBe('polite');
@@ -25,9 +23,7 @@ describe('ConfigConverter a11y live region 常設 (issue #483)', () => {
 
   it('validationResult 用 sr-only live region が検証前から role="status" aria-live="polite" で常設される', () => {
     const { container } = render(<ConfigConverterTool />);
-    const el = container.querySelector(
-      '[data-testid="config-converter-validation-announcement"]'
-    );
+    const el = container.querySelector('[data-testid="config-converter-validation-announcement"]');
     expect(el).not.toBeNull();
     expect(el!.getAttribute('role')).toBe('status');
     expect(el!.getAttribute('aria-live')).toBe('polite');

--- a/src/components/tools/__tests__/ConfigConverter.test.tsx
+++ b/src/components/tools/__tests__/ConfigConverter.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ConfigConverterTool } from '@/components/tools/ConfigConverter';
+
+afterEach(() => {
+  cleanup();
+});
+
+// issue #483: warnings / validationResult の live region を条件付きマウントから
+// 常設 sr-only 化した。入力前（warnings 空・validationResult null）でも live region
+// 要素が DOM に存在することを検証し、条件付きマウントへの逆戻りを検知する。
+describe('ConfigConverter a11y live region 常設 (issue #483)', () => {
+  it('warnings 用 sr-only live region が入力前から role="status" aria-live="polite" で常設される', () => {
+    const { container } = render(<ConfigConverterTool />);
+    const el = container.querySelector(
+      '[data-testid="config-converter-warning-announcement"]'
+    );
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('role')).toBe('status');
+    expect(el!.getAttribute('aria-live')).toBe('polite');
+    // 警告が無い初期状態では文言は空
+    expect(el!.textContent).toBe('');
+  });
+
+  it('validationResult 用 sr-only live region が検証前から role="status" aria-live="polite" で常設される', () => {
+    const { container } = render(<ConfigConverterTool />);
+    const el = container.querySelector(
+      '[data-testid="config-converter-validation-announcement"]'
+    );
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('role')).toBe('status');
+    expect(el!.getAttribute('aria-live')).toBe('polite');
+    expect(el!.textContent).toBe('');
+  });
+});

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -95,23 +95,51 @@ test.describe('a11y live region (issue #163, production CSP 適用)', () => {
     });
   });
 
-  test('ConfigConverter: 変換警告が role="status" aria-live="polite" で SR 通知可能（CSP 違反なし、issue #479）', async ({
+  test('ConfigConverter: 変換警告が常設 sr-only live region で SR 通知可能（CSP 違反なし、issue #483）', async ({
     browser,
   }) => {
     await withProductionCsp(browser, '/tools/config-converter', async (page) => {
-      // 変換先を .env にすると「値はすべて文字列に変換されます」警告が出る
+      const announcer = page.getByTestId('config-converter-warning-announcement');
+      // 常設: 警告が無い初期状態でも live region 要素は DOM に存在する（条件付きマウントへの逆戻り検知）
+      await expect(announcer).toBeAttached();
+      await expect(announcer).toHaveRole('status');
+      await expect(announcer).toHaveAttribute('aria-live', 'polite');
+
+      // 変換先を .env にすると warning が立ち、常設アナウンサに要約文言が入る
       await page
         .getByRole('group', { name: '変換先フォーマット' })
         .getByRole('button', { name: '.env' })
         .click();
       await page.locator('#config-converter-input').fill('{"KEY":"val"}');
+      await expect(announcer).toContainText('変換に関する警告が');
+    });
+  });
 
-      // OutputField も常時 role="status" を持つため、警告テキストで絞り込む（陽性対照の肝）
-      const warningStatus = page
-        .getByRole('status')
-        .filter({ hasText: '値はすべて文字列に変換されます' });
-      await expect(warningStatus).toBeVisible();
-      await expect(warningStatus).toHaveAttribute('aria-live', 'polite');
+  test('ConfigConverter: スキーマ検証エラーが常設 sr-only live region で assertive 通知可能（CSP 違反なし、issue #483）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/config-converter', async (page) => {
+      const announcer = page.getByTestId('config-converter-validation-announcement');
+      // 常設: 検証前でも live region は存在し、初期は polite
+      await expect(announcer).toBeAttached();
+      await expect(announcer).toHaveRole('status');
+      await expect(announcer).toHaveAttribute('aria-live', 'polite');
+
+      // from=to=JSON にして JSON 出力にし、スキーマ違反データで検証する
+      await page
+        .getByRole('group', { name: '変換先フォーマット' })
+        .getByRole('button', { name: 'JSON' })
+        .click();
+      await page.getByLabel('JSON (整形)').fill('{"age":"not-a-number"}');
+      await page.getByRole('button', { name: 'JSON Schema で検証する' }).click();
+      await page
+        .getByLabel('JSON Schema (貼り付け)')
+        .fill('{"type":"object","properties":{"age":{"type":"number"}}}');
+      await page.getByRole('button', { name: '検証する', exact: true }).click();
+
+      // 検証エラー時はアナウンサに要約文言が入り aria-live が assertive に切替わる
+      await expect(announcer).toContainText('エラーが見つかりました');
+      await expect(announcer).toHaveAttribute('aria-live', 'assertive');
     });
   });
 });

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -142,6 +142,30 @@ test.describe('a11y live region (issue #163, production CSP 適用)', () => {
       await expect(announcer).toHaveAttribute('aria-live', 'assertive');
     });
   });
+
+  test('ConfigConverter: スキーマ検証成功が常設 sr-only live region で polite 通知可能（CSP 違反なし、issue #483）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/config-converter', async (page) => {
+      const announcer = page.getByTestId('config-converter-validation-announcement');
+
+      // from=to=JSON にして JSON 出力にし、スキーマに適合するデータで検証する
+      await page
+        .getByRole('group', { name: '変換先フォーマット' })
+        .getByRole('button', { name: 'JSON' })
+        .click();
+      await page.getByLabel('JSON (整形)').fill('{"age":30}');
+      await page.getByRole('button', { name: 'JSON Schema で検証する' }).click();
+      await page
+        .getByLabel('JSON Schema (貼り付け)')
+        .fill('{"type":"object","properties":{"age":{"type":"number"}}}');
+      await page.getByRole('button', { name: '検証する', exact: true }).click();
+
+      // 検証成功時はアナウンサに成功文言が入り aria-live は polite を維持する
+      await expect(announcer).toContainText('スキーマ検証に成功しました');
+      await expect(announcer).toHaveAttribute('aria-live', 'polite');
+    });
+  });
 });
 
 test.describe('a11y aria-expanded (issue #163, production CSP 適用)', () => {


### PR DESCRIPTION
## 概要

PR #482 (#479) で warnings ブロックに `role="status"` + `aria-live="polite"` を付与したが、live region 要素自体が `warnings.length > 0 && (...)` で**条件付きマウント**されたままだった（`validationResult` も同様）。WAI-ARIA / MDN のガイドでは live region は**ページ読込時から DOM に存在し中身だけが変化する**構成が最も確実で、要素ごと動的追加すると SR/ブラウザの組合せで挿入が読み上げられないことがある。本 PR で両ブロックの live region を常設化する。

closes #483

## 変更内容

- **常設 sr-only アナウンサを追加**（`ConfigConverter.tsx`）: `CopyButton` / `QrCode` / `DummyText` と同じ確立パターン。ページ読込時から常設し、中身（要約文言）だけを state 駆動で変化させる。`sr-only` は `margin:-1px` / `position:absolute` で**レイアウト非干渉**のため VRT baseline 更新は不要。
  - warnings 用: `role="status" aria-live="polite"`
  - validationResult 用: `role="status"` 固定 + `aria-live` を valid=`polite` / invalid=`assertive` で切替（`VerifyTab.tsx` の先例に倣い live region の role は動的に変えない）
- **可視ボックスから role/aria-live を削除**: warnings / validationResult の見た目（`bg-warning-tint` / `alert-success` / `alert-error`）は不変。自動アナウンスは sr-only 側が担う。
- アナウンス文言は可視テキストの逐語複製ではなく**要約**（DummyText と同方式）。これにより既存 E2E の `getByText('値はすべて…')` / `getByText('スキーマ検証成功')` / `getByText('/age')` との strict-mode 重複マッチを回避。

## 設計上の判断

- 方式（sr-only 常設 / role 固定+aria-live 切替）は事前にオーナーと合意済み。
- 可視ボックスに `aria-hidden` は付けない（SR ナビゲーション時に読める静的テキストとして残す）。

## テスト

- [x] `node_modules/.bin/astro check`: 0 errors / 0 warnings / 0 hints
- [x] `npm run test`（ユニット）: 1365 passed（**常設の回帰ガード**を新規追加: 入力前から sr-only live region が role/aria-live 付きで存在することを検証）
- [x] `npm run test:e2e -- a11y-live-region.spec.ts config-converter.spec.ts`: 26 passed（既存 config-converter テストへのリグレッションなし）
- [x] **陽性対照（test-gates 準拠）**: sr-only アナウンサを一時除去すると新規 E2E 2 件・ユニット 2 件が `toBeAttached`/`not.toBeNull` で fail することをローカル実機確認 → 復元して green。SR 通知が機能することの検知能力を証明。

## 補足

レイアウト非干渉のため VRT 差分は出ない想定（CI の visual-regression で確認）。ツール追加/削除・ライブラリ変更なしのため README/SPEC/decisions の更新は不要。

---
_Generated by [Claude Code](https://claude.ai/code/session_0139nsdjS7mQAbbPCk2hgGm5)_