### PR TITLE
fix: ReDoS 攻撃文字列の表示を truncate しページ縦長化を解消 (#500)

### DIFF
--- a/src/components/tools/RegexVisualizer.tsx
+++ b/src/components/tools/RegexVisualizer.tsx
@@ -6,6 +6,9 @@ import { ClearButton } from '@/components/ui/ClearButton';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { useDebouncedTransform } from '@/hooks/useDebouncedTransform';
 import type { RegexAstNode, RedosResult, RailNode } from '@/utils/regex-visualizer';
+// 純粋関数のみの module を直接 import（barrel 経由だと recheck/regexp-tree の CJS が
+// SSR graph に載るため。barrel の SSR 注意書き参照）。
+import { truncateAttackString, ATTACK_STRING_DISPLAY_MAX } from '@/utils/regex-visualizer/format';
 import { RegexAstTree } from './RegexAstTree';
 import { RegexRailroad } from './RegexRailroad';
 import { RegexMatchTester } from './RegexMatchTester';
@@ -79,6 +82,8 @@ export function RegexVisualizer() {
   const ast = analysis.result?.ast ?? null;
   const redos = analysis.result?.redos ?? null;
   const rail = analysis.result?.rail ?? null;
+  // 攻撃文字列は pump で数千文字になりうるため表示用に truncate（全文はコピーで取得）。
+  const attack = redos?.attackString ? truncateAttackString(redos.attackString) : null;
 
   const toggleFlag = (f: string) =>
     setFlags((prev) => (prev.includes(f) ? prev.replace(f, '') : prev + f));
@@ -154,12 +159,21 @@ export function RegexVisualizer() {
             <p className="text-warning body-emphasis">
               ⚠ 脆弱：ReDoS のリスクがあります（{redos.complexity}）。
             </p>
-            {redos.attackString && (
-              <div className="flex items-center gap-2">
-                <code className="bg-subtle rounded px-2 py-1 font-mono break-all">
-                  {redos.attackString}
-                </code>
-                <CopyButton text={redos.attackString} label="攻撃文字列をコピー" />
+            {redos.attackString && attack && (
+              <div className="space-y-1">
+                <div className="flex items-start gap-2">
+                  <code className="bg-subtle rounded px-2 py-1 font-mono break-all">
+                    {attack.display}
+                    {attack.truncated && '…'}
+                  </code>
+                  <CopyButton text={redos.attackString} label="攻撃文字列をコピー" />
+                </div>
+                {attack.truncated && (
+                  <p className="caption text-subtle">
+                    全 {redos.attackString.length} 文字（先頭 {ATTACK_STRING_DISPLAY_MAX}{' '}
+                    文字を表示・全文はコピーで取得）
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/src/utils/regex-visualizer/__tests__/format.test.ts
+++ b/src/utils/regex-visualizer/__tests__/format.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { truncateAttackString, ATTACK_STRING_DISPLAY_MAX } from '../format';
+
+describe('truncateAttackString', () => {
+  // 陰性対照: 上限以下はそのまま返し truncated=false（短い指数時間の攻撃文字列など）
+  it('陰性対照: max 以下の文字列は truncate しない', () => {
+    const s = 'a'.repeat(ATTACK_STRING_DISPLAY_MAX);
+    const r = truncateAttackString(s);
+    expect(r.display).toBe(s);
+    expect(r.truncated).toBe(false);
+  });
+
+  // 陽性対照: 上限超（多項式時間の長大な pump 文字列）を必ず max 文字へ切り詰める。
+  // 旧実装（全長表示・truncate なし）に当てると display.length が一致せず fail する。
+  it('陽性対照: max 超の長大な文字列を max 文字へ truncate する', () => {
+    const s = '0'.repeat(2000);
+    const r = truncateAttackString(s);
+    expect(r.truncated).toBe(true);
+    expect(r.display.length).toBe(ATTACK_STRING_DISPLAY_MAX);
+    expect(r.display).toBe('0'.repeat(ATTACK_STRING_DISPLAY_MAX));
+  });
+
+  it('明示 max を指定すると境界で切り替わる', () => {
+    expect(truncateAttackString('abcde', 5)).toEqual({ display: 'abcde', truncated: false });
+    expect(truncateAttackString('abcdef', 5)).toEqual({ display: 'abcde', truncated: true });
+  });
+});

--- a/src/utils/regex-visualizer/__tests__/format.test.ts
+++ b/src/utils/regex-visualizer/__tests__/format.test.ts
@@ -24,4 +24,21 @@ describe('truncateAttackString', () => {
     expect(truncateAttackString('abcde', 5)).toEqual({ display: 'abcde', truncated: false });
     expect(truncateAttackString('abcdef', 5)).toEqual({ display: 'abcde', truncated: true });
   });
+
+  // 陽性対照: 切り出し位置が代理対を割る場合、孤立サロゲート（U+FFFD 表示）を残さない。
+  // '😀' は 2 コード単位（index 1=上位 / index 2=下位）。max=2 だと境界が😀の前半で割れる。
+  // 旧実装（無条件 slice(0, max)）に当てると display 末尾が上位サロゲート単独になり fail する。
+  it('陽性対照: 代理対を割る位置では孤立サロゲートを残さない', () => {
+    const r = truncateAttackString('a😀b', 2); // slice(0,2) は 'a' + 😀 の前半で割れる
+    expect(r.truncated).toBe(true);
+    expect(r.display).toBe('a'); // 割れる😀は丸ごと除外
+    // 末尾が孤立した上位サロゲートでないこと
+    const last = r.display.charCodeAt(r.display.length - 1);
+    expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+  });
+
+  it('代理対が境界内に収まる場合はそのまま含める', () => {
+    const r = truncateAttackString('😀b', 2); // '😀'(2) がちょうど max=2 に収まる
+    expect(r.display).toBe('😀');
+  });
 });

--- a/src/utils/regex-visualizer/format.ts
+++ b/src/utils/regex-visualizer/format.ts
@@ -15,5 +15,13 @@ export function truncateAttackString(
   max = ATTACK_STRING_DISPLAY_MAX
 ): { display: string; truncated: boolean } {
   if (s.length <= max) return { display: s, truncated: false };
-  return { display: s.slice(0, max), truncated: true };
+  // 切り出し位置（max-1）が代理対の前半（上位サロゲート）だと、相方が max 以降にあり
+  // 孤立サロゲート → U+FFFD 表示になる。その 1 コード単位だけ削って表示崩れを防ぐ
+  // （max は UTF-16 長の上限のまま維持。u フラグ + アストラル文字を含むパターン対策）。
+  const end = isHighSurrogate(s.charCodeAt(max - 1)) ? max - 1 : max;
+  return { display: s.slice(0, end), truncated: true };
+}
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
 }

--- a/src/utils/regex-visualizer/format.ts
+++ b/src/utils/regex-visualizer/format.ts
@@ -1,0 +1,19 @@
+// 攻撃文字列など表示用の整形ヘルパー（純粋関数のみ）。
+// recheck / regexp-tree（CJS）に依存しないため client component から静的 import しても
+// SSR module graph を汚さない（redos.ts / parse.ts を値 import すると CJS が SSR で評価され落ちる）。
+
+/** 攻撃文字列の表示上限文字数（pump 文字列は長大なため UI ではここで truncate する） */
+export const ATTACK_STRING_DISPLAY_MAX = 200;
+
+/**
+ * 攻撃文字列を表示用に truncate する。
+ * 多項式時間の脆弱性では pump 文字列が数千文字になりページが極端に縦長になるため、
+ * 先頭 max 文字のみ表示する。全文は呼び出し側がコピー用に元文字列を保持する。
+ */
+export function truncateAttackString(
+  s: string,
+  max = ATTACK_STRING_DISPLAY_MAX
+): { display: string; truncated: boolean } {
+  if (s.length <= max) return { display: s, truncated: false };
+  return { display: s.slice(0, max), truncated: true };
+}

--- a/src/utils/regex-visualizer/index.ts
+++ b/src/utils/regex-visualizer/index.ts
@@ -1,5 +1,6 @@
 export { parseRegex, type RegexAstNode } from './parse';
 export { analyzeRedos, type RedosResult, type RedosStatus } from './redos';
+export { truncateAttackString, ATTACK_STRING_DISPLAY_MAX } from './format';
 export { buildRailroad } from './railroad';
 export type { RailNode } from './railroad-layout';
 // 注意: この barrel は parse.ts / redos.ts（CJS の regexp-tree / recheck 依存）も re-export する。

--- a/tests/e2e/regex-visualizer.spec.ts
+++ b/tests/e2e/regex-visualizer.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { withProductionCsp } from './helpers';
+import { ATTACK_STRING_DISPLAY_MAX } from '../../src/utils/regex-visualizer/format';
 
 test.describe('正規表現ビジュアライザ', () => {
   test('フラグの凡例が表示される', async ({ browser }) => {
@@ -34,6 +35,27 @@ test.describe('正規表現ビジュアライザ', () => {
       await expect(
         page.getByRole('region', { name: 'ReDoS 判定' }).getByText(/脆弱：ReDoS/)
       ).toBeVisible();
+      await expect(page.getByRole('button', { name: '攻撃文字列をコピー' })).toBeVisible();
+    });
+  });
+
+  // issue #500 の回帰ガード（陽性対照）: 多項式時間で長大な pump 攻撃文字列を返すパターンで、
+  // 表示が ATTACK_STRING_DISPLAY_MAX 文字 + 省略記号へ truncate されること。
+  // truncate を外した旧実装では textContent が数千文字になりこの上限 assert が fail する。
+  test('長大な攻撃文字列は表示が truncate される（#500）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/regex-visualizer', async (page) => {
+      await page.getByLabel('正規表現').fill('(\\w+)@(\\w+)');
+      const region = page.getByRole('region', { name: 'ReDoS 判定' });
+      // 多項式時間で脆弱判定されるまで待つ
+      await expect(region.getByText(/脆弱：ReDoS/)).toBeVisible();
+      // 表示用 <code> の文字数が上限近傍（先頭 N 文字 + 省略記号「…」の 1 文字）に収まる
+      const code = region.locator('code');
+      await expect
+        .poll(async () => ((await code.textContent()) ?? '').length)
+        .toBeLessThanOrEqual(ATTACK_STRING_DISPLAY_MAX + 1);
+      // truncate 発生時の文字数キャプションが表示される
+      await expect(region.getByText(/全 \d+ 文字/)).toBeVisible();
+      // 全文取得用のコピーボタンは従来どおり存在する
       await expect(page.getByRole('button', { name: '攻撃文字列をコピー' })).toBeVisible();
     });
   });


### PR DESCRIPTION
## 概要

正規表現ビジュアライザ（`/tools/regex-visualizer`）の ReDoS 判定パネルが、多項式時間の脆弱性で recheck が返す**長大な pump 攻撃文字列を全長表示**していたため、`<code>` の `break-all` で何百行にも折り返され、ページ全体が ~23,000px に達していた問題（issue #500）を修正します。

Closes #500

## 変更内容

- 表示用の純粋関数 `truncateAttackString` を **CJS 非依存の `src/utils/regex-visualizer/format.ts`** に新設。
  - `redos.ts` は `recheck`（CJS）を静的 import するため、client component から値 import すると SSR module graph を汚す。barrel の SSR 注意書きに倣い、純粋関数は別 module に分離して直接 import。
- `RegexVisualizer.tsx` の vulnerable 表示部を **先頭 200 文字 + 省略記号「…」+ 全文字数キャプション**へ truncate。
  - 例: 「全 2001 文字（先頭 200 文字を表示・全文はコピーで取得）」
- **全文は従来どおりコピーボタンで取得可能**（`CopyButton` には元の全長文字列を渡す）。
- 指数時間の短い攻撃文字列は 200 文字以下のため truncate されず従来表示のまま。

## テスト（test-gates 準拠：陰性 + 陽性対照）

- ユニット `src/utils/regex-visualizer/__tests__/format.test.ts`
  - 陰性対照: max 以下は truncate しない
  - 陽性対照: max 超（`'0'.repeat(2000)`）を 200 文字へ truncate（旧実装＝全長表示に当てると fail）
- E2E `tests/e2e/regex-visualizer.spec.ts`（実 recheck・本番 CSP 下）
  - issue 再現パターン `(\w+)@(\w+)` で、判定 region 内 `<code>` の textContent 長が上限近傍（≤ 201）に収まることを assert（修正前は ~2000 文字で fail する陽性対照）
  - 「全 N 文字」キャプション表示とコピーボタン存在を確認

## 検証

- [x] `npm run test`（ユニット 14 passed）
- [x] `node_modules/.bin/astro check`（0 errors）
- [x] `npm run test:e2e`（regex-visualizer spec 13 passed・新規 #500 ガード含む）

## 補足

- 表示挙動のバグ修正でツール追加・ライブラリ変更はないため `README.md` / `SPEC.md` 更新は不要。
- VRT は既定ページ（入力空）のレンダリングが不変のため baseline 更新不要。


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETY8ENWTZqvGrxbj1e6UJU)_