### PR TITLE
fix(security): XML entity expansion を無効化 (#396)

### DIFF
--- a/src/utils/__tests__/json-xml.test.ts
+++ b/src/utils/__tests__/json-xml.test.ts
@@ -90,4 +90,11 @@ describe('xmlToJson', () => {
 
     expect(result.root.value).toBe(`&<>"'AA`);
   });
+
+  it('範囲外の数値文字参照は literal のまま保持される', () => {
+    const xml = `<root><value>&#x110000;</value></root>`;
+    const result = JSON.parse(xmlToJson(xml));
+
+    expect(result.root.value).toBe('&#x110000;');
+  });
 });

--- a/src/utils/__tests__/json-xml.test.ts
+++ b/src/utils/__tests__/json-xml.test.ts
@@ -1,3 +1,4 @@
+import { XMLParser } from 'fast-xml-parser';
 import { describe, it, expect } from 'vitest';
 import { jsonToXml, xmlToJson } from '../json-xml';
 
@@ -45,5 +46,30 @@ describe('xmlToJson', () => {
     const xml = `<root><key>value</key></root>`;
     const result = xmlToJson(xml);
     expect(result).toContain('\n');
+  });
+
+  it('processEntities を有効にした正の対照では内部実体が展開される', () => {
+    // Positive control: this proves the entity-expansion path exists in fast-xml-parser.
+    // If this test is removed, the security regression check below would no longer
+    // demonstrate that the old behavior expands custom entities.
+    const xml = `<!DOCTYPE note [<!ENTITY greeting "expanded">]><note><value>&greeting;</value></note>`;
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '@_',
+      textNodeName: '#text',
+      parseAttributeValue: true,
+      processEntities: true,
+    });
+
+    const result = parser.parse(xml);
+
+    expect(result.note.value).toBe('expanded');
+  });
+
+  it('xmlToJson は内部実体を展開しない', () => {
+    const xml = `<!DOCTYPE note [<!ENTITY greeting "expanded">]><note><value>&greeting;</value></note>`;
+    const result = JSON.parse(xmlToJson(xml));
+
+    expect(result.note.value).toBe('&greeting;');
   });
 });

--- a/src/utils/__tests__/json-xml.test.ts
+++ b/src/utils/__tests__/json-xml.test.ts
@@ -23,6 +23,17 @@ describe('jsonToXml', () => {
     expect(result).toContain('テスト');
   });
 
+  it('特殊文字を含む値は round-trip で保持される', () => {
+    const input = {
+      text: `A & B < C > D "quote" 'apostrophe'`,
+    };
+
+    const xml = jsonToXml(JSON.stringify(input));
+    const result = JSON.parse(xmlToJson(xml));
+
+    expect(result.root.text).toBe(input.text);
+  });
+
   it('不正なJSONでエラーを投げる', () => {
     expect(() => jsonToXml('{invalid}')).toThrow('有効なJSONではありません');
   });
@@ -71,5 +82,12 @@ describe('xmlToJson', () => {
     const result = JSON.parse(xmlToJson(xml));
 
     expect(result.note.value).toBe('&greeting;');
+  });
+
+  it('定義済みXML実体と数値文字参照は復元される', () => {
+    const xml = `<root><value>&amp;&lt;&gt;&quot;&apos;&#65;&#x41;</value></root>`;
+    const result = JSON.parse(xmlToJson(xml));
+
+    expect(result.root.value).toBe(`&<>"'AA`);
   });
 });

--- a/src/utils/json-xml.ts
+++ b/src/utils/json-xml.ts
@@ -34,12 +34,16 @@ function decodeXmlEntity(value: string): string {
 
     if (namedEntity.startsWith('#x')) {
       const codePoint = Number.parseInt(namedEntity.slice(2), 16);
-      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint);
+      return Number.isNaN(codePoint) || codePoint > 0x10ffff
+        ? entity
+        : String.fromCodePoint(codePoint);
     }
 
     if (namedEntity.startsWith('#')) {
       const codePoint = Number.parseInt(namedEntity.slice(1), 10);
-      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint);
+      return Number.isNaN(codePoint) || codePoint > 0x10ffff
+        ? entity
+        : String.fromCodePoint(codePoint);
     }
 
     return entity;

--- a/src/utils/json-xml.ts
+++ b/src/utils/json-xml.ts
@@ -16,6 +16,54 @@ const BUILDER_OPTIONS = {
   indentBy: '  ',
 };
 
+const PREDEFINED_XML_ENTITIES = new Map([
+  ['amp', '&'],
+  ['lt', '<'],
+  ['gt', '>'],
+  ['quot', '"'],
+  ['apos', "'"],
+]);
+
+function decodeXmlEntity(value: string): string {
+  return value.replace(/&(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);/g, (entity) => {
+    const namedEntity = entity.slice(1, -1);
+
+    if (PREDEFINED_XML_ENTITIES.has(namedEntity)) {
+      return PREDEFINED_XML_ENTITIES.get(namedEntity) ?? entity;
+    }
+
+    if (namedEntity.startsWith('#x')) {
+      const codePoint = Number.parseInt(namedEntity.slice(2), 16);
+      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint);
+    }
+
+    if (namedEntity.startsWith('#')) {
+      const codePoint = Number.parseInt(namedEntity.slice(1), 10);
+      return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint);
+    }
+
+    return entity;
+  });
+}
+
+function restoreXmlEntities(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return decodeXmlEntity(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => restoreXmlEntities(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, restoreXmlEntities(child)])
+    );
+  }
+
+  return value;
+}
+
 /** JSON文字列 → XML文字列。失敗時は Error を投げる */
 export function jsonToXml(jsonStr: string): string {
   let parsed: unknown;
@@ -39,5 +87,5 @@ export function xmlToJson(xmlStr: string): string {
   } catch {
     throw new Error('有効なXMLではありません');
   }
-  return JSON.stringify(result, null, 2);
+  return JSON.stringify(restoreXmlEntities(result), null, 2);
 }

--- a/src/utils/json-xml.ts
+++ b/src/utils/json-xml.ts
@@ -5,6 +5,7 @@ const PARSER_OPTIONS = {
   attributeNamePrefix: '@_',
   textNodeName: '#text',
   parseAttributeValue: true,
+  processEntities: false,
 };
 
 const BUILDER_OPTIONS = {


### PR DESCRIPTION
## 概要

Issue #533 の B 項目のうち #396 に対応します。

- `fast-xml-parser` の `XMLParser` に `processEntities: false` を明示
- JSON/XML 変換では不要な内部 entity 展開を無効化
- `processEntities: true` で entity が展開される陽性対照テストを追加
- production path の `xmlToJson` では entity が展開されないことを regression test で確認

## 検証

- `npm test -- src/utils/__tests__/json-xml.test.ts`
- `npm run build`

## 関連

- #533
- #396