### PR TITLE
feat: TOTP シークレットのランダム生成に視覚 / SR フィードバックを追加 (#426)

### DIFF
--- a/src/components/tools/TotpHotpGenerator.tsx
+++ b/src/components/tools/TotpHotpGenerator.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { InputField } from '@/components/ui/InputField';
@@ -166,6 +166,28 @@ export function TotpHotpGeneratorTool() {
     setVerificationResult(null);
   };
 
+  // ランダム生成時の視覚 / SR フィードバック (#426)。マスク状態 (type="password") では
+  // 値が dots 表示で変化が分かりにくいため、入力欄を一時ハイライトしつつ aria-live で announce する。
+  const [regenFlash, setRegenFlash] = useState(false);
+  const regenTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    return () => {
+      if (regenTimerRef.current !== null) window.clearTimeout(regenTimerRef.current);
+    };
+  }, []);
+
+  const handleRegenerateSecret = () => {
+    replaceSecret(generateRandomBase32Secret());
+    setCounterStr('0');
+    // 連打時もハイライトを再生させるため、一旦解除してから次フレームで再付与する。
+    setRegenFlash(false);
+    if (regenTimerRef.current !== null) window.clearTimeout(regenTimerRef.current);
+    requestAnimationFrame(() => {
+      setRegenFlash(true);
+      regenTimerRef.current = window.setTimeout(() => setRegenFlash(false), 1500);
+    });
+  };
+
   const handleGenerateHotp = async () => {
     if (!secretBytes || counterError) {
       setHotpCode('');
@@ -267,10 +289,7 @@ export function TotpHotpGeneratorTool() {
               <div className="flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() => {
-                    replaceSecret(generateRandomBase32Secret());
-                    setCounterStr('0');
-                  }}
+                  onClick={handleRegenerateSecret}
                   className="caption text-link-color btn-link-plain"
                   aria-label="ランダム生成（新しいシークレット）"
                 >
@@ -295,8 +314,15 @@ export function TotpHotpGeneratorTool() {
               mono
               aria-label="Base32 シークレット"
               error={!!secretError}
+              className={regenFlash ? 'input-flash' : undefined}
             />
             {secretError && <ErrorMessage message={secretError} />}
+            {/* ランダム生成の SR 通知 (#426)。条件付き mount で連打時も再 announce される。 */}
+            {regenFlash && (
+              <span role="status" aria-live="polite" className="sr-only">
+                シークレットを再生成しました
+              </span>
+            )}
           </div>
 
           <div>

--- a/src/components/tools/TotpHotpGenerator.tsx
+++ b/src/components/tools/TotpHotpGenerator.tsx
@@ -184,7 +184,10 @@ export function TotpHotpGeneratorTool() {
     if (regenTimerRef.current !== null) window.clearTimeout(regenTimerRef.current);
     requestAnimationFrame(() => {
       setRegenFlash(true);
-      regenTimerRef.current = window.setTimeout(() => setRegenFlash(false), 1500);
+      // flash state の寿命を .input-flash の animation 長 (1.2s) に揃える。
+      // ズレると animation 終了後も class が残り「ring 消失だが付与中」状態や、
+      // reduced-motion 環境での static ring 持続時間がアニメと食い違う。
+      regenTimerRef.current = window.setTimeout(() => setRegenFlash(false), 1200);
     });
   };
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -365,6 +365,27 @@
     border-color: var(--color-border);
   }
 
+  /* 入力欄の一時ハイライト (#426)。TOTP シークレットのランダム生成など、マスク状態で
+     値が変わったことを視覚的に伝えるため class 付与中に 1 回 ring を fade させる。
+     prefers-reduced-motion 環境では animation を止め、付与中は static な ring を表示する。 */
+  .input-flash {
+    animation: input-flash-kf 1.2s ease-out;
+  }
+  @keyframes input-flash-kf {
+    from {
+      box-shadow: 0 0 0 3px var(--color-primary);
+    }
+    to {
+      box-shadow: 0 0 0 3px transparent;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .input-flash {
+      animation: none;
+      box-shadow: 0 0 0 3px var(--color-primary);
+    }
+  }
+
   /* ToggleGroup: button 状態切替 + 動的 grid columns 受け口 */
   .toggle-grid {
     display: grid;

--- a/tests/e2e/totp-hotp.spec.ts
+++ b/tests/e2e/totp-hotp.spec.ts
@@ -152,6 +152,23 @@ test.describe('TOTP/HOTP ジェネレータ（production CSP 適用）', () => {
     });
   });
 
+  test('マスク状態でランダム生成すると視覚 / SR フィードバックが出る（#426・CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/totp-hotp', async (page) => {
+      const secretInput = page.getByLabel('Base32 シークレット');
+      // 既定は showSecret=false（type="password" のマスク状態）であることを確認
+      await expect(secretInput).toHaveAttribute('type', 'password');
+
+      await page.getByRole('button', { name: /ランダム生成/ }).click();
+
+      // 視覚フィードバック: 入力欄に一時ハイライト class が付く
+      await expect(secretInput).toHaveClass(/input-flash/);
+      // SR フィードバック: aria-live 領域に再生成の announce が出る
+      await expect(page.getByText('シークレットを再生成しました')).toBeVisible();
+    });
+  });
+
   test('HOTP モードでランダム生成すると counter が 0 にリセットされる（CSP 違反なし）', async ({
     browser,
   }) => {


### PR DESCRIPTION
## 概要

TOTP/HOTP ジェネレータで、マスク状態（`type="password"`）のときに「ランダム生成」を押しても値が dots 表示で変化が分かりにくい問題に対し、視覚 / スクリーンリーダー双方のフィードバックを追加します（Closes #426）。

issue の案 A（aria-live announce）と案 C（入力欄ハイライト）を**併用**し、SR 利用者と sighted 利用者の双方に通知します。secret を一瞬露出する案 B は露出リスクのため採用しません。

## 変更内容

- **`TotpHotpGenerator.tsx`**:
  - `handleRegenerateSecret` を追加。生成時に flash state を立て、1.5s 後に解除。連打時もハイライト/announce を再生させるため一旦解除 → `requestAnimationFrame` で再付与。
  - 入力欄に一時ハイライト class（`input-flash`）を付与。
  - `aria-live="polite"` の `sr-only` 領域で「シークレットを再生成しました」を announce（`CopyButton` と同じ条件付き mount パターンで連打時も再 announce）。
  - timer は unmount 時に `clearTimeout` でクリーンアップ。
- **`global.css`**: `.input-flash`（青リングを 1.2s で fade する animation）を追加。`prefers-reduced-motion: reduce` では animation を止め static ring を表示（a11y 配慮）。
- **`totp-hotp.spec.ts`**: マスク状態でランダム生成すると `input-flash` class と announce テキストが出ることを検証する E2E を追加。

## 検証

- `node_modules/.bin/astro check` → 0 errors
- `npm run test` → 91 files / 1648 passed
- `npm run test:e2e -- totp-hotp.spec.ts -g "ランダム生成"` → 4 passed（#426 新規含む）
- Playwright 実描画で、ランダム生成後に入力欄の computed `box-shadow` が `rgba(26,86,219,0.867) 0 0 0 3px`（青リング）になり、aria-live 領域に「シークレットを再生成しました」が出ることを確認。

## VRT

steady state（flash 非表示）では `sr-only` span も `input-flash` class も描画されないため、`/tools/totp-hotp` の VRT baseline は不変です（baseline 再生成不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
