### PR TITLE
docs: squash マージ時のコミットメッセージ規約を明文化

### DIFF
--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -122,6 +122,38 @@ gh api "repos/<owner>/<repo>/pulls/<n>/reviews" --jq '.[].body'
 
 ---
 
-## 6. マージ後の worktree 後始末
+## 6. squash マージ時のコミットメッセージ
+
+`gh pr merge --squash`（および GitHub UI の "Squash and merge"）で develop に乗る squash コミットは、**件名・本文の両方を整える**。squash 後の develop は「1 PR = 1 コミット」になり、後から `git log` で経緯を追う際はこのコミットだけが手がかりになるため。
+
+### 件名
+
+- 通常のコミットと同じ規約に従う（`docs/shared-agent-rules.md` 1 章）: **日本語必須** かつ **Conventional Commits 形式必須**（`feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:` / `style:` / `perf:` / `build:` / `ci:` / `revert:` の 11 種）
+- 末尾に PR 番号を付ける: `chore: Codex 用リポジトリ設定を追加 (#542)`
+
+**注意（事故が起きている箇所）**: GitHub の squash は件名の **デフォルトが PR タイトル**。PR タイトルに prefix が無いと prefix なしコミットがそのまま develop に入る。さらに **ローカル `.githooks/commit-msg` は GitHub 上の squash には効かない**（フックはローカル commit 時のみ）ため規約違反が検知されず通る。対策は次のどちらか:
+
+1. PR タイトル自体を Conventional Commits 形式の日本語で書く（squash 件名がそのまま規約準拠になる）
+2. squash マージ実行時に件名を手で `<prefix>: <日本語要約> (#<PR番号>)` に直す
+
+### 本文
+
+GitHub の squash はデフォルトで **ブランチ内の全コミットメッセージを箇条書きで丸ごと連結** する（`* feat: ...` / `* refactor: レビュー対応` / `---------` / 重複した `Co-authored-by` が並ぶ）。レビュー往復の途中経過まで永久に残るノイズなので、**この自動連結は消して PR 概要を 1〜5 行に要約** したものに置き換える:
+
+- PR 説明文（概要セクション）を数行に要約する。検証コマンドや scratch なやり取りは含めない
+- `---------` 区切りや重複した `Co-authored-by` 行は残さない（必要なら `Co-authored-by` は 1 つに集約）
+- ❌ 避ける: コミット列の機械連結をそのまま残す / PR 説明文を全文貼り付ける
+
+### 実行例
+
+```bash
+gh pr merge <PR> --squash --delete-branch \
+  --subject "chore: Codex 用リポジトリ設定を追加 (#<PR>)" \
+  --body-file /tmp/claude/squash_body.md
+```
+
+`--body-file` を使うのは、本文がほぼ常に複数行になるため（理由は `docs/shared-agent-rules.md` 6.1 と同じ）。
+
+## 7. マージ後の worktree 後始末
 
 `gh pr merge --delete-branch` を打つ前に worktree を unlock + remove する。`worktree-agent-<id>` の内部 branch も別途 `git branch -D` で削除（記憶: feedback_worktree_merge_order）。

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -11,6 +11,7 @@
   - `perf:` 性能改善 / `build:` ビルド設定 / `ci:` CI 設定 / `revert:` 取り消し
   - 例: ✅ `feat: 新しいツールを追加` / ❌ `feat: Add new tool`（英語） / ❌ `update: ...`（プレフィックス不正）
   - `Merge`, `Revert`, `fixup!`, `squash!` で始まるコミットはチェックをスキップ
+  - **squash マージで develop に乗るコミット件名も同じ規約に従う**。GitHub の squash は件名のデフォルトが PR タイトルで、`.githooks/commit-msg` は GitHub 上の squash には効かない（prefix なしコミットが素通りする事故あり）。手順・対策 → `docs/playbooks/pr-creation.md` 6 章
 - **コード内コメント**: 日本語を基本とする。
 
 ---


### PR DESCRIPTION
## 概要

GitHub の squash マージで develop に規約違反のコミットが乗る事故が起きていたため、squash マージ時のコミットメッセージ規約を明文化する。

実際に develop で観測された問題:

- `0414c15 ローカル skill の本体を .agents 配下へ移動` — **prefix なし件名**
- `3a55c5a` / `3770c0d` 等 — 本文がブランチ内の全コミットメッセージの機械連結（`* feat:...` / `* refactor: レビュー対応` / `---------` / 重複 `Co-authored-by`）になっており、レビュー往復の途中経過がノイズとして永久に残っている

## 変更内容

- **`docs/playbooks/pr-creation.md`**: 6 章「squash マージ時のコミットメッセージ」を新設
  - 件名: Conventional Commits 形式 + 日本語 + 末尾に PR 番号
  - 本文: GitHub の自動連結を消し、PR 概要を 1〜5 行に要約。`---------` や重複 `Co-authored-by` は残さない
  - `.githooks/commit-msg` は GitHub 上の squash には効かないため CLI で `--subject` / `--body-file` を明示する旨を記載
  - 既存の「マージ後の worktree 後始末」は 7 章へ繰り下げ
- **`docs/shared-agent-rules.md`**: 1 章のコミット規約に、squash 件名も同規約に従う旨と pr-creation.md 6 章への導線を追記

## 検証

- `npx prettier --check` クリーン
- commit hook: Prettier OK / TypeScript OK
