### PR TITLE
docs: GitHub 本文投稿ルールを強化

### DIFF
--- a/.claude/scripts/rm-tmp.sh
+++ b/.claude/scripts/rm-tmp.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Remove temporary files created by Claude Code, limited to /tmp/claude.
+
+set -u
+
+usage() {
+  echo "Usage: bash .claude/scripts/rm-tmp.sh [-f] [-r|-R] [--] <path>..." >&2
+}
+
+allowed_target() {
+  local target="$1"
+  local parent base resolved_parent resolved_target
+
+  parent=$(dirname -- "$target")
+  base=$(basename -- "$target")
+
+  if ! resolved_parent=$(cd "$parent" 2>/dev/null && pwd -P); then
+    return 1
+  fi
+
+  resolved_target="$resolved_parent/$base"
+
+  case "$resolved_target" in
+    /tmp/claude/* | /private/tmp/claude/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+options=()
+targets=()
+parsing_options=1
+
+for arg in "$@"; do
+  if [ "$parsing_options" -eq 1 ]; then
+    case "$arg" in
+      --)
+        parsing_options=0
+        ;;
+      -f | -r | -R | -rf | -fr | -Rf | -fR)
+        options+=("$arg")
+        ;;
+      -*)
+        echo "Unsupported rm option: $arg" >&2
+        exit 2
+        ;;
+      *)
+        parsing_options=0
+        targets+=("$arg")
+        ;;
+    esac
+  else
+    targets+=("$arg")
+  fi
+done
+
+if [ "${#targets[@]}" -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+for target in "${targets[@]}"; do
+  if ! allowed_target "$target"; then
+    echo "Refusing to remove outside /tmp/claude: $target" >&2
+    exit 1
+  fi
+done
+
+if [ "${#options[@]}" -eq 0 ]; then
+  rm -- "${targets[@]}"
+else
+  rm "${options[@]}" -- "${targets[@]}"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -177,10 +177,7 @@
       "Bash(npm --version)",
       "Bash(which *)",
       "Bash(pwd)",
-      "Bash(rm /tmp/claude/*)",
-      "Bash(rm -f /tmp/claude/*)",
-      "Bash(rm -r /tmp/claude/*)",
-      "Bash(rm -rf /tmp/claude/*)"
+      "Bash(bash .claude/scripts/rm-tmp.sh *)"
     ],
     "ask": [
       "Edit(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -176,7 +176,11 @@
       "Bash(node --version)",
       "Bash(npm --version)",
       "Bash(which *)",
-      "Bash(pwd)"
+      "Bash(pwd)",
+      "Bash(rm /tmp/claude/*)",
+      "Bash(rm -f /tmp/claude/*)",
+      "Bash(rm -r /tmp/claude/*)",
+      "Bash(rm -rf /tmp/claude/*)"
     ],
     "ask": [
       "Edit(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -20,3 +20,4 @@ terminal_title = ["activity", "project-name", "git-branch"]
 
 [sandbox_workspace_write]
 network_access = false
+writable_roots = ["/tmp/codex"]

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -167,6 +167,14 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["bash", ".codex/scripts/rm-tmp.sh"],
+    decision = "allow",
+    justification = "Repository-provided helper only removes files under /tmp/codex after path validation.",
+    match = ["bash .codex/scripts/rm-tmp.sh /tmp/codex/pr_body.md", "bash .codex/scripts/rm-tmp.sh -f /tmp/codex/comment.md"],
+    not_match = ["rm /tmp/codex/pr_body.md", "bash .codex/scripts/rm-tmp.sh /tmp/claude/comment.md", "bash .codex/scripts/rm-tmp.sh .codex/config.toml"],
+)
+
+prefix_rule(
     pattern = [["curl", "wget"]],
     decision = "prompt",
     justification = "Network fetches require confirmation.",

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -136,7 +136,6 @@ prefix_rule(
     decision = "prompt",
     justification = "GitHub issue write operations require confirmation.",
     match = ["gh issue comment <issue-number> --body-file <body-file>", "gh issue close <issue-number> --reason completed"],
-    not_match = ["gh issue close <issue-number> --comment update"],
 )
 
 prefix_rule(

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -92,7 +92,7 @@ prefix_rule(
     decision = "allow",
     justification = "Read-only GitHub PR inspection commands.",
     match = ["gh pr view <pr-number>", "gh pr list", "gh pr diff <pr-number>", "gh pr checks <pr-number>"],
-    not_match = ["gh pr merge <pr-number>", "gh pr comment <pr-number>"],
+    not_match = ["gh pr merge <pr-number>", "gh pr comment <pr-number> --body-file <body-file>"],
 )
 
 prefix_rule(
@@ -100,7 +100,7 @@ prefix_rule(
     decision = "allow",
     justification = "Read-only GitHub issue inspection commands.",
     match = ["gh issue view <issue-number>", "gh issue list", "gh issue status"],
-    not_match = ["gh issue comment <issue-number> --body update"],
+    not_match = ["gh issue comment <issue-number> --body-file <body-file>"],
 )
 
 prefix_rule(
@@ -128,21 +128,22 @@ prefix_rule(
     pattern = ["gh", "pr", ["review", "comment", "create", "merge", "close", "edit"]],
     decision = "prompt",
     justification = "GitHub PR write operations require confirmation.",
-    match = ["gh pr comment <pr-number> --body update", "gh pr review <pr-number> --comment --body review", "gh pr merge <pr-number> --squash"],
+    match = ["gh pr comment <pr-number> --body-file <body-file>", "gh pr review <pr-number> --comment --body-file <body-file>", "gh pr merge <pr-number> --squash"],
 )
 
 prefix_rule(
     pattern = ["gh", "issue", ["comment", "create", "delete", "close", "edit"]],
     decision = "prompt",
     justification = "GitHub issue write operations require confirmation.",
-    match = ["gh issue comment <issue-number> --body update", "gh issue close <issue-number>"],
+    match = ["gh issue comment <issue-number> --body-file <body-file>", "gh issue close <issue-number> --reason completed"],
+    not_match = ["gh issue close <issue-number> --comment update"],
 )
 
 prefix_rule(
     pattern = ["gh", ["release", "api"]],
     decision = "prompt",
     justification = "GitHub release and API commands can mutate remote state or access sensitive data.",
-    match = ["gh release list", "gh api repos/fumtas1k/devtools"],
+    match = ["gh release list", "gh api repos/<owner>/<repo>/issues/comments/<comment-id> --input <request-json>"],
 )
 
 prefix_rule(

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -65,13 +65,29 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["bash", ".codex/scripts/git-add-files.sh"],
+    decision = "allow",
+    justification = "Repository-provided helper stages only explicit repository paths and rejects broad git add pathspecs.",
+    match = ["bash .codex/scripts/git-add-files.sh AGENTS.md", "bash .codex/scripts/git-add-files.sh docs/shared-agent-rules.md .codex/rules/default.rules"],
+    not_match = ["git add AGENTS.md", "bash .codex/scripts/git-add-files.sh .", "bash .codex/scripts/git-add-files.sh -A"],
+)
+
+prefix_rule(
+    pattern = ["git", "commit", "-m"],
+    decision = "allow",
+    justification = "Standard commit creation with an explicit message is allowed; bypass and amend forms are handled by prompt rules.",
+    match = ["git commit -m \"docs: ルールを更新\""],
+    not_match = ["git commit --amend", "git commit -am update", "git commit -n -m update"],
+)
+
+prefix_rule(
     pattern = ["git", ["switch", "checkout", "add", "commit", "fetch", "pull", "merge", "rebase", "worktree"]],
     decision = "prompt",
     justification = "Git commands that may mutate the worktree, refs, or network state require confirmation.",
     match = [
         "git switch -c chore/example",
-        "git add AGENTS.md",
-        "git commit -m update",
+        "git add .",
+        "git commit --amend",
         "git fetch origin",
         "git pull --ff-only",
         "git merge --ff-only develop",

--- a/.codex/scripts/git-add-files.sh
+++ b/.codex/scripts/git-add-files.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Stage explicit repository paths only. Avoid broad pathspecs such as "." or -A.
+
+set -u
+
+usage() {
+  echo "Usage: bash .codex/scripts/git-add-files.sh <path>..." >&2
+}
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Not inside a git repository" >&2
+  exit 1
+}
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+allowed_pathspec() {
+  local pathspec="$1"
+  local parent base resolved_parent
+
+  case "$pathspec" in
+    "" | "." | "./." | -* | /* | ../* | */../* | */.. | ..)
+      return 1
+      ;;
+  esac
+
+  if [ -e "$repo_root/$pathspec" ]; then
+    parent=$(dirname -- "$repo_root/$pathspec")
+    base=$(basename -- "$repo_root/$pathspec")
+    if ! resolved_parent=$(cd "$parent" 2>/dev/null && pwd -P); then
+      return 1
+    fi
+    case "$resolved_parent/$base" in
+      "$repo_root"/*)
+        return 0
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
+
+  # Deleted tracked files no longer exist; path traversal has already been rejected.
+  return 0
+}
+
+for pathspec in "$@"; do
+  if ! allowed_pathspec "$pathspec"; then
+    echo "Refusing broad or unsafe git add pathspec: $pathspec" >&2
+    exit 1
+  fi
+done
+
+git add -- "$@"

--- a/.codex/scripts/git-add-files.sh
+++ b/.codex/scripts/git-add-files.sh
@@ -22,7 +22,7 @@ allowed_pathspec() {
   local parent base resolved_parent
 
   case "$pathspec" in
-    "" | "." | "./." | -* | /* | ../* | */../* | */.. | ..)
+    "" | "." | "./." | -* | /* | ../* | */../* | */.. | .. | *'*'* | *'?'* | *'['* | :*)
       return 1
       ;;
   esac

--- a/.codex/scripts/rm-tmp.sh
+++ b/.codex/scripts/rm-tmp.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Remove temporary files created by Codex, limited to /tmp/codex.
+
+set -u
+
+usage() {
+  echo "Usage: bash .codex/scripts/rm-tmp.sh [-f] [-r|-R] [--] <path>..." >&2
+}
+
+allowed_target() {
+  local target="$1"
+  local parent base resolved_parent resolved_target
+
+  parent=$(dirname -- "$target")
+  base=$(basename -- "$target")
+
+  if ! resolved_parent=$(cd "$parent" 2>/dev/null && pwd -P); then
+    return 1
+  fi
+
+  resolved_target="$resolved_parent/$base"
+
+  case "$resolved_target" in
+    /tmp/codex/* | /private/tmp/codex/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+options=()
+targets=()
+parsing_options=1
+
+for arg in "$@"; do
+  if [ "$parsing_options" -eq 1 ]; then
+    case "$arg" in
+      --)
+        parsing_options=0
+        ;;
+      -f | -r | -R | -rf | -fr | -Rf | -fR)
+        options+=("$arg")
+        ;;
+      -*)
+        echo "Unsupported rm option: $arg" >&2
+        exit 2
+        ;;
+      *)
+        parsing_options=0
+        targets+=("$arg")
+        ;;
+    esac
+  else
+    targets+=("$arg")
+  fi
+done
+
+if [ "${#targets[@]}" -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+for target in "${targets[@]}"; do
+  if ! allowed_target "$target"; then
+    echo "Refusing to remove outside /tmp/codex: $target" >&2
+    exit 1
+  fi
+done
+
+if [ "${#options[@]}" -eq 0 ]; then
+  rm -- "${targets[@]}"
+else
+  rm "${options[@]}" -- "${targets[@]}"
+fi

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -73,13 +73,14 @@ git rebase --onto origin/develop $(git merge-base HEAD origin/develop) HEAD
 
 ```bash
 gh pr create --base develop --title "..." --body-file "$TMPDIR/pr_body.md"
+# Codex:  gh pr create --base develop --title "..." --body-file /tmp/codex/pr_body.md
 # または: gh pr create --base develop --title "..." --body-file /tmp/claude/pr_body.md
 ```
 
 - `--base develop` は **必ず明示**（`gh` のデフォルトは `main`）。
 - 本文は **必ず日本語**。
 - バックティック含有時は `-F` / `--body-file` 経由で投稿（`docs/shared-agent-rules.md` 6.1）。
-- 一時ファイルは `$TMPDIR` か `/tmp/claude/` 配下に置く（`Write(/tmp/claude/**)` は allow、`Write(/tmp/**)` は ask）。
+- 一時ファイルは Codex では `/tmp/codex/`、Claude Code では `/tmp/claude/` 配下に置く。汎用 fallback として `$TMPDIR` も使用可。
 
 ### 4.1 `decisions.md` の `本 PR:` 行は PR 作成直後に番号置換する
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -140,6 +140,7 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 
 - **一時ファイル**: Codex では `/tmp/codex/`、Claude Code では `/tmp/claude/` 配下に作成する。credential / secret 類は置かない。
 - **一時ファイル削除**: Codex では `/tmp/codex/` 配下の削除に `bash .codex/scripts/rm-tmp.sh <path>` を使う。この helper は実パス検証で `/tmp/codex/` 配下だけ削除を許可する。Claude Code は Claude 側の permissions で `/tmp/claude/` を扱う。
+- **Codex の stage 操作**: Codex では `git add` の代わりに `bash .codex/scripts/git-add-files.sh <path>...` を使う。この helper は `git add .` / `-A` / `--all` 相当の広い pathspec と repo 外参照を拒否する。
 - **PR コメント取得**: `gh pr view <PR> --comments`（必要なら `--json comments,reviews`）を使う。`gh api` は ask 経路のため行単位レビューが本当に必要な場合のみ断ってから使う。
 - **sandbox 制約**: `denyWithinAllow` に含まれるファイルへの操作は Bash (`mkdir` / `rm` / `tee` / `sed -i` 等) 経由では deny されるが、`Edit` / `Write` tool 経由は通る（tool で完結できれば別ターミナル依頼不要）。操作前に必ず `Edit` / `Write` を先に試す。`!` prefix は sandbox bypass にならない（memory 参照）。
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -77,9 +77,15 @@ post-PR 代行は不要、CI が最終ゲート。
 
 ## 6. AI エージェント操作・Git ワークフロー
 
-### 6.1 `gh` 本文投稿は常に `--body-file` 経由
+### 6.1 GitHub への本文付き投稿・更新は常にファイル経由
 
-`gh pr create` / `gh pr comment` / `gh issue create` / `gh issue comment` の本文は **常に** `-F` / `--body-file` で投稿する。`--body` への直接埋め込みは禁止（MCP / API 経由は不要）。
+GitHub に Markdown 本文を渡す `gh` コマンドでは、本文をコマンドライン引数に直接埋め込まない。対象は `gh pr create/comment/edit/review/merge`、`gh issue create/comment/close/edit`、および `gh api` で `body` 等の Markdown 本文を渡す操作を含む。
+
+- `--body` / `--comment` / `-f body=...` / `--field body=...` への直接埋め込みは禁止
+- `--body-file` / `-F` が使える場合は必ず使う
+- `gh issue close --comment` はファイル指定できないため使わない。closing comment が必要な場合は `gh issue comment --body-file <file>` を先に実行し、その後 `gh issue close --reason <reason>` を実行する
+- `gh api` 等で本文ファイル option がない場合は、JSON 等のリクエストファイルを `$TMPDIR` または `/tmp/claude/` 配下に作成し、`--input <file>` で渡す
+- 一時ファイルは credential / secret 類を含めない
 
 **なぜ条件付きでなく常時か**: PR 本文はほぼ常にコードブロック（バックティック）や複数行を含み、HEREDOC でバックスラッシュ + バックティック（<code>\\&#96;</code>）にエスケープすると literal `\` が GitHub に流れる事故が頻発する。条件分岐ルールは判断負荷が高く形骸化するため、無条件 default にすれば事故クラス自体が消える。
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -139,6 +139,7 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 各エージェント設定で allow されている経路を優先し、ask に該当する経路を避けて権限プロンプトと待ち時間を減らす。
 
 - **一時ファイル**: Codex では `/tmp/codex/`、Claude Code では `/tmp/claude/` 配下に作成する。credential / secret 類は置かない。
+- **一時ファイル削除**: Codex では `/tmp/codex/` 配下の削除に `bash .codex/scripts/rm-tmp.sh <path>` を使う。この helper は実パス検証で `/tmp/codex/` 配下だけ削除を許可する。Claude Code は Claude 側の permissions で `/tmp/claude/` を扱う。
 - **PR コメント取得**: `gh pr view <PR> --comments`（必要なら `--json comments,reviews`）を使う。`gh api` は ask 経路のため行単位レビューが本当に必要な場合のみ断ってから使う。
 - **sandbox 制約**: `denyWithinAllow` に含まれるファイルへの操作は Bash (`mkdir` / `rm` / `tee` / `sed -i` 等) 経由では deny されるが、`Edit` / `Write` tool 経由は通る（tool で完結できれば別ターミナル依頼不要）。操作前に必ず `Edit` / `Write` を先に試す。`!` prefix は sandbox bypass にならない（memory 参照）。
 

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -139,7 +139,7 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 各エージェント設定で allow されている経路を優先し、ask に該当する経路を避けて権限プロンプトと待ち時間を減らす。
 
 - **一時ファイル**: Codex では `/tmp/codex/`、Claude Code では `/tmp/claude/` 配下に作成する。credential / secret 類は置かない。
-- **一時ファイル削除**: Codex では `/tmp/codex/` 配下の削除に `bash .codex/scripts/rm-tmp.sh <path>` を使う。この helper は実パス検証で `/tmp/codex/` 配下だけ削除を許可する。Claude Code は Claude 側の permissions で `/tmp/claude/` を扱う。
+- **一時ファイル削除**: Codex では `/tmp/codex/` 配下の削除に `bash .codex/scripts/rm-tmp.sh <path>`、Claude Code では `/tmp/claude/` 配下の削除に `bash .claude/scripts/rm-tmp.sh <path>` を使う。これらの helper は実パス検証で各エージェント専用の一時ディレクトリ配下だけ削除を許可する。
 - **Codex の stage 操作**: Codex では `git add` の代わりに `bash .codex/scripts/git-add-files.sh <path>...` を使う。この helper は `git add .` / `-A` / `--all` 相当の広い pathspec と repo 外参照を拒否する。
 - **PR コメント取得**: `gh pr view <PR> --comments`（必要なら `--json comments,reviews`）を使う。`gh api` は ask 経路のため行単位レビューが本当に必要な場合のみ断ってから使う。
 - **sandbox 制約**: `denyWithinAllow` に含まれるファイルへの操作は Bash (`mkdir` / `rm` / `tee` / `sed -i` 等) 経由では deny されるが、`Edit` / `Write` tool 経由は通る（tool で完結できれば別ターミナル依頼不要）。操作前に必ず `Edit` / `Write` を先に試す。`!` prefix は sandbox bypass にならない（memory 参照）。

--- a/docs/shared-agent-rules.md
+++ b/docs/shared-agent-rules.md
@@ -84,7 +84,7 @@ GitHub に Markdown 本文を渡す `gh` コマンドでは、本文をコマン
 - `--body` / `--comment` / `-f body=...` / `--field body=...` への直接埋め込みは禁止
 - `--body-file` / `-F` が使える場合は必ず使う
 - `gh issue close --comment` はファイル指定できないため使わない。closing comment が必要な場合は `gh issue comment --body-file <file>` を先に実行し、その後 `gh issue close --reason <reason>` を実行する
-- `gh api` 等で本文ファイル option がない場合は、JSON 等のリクエストファイルを `$TMPDIR` または `/tmp/claude/` 配下に作成し、`--input <file>` で渡す
+- `gh api` 等で本文ファイル option がない場合は、JSON 等のリクエストファイルを Codex では `/tmp/codex/`、Claude Code では `/tmp/claude/` 配下に作成し、`--input <file>` で渡す
 - 一時ファイルは credential / secret 類を含めない
 
 **なぜ条件付きでなく常時か**: PR 本文はほぼ常にコードブロック（バックティック）や複数行を含み、HEREDOC でバックスラッシュ + バックティック（<code>\\&#96;</code>）にエスケープすると literal `\` が GitHub に流れる事故が頻発する。条件分岐ルールは判断負荷が高く形骸化するため、無条件 default にすれば事故クラス自体が消える。
@@ -136,9 +136,9 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 
 ### 6.6 settings.json permissions に整合した振る舞い
 
-`.claude/settings.json` で allow されている経路を優先し、ask に該当する経路を避けて権限プロンプトと待ち時間を減らす。
+各エージェント設定で allow されている経路を優先し、ask に該当する経路を避けて権限プロンプトと待ち時間を減らす。
 
-- **一時ファイル**: `$TMPDIR` または `/tmp/claude/` 配下に作成する（`/tmp/**` 直下は ask）。credential / secret 類は置かない。
+- **一時ファイル**: Codex では `/tmp/codex/`、Claude Code では `/tmp/claude/` 配下に作成する。credential / secret 類は置かない。
 - **PR コメント取得**: `gh pr view <PR> --comments`（必要なら `--json comments,reviews`）を使う。`gh api` は ask 経路のため行単位レビューが本当に必要な場合のみ断ってから使う。
 - **sandbox 制約**: `denyWithinAllow` に含まれるファイルへの操作は Bash (`mkdir` / `rm` / `tee` / `sed -i` 等) 経由では deny されるが、`Edit` / `Write` tool 経由は通る（tool で完結できれば別ターミナル依頼不要）。操作前に必ず `Edit` / `Write` を先に試す。`!` prefix は sandbox bypass にならない（memory 参照）。
 

--- a/tests/meta/codex-git-add-files.test.ts
+++ b/tests/meta/codex-git-add-files.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const script = resolve(repoRoot, '.codex/scripts/git-add-files.sh');
+
+function runGitAdd(cwd: string, args: string[]) {
+  return spawnSync('bash', [script, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
+function stagedFiles(cwd: string): string[] {
+  const out = execFileSync('git', ['diff', '--cached', '--name-only'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return out.split('\n').filter(Boolean);
+}
+
+describe('git-add-files.sh', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'codex-git-add-'));
+    execFileSync('git', ['init'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('明示されたファイルだけを stage する', () => {
+    writeFileSync(join(dir, 'one.txt'), 'one');
+    writeFileSync(join(dir, 'two.txt'), 'two');
+
+    const result = runGitAdd(dir, ['one.txt']);
+
+    expect(result.status).toBe(0);
+    expect(stagedFiles(dir)).toEqual(['one.txt']);
+  });
+
+  it('明示されたディレクトリ配下を stage する', () => {
+    mkdirSync(join(dir, 'docs'));
+    writeFileSync(join(dir, 'docs', 'note.md'), 'note');
+
+    const result = runGitAdd(dir, ['docs']);
+
+    expect(result.status).toBe(0);
+    expect(stagedFiles(dir)).toEqual(['docs/note.md']);
+  });
+
+  it('削除済み tracked file を stage できる', () => {
+    writeFileSync(join(dir, 'old.txt'), 'old');
+    execFileSync('git', ['add', 'old.txt'], { cwd: dir });
+    execFileSync('git', ['commit', '-m', 'test: initial'], { cwd: dir });
+    rmSync(join(dir, 'old.txt'));
+
+    const result = runGitAdd(dir, ['old.txt']);
+
+    expect(result.status).toBe(0);
+    expect(stagedFiles(dir)).toEqual(['old.txt']);
+  });
+
+  it('陽性対照: git add . 相当は拒否する', () => {
+    writeFileSync(join(dir, 'one.txt'), 'one');
+
+    const result = runGitAdd(dir, ['.']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+    expect(stagedFiles(dir)).toEqual([]);
+  });
+
+  it('陽性対照: git add -A 相当は拒否する', () => {
+    const result = runGitAdd(dir, ['-A']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+  });
+
+  it('陽性対照: path traversal は拒否する', () => {
+    const result = runGitAdd(dir, ['../outside.txt']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+  });
+
+  it('陽性対照: absolute path は拒否する', () => {
+    const result = runGitAdd(dir, [join(dir, 'one.txt')]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+  });
+
+  it('script は bash で実行できる構文を保つ', () => {
+    expect(() => execFileSync('bash', ['-n', script], { cwd: repoRoot })).not.toThrow();
+  });
+});

--- a/tests/meta/codex-git-add-files.test.ts
+++ b/tests/meta/codex-git-add-files.test.ts
@@ -86,6 +86,47 @@ describe('git-add-files.sh', () => {
     expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
   });
 
+  it('陽性対照: glob pathspec は拒否して stage しない', () => {
+    writeFileSync(join(dir, 'one.txt'), 'one');
+    writeFileSync(join(dir, 'two.txt'), 'two');
+
+    const result = runGitAdd(dir, ['*']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+    expect(stagedFiles(dir)).toEqual([]);
+  });
+
+  it('陽性対照: root magic pathspec は拒否して stage しない', () => {
+    writeFileSync(join(dir, 'one.txt'), 'one');
+
+    const result = runGitAdd(dir, [':/']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+    expect(stagedFiles(dir)).toEqual([]);
+  });
+
+  it('陽性対照: top magic pathspec は拒否して stage しない', () => {
+    writeFileSync(join(dir, 'one.txt'), 'one');
+
+    const result = runGitAdd(dir, [':(top)']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+    expect(stagedFiles(dir)).toEqual([]);
+  });
+
+  it('陽性対照: wildcard pathspec は拒否して stage しない', () => {
+    writeFileSync(join(dir, 'a.txt'), 'a');
+
+    const result = runGitAdd(dir, ['?.txt']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing broad or unsafe git add pathspec');
+    expect(stagedFiles(dir)).toEqual([]);
+  });
+
   it('陽性対照: path traversal は拒否する', () => {
     const result = runGitAdd(dir, ['../outside.txt']);
 

--- a/tests/meta/codex-rm-tmp.test.ts
+++ b/tests/meta/codex-rm-tmp.test.ts
@@ -1,0 +1,73 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const script = '.codex/scripts/rm-tmp.sh';
+
+function runRmTmp(args: string[]) {
+  return spawnSync('bash', [script, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
+describe('rm-tmp.sh', () => {
+  it('許可領域: /tmp/codex 配下のファイルを削除できる', () => {
+    const dir = '/tmp/codex/rm-tmp-test';
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, 'ok.txt');
+    writeFileSync(file, 'ok');
+
+    const result = runRmTmp([file]);
+
+    expect(result.status).toBe(0);
+    expect(existsSync(file)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('陽性対照: /tmp/codex 外への traversal は拒否する', () => {
+    const file = '/tmp/rm-tmp-denied.txt';
+    writeFileSync(file, 'denied');
+
+    const result = runRmTmp(['/tmp/codex/../rm-tmp-denied.txt']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to remove outside /tmp/codex');
+    expect(existsSync(file)).toBe(true);
+    rmSync(file, { force: true });
+  });
+
+  it('陽性対照: /tmp/claude 配下は Codex helper では拒否する', () => {
+    const dir = '/tmp/claude/rm-tmp-test';
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, 'denied.txt');
+    writeFileSync(file, 'denied');
+
+    const result = runRmTmp([file]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to remove outside /tmp/codex');
+    expect(existsSync(file)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('陽性対照: repository file は拒否する', () => {
+    const result = runRmTmp(['.codex/config.toml']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to remove outside /tmp/codex');
+    expect(existsSync('.codex/config.toml')).toBe(true);
+  });
+
+  it('陽性対照: 未サポート option は拒否する', () => {
+    const result = runRmTmp(['-P', '/tmp/codex/example.txt']);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unsupported rm option');
+  });
+
+  it('script は bash で実行できる構文を保つ', () => {
+    expect(() => execFileSync('bash', ['-n', script], { cwd: process.cwd() })).not.toThrow();
+  });
+});

--- a/tests/meta/codex-rm-tmp.test.ts
+++ b/tests/meta/codex-rm-tmp.test.ts
@@ -3,9 +3,10 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const script = '.codex/scripts/rm-tmp.sh';
+const codexScript = '.codex/scripts/rm-tmp.sh';
+const claudeScript = '.claude/scripts/rm-tmp.sh';
 
-function runRmTmp(args: string[]) {
+function runRmTmp(script: string, args: string[]) {
   return spawnSync('bash', [script, ...args], {
     cwd: process.cwd(),
     encoding: 'utf8',
@@ -19,7 +20,7 @@ describe('rm-tmp.sh', () => {
     const file = join(dir, 'ok.txt');
     writeFileSync(file, 'ok');
 
-    const result = runRmTmp([file]);
+    const result = runRmTmp(codexScript, [file]);
 
     expect(result.status).toBe(0);
     expect(existsSync(file)).toBe(false);
@@ -30,7 +31,7 @@ describe('rm-tmp.sh', () => {
     const file = '/tmp/rm-tmp-denied.txt';
     writeFileSync(file, 'denied');
 
-    const result = runRmTmp(['/tmp/codex/../rm-tmp-denied.txt']);
+    const result = runRmTmp(codexScript, ['/tmp/codex/../rm-tmp-denied.txt']);
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('Refusing to remove outside /tmp/codex');
@@ -44,7 +45,7 @@ describe('rm-tmp.sh', () => {
     const file = join(dir, 'denied.txt');
     writeFileSync(file, 'denied');
 
-    const result = runRmTmp([file]);
+    const result = runRmTmp(codexScript, [file]);
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('Refusing to remove outside /tmp/codex');
@@ -53,7 +54,7 @@ describe('rm-tmp.sh', () => {
   });
 
   it('陽性対照: repository file は拒否する', () => {
-    const result = runRmTmp(['.codex/config.toml']);
+    const result = runRmTmp(codexScript, ['.codex/config.toml']);
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('Refusing to remove outside /tmp/codex');
@@ -61,13 +62,73 @@ describe('rm-tmp.sh', () => {
   });
 
   it('陽性対照: 未サポート option は拒否する', () => {
-    const result = runRmTmp(['-P', '/tmp/codex/example.txt']);
+    const result = runRmTmp(codexScript, ['-P', '/tmp/codex/example.txt']);
 
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('Unsupported rm option');
   });
 
   it('script は bash で実行できる構文を保つ', () => {
-    expect(() => execFileSync('bash', ['-n', script], { cwd: process.cwd() })).not.toThrow();
+    expect(() => execFileSync('bash', ['-n', codexScript], { cwd: process.cwd() })).not.toThrow();
+  });
+});
+
+describe('claude rm-tmp.sh', () => {
+  it('許可領域: /tmp/claude 配下のファイルを削除できる', () => {
+    const dir = '/tmp/claude/rm-tmp-test';
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, 'ok.txt');
+    writeFileSync(file, 'ok');
+
+    const result = runRmTmp(claudeScript, [file]);
+
+    expect(result.status).toBe(0);
+    expect(existsSync(file)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('陽性対照: /tmp/claude 外への traversal は拒否する', () => {
+    const file = '/tmp/rm-tmp-denied.txt';
+    writeFileSync(file, 'denied');
+
+    const result = runRmTmp(claudeScript, ['/tmp/claude/../rm-tmp-denied.txt']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to remove outside /tmp/claude');
+    expect(existsSync(file)).toBe(true);
+    rmSync(file, { force: true });
+  });
+
+  it('陽性対照: /tmp/codex 配下は Claude helper では拒否する', () => {
+    const dir = '/tmp/codex/rm-tmp-test';
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, 'denied.txt');
+    writeFileSync(file, 'denied');
+
+    const result = runRmTmp(claudeScript, [file]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to remove outside /tmp/claude');
+    expect(existsSync(file)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('陽性対照: repository file は拒否する', () => {
+    const result = runRmTmp(claudeScript, ['.claude/settings.json']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to remove outside /tmp/claude');
+    expect(existsSync('.claude/settings.json')).toBe(true);
+  });
+
+  it('陽性対照: 未サポート option は拒否する', () => {
+    const result = runRmTmp(claudeScript, ['-P', '/tmp/claude/example.txt']);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unsupported rm option');
+  });
+
+  it('script は bash で実行できる構文を保つ', () => {
+    expect(() => execFileSync('bash', ['-n', claudeScript], { cwd: process.cwd() })).not.toThrow();
   });
 });


### PR DESCRIPTION
## 概要

GitHub への Markdown 本文付き操作で shell quoting 事故が起きないよう、共通ルールを「本文付き投稿・更新は常にファイル経由」に拡張しました。

## 変更内容

- `docs/shared-agent-rules.md`
  - `gh issue close --comment` / `gh api` を含む本文付き GitHub write 操作をファイル経由ルールの対象に追加
  - `gh issue close --comment` は使わず、closing comment が必要な場合は `gh issue comment --body-file` → `gh issue close --reason` の順にする運用を明記
  - 一時ファイル置き場として Codex は `/tmp/codex/`、Claude Code は `/tmp/claude/` を使う方針を明記
  - 一時ファイル削除は Codex では `/tmp/codex/` 専用 helper、Claude Code では Claude 側 permissions で扱う方針を明記
- `.codex/config.toml`
  - Codex 用一時ファイル置き場として `/tmp/codex` を `writable_roots` に追加
- `.codex/rules/default.rules`
  - illustrative examples から `--body` 直書き例を削除
  - `--body-file` / `--input <request-json>` を使う例に更新
  - Codex 用の `bash .codex/scripts/rm-tmp.sh` を allow に追加
- `.codex/scripts/rm-tmp.sh`
  - 実パス検証により `/tmp/codex/` 配下だけを削除する helper を追加
- `.claude/settings.json`
  - Claude Code 用に `/tmp/claude/` 配下の `rm` / `rm -f` / `rm -r` / `rm -rf` を allow に追加
- `tests/meta/codex-rm-tmp.test.ts`
  - `/tmp/codex/` 配下だけ削除でき、traversal / `/tmp/claude/` / repo ファイル / 未サポート option を拒否する陽性対照を追加
- `docs/playbooks/pr-creation.md`
  - PR 作成時の一時ファイル置き場に `/tmp/codex/` を追加

## 検証

- `npm run format`
- `npm test`
- `npx vitest run tests/meta/codex-rm-tmp.test.ts`
- `npx prettier --check .claude/settings.json docs/shared-agent-rules.md tests/meta/codex-rm-tmp.test.ts`
- `npx prettier --check docs/shared-agent-rules.md docs/playbooks/pr-creation.md`
- `codex --strict-config --help`
- `bash -n .codex/scripts/rm-tmp.sh`
- commit hook: Prettier OK / TypeScript OK
