### PR TITLE
fix: 正規表現ビジュアライザの不正正規表現エラーを日本語化 (#489)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -362,7 +362,7 @@ YAML・JSON・TOML・.env を相互変換する。各フォーマットを中間
 
 入力された正規表現パターンとフラグを 3 系統で処理する。
 
-1. **構文解析（AST）**: まず native `new RegExp(pattern, flags)` で構文・フラグを検証し（不正なら `SyntaxError`）、[regexp-tree](https://github.com/DmitrySoshnikov/regexp-tree) で位置情報付き AST を得る。各ノードを日本語ラベル（「キャプチャグループ #1」「1 回以上の繰り返し」「選択肢 (\|)」等）に変換して構造ツリーとして描画する。regexp-tree は `/pattern/` リテラル基準で位置を返すため、先頭 `/` の分だけオフセットを −1 補正して pattern 文字列基準に揃える。
+1. **構文解析（AST）**: まず native `new RegExp(pattern, flags)` で構文・フラグを検証し（不正なら `SyntaxError`）、[regexp-tree](https://github.com/DmitrySoshnikov/regexp-tree) で位置情報付き AST を得る。各ノードを日本語ラベル（「キャプチャグループ #1」「1 回以上の繰り返し」「選択肢 (\|)」等）に変換して構造ツリーとして描画する。regexp-tree は `/pattern/` リテラル基準で位置を返すため、先頭 `/` の分だけオフセットを −1 補正して pattern 文字列基準に揃える。不正な正規表現のエラーは、JS エンジンの英語メッセージをそのまま出さず「正規表現が不正です: 〈英語の詳細〉」という日本語見出し付きに整形して表示する（V8 系の重複する `Invalid regular expression: ` 接頭辞は除去し、不正箇所・理由の詳細は残す）。
 2. **鉄道図（railroad diagram）**: 同じ AST から `buildRailroad` でレイアウトを構築し、SVG の鉄道図として可視化する。
 3. **ReDoS 検出**: [recheck](https://github.com/makenowjust-labs/recheck) の `checkSync(pattern, flags, { timeout: 1000 })` で壊滅的バックトラッキングを静的解析する。結果は **安全 / 脆弱 / 不明** の 3 状態に正規化する。脆弱と判定された場合は攻撃文字列・複雑度（指数時間 / 多項式時間の次数）・パターン内の危険箇所（hotspot のオフセット範囲）を提示する。
 

--- a/src/utils/regex-visualizer/__tests__/parse.test.ts
+++ b/src/utils/regex-visualizer/__tests__/parse.test.ts
@@ -50,6 +50,29 @@ describe('parseRegex', () => {
   it('不正なフラグで例外を投げる', () => {
     expect(() => parseRegex('a', 'Z')).toThrow();
   });
+
+  // #489: engine の英語 SyntaxError を日本語見出し付きへ変換する
+  it('不正な正規表現のエラーメッセージが日本語見出しで始まる', () => {
+    expect(() => parseRegex('(', '')).toThrow(/^正規表現が不正です: /);
+  });
+
+  it('英語詳細（不正箇所・理由）を見出しの後に保持する', () => {
+    // detail は engine 依存だが、重複する "Invalid regular expression: " 接頭辞は除去される
+    let message = '';
+    try {
+      parseRegex('(', '');
+    } catch (e) {
+      message = e instanceof Error ? e.message : String(e);
+    }
+    expect(message).toMatch(/^正規表現が不正です: /);
+    expect(message).not.toMatch(/Invalid regular expression:/i);
+    // 不正箇所の詳細（"Unterminated group" 等）が残っている
+    expect(message.length).toBeGreaterThan('正規表現が不正です: '.length);
+  });
+
+  it('不正なフラグのエラーも日本語見出しで始まる', () => {
+    expect(() => parseRegex('a', 'Z')).toThrow(/^正規表現が不正です: /);
+  });
 });
 
 describe('parseToRegExpTree', () => {

--- a/src/utils/regex-visualizer/parse.ts
+++ b/src/utils/regex-visualizer/parse.ts
@@ -123,7 +123,7 @@ function toJapaneseRegexError(e: unknown): Error {
  * 不正時は engine の英語メッセージを日本語見出し付きへ変換して throw する（#489）。
  */
 export function parseRegex(pattern: string, flags: string): RegexAstNode {
-  let ast;
+  let ast: ReturnType<typeof parseToRegExpTree>;
   try {
     ast = parseToRegExpTree(pattern, flags);
   } catch (e) {

--- a/src/utils/regex-visualizer/parse.ts
+++ b/src/utils/regex-visualizer/parse.ts
@@ -1,4 +1,5 @@
 import { parse as parseRegExpTree } from 'regexp-tree';
+import { getErrorMessage } from '@/utils/errors';
 
 export interface RegexAstNode {
   /** regexp-tree のノード種別（'Char' | 'Repetition' | 'Group' | 'Disjunction' | 'Alternative' | 'CharacterClass' | 'Assertion' | 'Backreference' | 'Root' 等） */
@@ -103,12 +104,31 @@ export function parseToRegExpTree(pattern: string, flags: string) {
 }
 
 /**
+ * engine の英語 SyntaxError を日本語見出し付きのエラーへ整形する。
+ * 例: `Invalid regular expression: /(/: Unterminated group`
+ *   → `正規表現が不正です: /(/: Unterminated group`
+ * V8 系の `Invalid regular expression: ` 接頭辞は日本語見出しと重複するため除去し、
+ * 不正箇所・理由を示す英語詳細は情報量があるため残す（他ツールの ErrorMessage 表示と一貫）。
+ */
+function toJapaneseRegexError(e: unknown): Error {
+  const raw = getErrorMessage(e, '構文を確認してください');
+  const detail = raw.replace(/^Invalid regular expression:\s*/i, '');
+  return new Error(`正規表現が不正です: ${detail}`);
+}
+
+/**
  * pattern + flags を描画用 AST へ変換する。
  * native `new RegExp` で構文・フラグを検証（不正なら SyntaxError を投げる）し、
  * regexp-tree で位置情報付き AST を得る。ルートは body を Root ノードに包んで返す。
+ * 不正時は engine の英語メッセージを日本語見出し付きへ変換して throw する（#489）。
  */
 export function parseRegex(pattern: string, flags: string): RegexAstNode {
-  const ast = parseToRegExpTree(pattern, flags);
+  let ast;
+  try {
+    ast = parseToRegExpTree(pattern, flags);
+  } catch (e) {
+    throw toJapaneseRegexError(e);
+  }
   const body = ast.body as unknown as RegExpTreeNode;
   const rendered = toRenderNode(body);
   return {

--- a/tests/e2e/regex-visualizer.spec.ts
+++ b/tests/e2e/regex-visualizer.spec.ts
@@ -82,7 +82,11 @@ test.describe('正規表現ビジュアライザ', () => {
     await withProductionCsp(browser, '/tools/regex-visualizer', async (page) => {
       await page.getByLabel('正規表現').fill('(');
       // ErrorMessage コンポーネントは role="alert" で描画される
-      await expect(page.getByRole('alert').first()).toBeVisible();
+      const alert = page.getByRole('alert').first();
+      await expect(alert).toBeVisible();
+      // #489: engine の英語メッセージそのままではなく日本語見出しで表示される
+      await expect(alert).toContainText('正規表現が不正です');
+      await expect(alert).not.toContainText('Invalid regular expression:');
     });
   });
 


### PR DESCRIPTION
## 概要

正規表現ビジュアライザ（`/tools/regex-visualizer`）で不正な正規表現を入力した際、JS エンジンの英語 SyntaxError（例: `Invalid regular expression: /(/: Unterminated group`）がそのまま表示されていた問題を修正します（Closes #489）。

## 変更内容

- **`src/utils/regex-visualizer/parse.ts`**: `parseRegex` で `parseToRegExpTree` の throw を catch し、日本語見出し付き（「正規表現が不正です: 〈詳細〉」）へ変換して再 throw。V8 系の重複する `Invalid regular expression: ` 接頭辞は除去し、不正箇所・理由を示す英語詳細は情報量があるため残す（issue の「日本語見出し + 英語詳細」方針）。他ツールの `ErrorMessage` 表示と一貫。
- **`parse.test.ts`**: 日本語見出しで始まること / 英語詳細を保持し重複接頭辞を除去すること / フラグエラーも日本語化されることを assert。
- **`regex-visualizer.spec.ts`**: 既存のエラー E2E を強化し、`role="alert"` に「正規表現が不正です」が表示され `Invalid regular expression:` が出ないことを assert。
- **`docs/tools.md`**: 構文解析の項にエラー日本語化の挙動を追記。

## 検証

- `node_modules/.bin/astro check` → 0 errors
- `npm run test` → 91 files / 1651 passed
- `npm run test:e2e -- regex-visualizer.spec.ts -g "不正な正規表現でエラーが出る"` → pass
- **陽性対照**: 日本語変換を外して raw error を再 throw する旧挙動に戻すと、追加した 3 つの parse テストが fail することをローカルで確認（fail-on-regression を実証）。

## 補足

`useDebouncedTransform` の `fallbackError` は Error 以外の throw 用の安全網としてそのまま残しています（通常経路は parse.ts が日本語 Error を throw）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
