### PR TITLE
[codex] git add 直実行を抑止

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -14,6 +14,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/scripts/block-direct-git-add.sh",
+            "statusMessage": "git add の実行経路を確認中"
+          }
+        ]
+      },
+      {
         "matcher": "apply_patch|Edit|Write",
         "hooks": [
           {

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -73,17 +73,20 @@ prefix_rule(
 )
 
 # Intentionally allow the staging helper instead of direct `git add <path>`.
-# Command rules are prefix-only, so `pattern = ["git", "add"]` would also allow
-# broad pathspecs such as `git add .` and `git add -A`. The helper validates
-# pathspecs first, then runs `git add -- <path>...`. `not_match` can only list
-# genuinely different command prefixes (here, direct `git add`); a bad path
-# argument to the helper still matches this prefix and is rejected at runtime.
+# Direct `git add` is forbidden below so the helper is the only staging path.
+# The helper validates pathspecs first, then runs `git add -- <path>...`.
 prefix_rule(
     pattern = ["bash", ".codex/scripts/git-add-files.sh"],
     decision = "allow",
     justification = "Repository-provided helper stages only explicit repository paths and rejects broad git add pathspecs.",
     match = ["bash .codex/scripts/git-add-files.sh AGENTS.md", "bash .codex/scripts/git-add-files.sh .agents/rules/common.md .codex/rules/default.rules"],
-    not_match = ["git add AGENTS.md", "git add .", "git add -A"],
+)
+
+prefix_rule(
+    pattern = ["git", "add"],
+    decision = "forbidden",
+    justification = "Stage changes only through .codex/scripts/git-add-files.sh so explicit path validation is always enforced.",
+    match = ["git add AGENTS.md", "git add .", "git add -A"],
 )
 
 prefix_rule(
@@ -95,12 +98,11 @@ prefix_rule(
 )
 
 prefix_rule(
-    pattern = ["git", ["switch", "checkout", "add", "commit", "fetch", "pull", "merge", "rebase", "worktree"]],
+    pattern = ["git", ["switch", "checkout", "commit", "fetch", "pull", "merge", "rebase", "worktree"]],
     decision = "prompt",
     justification = "Git commands that may mutate the worktree, refs, or network state require confirmation.",
     match = [
         "git switch -c chore/example",
-        "git add .",
         "git commit --amend",
         "git fetch origin",
         "git pull --ff-only",

--- a/.codex/scripts/block-direct-git-add.sh
+++ b/.codex/scripts/block-direct-git-add.sh
@@ -22,13 +22,11 @@ process.stdin.on("end", () => {
 
 command=$(json_get_command)
 
-case "$command" in
-  *".codex/scripts/git-add-files.sh"* )
-    exit 0
-    ;;
-esac
+if printf '%s' "$command" | grep -Eq '^[[:space:]]*bash[[:space:]]+\.codex/scripts/git-add-files\.sh([[:space:]]+[^;&|<>`$()\\]+)*[[:space:]]*$'; then
+  exit 0
+fi
 
-if printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]_./-])git[[:space:]]+add([[:space:]]|$)'; then
+if printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]_./-])(([^[:space:];|&()]+/)*git|command[[:space:]]+git)([[:space:]][^;&|()]*)*[[:space:]]+add([[:space:]]|$)'; then
   echo "Use bash .codex/scripts/git-add-files.sh instead of direct git add." >&2
   exit 1
 fi

--- a/.codex/scripts/block-direct-git-add.sh
+++ b/.codex/scripts/block-direct-git-add.sh
@@ -91,6 +91,7 @@ function isGitToken(token) {
 
 function hasDirectGitAdd(input, seen = new Set()) {
   if (helperPattern.test(input)) return false;
+  if (/[`$]/.test(input)) return true;
   if (seen.has(input)) return false;
   seen.add(input);
 

--- a/.codex/scripts/block-direct-git-add.sh
+++ b/.codex/scripts/block-direct-git-add.sh
@@ -22,13 +22,39 @@ process.stdin.on("end", () => {
 
 command=$(json_get_command)
 
-if printf '%s' "$command" | grep -Eq '^[[:space:]]*bash[[:space:]]+\.codex/scripts/git-add-files\.sh([[:space:]]+[^;&|<>`$()\\]+)*[[:space:]]*$'; then
-  exit 0
-fi
+python3 - "$command" <<'PY'
+import re
+import shlex
+import sys
 
-if printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]_./-])(([^[:space:];|&()]+/)*git|command[[:space:]]+git)([[:space:]][^;&|()]*)*[[:space:]]+add([[:space:]]|$)'; then
-  echo "Use bash .codex/scripts/git-add-files.sh instead of direct git add." >&2
-  exit 1
-fi
+command = sys.argv[1]
+helper_pattern = re.compile(
+    r'^\s*bash\s+\.codex/scripts/git-add-files\.sh(?:\s+[^;&|<>`$()\\]+)*\s*$'
+)
+deny_message = 'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
 
-exit 0
+if helper_pattern.fullmatch(command):
+    raise SystemExit(0)
+
+if re.search(r'[;&|<>`$()\n]', command):
+    print(deny_message, file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    tokens = shlex.split(command, posix=True)
+except ValueError:
+    print(deny_message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def is_git_command(token: str) -> bool:
+    return token == 'git' or token.endswith('/git')
+
+
+for index, token in enumerate(tokens):
+    if is_git_command(token) and any(later == 'add' for later in tokens[index + 1 :]):
+        print(deny_message, file=sys.stderr)
+        raise SystemExit(1)
+
+raise SystemExit(0)
+PY

--- a/.codex/scripts/block-direct-git-add.sh
+++ b/.codex/scripts/block-direct-git-add.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Codex PreToolUse hook: direct `git add` を拒否し、staging helper のみ許可する。
+
+set -euo pipefail
+
+input=$(cat)
+
+json_get_command() {
+  printf '%s' "$input" | node -e '
+let data = "";
+process.stdin.on("data", (chunk) => (data += chunk));
+process.stdin.on("end", () => {
+  try {
+    const payload = JSON.parse(data);
+    process.stdout.write(payload?.tool_input?.command ?? "");
+  } catch {
+    process.stdout.write("");
+  }
+});
+'
+}
+
+command=$(json_get_command)
+
+case "$command" in
+  *".codex/scripts/git-add-files.sh"* )
+    exit 0
+    ;;
+esac
+
+if printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]_./-])git[[:space:]]+add([[:space:]]|$)'; then
+  echo "Use bash .codex/scripts/git-add-files.sh instead of direct git add." >&2
+  exit 1
+fi
+
+exit 0

--- a/.codex/scripts/block-direct-git-add.sh
+++ b/.codex/scripts/block-direct-git-add.sh
@@ -22,39 +22,100 @@ process.stdin.on("end", () => {
 
 command=$(json_get_command)
 
-python3 - "$command" <<'PY'
-import re
-import shlex
-import sys
+node - "$command" <<'NODE'
+const command = process.argv[2] ?? '';
+const helperPattern = /^\s*bash\s+\.codex\/scripts\/git-add-files\.sh(?:\s+[^;&|<>`$()\\]+)*\s*$/;
+const denyMessage = 'Use bash .codex/scripts/git-add-files.sh instead of direct git add.';
 
-command = sys.argv[1]
-helper_pattern = re.compile(
-    r'^\s*bash\s+\.codex/scripts/git-add-files\.sh(?:\s+[^;&|<>`$()\\]+)*\s*$'
-)
-deny_message = 'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+function tokenize(input) {
+  const tokens = [];
+  let current = '';
+  let state = 'unquoted';
 
-if helper_pattern.fullmatch(command):
-    raise SystemExit(0)
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i];
 
-if re.search(r'[;&|<>`$()\n]', command):
-    print(deny_message, file=sys.stderr)
-    raise SystemExit(1)
+    if (state === 'unquoted') {
+      if (/\s/.test(ch)) {
+        if (current) {
+          tokens.push(current);
+          current = '';
+        }
+        continue;
+      }
+      if (ch === "'") {
+        state = 'single';
+        continue;
+      }
+      if (ch === '"') {
+        state = 'double';
+        continue;
+      }
+      if (ch === '\\') {
+        i += 1;
+        if (i < input.length) current += input[i];
+        continue;
+      }
+      current += ch;
+      continue;
+    }
 
-try:
-    tokens = shlex.split(command, posix=True)
-except ValueError:
-    print(deny_message, file=sys.stderr)
-    raise SystemExit(1)
+    if (state === 'single') {
+      if (ch === "'") {
+        state = 'unquoted';
+      } else {
+        current += ch;
+      }
+      continue;
+    }
 
+    if (ch === '"') {
+      state = 'unquoted';
+      continue;
+    }
+    if (ch === '\\') {
+      i += 1;
+      if (i < input.length) current += input[i];
+      continue;
+    }
+    current += ch;
+  }
 
-def is_git_command(token: str) -> bool:
-    return token == 'git' or token.endswith('/git')
+  if (current) tokens.push(current);
+  return tokens;
+}
 
+function isGitToken(token) {
+  return token === 'git' || token.endsWith('/git');
+}
 
-for index, token in enumerate(tokens):
-    if is_git_command(token) and any(later == 'add' for later in tokens[index + 1 :]):
-        print(deny_message, file=sys.stderr)
-        raise SystemExit(1)
+function hasDirectGitAdd(input, seen = new Set()) {
+  if (helperPattern.test(input)) return false;
+  if (seen.has(input)) return false;
+  seen.add(input);
 
-raise SystemExit(0)
-PY
+  const tokens = tokenize(input);
+
+  for (const token of tokens) {
+    if (/\s/.test(token) && hasDirectGitAdd(token, seen)) {
+      return true;
+    }
+  }
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    if (!isGitToken(tokens[i])) continue;
+    for (let j = i + 1; j < tokens.length; j += 1) {
+      if (tokens[j] === 'add') return true;
+    }
+  }
+
+  return false;
+}
+
+if (hasDirectGitAdd(command)) {
+  console.error(denyMessage);
+  process.exit(1);
+}
+
+process.exit(0);
+NODE

--- a/docs/superpowers/plans/2026-05-31-codex-git-add-enforcement.md
+++ b/docs/superpowers/plans/2026-05-31-codex-git-add-enforcement.md
@@ -1,0 +1,125 @@
+# Codex Git Add Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Codex で `git add` 直実行を止め、明示的な staging helper 経由のみを許可する。
+
+**Architecture:** 直接 `git add` を拒否する rule を追加し、Bash 実行時に direct `git add` を検知して失敗させる PreToolUse hook を追加する。helper の `bash .codex/scripts/git-add-files.sh` は従来どおり allow に残し、運用上の staging 経路を一本化する。
+
+**Tech Stack:** `.codex/rules/default.rules`, `.codex/hooks.json`, Bash
+
+---
+
+### Task 1: direct `git add` を拒否する
+
+**Files:**
+
+- Modify: `.codex/rules/default.rules`
+
+- [ ] **Step 1: 直接 `git add` を forbidden にする**
+
+```rules
+prefix_rule(
+    pattern = ["git", "add"],
+    decision = "forbidden",
+    justification = "Stage changes only through .codex/scripts/git-add-files.sh so explicit path validation is always enforced.",
+    match = ["git add AGENTS.md", "git add .", "git add -A"],
+)
+```
+
+- [ ] **Step 2: broad git mutating rule から `add` を外す**
+
+```rules
+prefix_rule(
+    pattern = ["git", ["switch", "checkout", "commit", "fetch", "pull", "merge", "rebase", "worktree"]],
+    decision = "prompt",
+    justification = "Git commands that may mutate the worktree, refs, or network state require confirmation.",
+    match = [
+        "git switch -c chore/example",
+        "git commit --amend",
+        "git fetch origin",
+        "git pull --ff-only",
+        "git merge --ff-only develop",
+        "git rebase --continue",
+        "git worktree prune",
+    ],
+)
+```
+
+### Task 2: hook で direct `git add` を止める
+
+**Files:**
+
+- Create: `.codex/scripts/block-direct-git-add.sh`
+- Modify: `.codex/hooks.json`
+
+- [ ] **Step 1: direct `git add` を検知して exit 1 する hook script を作る**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+input=$(cat)
+
+command=$(printf '%s' "$input" | node -e '
+let data = "";
+process.stdin.on("data", (chunk) => (data += chunk));
+process.stdin.on("end", () => {
+  try {
+    const payload = JSON.parse(data);
+    process.stdout.write(payload?.tool_input?.command ?? "");
+  } catch {
+    process.stdout.write("");
+  }
+});
+')
+
+case "$command" in
+  git\ add|git\ add\ *)
+    case "$command" in
+      bash\ .codex/scripts/git-add-files.sh* ) exit 0 ;;
+      git\ add\ *) echo "Use bash .codex/scripts/git-add-files.sh instead of direct git add." >&2; exit 1 ;;
+    esac
+    ;;
+esac
+```
+
+- [ ] **Step 2: Bash 実行時に hook を走らせる**
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "bash .codex/scripts/block-direct-git-add.sh",
+      "statusMessage": "git add の実行経路を確認中"
+    }
+  ]
+}
+```
+
+### Task 3: 陽性対照を確認してコミットする
+
+**Files:**
+
+- Modify: `.codex/rules/default.rules`
+- Modify: `.codex/hooks.json`
+- Create: `.codex/scripts/block-direct-git-add.sh`
+
+- [ ] **Step 1: helper は引き続き使えることを確認する**
+
+Run: `bash .codex/scripts/git-add-files.sh .codex/rules/default.rules`
+Expected: 失敗せずに stage される。
+
+- [ ] **Step 2: direct `git add` が拒否されることを確認する**
+
+Run: `git add .codex/rules/default.rules`
+Expected: helper 使用を促すメッセージで拒否される。
+
+- [ ] **Step 3: 変更をコミットする**
+
+```bash
+git add .codex/rules/default.rules .codex/hooks.json .codex/scripts/block-direct-git-add.sh docs/superpowers/plans/2026-05-31-codex-git-add-enforcement.md
+git commit -m "fix: git add 直実行を抑止"
+```

--- a/tests/meta/codex-block-direct-git-add.test.ts
+++ b/tests/meta/codex-block-direct-git-add.test.ts
@@ -56,4 +56,22 @@ describe('block-direct-git-add.sh', () => {
       'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
     );
   });
+
+  it('陽性対照: quoted command name の git add も拒否する', () => {
+    const result = runHook('"git" add .');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
+
+  it('陽性対照: escaped command name の git add も拒否する', () => {
+    const result = runHook('\\git add .');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
 });

--- a/tests/meta/codex-block-direct-git-add.test.ts
+++ b/tests/meta/codex-block-direct-git-add.test.ts
@@ -74,4 +74,22 @@ describe('block-direct-git-add.sh', () => {
       'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
     );
   });
+
+  it('陽性対照: parameter expansion で git になる command も拒否する', () => {
+    const result = runHook('${GIT:-git} add .');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
+
+  it('陽性対照: ANSI-C quoting で git になる command も拒否する', () => {
+    const result = runHook("$'git' add .");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
 });

--- a/tests/meta/codex-block-direct-git-add.test.ts
+++ b/tests/meta/codex-block-direct-git-add.test.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const script = resolve(repoRoot, '.codex/scripts/block-direct-git-add.sh');
+
+function runHook(command: string) {
+  return spawnSync('bash', [script], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input: JSON.stringify({ tool_input: { command } }),
+  });
+}
+
+describe('block-direct-git-add.sh', () => {
+  it('陰性対照: helper 単体の staging は許可する', () => {
+    const result = runHook('bash .codex/scripts/git-add-files.sh .codex/rules/default.rules');
+
+    expect(result.status).toBe(0);
+  });
+
+  it('陽性対照: direct git add を拒否する', () => {
+    const result = runHook('git add .codex/rules/default.rules');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
+
+  it('陽性対照: helper の後ろに direct git add を連結した複合コマンドも拒否する', () => {
+    const result = runHook('bash .codex/scripts/git-add-files.sh AGENTS.md; git add .');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
+
+  it('陽性対照: git の絶対パスでも拒否する', () => {
+    const result = runHook('/usr/bin/git add .');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
+
+  it('陽性対照: global option 付きの git add も拒否する', () => {
+    const result = runHook('git -C . add .');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Use bash .codex/scripts/git-add-files.sh instead of direct git add.'
+    );
+  });
+});


### PR DESCRIPTION
## 変更点
- direct `git add` を `/.codex/rules/default.rules` で forbidden に変更
- Bash 実行時に direct `git add` を拒否する hook を追加
- staging helper の `bash .codex/scripts/git-add-files.sh` のみを staging 経路として残す

## 理由
- `git add` 直実行を避け、明示 pathspec 検証を helper に一本化するため
- Codex の staging 操作をリポジトリ共通の安全な経路に寄せるため

## 検証
- `printf '%s' '{"tool_input":{"command":"git add .codex/rules/default.rules"}}' | bash .codex/scripts/block-direct-git-add.sh`
- `printf '%s' '{"tool_input":{"command":"bash -lc \"git add .codex/rules/default.rules\""}}' | bash .codex/scripts/block-direct-git-add.sh`
- `printf '%s' '{"tool_input":{"command":"bash .codex/scripts/git-add-files.sh .codex/rules/default.rules"}}' | bash .codex/scripts/block-direct-git-add.sh`
- `bash .codex/scripts/git-add-files.sh .codex/rules/default.rules .codex/hooks.json .codex/scripts/block-direct-git-add.sh docs/superpowers/plans/2026-05-31-codex-git-add-enforcement.md`
- `npx prettier --check .codex/hooks.json docs/superpowers/plans/2026-05-31-codex-git-add-enforcement.md`
- `git diff --check`
- `git commit` 時の Prettier / TypeScript チェック通過