### PR TITLE
fix: タッチ端末でツリーの行コピーを常時表示 (#508)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -994,6 +994,14 @@
     opacity: 1;
     pointer-events: auto;
   }
+  /* タッチ端末（hover 不可）では hover/focus で出せないため常時表示する（issue #508）。
+     絶対配置のため行高さは増えない。デスクトップは従来どおり hover 表示。 */
+  @media (hover: none) {
+    .json-row-actions {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
 }
 
 /* 前庭障害ユーザー向けに transition / animation を抑止する。

--- a/tests/e2e/json-formatter.spec.ts
+++ b/tests/e2e/json-formatter.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, devices } from '@playwright/test';
-import { withProductionCsp } from './helpers';
+import { withProductionCsp, waitForReactHydration } from './helpers';
 
 test.describe('JSON整形・ビューア（production CSP 適用）', () => {
   test('サンプルを整形し、大きな整数の精度を保持する（CSP 違反なし）', async ({ browser }) => {
@@ -239,6 +239,7 @@ test.describe('JSON整形・ビューア（production CSP 適用）', () => {
     try {
       const page = await context.newPage();
       await page.goto('/tools/json-formatter');
+      await waitForReactHydration(page); // hydration 前のクリックは no-op になるため待つ
       // hover:none が効いていることを前提確認（emulation 健全性）
       expect(await page.evaluate(() => matchMedia('(hover: none)').matches)).toBe(true);
 
@@ -246,12 +247,16 @@ test.describe('JSON整形・ビューア（production CSP 適用）', () => {
       await page.getByRole('button', { name: 'ツリー' }).click();
       await expect(page.getByRole('group', { name: 'JSON ツリー' })).toBeVisible();
 
-      // hover していない状態でも行アクションが可視（opacity:1）
-      const opacity = await page
+      // hover していない状態でも行アクションが可視（opacity:1）かつタップ可能（pointer-events:auto）
+      const style = await page
         .locator('.json-row-actions')
         .first()
-        .evaluate((el) => getComputedStyle(el).opacity);
-      expect(opacity).toBe('1');
+        .evaluate((el) => {
+          const s = getComputedStyle(el);
+          return { opacity: s.opacity, pointerEvents: s.pointerEvents };
+        });
+      expect(style.opacity).toBe('1');
+      expect(style.pointerEvents).toBe('auto');
     } finally {
       await context.close();
     }

--- a/tests/e2e/json-formatter.spec.ts
+++ b/tests/e2e/json-formatter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, devices } from '@playwright/test';
 import { withProductionCsp } from './helpers';
 
 test.describe('JSON整形・ビューア（production CSP 適用）', () => {
@@ -226,5 +226,34 @@ test.describe('JSON整形・ビューア（production CSP 適用）', () => {
       const download = await downloadPromise;
       expect(download.suggestedFilename()).toBe('types.ts');
     });
+  });
+
+  // タッチ端末（hover 不可）ではツリー行のコピーアクションが hover で出せないため、
+  // @media (hover: none) で常時表示する（issue #508）。モバイル端末を emulate して
+  // .json-row-actions の opacity が 1 であることを確認する。旧 CSS（hover/focus のみ）
+  // では opacity 0 のままで fail する回帰ガード。CSP 非依存のため独自 context で検証。
+  test('ツリー: タッチ端末では行コピーアクションが常時表示される（issue #508）', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ ...devices['Pixel 5'] });
+    try {
+      const page = await context.newPage();
+      await page.goto('/tools/json-formatter');
+      // hover:none が効いていることを前提確認（emulation 健全性）
+      expect(await page.evaluate(() => matchMedia('(hover: none)').matches)).toBe(true);
+
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await page.getByRole('button', { name: 'ツリー' }).click();
+      await expect(page.getByRole('group', { name: 'JSON ツリー' })).toBeVisible();
+
+      // hover していない状態でも行アクションが可視（opacity:1）
+      const opacity = await page
+        .locator('.json-row-actions')
+        .first()
+        .evaluate((el) => getComputedStyle(el).opacity);
+      expect(opacity).toBe('1');
+    } finally {
+      await context.close();
+    }
   });
 });


### PR DESCRIPTION
## 概要

issue #508 の対応。json-formatter のツリービュー各行のパス/値コピーボタン（`.json-row-actions`）は `hover` / `focus-within` でのみ表示される設計で、ホバーの無い**タッチ端末では起動できなかった**。

## 変更

- `src/styles/global.css` に `@media (hover: none)` を追加し、タッチ端末では行コピーアクションを**常時表示**する。
  - 絶対配置のため行の高さは増えない（視覚ノイズのみ）。
  - デスクトップ（hover 可）は従来どおり hover/focus 表示のまま。
- 全体コピー（結果ヘッダ）は従来どおり利用可能。

## 方針

issue の 2 案（タップ toggle / `hover:none` 常時表示）のうち、**純 CSS・JS 不要・行高不変・開閉トグルとのタップ競合なし**の `hover:none` 常時表示を採用。

## テスト

- 回帰 E2E を追加: モバイル端末を emulate（`devices['Pixel 5']` → `(hover: none)` が true）し、ホバー無しで `.json-row-actions` の `opacity` が `1` であることを assert。**旧 CSS（hover/focus のみ）では opacity 0 のままで fail する**回帰ガード。
- `astro check`: 0 errors
- E2E（json-formatter）: 18 passed（新規タッチテスト含む、CSP 違反なし）
- 本番ビルドで `@media (hover:none){.json-row-actions{opacity:1;...}}` が生成されることを確認済み（§7.1）。

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
