### PR TITLE
fix: json-formatter マスクモードの上端整列とサンプル改善

### DIFF
--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -37,6 +37,7 @@ const SAMPLE = `{
   "id": 1234567890123456789,
   "tags": ["観光", "電波塔"],
   "location": { "lat": 35.6586, "lng": 139.7454 },
+  "contact": { "email": "info@tokyo-tower.jp", "tel": "03-3433-5111" },
   "renovated": null
 }`;
 

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -4,7 +4,7 @@ import { OutputField } from '@/components/ui/OutputField';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { DownloadButton } from '@/components/ui/DownloadButton';
-import { JsonMaskResult } from '@/components/tools/JsonMaskResult';
+import { JsonMaskControls } from '@/components/tools/JsonMaskControls';
 import { JsonTreeResult } from '@/components/tools/JsonTreeResult';
 import {
   processJson,
@@ -262,6 +262,16 @@ export function JsonFormatter() {
         mono
       />
 
+      {/* マスク操作部（全幅）。結果カラム内に置くと入力欄と上端がずれるため、
+          入力/結果行の上に出して両カラムの textarea 上端を揃える。 */}
+      {view === 'mask' && (
+        <JsonMaskControls
+          counts={maskEval?.counts ?? null}
+          enabled={maskEnabled}
+          onToggle={toggleCategory}
+        />
+      )}
+
       {/* 入力・結果（PC 横並び・モバイル縦並び） */}
       <div className="flex flex-col md:flex-row gap-4 items-start">
         <div className="w-full md:flex-1 min-w-0">
@@ -282,11 +292,12 @@ export function JsonFormatter() {
 
         <div className="w-full md:flex-1 min-w-0">
           {view === 'mask' ? (
-            <JsonMaskResult
-              output={effectiveOutput}
-              counts={maskEval?.counts ?? null}
-              enabled={maskEnabled}
-              onToggle={toggleCategory}
+            <OutputField
+              id="json-formatter-mask-output"
+              label="結果（マスク済み）"
+              value={effectiveOutput}
+              rows={18}
+              ariaLabel="マスク済み結果"
               rightSlot={downloadButton}
             />
           ) : view === 'type' ? (

--- a/src/components/tools/JsonMaskControls.tsx
+++ b/src/components/tools/JsonMaskControls.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react';
-import { OutputField } from '@/components/ui/OutputField';
 import { MASK_CATEGORIES, type MaskCategory } from '@/utils/json-formatter';
 
 const CATEGORY_LABEL: Record<MaskCategory, string> = {
@@ -12,28 +10,24 @@ const CATEGORY_LABEL: Record<MaskCategory, string> = {
 };
 
 interface Props {
-  /** このモードの実効出力（マスク済み JSON 文字列）。 */
-  output: string;
   /** 種別別の検出件数。未評価（入力空/不正）のときは null。 */
   counts: Record<MaskCategory, number> | null;
   /** 種別ごとのオン/オフ状態 */
   enabled: Record<MaskCategory, boolean>;
   /** 種別トグルのハンドラ */
   onToggle: (cat: MaskCategory) => void;
-  /** ラベル右に並べる要素（ダウンロードボタン） */
-  rightSlot: ReactNode;
 }
 
 /**
- * マスクモードの結果パネル。種別トグル＋検出内訳バッジ＋共通 OutputField を描画する。
- * 出力は共通 OutputField を再利用（aria-live ラップ・コピー内蔵）。CLAUDE.md §5。
+ * マスクモードの操作部（種別トグル＋検出内訳バッジ）。
+ * 入力・結果の上端を揃えるため、結果カラム内ではなく入力/結果行の上に全幅で配置する。
  */
-export function JsonMaskResult({ output, counts, enabled, onToggle, rightSlot }: Props) {
+export function JsonMaskControls({ counts, enabled, onToggle }: Props) {
   const detected = counts ? MASK_CATEGORIES.filter((c) => counts[c] > 0) : [];
   return (
-    <div className="w-full">
+    <div>
       {/* マスク対象の種別トグル */}
-      <fieldset className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1">
+      <fieldset className="flex flex-wrap items-center gap-x-4 gap-y-1">
         <legend className="caption text-muted">マスク対象</legend>
         {MASK_CATEGORIES.map((cat) => (
           <label key={cat} className="caption inline-flex items-center gap-1">
@@ -50,21 +44,12 @@ export function JsonMaskResult({ output, counts, enabled, onToggle, rightSlot }:
 
       {/* 検出内訳バッジ */}
       {counts && (
-        <p className="caption text-muted mb-2" role="status" aria-live="polite">
+        <p className="caption text-muted mt-1" role="status" aria-live="polite">
           {detected.length === 0
             ? '検出された機密データはありません。'
             : '検出: ' + detected.map((c) => `${CATEGORY_LABEL[c]} ${counts[c]}`).join(' ・ ')}
         </p>
       )}
-
-      <OutputField
-        id="json-formatter-mask-output"
-        label="結果（マスク済み）"
-        value={output}
-        rows={16}
-        ariaLabel="マスク済み結果"
-        rightSlot={rightSlot}
-      />
     </div>
   );
 }

--- a/tests/e2e/json-formatter.spec.ts
+++ b/tests/e2e/json-formatter.spec.ts
@@ -153,6 +153,22 @@ test.describe('JSON整形・ビューア（production CSP 適用）', () => {
     });
   });
 
+  // サンプルはマスクの意義が伝わるよう、検出対象を含む必要がある（役目の回帰ガード）。
+  test('マスク: サンプルは検出対象を含む（メール・電話番号）（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/json-formatter', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await page.getByRole('button', { name: 'マスク' }).click();
+
+      const out = page.getByRole('textbox', { name: 'マスク済み結果' });
+      await expect(out).toHaveValue(/\[REDACTED:EMAIL\]/);
+      await expect(out).toHaveValue(/\[REDACTED:PHONE_JP\]/);
+      await expect(out).not.toHaveValue(/info@tokyo-tower\.jp/);
+      await expect(page.getByText(/検出:/)).toBeVisible();
+    });
+  });
+
   test('型生成: サンプルから TypeScript interface を生成する（CSP 違反なし）', async ({
     browser,
   }) => {

--- a/tests/e2e/json-formatter.spec.ts
+++ b/tests/e2e/json-formatter.spec.ts
@@ -169,6 +169,22 @@ test.describe('JSON整形・ビューア（production CSP 適用）', () => {
     });
   });
 
+  // PC（md:flex-row）でマスクモードの入力欄と結果欄の textarea 上端が揃うことの回帰ガード。
+  // 操作部が結果カラム内に積まれると上端がずれる（本 PR で修正した不具合）。
+  test('マスク: PC で入力と結果の textarea 上端が揃う（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/json-formatter', async (page) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await page.getByRole('button', { name: 'マスク' }).click();
+
+      const inputBox = await page.getByLabel('入力').boundingBox();
+      const resultBox = await page.getByRole('textbox', { name: 'マスク済み結果' }).boundingBox();
+      expect(inputBox).not.toBeNull();
+      expect(resultBox).not.toBeNull();
+      expect(Math.abs(inputBox!.y - resultBox!.y)).toBeLessThan(2);
+    });
+  });
+
   test('型生成: サンプルから TypeScript interface を生成する（CSP 違反なし）', async ({
     browser,
   }) => {


### PR DESCRIPTION
## 概要

json-formatter のマスクモードに関する 2 つの UI 改善（いずれも実機目視・E2E 確認済み）。

## 1. マスクモードの入力/結果の上端ずれを修正

PC でマスクモードを開くと、結果カラム内に「マスク対象トグル＋検出バッジ」が積まれ、その分だけ **結果 textarea が入力 textarea より下にずれていた**（text/tree/型 はヘッダ 1 行なので揃っていた）。

- マスク操作部を結果カラム内から **全幅の独立行（入力/結果行の上、クエリ欄と同方式）** へ移動。
- 結果カラムは text/型 と同じ素の `OutputField` になり、入力欄と上端が揃う。出力 `rows` を 16→18 で入力と統一。
- `JsonMaskResult.tsx` を `JsonMaskControls.tsx`（トグル＋バッジのみ）に再編。挙動不変。

## 2. サンプル JSON にマスク対象を追加

サンプルに機密データが一切無く、マスク機能の役目を果たしていなかった。東京タワーの連絡先として `"contact": { "email": "info@tokyo-tower.jp", "tel": "03-3433-5111" }` を追加し、マスクモードで **メール 1・電話番号 1** が検出されるようにした。

- サンプルが検出対象を含むことを E2E で回帰ガード（将来サンプルから機密を消すと fail）。

## テスト

- `astro check`: 0 errors
- `npm run test`: 1614 passed
- E2E（production CSP）: json-formatter 16 passed（新規「サンプルは検出対象を含む」含む、CSP 違反なし）
- 実機目視: PC(1280×800)・スマホ(390×844) でマスクモードの上端整列・検出バッジ・伏字化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
