### PR TITLE
test: tools.md ↔ tools.ts カバレッジ検証 meta テストを追加（issue #524）

### DIFF
--- a/tests/meta/tools-docs-coverage.test.ts
+++ b/tests/meta/tools-docs-coverage.test.ts
@@ -33,6 +33,18 @@ function findOrphanHeadings(toolList: { name: string }[], headings: Set<string>)
   return [...headings].filter((h) => !toolNames.has(h));
 }
 
+/** docs/tools.md 内で複数回出現する ### 見出しを返す（Set 重複除去をすり抜けるバグ検出用）*/
+function findDuplicateH3Headings(content: string): string[] {
+  const all = [...content.matchAll(/^### (.+)$/gm)].map((m) => m[1].trim());
+  const seen = new Set<string>();
+  const dups = new Set<string>();
+  for (const h of all) {
+    if (seen.has(h)) dups.add(h);
+    else seen.add(h);
+  }
+  return [...dups];
+}
+
 // --- 陰性対照: 現状の正常系で pass ---
 
 describe('tools.md ↔ tools.ts カバレッジ', () => {
@@ -112,5 +124,30 @@ describe('[陽性対照] orphan 検出機構', () => {
     const fakeHeadings = extractH3Headings(fakeContent);
     const orphans = findOrphanHeadings([], fakeHeadings);
     expect(orphans.length).toBe(2);
+  });
+});
+
+// --- 重複見出し検出: 同じ ### 見出しが 2 回書かれると Set が dedup して missing/orphan を両方すり抜ける ---
+
+describe('tools.md 重複見出し検出', () => {
+  it('docs/tools.md に重複する ### 見出しがない', () => {
+    const content = readFileSync(toolsMdPath, 'utf-8');
+    const dups = findDuplicateH3Headings(content);
+    expect(dups, `docs/tools.md に重複している ### 見出し: ${dups.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('[陽性対照] 重複見出し検出機構', () => {
+  it('同じ見出しを 2 回含む偽 doc では重複として検出される', () => {
+    const fakeContent =
+      '### URLエンコード/デコード\n### JWTデコーダー\n### URLエンコード/デコード\n';
+    const dups = findDuplicateH3Headings(fakeContent);
+    expect(dups).toEqual(['URLエンコード/デコード']);
+  });
+
+  it('重複なし fixture では何も検出しない（過検知なし）', () => {
+    const fakeContent = '### URLエンコード/デコード\n### JWTデコーダー\n';
+    const dups = findDuplicateH3Headings(fakeContent);
+    expect(dups).toEqual([]);
   });
 });

--- a/tests/meta/tools-docs-coverage.test.ts
+++ b/tests/meta/tools-docs-coverage.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { tools } from '@/data/tools';
+
+/**
+ * meta test: tools.md 見出しカバレッジ漏れ検出 (issue #524 再発防止策)
+ *
+ * `src/data/tools.ts` の全ツール表示名に対して、`docs/tools.md` に
+ * 対応する `### <表示名>` 見出しが存在するかを機械的に検証する。
+ *
+ * 背景: PR #523 で docs/tools.md を新設したが、新規ツール追加時に見出しを
+ * 足し忘れても CI が通ってしまう silent drift が起きうる。
+ * 本テストを `npm run test` (Vitest) で走らせることで、ツール追加 PR で
+ * 見出し追加漏れが merge 前に fail として検知される。
+ */
+
+const toolsMdPath = fileURLToPath(new URL('../../docs/tools.md', import.meta.url));
+
+/** docs/tools.md から `###` レベル見出し一覧を抽出する純粋関数 */
+function extractH3Headings(content: string): Set<string> {
+  return new Set([...content.matchAll(/^### (.+)$/gm)].map((m) => m[1].trim()));
+}
+
+/** tools.ts の name に対応する ### 見出しが欠落しているツール名を返す */
+function findMissingToolHeadings(
+  toolList: { name: string }[],
+  headings: Set<string>,
+): string[] {
+  return toolList.filter((t) => !headings.has(t.name)).map((t) => t.name);
+}
+
+/** docs/tools.md の ### 見出しのうち tools.ts のツール名と対応しないものを返す */
+function findOrphanHeadings(toolList: { name: string }[], headings: Set<string>): string[] {
+  const toolNames = new Set(toolList.map((t) => t.name));
+  return [...headings].filter((h) => !toolNames.has(h));
+}
+
+// --- 陰性対照: 現状の正常系で pass ---
+
+describe('tools.md ↔ tools.ts カバレッジ', () => {
+  const content = readFileSync(toolsMdPath, 'utf-8');
+  const headings = extractH3Headings(content);
+
+  it('src/data/tools.ts の全ツールに対応する ### 見出しが docs/tools.md に存在する', () => {
+    const missing = findMissingToolHeadings(tools, headings);
+    expect(
+      missing,
+      `docs/tools.md に見出しが不足しているツール: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+});
+
+// --- 陽性対照: 検知機構が空回りしていないことを保証 (test-gates skill 準拠) ---
+
+describe('[陽性対照] tools.md カバレッジ検知機構', () => {
+  const content = readFileSync(toolsMdPath, 'utf-8');
+  const headings = extractH3Headings(content);
+
+  it('存在しないツール名を fixture に注入すると欠落として検出される', () => {
+    const fakeTools = [{ name: '存在しないツール（テスト専用）' }];
+    const missing = findMissingToolHeadings(fakeTools, headings);
+    expect(missing).toEqual(['存在しないツール（テスト専用）']);
+  });
+
+  it('登録済み + 未登録の混在 fixture で未登録のみを検出する（過検知なし）', () => {
+    const fakeTools = [
+      { name: 'URLエンコード/デコード' }, // 既存（見出しあり）
+      { name: '存在しないツールA' },
+      { name: '存在しないツールB' },
+    ];
+    const missing = findMissingToolHeadings(fakeTools, headings);
+    expect(missing.sort()).toEqual(['存在しないツールA', '存在しないツールB']);
+  });
+
+  it('全登録済み fixture では何も検出しない（過検知なし）', () => {
+    const fakeTools = [{ name: 'URLエンコード/デコード' }, { name: 'JWTデコーダー' }];
+    const missing = findMissingToolHeadings(fakeTools, headings);
+    expect(missing).toEqual([]);
+  });
+});
+
+// --- orphan 検出: tools.md に見出しがあるが tools.ts に対応するツールが存在しない ---
+
+describe('tools.md orphan 見出し検出', () => {
+  const content = readFileSync(toolsMdPath, 'utf-8');
+  const headings = extractH3Headings(content);
+
+  it('docs/tools.md の ### 見出しはすべて tools.ts のツール名と対応している', () => {
+    const orphans = findOrphanHeadings(tools, headings);
+    expect(
+      orphans,
+      `tools.ts に対応するツールがない orphan 見出し: ${orphans.join(', ')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('[陽性対照] orphan 検出機構', () => {
+  it('tools.ts に存在しないツール名の見出しを偽 doc に注入すると orphan として検出される', () => {
+    const fakeContent = '### URLエンコード/デコード\n### 存在しないオーファンツール\n';
+    const fakeHeadings = extractH3Headings(fakeContent);
+    const fakeTools = [{ name: 'URLエンコード/デコード' }];
+    const orphans = findOrphanHeadings(fakeTools, fakeHeadings);
+    expect(orphans).toEqual(['存在しないオーファンツール']);
+  });
+
+  it('全ツール名が一致する場合は orphan なし（過検知なし）', () => {
+    const fakeContent = '### URLエンコード/デコード\n### JWTデコーダー\n';
+    const fakeHeadings = extractH3Headings(fakeContent);
+    const fakeTools = [{ name: 'URLエンコード/デコード' }, { name: 'JWTデコーダー' }];
+    const orphans = findOrphanHeadings(fakeTools, fakeHeadings);
+    expect(orphans).toEqual([]);
+  });
+
+  it('ツール 0 件 fixture では全 ### 見出しが orphan として検出される', () => {
+    const fakeContent = '### URLエンコード/デコード\n### JWTデコーダー\n';
+    const fakeHeadings = extractH3Headings(fakeContent);
+    const orphans = findOrphanHeadings([], fakeHeadings);
+    expect(orphans.length).toBe(2);
+  });
+});

--- a/tests/meta/tools-docs-coverage.test.ts
+++ b/tests/meta/tools-docs-coverage.test.ts
@@ -23,10 +23,7 @@ function extractH3Headings(content: string): Set<string> {
 }
 
 /** tools.ts の name に対応する ### 見出しが欠落しているツール名を返す */
-function findMissingToolHeadings(
-  toolList: { name: string }[],
-  headings: Set<string>,
-): string[] {
+function findMissingToolHeadings(toolList: { name: string }[], headings: Set<string>): string[] {
   return toolList.filter((t) => !headings.has(t.name)).map((t) => t.name);
 }
 
@@ -44,10 +41,9 @@ describe('tools.md ↔ tools.ts カバレッジ', () => {
 
   it('src/data/tools.ts の全ツールに対応する ### 見出しが docs/tools.md に存在する', () => {
     const missing = findMissingToolHeadings(tools, headings);
-    expect(
-      missing,
-      `docs/tools.md に見出しが不足しているツール: ${missing.join(', ')}`,
-    ).toEqual([]);
+    expect(missing, `docs/tools.md に見出しが不足しているツール: ${missing.join(', ')}`).toEqual(
+      []
+    );
   });
 });
 
@@ -88,10 +84,9 @@ describe('tools.md orphan 見出し検出', () => {
 
   it('docs/tools.md の ### 見出しはすべて tools.ts のツール名と対応している', () => {
     const orphans = findOrphanHeadings(tools, headings);
-    expect(
-      orphans,
-      `tools.ts に対応するツールがない orphan 見出し: ${orphans.join(', ')}`,
-    ).toEqual([]);
+    expect(orphans, `tools.ts に対応するツールがない orphan 見出し: ${orphans.join(', ')}`).toEqual(
+      []
+    );
   });
 });
 


### PR DESCRIPTION
## 概要

issue #524 対応。`docs/tools.md` に全ツールの `### <表示名>` 見出しが存在するかを CI で機械的に強制する meta テストを追加。

## 背景

PR #523 で `docs/tools.md` を新設したが、新規ツール追加時に見出しを追加するルールはソフトな歯止めに過ぎず、CI で検知する仕組みがなかった。今後ツールを追加した際に見出しを足し忘れても CI が通ってしまう **silent drift** が起きうる。

## 変更内容

### 追加ファイル

**`tests/meta/tools-docs-coverage.test.ts`**（1ファイルのみ）

`vrt-pages-coverage.test.ts`（issue #355）と同構造で実装：

| describe | 役割 |
|---|---|
| `tools.md ↔ tools.ts カバレッジ` | 陰性対照: 全ツールの見出しが揃っている現状で pass |
| `[陽性対照] tools.md カバレッジ検知機構` | fixture 注入で欠落検出・過検知なしを実証 |
| `tools.md orphan 見出し検出` | tools.ts にないが docs に残る逆方向の drift を検出 |
| `[陽性対照] orphan 検出機構` | fixture 注入で orphan 検出・過検知なしを実証 |

陽性対照は **test-gates skill 準拠**（issue 本文に明記）。陰性対照と別 `describe` に分離し、検知能力ゼロの空回りを防ぐ。

## テスト結果

```
✓ tools.md ↔ tools.ts カバレッジ > 全ツールに対応する見出しが存在する
✓ [陽性対照] tools.md カバレッジ検知機構 > 存在しないツール名を fixture に注入すると欠落として検出される
✓ [陽性対照] tools.md カバレッジ検知機構 > 混在 fixture で未登録のみを検出する（過検知なし）
✓ [陽性対照] tools.md カバレッジ検知機構 > 全登録済み fixture では何も検出しない（過検知なし）
✓ tools.md orphan 見出し検出 > 全 ### 見出しが tools.ts と対応している
✓ [陽性対照] orphan 検出機構 > 偽 doc に orphan 見出しを注入すると検出される
✓ [陽性対照] orphan 検出機構 > 全ツール名が一致する場合は orphan なし（過検知なし）
✓ [陽性対照] orphan 検出機構 > ツール 0 件 fixture では全見出しが orphan として検出される

Tests  8 passed (8)
```

## 関連

- Closes #524
- 参考: issue #355 / `tests/meta/vrt-pages-coverage.test.ts`（同種カバレッジ検知の先例）

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyfFgFkUL8X2KVj9quCR5z)_