### PR TITLE
fix: InputField で error と hint を併存表示 (#510)

### DIFF
--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -101,13 +101,14 @@ export function InputField({
         />
       )}
 
-      {error ? (
-        <ErrorMessage id={errorId} message={error} />
-      ) : hint ? (
+      {/* error と hint は併存表示する（error 時に hint=構文ヒント等が消えないように）。
+         error を上、hint をその下に薄く出す。aria-describedby は両 id を参照（#510）。 */}
+      {error && <ErrorMessage id={errorId} message={error} />}
+      {hint && (
         <p id={hintId} className="caption text-muted mt-1">
           {hint}
         </p>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/src/components/ui/__tests__/InputField.test.tsx
+++ b/src/components/ui/__tests__/InputField.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { InputField } from '@/components/ui/InputField';
+
+afterEach(() => {
+  cleanup();
+});
+
+const noop = () => {};
+
+describe('InputField error/hint 表示契約 (#510)', () => {
+  it('error と hint が同時指定なら両方描画する（併存）', () => {
+    render(
+      <InputField
+        id="f"
+        label="ラベル"
+        value="x"
+        onChange={noop}
+        error="不正です"
+        hint="ヒント文"
+      />
+    );
+    // 旧実装（排他）では error 時に hint が描画されず、この行で fail する（陽性対照）。
+    expect(screen.getByText('ヒント文')).toBeTruthy();
+    expect(screen.getByRole('alert').textContent).toContain('不正です');
+  });
+
+  it('error の id が aria-describedby に含まれ、その要素が実在する（dangling 参照なし）', () => {
+    render(
+      <InputField
+        id="f"
+        label="ラベル"
+        value="x"
+        onChange={noop}
+        error="不正です"
+        hint="ヒント文"
+      />
+    );
+    const input = screen.getByLabelText('ラベル');
+    const ids = (input.getAttribute('aria-describedby') ?? '').split(' ').filter(Boolean);
+    expect(ids).toContain('f-error');
+    expect(ids).toContain('f-hint');
+    for (const id of ids) {
+      expect(document.getElementById(id)).not.toBeNull();
+    }
+  });
+
+  it('hint のみ指定なら hint だけ・error なし', () => {
+    render(<InputField id="f" label="ラベル" value="x" onChange={noop} hint="ヒント文" />);
+    expect(screen.getByText('ヒント文')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('error のみ指定なら error だけ表示する', () => {
+    render(<InputField id="f" label="ラベル" value="x" onChange={noop} error="不正です" />);
+    expect(screen.getByRole('alert').textContent).toContain('不正です');
+  });
+});

--- a/tests/e2e/json-formatter.spec.ts
+++ b/tests/e2e/json-formatter.spec.ts
@@ -97,6 +97,10 @@ test.describe('JSON整形・ビューア（production CSP 適用）', () => {
       await page.getByLabel('入力').fill('{"a":1}');
       await page.getByLabel('クエリ (JMESPath)').fill('items[?(');
       await expect(page.getByRole('alert')).toContainText('クエリ式が不正です');
+      // #510: クエリ式エラー表示中も構文ヒントが消えず併存する
+      await expect(
+        page.getByText('JMESPath 構文（フィルタ・射影対応）', { exact: false })
+      ).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## 概要

issue #510 の対応。共通コンポーネント `InputField` は `error` と `hint` を**排他表示**していたため、json-formatter のクエリ欄でクエリ式が不正なとき（error 表示中）に JMESPath 構文ヒントが消えていた（最も要るタイミングで消える）。

## 変更

- `src/components/ui/InputField.tsx`: error と hint を**併存表示**（error を上、hint をその下に薄く）。
- `aria-describedby` は元から両 id を参照していたため a11y が整合（error 時に hintId 要素が DOM に無い既存の不整合も解消）。

## 影響範囲

`InputField` は全ツール共通。ただし変更が顕在化するのは **error と hint が同時に存在するときのみ**で、これはユーザー操作中の一時状態。各ツールの既定（空入力）表示は error が出ないため不変 → VRT baseline への影響なし想定。

## テスト

- json-formatter のクエリ式エラー時に構文ヒントが残ることを E2E で回帰ガード（旧排他表示では hint が非表示で fail）。
- `astro check`: 0 errors
- `npm run test`（単体）: 1614 passed
- **E2E 全ツール: 269 passed / 1 skipped**（共通コンポーネント変更のため全 spec 実行、回帰なし）

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
