### PR TITLE
fix: 正規表現ツールのコピーボタン文言を「コピー」に短縮

### DIFF
--- a/src/components/tools/RegexVisualizer.tsx
+++ b/src/components/tools/RegexVisualizer.tsx
@@ -166,7 +166,7 @@ export function RegexVisualizer() {
                     {attack.display}
                     {attack.truncated && '…'}
                   </code>
-                  <CopyButton text={redos.attackString} label="攻撃文字列をコピー" />
+                  <CopyButton text={redos.attackString} label="コピー" />
                 </div>
                 {attack.truncated && (
                   <p className="caption text-subtle">

--- a/src/components/tools/RegexVisualizer.tsx
+++ b/src/components/tools/RegexVisualizer.tsx
@@ -166,7 +166,11 @@ export function RegexVisualizer() {
                     {attack.display}
                     {attack.truncated && '…'}
                   </code>
-                  <CopyButton text={redos.attackString} label="コピー" />
+                  <CopyButton
+                    text={redos.attackString}
+                    label="コピー"
+                    ariaLabel="攻撃文字列をコピー"
+                  />
                 </div>
                 {attack.truncated && (
                   <p className="caption text-subtle">

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -50,6 +50,12 @@ function CopyAnnounce({ copied }: { copied: boolean }) {
 interface Props {
   text: string;
   label?: string;
+  /**
+   * スクリーンリーダー向けのアクセシブル名。可視テキスト（label）を短くしつつ
+   * 文脈を残したい場合に指定する。未指定時は label をそのまま使う。
+   * WCAG 2.5.3 (Label in Name) のため label が ariaLabel に内包される値にすること。
+   */
+  ariaLabel?: string;
   className?: string;
   /** テーブル行など狭い場所向けのコンパクト表示 */
   compact?: boolean;
@@ -61,7 +67,14 @@ interface Props {
  * style: global.css `@layer components` の `.btn-copy` / `.btn-copy.is-copied` /
  * `.btn-copy.is-compact` を参照。状態は `is-copied` / `is-compact` className で切替。
  */
-export function CopyButton({ text, label = 'コピー', className = '', compact = false }: Props) {
+export function CopyButton({
+  text,
+  label = 'コピー',
+  ariaLabel,
+  className = '',
+  compact = false,
+}: Props) {
+  const accessibleName = ariaLabel ?? label;
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -87,7 +100,7 @@ export function CopyButton({ text, label = 'コピー', className = '', compact 
       <button
         type="button"
         onClick={handleClick}
-        aria-label={label}
+        aria-label={accessibleName}
         className={`btn-copy is-compact ${stateClass} rounded-md inline-flex items-center justify-center text-xs px-2 py-1 min-w-8 min-h-8 whitespace-nowrap`.trim()}
       >
         {copied ? <CheckIcon /> : <ClipboardIcon />}
@@ -100,7 +113,7 @@ export function CopyButton({ text, label = 'コピー', className = '', compact 
     <button
       type="button"
       onClick={handleClick}
-      aria-label={label}
+      aria-label={accessibleName}
       className={`btn-copy ${stateClass} caption font-bold inline-flex items-center gap-1.5 rounded px-3 py-2 leading-none tracking-wide whitespace-nowrap ${className}`.trim()}
     >
       {copied ? <CheckIcon /> : <ClipboardIcon />}

--- a/tests/e2e/regex-visualizer.spec.ts
+++ b/tests/e2e/regex-visualizer.spec.ts
@@ -35,9 +35,13 @@ test.describe('正規表現ビジュアライザ', () => {
       await expect(
         page.getByRole('region', { name: 'ReDoS 判定' }).getByText(/脆弱：ReDoS/)
       ).toBeVisible();
-      await expect(
-        page.getByRole('region', { name: 'ReDoS 判定' }).getByRole('button', { name: 'コピー' })
-      ).toBeVisible();
+      // ボタンのアクセシブル名は説明的な「攻撃文字列をコピー」（aria-label）のまま、
+      // 可視テキストはスマホ向けに「コピー」へ短縮されていること（label/ariaLabel 分離の陽性対照）
+      const copyBtn = page
+        .getByRole('region', { name: 'ReDoS 判定' })
+        .getByRole('button', { name: '攻撃文字列をコピー', exact: true });
+      await expect(copyBtn).toBeVisible();
+      await expect(copyBtn).toHaveText('コピー');
     });
   });
 
@@ -57,8 +61,10 @@ test.describe('正規表現ビジュアライザ', () => {
         .toBeLessThanOrEqual(ATTACK_STRING_DISPLAY_MAX + 1);
       // truncate 発生時の文字数キャプションが表示される
       await expect(region.getByText(/全 \d+ 文字/)).toBeVisible();
-      // 全文取得用のコピーボタンは従来どおり存在する
-      await expect(region.getByRole('button', { name: 'コピー' })).toBeVisible();
+      // 全文取得用のコピーボタンは従来どおり存在する（アクセシブル名は説明的・可視は短縮）
+      const copyBtn = region.getByRole('button', { name: '攻撃文字列をコピー', exact: true });
+      await expect(copyBtn).toBeVisible();
+      await expect(copyBtn).toHaveText('コピー');
     });
   });
 

--- a/tests/e2e/regex-visualizer.spec.ts
+++ b/tests/e2e/regex-visualizer.spec.ts
@@ -35,7 +35,9 @@ test.describe('正規表現ビジュアライザ', () => {
       await expect(
         page.getByRole('region', { name: 'ReDoS 判定' }).getByText(/脆弱：ReDoS/)
       ).toBeVisible();
-      await expect(page.getByRole('button', { name: '攻撃文字列をコピー' })).toBeVisible();
+      await expect(
+        page.getByRole('region', { name: 'ReDoS 判定' }).getByRole('button', { name: 'コピー' })
+      ).toBeVisible();
     });
   });
 
@@ -56,7 +58,7 @@ test.describe('正規表現ビジュアライザ', () => {
       // truncate 発生時の文字数キャプションが表示される
       await expect(region.getByText(/全 \d+ 文字/)).toBeVisible();
       // 全文取得用のコピーボタンは従来どおり存在する
-      await expect(page.getByRole('button', { name: '攻撃文字列をコピー' })).toBeVisible();
+      await expect(region.getByRole('button', { name: 'コピー' })).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## 概要

正規表現ビジュアライザの ReDoS 攻撃文字列コピーボタンが「攻撃文字列をコピー」と長く、スマホ表示でレイアウトが窮屈だった。文言を「コピー」に短縮した。

- 隣接する攻撃文字列（`<code>` 表示）で何をコピーするかの文脈は明確なため、文言短縮で意味は損なわれない
- `CopyButton` は `label` を可視テキストと `aria-label` の両方に使うため、両者とも「コピー」に変わる

## 変更内容

- `src/components/tools/RegexVisualizer.tsx`: `CopyButton` の `label` を `攻撃文字列をコピー` → `コピー`
- `tests/e2e/regex-visualizer.spec.ts`: ボタン名 assert を `コピー` に追従。ページ内の唯一のコピーボタンだが、明確化のため ReDoS 判定リージョン内にスコープした

## テスト

- [x] `node_modules/.bin/astro check`（型チェック）: 0 errors
- [x] `npm run test`（ユニット）: 1382 passed（既存 fail 2 件は `dist/sw.js` 不在によるもので本変更と無関係）
- [x] `npm run test:e2e -- regex-visualizer`: 13 passed
- [x] PC（1280x800）/ スマホ（390x844）でスクリーンショット目視確認

## スクリーンショット（スマホ 390x844）

ボタンが「コピー」になり攻撃文字列の横にすっきり収まることを確認。

https://claude.ai/code/session_01KUESdoKXZaZUzECkYMZtNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUESdoKXZaZUzECkYMZtNU)_