### PR TITLE
Codex 用リポジトリ設定を追加

### DIFF
--- a/.claude/scripts/test-edit-context.sh
+++ b/.claude/scripts/test-edit-context.sh
@@ -18,20 +18,28 @@ set -e
 # 入力 JSON 全体を読む
 input=$(cat)
 
-# ファイルパスを抽出 (Edit/Write/MultiEdit すべて tool_input.file_path を持つ)。
-# 不正な JSON のときは空文字 (best-effort: reminder hook なので edit 自体は止めない)。
-file_path=$(printf '%s' "$input" | node -e '
+# JSON のフィールドを node で取り出す (dotted path を argv で受ける)。
+# 不正な JSON のときは空文字を返す (best-effort: reminder hook なので edit 自体は止めない)。
+# .codex/scripts/test-edit-context.sh と同じヘルパーで、今後フィールドを増やしても流用できる。
+json_get() {
+  printf '%s' "$input" | node -e '
+const path = process.argv[1].split(".");
 let d = "";
 process.stdin.on("data", (c) => (d += c));
 process.stdin.on("end", () => {
   try {
-    const j = JSON.parse(d);
-    process.stdout.write(String(j?.tool_input?.file_path ?? ""));
+    let v = JSON.parse(d);
+    for (const k of path) v = v == null ? undefined : v[k];
+    process.stdout.write(v == null ? "" : String(v));
   } catch {
     process.stdout.write("");
   }
 });
-')
+' "$1"
+}
+
+# ファイルパスを抽出 (Edit/Write/MultiEdit すべて tool_input.file_path を持つ)。
+file_path=$(json_get "tool_input.file_path")
 
 # 空ならパスなしで何もしない
 if [ -z "$file_path" ]; then

--- a/.claude/scripts/test-edit-context.sh
+++ b/.claude/scripts/test-edit-context.sh
@@ -8,14 +8,30 @@
 # 出力: stdout に hookSpecificOutput JSON を出すと additionalContext として
 #       Claude のコンテキストに注入される (Claude Code Hook 仕様)。
 #       マッチしないときは何も出さない (silent pass)。
+#
+# JSON parse は jq ではなく node を使う: このリポジトリは Node 22 前提で node は
+# 必ず存在するが、jq は暗黙の外部依存になり、欠落環境では `|| true` で hook が
+# 黙って no-op になり「テスト編集を検知できないまま green」になる (PR #542 レビュー指摘)。
 
 set -e
 
 # 入力 JSON 全体を読む
 input=$(cat)
 
-# ファイルパスを抽出 (Edit/Write/MultiEdit すべて tool_input.file_path を持つ)
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)
+# ファイルパスを抽出 (Edit/Write/MultiEdit すべて tool_input.file_path を持つ)。
+# 不正な JSON のときは空文字 (best-effort: reminder hook なので edit 自体は止めない)。
+file_path=$(printf '%s' "$input" | node -e '
+let d = "";
+process.stdin.on("data", (c) => (d += c));
+process.stdin.on("end", () => {
+  try {
+    const j = JSON.parse(d);
+    process.stdout.write(String(j?.tool_input?.file_path ?? ""));
+  } catch {
+    process.stdout.write("");
+  }
+});
+')
 
 # 空ならパスなしで何もしない
 if [ -z "$file_path" ]; then

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -14,9 +14,9 @@ status_line = [
   "context-used",
   "five-hour-limit",
   "weekly-limit",
+  "pull-request-number"
 ]
 terminal_title = ["activity", "project-name", "git-branch"]
 
 [sandbox_workspace_write]
 network_access = false
-

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,22 @@
+# Project-local Codex settings. Loaded only after this repo is trusted by Codex.
+
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[features]
+hooks = true
+
+[tui]
+status_line = [
+  "model-with-reasoning",
+  "current-dir",
+  "git-branch",
+  "context-used",
+  "five-hour-limit",
+  "weekly-limit",
+]
+terminal_title = ["activity", "project-name", "git-branch"]
+
+[sandbox_workspace_write]
+network_access = false
+

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/scripts/session-install.sh",
+            "statusMessage": "依存関係を確認中"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/scripts/test-edit-context.sh",
+            "statusMessage": "テスト編集ルールを確認中"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,0 +1,238 @@
+# Project-local Codex command approval rules.
+# Mirrors the intent of .claude/settings.json: common read/check commands are
+# allowed, mutating or network-sensitive actions prompt, and destructive actions
+# are forbidden.
+
+prefix_rule(
+    pattern = ["npm", "run"],
+    decision = "allow",
+    justification = "Project npm scripts are common development and verification commands.",
+    match = ["npm run build", "npm run format:check", "npm run test:e2e"],
+)
+
+prefix_rule(
+    pattern = ["npm", ["test", "ci", "list", "outdated", "view"]],
+    decision = "allow",
+    justification = "Routine npm verification and dependency inspection commands.",
+    match = ["npm test", "npm ci", "npm list", "npm view astro version"],
+)
+
+prefix_rule(
+    pattern = ["npx", ["playwright", "tsc", "vitest", "astro", "prettier"]],
+    decision = "allow",
+    justification = "Project toolchain commands used for tests, builds, and formatting.",
+    match = [
+        "npx playwright test",
+        "npx tsc --noEmit",
+        "npx vitest run",
+        "npx astro check",
+        "npx prettier --check AGENTS.md",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", ["status", "diff", "log", "show", "branch", "rev-parse"]],
+    decision = "allow",
+    justification = "Read-only git inspection commands.",
+    match = ["git status --short", "git diff", "git log --oneline", "git show HEAD"],
+)
+
+prefix_rule(
+    pattern = ["git", "remote", "-v"],
+    decision = "allow",
+    justification = "Read-only repository remote inspection.",
+    match = ["git remote -v"],
+)
+
+prefix_rule(
+    pattern = ["git", "stash", "list"],
+    decision = "allow",
+    justification = "Read-only stash inspection.",
+    match = ["git stash list"],
+)
+
+prefix_rule(
+    pattern = ["git", "config", "--get"],
+    decision = "allow",
+    justification = "Read-only git configuration lookup.",
+    match = ["git config --get remote.origin.url"],
+)
+
+prefix_rule(
+    pattern = ["git", ["switch", "checkout", "add", "commit", "fetch", "pull", "merge", "rebase", "worktree"]],
+    decision = "prompt",
+    justification = "Git commands that may mutate the worktree, refs, or network state require confirmation.",
+    match = [
+        "git switch -c chore/example",
+        "git add AGENTS.md",
+        "git commit -m update",
+        "git fetch origin",
+        "git pull --ff-only",
+        "git merge --ff-only develop",
+        "git rebase --continue",
+        "git worktree prune",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "push"],
+    decision = "prompt",
+    justification = "Pushing changes publishes repository state and requires confirmation.",
+    match = ["git push origin HEAD"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", ["list", "view", "status", "diff", "checks"]],
+    decision = "allow",
+    justification = "Read-only GitHub PR inspection commands.",
+    match = ["gh pr view <pr-number>", "gh pr list", "gh pr diff <pr-number>", "gh pr checks <pr-number>"],
+    not_match = ["gh pr merge <pr-number>", "gh pr comment <pr-number>"],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", ["list", "view", "status"]],
+    decision = "allow",
+    justification = "Read-only GitHub issue inspection commands.",
+    match = ["gh issue view <issue-number>", "gh issue list", "gh issue status"],
+    not_match = ["gh issue comment <issue-number> --body update"],
+)
+
+prefix_rule(
+    pattern = ["gh", ["repo", "run", "workflow"], ["view", "list"]],
+    decision = "allow",
+    justification = "Read-only GitHub repository, workflow, and run inspection commands.",
+    match = ["gh repo view", "gh run list", "gh workflow view test"],
+)
+
+prefix_rule(
+    pattern = ["gh", "run", "view"],
+    decision = "allow",
+    justification = "Read-only GitHub Actions run inspection.",
+    match = ["gh run view <run-id>"],
+)
+
+prefix_rule(
+    pattern = ["gh", "workflow", "view"],
+    decision = "allow",
+    justification = "Read-only GitHub workflow inspection.",
+    match = ["gh workflow view <workflow-file>"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", ["review", "comment", "create", "merge", "close", "edit"]],
+    decision = "prompt",
+    justification = "GitHub PR write operations require confirmation.",
+    match = ["gh pr comment <pr-number> --body update", "gh pr review <pr-number> --comment --body review", "gh pr merge <pr-number> --squash"],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", ["comment", "create", "delete", "close", "edit"]],
+    decision = "prompt",
+    justification = "GitHub issue write operations require confirmation.",
+    match = ["gh issue comment <issue-number> --body update", "gh issue close <issue-number>"],
+)
+
+prefix_rule(
+    pattern = ["gh", ["release", "api"]],
+    decision = "prompt",
+    justification = "GitHub release and API commands can mutate remote state or access sensitive data.",
+    match = ["gh release list", "gh api repos/fumtas1k/devtools"],
+)
+
+prefix_rule(
+    pattern = ["gh", "workflow", ["run", "disable"]],
+    decision = "prompt",
+    justification = "GitHub workflow mutations require confirmation.",
+    match = ["gh workflow run <workflow-file>", "gh workflow disable <workflow-file>"],
+)
+
+prefix_rule(
+    pattern = [["node", "npm"], "--version"],
+    decision = "allow",
+    justification = "Tool version checks are safe.",
+    match = ["node --version", "npm --version"],
+)
+
+prefix_rule(
+    pattern = [["which", "pwd"]],
+    decision = "allow",
+    justification = "Local environment inspection commands are safe.",
+    match = ["which node", "pwd"],
+)
+
+prefix_rule(
+    pattern = [["curl", "wget"]],
+    decision = "prompt",
+    justification = "Network fetches require confirmation.",
+    match = ["curl https://example.com", "wget https://example.com/file"],
+)
+
+prefix_rule(
+    pattern = ["npm", ["install", "exec"]],
+    decision = "prompt",
+    justification = "Installing or executing packages can change dependencies or run untrusted code.",
+    match = ["npm install astro", "npm exec playwright install"],
+)
+
+prefix_rule(
+    pattern = ["npm", ["publish"]],
+    decision = "forbidden",
+    justification = "Publishing packages is not part of repository maintenance from Codex.",
+    match = ["npm publish"],
+)
+
+prefix_rule(
+    pattern = ["npm", ["install", "i"], ["-g", "--global", "--location=global"]],
+    decision = "forbidden",
+    justification = "Do not install global npm packages from this repository session.",
+    match = ["npm install -g eslint", "npm i --global pnpm", "npm install --location=global eslint"],
+)
+
+prefix_rule(
+    pattern = ["npm", ["install", "i"], "--location", "global"],
+    decision = "forbidden",
+    justification = "Do not install global npm packages from this repository session.",
+    match = ["npm install --location global eslint"],
+)
+
+prefix_rule(
+    pattern = ["git", "push", ["--force", "-f"]],
+    decision = "forbidden",
+    justification = "Force-push is blocked; use a non-forced push or ask the user for a manual operation.",
+    match = ["git push --force", "git push -f origin HEAD"],
+)
+
+prefix_rule(
+    pattern = ["git", "reset", "--hard"],
+    decision = "forbidden",
+    justification = "Hard reset can discard user work and must not be automated.",
+    match = ["git reset --hard", "git reset --hard HEAD"],
+)
+
+prefix_rule(
+    pattern = ["gh", "repo", ["delete"]],
+    decision = "forbidden",
+    justification = "Repository deletion is blocked.",
+    match = ["gh repo delete <owner/repo>"],
+)
+
+prefix_rule(
+    pattern = ["gh", "secret", ["delete", "remove", "set"]],
+    decision = "forbidden",
+    justification = "Secret mutation is blocked from Codex repository sessions.",
+    match = ["gh secret delete <name>", "gh secret set <name>"],
+)
+
+prefix_rule(
+    pattern = ["gh", "ssh-key", "delete"],
+    decision = "forbidden",
+    justification = "SSH key deletion is blocked.",
+    match = ["gh ssh-key delete <key-id>"],
+)
+
+prefix_rule(
+    pattern = ["gh", "auth", "logout"],
+    decision = "forbidden",
+    justification = "Authentication logout is blocked.",
+    match = ["gh auth logout"],
+)

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -2,6 +2,12 @@
 # Mirrors the intent of .claude/settings.json: common read/check commands are
 # allowed, mutating or network-sensitive actions prompt, and destructive actions
 # are forbidden.
+#
+# Matching is driven solely by `pattern` (a prefix match on the parsed argv).
+# The `match` / `not_match` entries are illustrative examples for documentation
+# and self-review only; they are NOT enforcement inputs. Placeholders such as
+# <pr-number> / <issue-number> / <run-id> stand for arbitrary user-supplied
+# arguments and are never matched literally.
 
 prefix_rule(
     pattern = ["npm", "run"],

--- a/.codex/scripts/session-install.sh
+++ b/.codex/scripts/session-install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Codex SessionStart hook: package-lock.json のハッシュが変わったときだけ npm ci を実行する。
+# Claude Code 用 .claude/scripts/session-install.sh と同じ方針。
+
+set -u
+
+[ -f package-lock.json ] || exit 0
+
+hash=$({ sha256sum package-lock.json 2>/dev/null || shasum -a 256 package-lock.json; } | cut -d' ' -f1)
+
+if [ ! -d node_modules ] || [ "$(cat node_modules/.lockhash 2>/dev/null)" != "$hash" ]; then
+  npm ci && echo "$hash" >node_modules/.lockhash
+fi
+

--- a/.codex/scripts/test-edit-context.sh
+++ b/.codex/scripts/test-edit-context.sh
@@ -1,13 +1,36 @@
 #!/bin/bash
 # Codex PreToolUse hook: テスト編集時に test-gates 参照を model-visible context として注入する。
+#
+# JSON parse は jq ではなく node を使う (理由は .claude/scripts/test-edit-context.sh と同じ):
+# このリポジトリは Node 22 前提で node は必ず存在するが、jq は暗黙の外部依存になり、
+# 欠落環境では `|| true` で hook が黙って no-op になり検知漏れを招く (PR #542 レビュー指摘)。
 
 set -e
 
 input=$(cat)
 
-tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null || true)
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)
-command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+# JSON のフィールドを node で取り出す (dotted path を argv で受ける)。
+# 不正な JSON のときは空文字を返す (best-effort)。
+json_get() {
+  printf '%s' "$input" | node -e '
+const path = process.argv[1].split(".");
+let d = "";
+process.stdin.on("data", (c) => (d += c));
+process.stdin.on("end", () => {
+  try {
+    let v = JSON.parse(d);
+    for (const k of path) v = v == null ? undefined : v[k];
+    process.stdout.write(v == null ? "" : String(v));
+  } catch {
+    process.stdout.write("");
+  }
+});
+' "$1"
+}
+
+tool_name=$(json_get "tool_name")
+file_path=$(json_get "tool_input.file_path")
+command=$(json_get "tool_input.command")
 
 matches_test_path() {
   case "$1" in
@@ -35,4 +58,3 @@ cat <<'JSON'
 JSON
 
 exit 0
-

--- a/.codex/scripts/test-edit-context.sh
+++ b/.codex/scripts/test-edit-context.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Codex PreToolUse hook: テスト編集時に test-gates 参照を model-visible context として注入する。
+
+set -e
+
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null || true)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)
+command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+
+matches_test_path() {
+  case "$1" in
+    */tests/*|*/__tests__/*|*.test.*|*.spec.*|*/test/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+matched=0
+if [ -n "$file_path" ] && matches_test_path "$file_path"; then
+  matched=1
+elif [ "$tool_name" = "apply_patch" ] && printf '%s\n' "$command" | grep -Eq '(^|\s)(tests/|[^[:space:]]*(\.test\.|\.spec\.|/__tests__/|/test/))'; then
+  matched=1
+fi
+
+[ "$matched" = "1" ] || exit 0
+
+cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": "テストファイル編集を検知しました。ガード / バリデータ / 違反検知機構 / regression 防止テストを追加 / 修正する場合は test-gates skill を参照し、陽性対照テスト併設ルールを確認してください。陰性対照のみだと検知機構として不完全です。"
+  }
+}
+JSON
+
+exit 0
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## プロジェクト構成
+
+このリポジトリは、ブラウザ内で完結する開発者ツール集を提供する Astro 6 サイトです。主要コードは `src/` 配下にあります。ページは `src/pages`、共通レイアウトは `src/layouts`、React UI は `src/components`、hooks は `src/hooks`、ツール定義は `src/data`、純粋関数系の処理は `src/utils` に配置します。グローバル CSS は `src/styles/global.css`、静的アセットと配信ヘッダーは `public/` にあります。テストは Playwright のブラウザテストを `tests/e2e`、リポジトリ整合性チェックを `tests/meta` に置きます。設計判断や運用メモは `docs/`、Codex 設定は `.codex/`、agent skill 本体は `.agents/skills` に置き、`.claude/skills` は互換用 symlink として扱います。
+
+## ビルド・テスト・開発コマンド
+
+Node.js は `>=22.12.0` を使います。
+
+- `npm ci`: lockfile に従って依存関係をインストールします。
+- `npm run dev`: Astro 開発サーバーを `http://localhost:4321` で起動します。
+- `npm run build`: 本番ビルドを `dist/` に生成します。
+- `npm run preview`: ビルド済みサイトをローカル確認します。
+- `npm test`: Vitest の単体・meta テストを実行します。
+- `npm run test:e2e`: Playwright E2E テストを実行します。
+- `npm run test:vrt`: visual regression テストを実行します。
+- `npm run format` / `npm run format:check`: Prettier で整形・確認します。
+
+初回 clone 後は `git config core.hooksPath .githooks` を 1 回実行して hook を有効化してください。
+
+## コーディング規約
+
+TypeScript、Astro、React 19、Tailwind CSS v4 を前提にします。整形は Prettier を正とし、Markdown と Astro も対象です。小さな純粋関数は `src/utils`、再利用 UI は `src/components` に分けます。ファイル名は既存に合わせて kebab-case または領域名ベースにします。例: `json-csv.ts`, `uuid-v7.ts`。このサイトはクライアントサイド完結が原則なので、ユーザー入力データを外部送信する処理を追加しないでください。
+
+## テスト方針
+
+ユーザー操作に関わる変更は `tests/e2e/*.spec.ts` に Playwright テストを追加します。リポジトリ構造やドキュメント整合性の検証は `tests/meta/*.test.ts` に置きます。ガード、validator、CSP チェック、lint 的検出器、リグレッション防止テストを追加・修正する場合は、意図的に違反を起こして検知できることを証明する陽性対照テストを同じ PR に含めます。
+
+## Commit と Pull Request
+
+履歴では `feat: ...`、`fix: ...`、`test: ...` などの短い subject と、日本語の説明的な件名が使われています。commit は目的ごとに小さく保ってください。PR には日本語の概要、検証コマンド、関連 issue、UI 変更時のスクリーンショットを含めます。レビュー依頼前に CI が通っていることを確認します。
+
+## セキュリティと設定
+
+`public/_headers` の strict CSP を尊重し、HTML inline `style` は避けて `global.css` の semantic class を使います。UI 変更では `.agents/skills/dads-design-system`、共通ルールでは `docs/shared-agent-rules.md` を参照してください。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ Node.js は `>=22.12.0` を使います。
 
 初回 clone 後は `git config core.hooksPath .githooks` を 1 回実行して hook を有効化してください。
 
+Codex で作業する場合、`.codex/hooks.json` の SessionStart / PreToolUse hook は初回起動時に trust するかどうかの確認が表示されます。trust しないと依存インストールやテスト編集時のガード注入が働かないため、内容を確認のうえ承認してください。
+
 ## コーディング規約
 
 TypeScript、Astro、React 19、Tailwind CSS v4 を前提にします。整形は Prettier を正とし、Markdown と Astro も対象です。小さな純粋関数は `src/utils`、再利用 UI は `src/components` に分けます。ファイル名は既存に合わせて kebab-case または領域名ベースにします。例: `json-csv.ts`, `uuid-v7.ts`。このサイトはクライアントサイド完結が原則なので、ユーザー入力データを外部送信する処理を追加しないでください。

--- a/tests/meta/test-edit-context.test.ts
+++ b/tests/meta/test-edit-context.test.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// test-edit-context hook (PreToolUse) の陽性 / 陰性対照テスト。
+//
+// このフックはテストファイル編集を検知して test-gates 参照を additionalContext として
+// 注入する「検知機構 (ガード)」。陰性対照 (非テスト編集で無出力) だけでは「検知能力ゼロでも
+// green」と区別できないため、陽性対照 (テスト編集で確かに注入される) を必須で併設する。
+// PR #542 レビューで .codex 側の本フックに陽性対照が無いと指摘されたのを受けて追加。
+//
+// あわせて、JSON parse を jq から node に置き換えたことの回帰防止も兼ねる (jq 欠落環境で
+// hook が黙って no-op になる検知漏れを防ぐ)。
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+function runHook(script: string, payload: unknown, pathPrefix?: string): string {
+  const env = pathPrefix
+    ? { ...process.env, PATH: `${pathPrefix}:${process.env.PATH ?? ''}` }
+    : process.env;
+  return execFileSync('bash', [resolve(repoRoot, script)], {
+    cwd: repoRoot,
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env,
+  });
+}
+
+// jq を「壊れている (= 実質欠落)」状態にする stub を PATH 先頭に差し込んで実行する。
+// 旧実装は `jq ... || true` で file_path が空になり no-op (検知漏れ) になるため、
+// この経路を通すと旧実装では陽性対照が fail し、node 化した新実装でのみ pass する。
+function runHookWithoutJq(script: string, payload: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'test-edit-context-nojq-'));
+  try {
+    const stub = join(dir, 'jq');
+    writeFileSync(stub, '#!/bin/sh\nexit 127\n');
+    chmodSync(stub, 0o755);
+    return runHook(script, payload, dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const scripts = [
+  { label: '.claude', path: '.claude/scripts/test-edit-context.sh' },
+  { label: '.codex', path: '.codex/scripts/test-edit-context.sh' },
+];
+
+describe.each(scripts)('$label test-edit-context hook', ({ path }) => {
+  it('陽性対照: テストファイル編集で additionalContext を注入する', () => {
+    const out = runHook(path, {
+      tool_name: 'Edit',
+      tool_input: { file_path: 'src/components/tools/__tests__/Foo.test.tsx' },
+    });
+
+    expect(out).toContain('テストファイル編集を検知');
+
+    // 出力が valid JSON で、Hook 仕様の形になっていること。
+    const parsed = JSON.parse(out);
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(typeof parsed.hookSpecificOutput.additionalContext).toBe('string');
+  });
+
+  it('陽性対照: tests/ 配下の .spec ファイルでも注入する', () => {
+    const out = runHook(path, {
+      tool_name: 'Write',
+      tool_input: { file_path: 'tests/e2e/example.spec.ts' },
+    });
+    expect(out).toContain('テストファイル編集を検知');
+  });
+
+  // 陽性対照 (jq→node 化の証明): jq が壊れている / 欠落していても検知できること。
+  // 旧 jq 実装にこのテストを当てると file_path が空になり no-op → fail する = 修正の意味の証明。
+  it('陽性対照: jq が無くてもテストファイル編集を検知する', () => {
+    const out = runHookWithoutJq(path, {
+      tool_name: 'Edit',
+      tool_input: { file_path: 'tests/e2e/example.spec.ts' },
+    });
+    expect(out).toContain('テストファイル編集を検知');
+  });
+
+  it('陰性対照: 非テストファイル編集では何も出力しない', () => {
+    const out = runHook(path, {
+      tool_name: 'Edit',
+      tool_input: { file_path: 'src/components/tools/Foo.tsx' },
+    });
+    expect(out.trim()).toBe('');
+  });
+
+  it('陰性対照: file_path が無い入力では何も出力しない', () => {
+    const out = runHook(path, { tool_name: 'Edit', tool_input: {} });
+    expect(out.trim()).toBe('');
+  });
+});
+
+// apply_patch 経由のテスト編集は .codex フックのみが扱う (Codex 固有 tool)。
+describe('.codex test-edit-context hook (apply_patch)', () => {
+  const path = '.codex/scripts/test-edit-context.sh';
+
+  it('陽性対照: apply_patch でテストファイルを編集すると注入する', () => {
+    const out = runHook(path, {
+      tool_name: 'apply_patch',
+      tool_input: {
+        command: '*** Begin Patch\n*** Update File: tests/e2e/example.spec.ts\n*** End Patch',
+      },
+    });
+    expect(out).toContain('テストファイル編集を検知');
+  });
+
+  it('陰性対照: apply_patch で非テストファイルなら無出力', () => {
+    const out = runHook(path, {
+      tool_name: 'apply_patch',
+      tool_input: {
+        command: '*** Begin Patch\n*** Update File: src/components/tools/Foo.tsx\n*** End Patch',
+      },
+    });
+    expect(out.trim()).toBe('');
+  });
+});


### PR DESCRIPTION
## 概要
- contributor guide として AGENTS.md を追加
- Codex 用の repo-local 設定を .codex/config.toml に追加
- SessionStart / PreToolUse hook を .codex/hooks.json と .codex/scripts に追加
- Claude Code の statusLine は Codex の組み込み status_line 項目で代替

## レビュー対応 (#3 / #4)
- test-edit-context hook の JSON parse を jq から node に置換（jq 欠落環境で hook が黙って no-op になる検知漏れを解消）。Codex 版の修正に合わせ、同じ問題を持つ Claude 版 `.claude/scripts/test-edit-context.sh` も同時に修正
- `tests/meta/test-edit-context.test.ts` を新規追加。`.claude` / `.codex` 両 hook の陽性 / 陰性対照、jq 破損環境でも検知できる陽性対照（旧実装に当てると fail）、apply_patch 経路を検証

## 検証
- npx prettier --check AGENTS.md .codex/hooks.json
- jq empty .codex/hooks.json
- bash -n .codex/scripts/session-install.sh
- bash -n .codex/scripts/test-edit-context.sh
- npx vitest run tests/meta/test-edit-context.test.ts → 12 passed
- node_modules/.bin/astro check → 0 errors
- codex --strict-config doctor --summary
  - config loaded は確認済み
  - sandbox 外では Responses WebSocket は接続成功
  - HTTP reachability は chatgpt.com/backend-api へのチェックが timeout し doctor 全体は非ゼロ終了。直接 curl では Cloudflare challenge の 403 を確認しており、今回追加した .codex 設定の構文問題ではない
