### PR TITLE
test(meta): ツールアイコン付与漏れ検知 meta テストを追加

### DIFF
--- a/tests/meta/tool-icon-coverage.test.ts
+++ b/tests/meta/tool-icon-coverage.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { tools } from '@/data/tools';
+
+/**
+ * meta test: ツールアイコン付与漏れ検出 (issue #496 再発防止策)
+ *
+ * `src/data/tools.ts` に登録した全 tool slug が `src/components/ui/ToolIcon.astro` に
+ * アイコン定義（`slug === '...'` の SVG ブロック）を持つかを機械的に検証する。
+ *
+ * 背景: `ToolIcon` は該当 slug 不在時に fallback を持たず、トップカード / サイドバー /
+ * ドロワー / ツールページヘッダで空白アイコンが無言で描画される。実際に
+ * sql-formatter / regex-visualizer は #490〜#492 の追加時にアイコン付与が漏れ、
+ * #494 で後追い修正したが CI も VRT も「空白アイコン」を regression として検知できなかった。
+ * 本 test を CI (`npm run test`) で走らせることで、新規ツール追加 PR で付与漏れが
+ * merge 前に必ず fail として検知される。
+ *
+ * 取得方法 (a): ToolIcon.astro のソースを read して slug を正規表現抽出する。
+ * 実レンダリング元（SVG ブロック）が唯一の真実源となりドリフトしない。
+ */
+
+const iconSrcPath = fileURLToPath(
+  new URL('../../src/components/ui/ToolIcon.astro', import.meta.url)
+);
+
+/** ToolIcon.astro ソースから `slug === '...'` の slug を列挙する純粋関数 (fixture 注入可能) */
+function extractIconSlugs(source: string): string[] {
+  const slugs: string[] = [];
+  const re = /slug === '([^']+)'/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    slugs.push(m[1]);
+  }
+  return slugs;
+}
+
+/** アイコン定義を持たない tool slug を返す純粋関数 (陰性/陽性両対照で共有) */
+function findMissingIcons(toolList: { slug: string }[], iconSlugs: string[]): string[] {
+  const iconSet = new Set(iconSlugs);
+  return toolList.filter((t) => !iconSet.has(t.slug)).map((t) => t.slug);
+}
+
+/** tools.ts に対応する slug が無い orphan アイコン slug を返す純粋関数 */
+function findOrphanIcons(toolList: { slug: string }[], iconSlugs: string[]): string[] {
+  const toolSet = new Set(toolList.map((t) => t.slug));
+  return iconSlugs.filter((slug) => !toolSet.has(slug));
+}
+
+const realSource = readFileSync(iconSrcPath, 'utf8');
+const iconSlugs = extractIconSlugs(realSource);
+
+describe('ToolIcon アイコンカバレッジ', () => {
+  it('ToolIcon.astro から slug を 1 つ以上抽出できる (regex 形式破壊の sanity)', () => {
+    // 抽出が 0 件だと全ツールが「漏れ」扱いになり別 test が誤検知するため、
+    // 抽出器が live ソースに対して機能していることを先に保証する。
+    expect(iconSlugs.length).toBeGreaterThan(0);
+  });
+
+  it('src/data/tools.ts の全 tool slug が ToolIcon.astro にアイコン定義を持つ', () => {
+    const missing = findMissingIcons(tools, iconSlugs);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('ToolIcon orphan 検出', () => {
+  it('ToolIcon.astro に定義されているが tools.ts に対応 slug が無い orphan アイコンが無い', () => {
+    const orphans = findOrphanIcons(tools, iconSlugs);
+    expect(orphans).toEqual([]);
+  });
+});
+
+// 陽性対照: 抽出器が空回りしていないことを保証 (test-gates skill 準拠)。
+// fixture 文字列を注入し、抽出が「常に空」「常に全部」ではなく実際に拾うことを証明する。
+describe('[陽性対照] extractIconSlugs 抽出機構', () => {
+  it("slug === '...' ブロックを含む fixture から該当 slug を抽出する", () => {
+    const fixture = `
+      { slug === 'fixture-a' && (<svg><path d="M0 0" /></svg>) }
+      { slug === 'fixture-b' && (<svg><circle cx="1" cy="1" r="1" /></svg>) }
+    `;
+    expect(extractIconSlugs(fixture)).toEqual(['fixture-a', 'fixture-b']);
+  });
+
+  it('slug 定義が無い fixture からは何も抽出しない (過検知なし)', () => {
+    const fixture = `<svg><path d="M0 0" /></svg>`;
+    expect(extractIconSlugs(fixture)).toEqual([]);
+  });
+});
+
+// 陽性対照: 付与漏れ検知機構が空回りしていないことを保証。
+describe('[陽性対照] 付与漏れ検知機構', () => {
+  it('アイコン未定義の slug を fixture に注入すると findMissingIcons が検出する', () => {
+    const missing = findMissingIcons([{ slug: 'no-icon-fake-tool' }], iconSlugs);
+    expect(missing).toEqual(['no-icon-fake-tool']);
+  });
+
+  it('定義済み + 未定義の混在 fixture で未定義のみを列挙する (過検知なし)', () => {
+    const fakeTools = [
+      { slug: 'fake-a' },
+      { slug: 'url-encode' }, // 既存 (アイコン定義済み)
+      { slug: 'fake-b' },
+    ];
+    const missing = findMissingIcons(fakeTools, iconSlugs);
+    expect(missing.sort()).toEqual(['fake-a', 'fake-b']);
+  });
+
+  it('全アイコン定義済み fixture では何も検出しない (過検知なし)', () => {
+    const missing = findMissingIcons([{ slug: 'url-encode' }, { slug: 'qr-code' }], iconSlugs);
+    expect(missing).toEqual([]);
+  });
+});
+
+// 陽性対照: orphan 検知機構が空回りしていないことを保証。
+describe('[陽性対照] orphan 検知機構', () => {
+  it('tools.ts に無いアイコン slug を注入すると findOrphanIcons が検出する', () => {
+    const orphans = findOrphanIcons([{ slug: 'url-encode' }], ['url-encode', 'orphan-fake']);
+    expect(orphans).toEqual(['orphan-fake']);
+  });
+
+  it('全アイコンが tools.ts に対応する fixture では何も検出しない (過検知なし)', () => {
+    const orphans = findOrphanIcons(
+      [{ slug: 'url-encode' }, { slug: 'qr-code' }],
+      ['url-encode', 'qr-code']
+    );
+    expect(orphans).toEqual([]);
+  });
+});

--- a/tests/meta/tool-icon-coverage.test.ts
+++ b/tests/meta/tool-icon-coverage.test.ts
@@ -70,6 +70,26 @@ describe('ToolIcon orphan 検出', () => {
   });
 });
 
+// 同一 slug の `slug === '...'` ブロックが 2 つあると両 `&&` が truthy になり <svg> が
+// 二重描画される実バグだが、missing / orphan 検知は Set で重複を吸収するため見逃す。
+// 姉妹の vrt-pages-coverage.test.ts の「重複登録検出」と parity を取る (issue #498 レビュー提案)。
+describe('ToolIcon 重複定義検出', () => {
+  it('ToolIcon.astro に同一 slug のアイコン定義が重複していない', () => {
+    expect(new Set(iconSlugs).size).toBe(iconSlugs.length);
+  });
+});
+
+// 陽性対照: 重複検知機構が空回りしていないことを保証 (test-gates skill 準拠)。
+// 同一 slug を重複させた fixture を production の抽出経路 (extractIconSlugs) に通し、
+// 重複が array に残り Set サイズが配列長を下回ることを assert する。
+describe('[陽性対照] 重複検出機構', () => {
+  it('同一 slug を重複させた fixture では Set サイズが配列長より小さくなる', () => {
+    const dup = extractIconSlugs(`{ slug === 'dup-a' } { slug === 'dup-b' } { slug === 'dup-a' }`);
+    expect(dup).toEqual(['dup-a', 'dup-b', 'dup-a']);
+    expect(new Set(dup).size).toBeLessThan(dup.length);
+  });
+});
+
 // 陽性対照: 抽出器が空回りしていないことを保証 (test-gates skill 準拠)。
 // fixture 文字列を注入し、抽出が「常に空」「常に全部」ではなく実際に拾うことを証明する。
 describe('[陽性対照] extractIconSlugs 抽出機構', () => {


### PR DESCRIPTION
## 概要

`src/data/tools.ts` に登録したツールが `src/components/ui/ToolIcon.astro` にアイコン定義（`slug === '...'` の SVG ブロック）を持たない「付与漏れ」を `npm run test` で機械的に fail させる meta テストを追加します。`tests/meta/vrt-pages-coverage.test.ts`（#355）と同型の思想です。

Closes #496

## 背景

`ToolIcon` は該当 slug 不在時に fallback を持たないため、トップカード / サイドバー / ドロワー / ツールページヘッダで空白アイコンが無言で描画されます。実際に `sql-formatter` / `regex-visualizer` は #490〜#492 の追加時に付与が漏れ #494 で後追い修正しましたが、CI も VRT も regression として検知できませんでした。

## 実装

新規ファイル `tests/meta/tool-icon-coverage.test.ts`。

- **取得方法 (a)**: `ToolIcon.astro` のソースを `readFileSync` で読み `slug === '...'` を正規表現抽出。実レンダリング元（SVG ブロック）が唯一の真実源となりドリフトしません。`ToolIcon.astro` は無改修。
- **双方向検知**:
  - 付与漏れ検知: `tools.ts` の全 slug ⊆ アイコン集合
  - orphan 検知: アイコンはあるが `tools.ts` に無い slug
- **陽性対照（test-gates 準拠）**: 抽出器・付与漏れ検知・orphan 検知それぞれに、fixture を注入して「検知能力が空回りしていない」ことを証明する陽性対照を別 test として併設。「常に空 / 常に全部」では fail するよう設計。

## テスト

- [x] `npx vitest run tests/meta/tool-icon-coverage.test.ts` — 10 件 green
- [x] `npm run test` — 新規テスト含め green（`sw-cache-version.test.ts` の 2 件は `dist/sw.js` 未生成による既存の build 前提失敗で本 PR と無関係。CI は build 後に実行）
- [x] `node_modules/.bin/astro check` — 0 errors

https://claude.ai/code/session_01BtK9HSicTya23xcwqvVSuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtK9HSicTya23xcwqvVSuW)_