### PR TITLE
fix: ActionButton danger+disabled の border を中立グレーに統一 (#259)

### DIFF
--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -33,7 +33,7 @@ const SIZE_CLASS: Record<Size, string> = {
  * - ローディング中の子要素はそのまま表示するため、呼び出し元でローディング文言に切り替えること
  *   （例: `{loading ? '生成中…' : '生成'}`）
  * - `disabled=true`: variant ごとに disabled 時の bg/border を CSS `:disabled` 擬似で上書き
- *   （primary は border 不可視・secondary は背景透過維持）
+ *   （primary は border 不可視・secondary/danger は中立グレーボーダーに統一）
  * - `aria-*` など ButtonHTMLAttributes のほとんどの属性を渡せる
  *
  * style: global.css `@layer components` の `.btn-action` / `.btn-action--{variant}` を参照。

--- a/src/components/ui/__tests__/ActionButton.test.tsx
+++ b/src/components/ui/__tests__/ActionButton.test.tsx
@@ -139,6 +139,19 @@ describe('ActionButton', () => {
     expect(btn.className).toContain('btn-action--default');
   });
 
+  it('variant="danger" + disabled は disabled 属性と btn-action--danger クラスを持つ', () => {
+    render(
+      <ActionButton onClick={() => {}} variant="danger" disabled>
+        無効削除
+      </ActionButton>
+    );
+    const btn = screen.getByRole('button') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    // disabled でも variant class は剥がれない（border 中立グレー化は CSS :disabled 擬似で実現、
+    // class が維持されることが前提。スタイル値検証は E2E/VRT に委ねる）。issue #259
+    expect(btn.className).toContain('btn-action--danger');
+  });
+
   it('disabled 時は variant 不問で disabled 属性が付く', () => {
     render(
       <ActionButton onClick={() => {}} variant="primary" disabled>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -357,6 +357,13 @@
     border-color: var(--color-border);
     background: transparent;
   }
+  /* danger も disabled 時は中立グレーに揃える (secondary:disabled と統一)。
+     赤 (--color-error) は「危険・注意喚起」シグナルだが disabled は非アクティブ状態を
+     意味するため、両者は矛盾する。disabled 時は variant 共通で注意を引かない表現にする。
+     issue #259 (起源: #176 / #256 final code review)。 */
+  .btn-action--danger:disabled {
+    border-color: var(--color-border);
+  }
 
   /* ToggleGroup: button 状態切替 + 動的 grid columns 受け口 */
   .toggle-grid {


### PR DESCRIPTION
## 概要

`ActionButton` の `variant="danger"` + `disabled` で `border-color` が `var(--color-error)`（赤）のまま残り、`primary`（不可視）/ `secondary`（中立グレー）と視覚的に不整合だった問題を修正します（issue #259）。

`disabled` は「非アクティブ・注意を引かない」状態を意味するのに対し、赤ボーダーは「危険・注意喚起」のシグナルで意味的に矛盾します。`disabled` 時は variant 横断で注意を引かない表現に統一するのが適切と判断し、**Option A（中立グレーに統一）** で対応しました。

## 変更内容

- `src/styles/global.css`: `.btn-action--danger:disabled { border-color: var(--color-border); }` を追加（`secondary:disabled` と同じ中立グレー）
- `src/components/ui/ActionButton.tsx`: JSDoc の disabled 挙動説明を danger 反映に更新

## 検証

- `node_modules/.bin/astro check` → 0 errors
- `npm run build` 成功 + dist CSS にルール生成を確認（`btn-action--danger:disabled{border-color:var(--color-border)}`）
- ActionButton ユニットテスト 17 passed
- Playwright 実描画で danger 無効が `rgb(229,231,235)`（中立グレー）になり `secondary` 無効と一致することを目視確認

### VRT/E2E について

`variant="danger"` の唯一の利用箇所（`VerifyTab.tsx` のカメラ停止ボタン）は `disabled` を渡さないため、この state はどのページにも出現せず VRT 対象外です。再現ページが無いため新規 E2E/VRT は追加していません。

## 関連

- Closes #259
- 起源: #176 / #256 final code review (Important #1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
