### PR TITLE
refactor: json-formatter の結果パネルを mode 別コンポーネントに切り出し (#515)

### DIFF
--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -3,14 +3,13 @@ import { InputField } from '@/components/ui/InputField';
 import { OutputField } from '@/components/ui/OutputField';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { ClearButton } from '@/components/ui/ClearButton';
-import { CopyButton } from '@/components/ui/CopyButton';
 import { DownloadButton } from '@/components/ui/DownloadButton';
-import { JsonTreeView } from '@/components/tools/JsonTreeView';
+import { JsonMaskResult } from '@/components/tools/JsonMaskResult';
+import { JsonTreeResult } from '@/components/tools/JsonTreeResult';
 import {
   processJson,
   runQuery,
   maskValue,
-  MASK_CATEGORIES,
   generateTypeScript,
   type IndentStyle,
   type TreeNode,
@@ -40,15 +39,6 @@ const SAMPLE = `{
   "location": { "lat": 35.6586, "lng": 139.7454 },
   "renovated": null
 }`;
-
-const CATEGORY_LABEL: Record<MaskCategory, string> = {
-  SECRET: 'キー名',
-  EMAIL: 'メール',
-  JWT: 'JWT',
-  IP: 'IP',
-  CREDIT_CARD: 'カード番号',
-  PHONE_JP: '電話番号',
-};
 
 const ALL_CATEGORIES_ON: Record<MaskCategory, boolean> = {
   SECRET: true,
@@ -292,45 +282,13 @@ export function JsonFormatter() {
 
         <div className="w-full md:flex-1 min-w-0">
           {view === 'mask' ? (
-            <div className="w-full">
-              {/* マスク対象の種別トグル */}
-              <fieldset className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1">
-                <legend className="caption text-muted">マスク対象</legend>
-                {MASK_CATEGORIES.map((cat) => (
-                  <label key={cat} className="caption inline-flex items-center gap-1">
-                    <input
-                      type="checkbox"
-                      className="accent-link"
-                      checked={maskEnabled[cat]}
-                      onChange={() => toggleCategory(cat)}
-                    />
-                    {CATEGORY_LABEL[cat]}
-                  </label>
-                ))}
-              </fieldset>
-
-              {/* 検出内訳バッジ */}
-              {maskEval && (
-                <p className="caption text-muted mb-2" role="status" aria-live="polite">
-                  {MASK_CATEGORIES.filter((c) => maskEval.counts[c] > 0).length === 0
-                    ? '検出された機密データはありません。'
-                    : '検出: ' +
-                      MASK_CATEGORIES.filter((c) => maskEval.counts[c] > 0)
-                        .map((c) => `${CATEGORY_LABEL[c]} ${maskEval.counts[c]}`)
-                        .join(' ・ ')}
-                </p>
-              )}
-
-              {/* 出力は共通 OutputField を再利用（aria-live ラップ・コピー内蔵）。CLAUDE.md §5 */}
-              <OutputField
-                id="json-formatter-mask-output"
-                label="結果（マスク済み）"
-                value={effectiveOutput}
-                rows={16}
-                ariaLabel="マスク済み結果"
-                rightSlot={downloadButton}
-              />
-            </div>
+            <JsonMaskResult
+              output={effectiveOutput}
+              counts={maskEval?.counts ?? null}
+              enabled={maskEnabled}
+              onToggle={toggleCategory}
+              rightSlot={downloadButton}
+            />
           ) : view === 'type' ? (
             <OutputField
               id="json-formatter-type-output"
@@ -350,26 +308,13 @@ export function JsonFormatter() {
               rightSlot={downloadButton}
             />
           ) : (
-            <div className="w-full">
-              <div className="flex items-center justify-between mb-3 min-h-8 gap-2">
-                <span className="body-emphasis text-default">結果</span>
-                {hasResult && (
-                  <div className="flex items-center gap-2">
-                    {downloadButton}
-                    <CopyButton text={displayOutput} ariaLabel="整形結果をコピー" />
-                  </div>
-                )}
-              </div>
-              <div className="json-tree-box rounded-lg border border-default bg-subtle px-3 py-2">
-                {displayTree ? (
-                  <JsonTreeView key={treeKey} node={displayTree} defaultOpen={treeOpen} />
-                ) : (
-                  <p className="caption text-muted">
-                    有効な JSON を入力するとツリーが表示されます。
-                  </p>
-                )}
-              </div>
-            </div>
+            <JsonTreeResult
+              tree={displayTree}
+              output={displayOutput}
+              treeKey={treeKey}
+              defaultOpen={treeOpen}
+              rightSlot={downloadButton}
+            />
           )}
         </div>
       </div>

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -308,9 +308,11 @@ export function JsonFormatter() {
               rightSlot={downloadButton}
             />
           ) : (
+            // tree モードでは effectiveOutput === displayOutput。両結果パネルに
+            // 一貫して effectiveOutput を渡し、prop の取り違えを防ぐ（レビュー #517）。
             <JsonTreeResult
               tree={displayTree}
-              output={displayOutput}
+              output={effectiveOutput}
               treeKey={treeKey}
               defaultOpen={treeOpen}
               rightSlot={downloadButton}

--- a/src/components/tools/JsonMaskResult.tsx
+++ b/src/components/tools/JsonMaskResult.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from 'react';
+import { OutputField } from '@/components/ui/OutputField';
+import { MASK_CATEGORIES, type MaskCategory } from '@/utils/json-formatter';
+
+const CATEGORY_LABEL: Record<MaskCategory, string> = {
+  SECRET: 'キー名',
+  EMAIL: 'メール',
+  JWT: 'JWT',
+  IP: 'IP',
+  CREDIT_CARD: 'カード番号',
+  PHONE_JP: '電話番号',
+};
+
+interface Props {
+  /** マスク済み JSON 文字列 */
+  output: string;
+  /** 種別別の検出件数。未評価（入力空/不正）のときは null。 */
+  counts: Record<MaskCategory, number> | null;
+  /** 種別ごとのオン/オフ状態 */
+  enabled: Record<MaskCategory, boolean>;
+  /** 種別トグルのハンドラ */
+  onToggle: (cat: MaskCategory) => void;
+  /** ラベル右に並べる要素（ダウンロードボタン） */
+  rightSlot: ReactNode;
+}
+
+/**
+ * マスクモードの結果パネル。種別トグル＋検出内訳バッジ＋共通 OutputField を描画する。
+ * 出力は共通 OutputField を再利用（aria-live ラップ・コピー内蔵）。CLAUDE.md §5。
+ */
+export function JsonMaskResult({ output, counts, enabled, onToggle, rightSlot }: Props) {
+  const detected = counts ? MASK_CATEGORIES.filter((c) => counts[c] > 0) : [];
+  return (
+    <div className="w-full">
+      {/* マスク対象の種別トグル */}
+      <fieldset className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1">
+        <legend className="caption text-muted">マスク対象</legend>
+        {MASK_CATEGORIES.map((cat) => (
+          <label key={cat} className="caption inline-flex items-center gap-1">
+            <input
+              type="checkbox"
+              className="accent-link"
+              checked={enabled[cat]}
+              onChange={() => onToggle(cat)}
+            />
+            {CATEGORY_LABEL[cat]}
+          </label>
+        ))}
+      </fieldset>
+
+      {/* 検出内訳バッジ */}
+      {counts && (
+        <p className="caption text-muted mb-2" role="status" aria-live="polite">
+          {detected.length === 0
+            ? '検出された機密データはありません。'
+            : '検出: ' + detected.map((c) => `${CATEGORY_LABEL[c]} ${counts[c]}`).join(' ・ ')}
+        </p>
+      )}
+
+      <OutputField
+        id="json-formatter-mask-output"
+        label="結果（マスク済み）"
+        value={output}
+        rows={16}
+        ariaLabel="マスク済み結果"
+        rightSlot={rightSlot}
+      />
+    </div>
+  );
+}

--- a/src/components/tools/JsonMaskResult.tsx
+++ b/src/components/tools/JsonMaskResult.tsx
@@ -12,7 +12,7 @@ const CATEGORY_LABEL: Record<MaskCategory, string> = {
 };
 
 interface Props {
-  /** マスク済み JSON 文字列 */
+  /** このモードの実効出力（マスク済み JSON 文字列）。 */
   output: string;
   /** 種別別の検出件数。未評価（入力空/不正）のときは null。 */
   counts: Record<MaskCategory, number> | null;

--- a/src/components/tools/JsonTreeResult.tsx
+++ b/src/components/tools/JsonTreeResult.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { JsonTreeView } from '@/components/tools/JsonTreeView';
+import type { TreeNode } from '@/utils/json-formatter';
+
+interface Props {
+  /** 表示するツリー。null のときは案内文を出す。 */
+  tree: TreeNode | null;
+  /** コピー対象の整形テキスト（ヘッダのコピーボタン用）。 */
+  output: string;
+  /** key を変えて全行の開閉状態をリセットするための再マウントキー。 */
+  treeKey: number;
+  /** 各行の初期開閉状態（全展開/全折りたたみ）。 */
+  defaultOpen: boolean;
+  /** ラベル右に並べる要素（ダウンロードボタン）。 */
+  rightSlot: ReactNode;
+}
+
+/**
+ * ツリーモードの結果パネル。ヘッダ（ラベル＋DL＋コピー）＋折りたたみツリーを描画する。
+ */
+export function JsonTreeResult({ tree, output, treeKey, defaultOpen, rightSlot }: Props) {
+  const hasResult = output !== '';
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between mb-3 min-h-8 gap-2">
+        <span className="body-emphasis text-default">結果</span>
+        {hasResult && (
+          <div className="flex items-center gap-2">
+            {rightSlot}
+            <CopyButton text={output} ariaLabel="整形結果をコピー" />
+          </div>
+        )}
+      </div>
+      <div className="json-tree-box rounded-lg border border-default bg-subtle px-3 py-2">
+        {tree ? (
+          <JsonTreeView key={treeKey} node={tree} defaultOpen={defaultOpen} />
+        ) : (
+          <p className="caption text-muted">有効な JSON を入力するとツリーが表示されます。</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/tools/JsonTreeResult.tsx
+++ b/src/components/tools/JsonTreeResult.tsx
@@ -6,7 +6,7 @@ import type { TreeNode } from '@/utils/json-formatter';
 interface Props {
   /** 表示するツリー。null のときは案内文を出す。 */
   tree: TreeNode | null;
-  /** コピー対象の整形テキスト（ヘッダのコピーボタン用）。 */
+  /** このモードの実効出力（整形テキスト）。コピー対象・結果有無判定に使う。 */
   output: string;
   /** key を変えて全行の開閉状態をリセットするための再マウントキー。 */
   treeKey: number;


### PR DESCRIPTION
## 概要

issue #515 の対応。PR4（型生成）で 4 モード（text/tree/mask/type）＋クエリ＋マスク種別トグルが同居して肥大化した `JsonFormatter.tsx`（383 行）の **結果カラムを mode 別コンポーネントに切り出す pure refactor**（挙動不変）。

## 変更

- **`JsonMaskResult.tsx`（新規）**: マスクモードの結果パネル（種別トグル＋検出内訳バッジ＋共通 OutputField）。`CATEGORY_LABEL` 定数を mask 側へ移動。
- **`JsonTreeResult.tsx`（新規）**: ツリーモードの結果パネル（ヘッダ＋コピー＋折りたたみツリー、既存 `JsonTreeView` をラップ）。
- **`JsonFormatter.tsx`**: 4 分岐ネスト三項を `mode → コンポーネント` の単純分岐に整理。text/type は `OutputField` 一行のため inline 維持。eval orchestration（query/mask/type の useMemo）は component の責務として本体に残す。
- 383 → 328 行（-55）。`CopyButton` / `JsonTreeView` / `MASK_CATEGORIES` の import は抽出先へ移動。

## スコープ外（据え置き）

- eval ロジックの hook 化は、相互依存（`baseValue ← queryEval`）の orchestration を本体に残す方が自然と判断し見送り（issue #515 でも「検討」扱い）。

## テスト（挙動不変の担保）

- 挙動不変の pure refactor。JSX は新コンポーネントへ**逐語移設**（DOM 構造は同一）。
- E2E（production CSP）15 件 = text/tree/mask/type 全モード＋クエリ＋マスク＋型を被覆 → 全 pass。
- 単体 1614 passed / `astro check` 0 errors。
- VRT は DOM 不変のため baseline 影響なし想定（既定表示はテキスト）。

## Test plan

- [x] `astro check`: 0 errors
- [x] `npm run test`: 1614 passed
- [x] `npm run test:e2e`（json-formatter）: 15 passed
- [ ] VRT（DOM 不変のため pass 想定。CI 判定）

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)
