### PR TITLE
fix(a11y): aria-label form fields の autocomplete を明示 (#418)

### DIFF
--- a/src/components/tools/CharCount.tsx
+++ b/src/components/tools/CharCount.tsx
@@ -235,6 +235,7 @@ export function CharCountTool() {
                   onChange={handleSnsLimitChange}
                   aria-label="任意上限"
                   min="1"
+                  autoComplete="off"
                 />
               </span>
             }

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -301,6 +301,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                       value={field.ai}
                       onChange={(v) => handleAiSelect(i, v)}
                       ariaLabel={`AI コード ${i + 1}`}
+                      autoComplete="off"
                       options={AI_DEFS.map((d) => ({
                         value: d.ai,
                         label: d.label,
@@ -318,6 +319,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
                         mono
                         error={!!field.error}
                         aria-label={`AI フィールド値 ${i + 1}`}
+                        autoComplete="off"
                       />
                       {field.error && (
                         <p role="alert" className="caption text-error mt-1">

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -157,6 +157,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
                   rows={4}
                   className="caption font-mono w-full px-3 py-2 rounded-lg border border-input bg-surface text-default resize-none"
                   aria-label="秘密鍵（主催者が保管）"
+                  autoComplete="off"
                 />
               </div>
               <div>
@@ -172,6 +173,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
                   rows={4}
                   className="caption font-mono w-full px-3 py-2 rounded-lg border border-input bg-surface text-default resize-none"
                   aria-label="公開鍵（検証スタッフへ共有）"
+                  autoComplete="off"
                 />
               </div>
             </div>
@@ -246,6 +248,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
                       placeholder={generateTicketId(i + 1)}
                       mono
                       aria-label={`チケットID ${i + 1}`}
+                      autoComplete="off"
                     />
                   </div>
                   <div className="flex-1 min-w-0 flex flex-col gap-1">
@@ -257,6 +260,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
                       onChange={(v) => onUpdateTicket(i, 'name', v)}
                       placeholder="山田 太郎"
                       aria-label={`参加者名 ${i + 1}`}
+                      autoComplete="off"
                     />
                   </div>
                   <div className="flex-1 min-w-0 flex flex-col gap-1">
@@ -268,6 +272,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
                       onChange={(v) => onUpdateTicket(i, 'category', v)}
                       placeholder="一般・VIP など"
                       aria-label={`料金区分 ${i + 1}`}
+                      autoComplete="off"
                     />
                   </div>
                   <div className="flex items-center justify-between md:justify-end gap-2 mt-2 md:mt-0">

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -10,9 +10,17 @@ interface Props<T extends string> {
   onChange: (value: T) => void;
   ariaLabel?: string;
   id?: string;
+  autoComplete?: string;
 }
 
-export function Select<T extends string>({ options, value, onChange, ariaLabel, id }: Props<T>) {
+export function Select<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  id,
+  autoComplete,
+}: Props<T>) {
   return (
     <div className="relative">
       <select
@@ -20,6 +28,7 @@ export function Select<T extends string>({ options, value, onChange, ariaLabel, 
         value={value}
         onChange={(e) => onChange(e.target.value as T)}
         aria-label={ariaLabel}
+        autoComplete={autoComplete}
         className="caption w-full rounded-lg border border-input bg-default text-default appearance-none pl-3 pr-10 py-2"
       >
         {options.map((opt) => (

--- a/src/components/ui/__tests__/BareInput.test.tsx
+++ b/src/components/ui/__tests__/BareInput.test.tsx
@@ -58,4 +58,10 @@ describe('BareInput', () => {
     render(<BareInput value="" onChange={() => {}} aria-label="チケットID 1" />);
     expect(screen.getByRole('textbox', { name: 'チケットID 1' })).toBeTruthy();
   });
+
+  it('autoComplete を input に透過する', () => {
+    render(<BareInput value="" onChange={() => {}} autoComplete="off" aria-label="テスト" />);
+    const input = screen.getByLabelText('テスト') as HTMLInputElement;
+    expect(input.getAttribute('autocomplete')).toBe('off');
+  });
 });

--- a/src/components/ui/__tests__/Select.test.tsx
+++ b/src/components/ui/__tests__/Select.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Select } from '@/components/ui/Select';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Select', () => {
+  it('autoComplete を select に透過する', () => {
+    render(
+      <Select
+        value="a"
+        onChange={() => {}}
+        ariaLabel="サンプル"
+        autoComplete="off"
+        options={[{ value: 'a', label: 'A' }]}
+      />
+    );
+
+    const select = screen.getByLabelText('サンプル') as HTMLSelectElement;
+    expect(select.getAttribute('autocomplete')).toBe('off');
+  });
+});


### PR DESCRIPTION
## 概要

Issue #533 の B 項目のうち #418 に対応します。

- `aria-label` のみで識別している autofill 不要な form field に `autoComplete="off"` を追加
- `Select` が `autoComplete` を underlying `<select>` に透過できるように拡張
- `BareInput` / `Select` の prop 透過 unit test を追加

## 対象

- GS1 DataBar の AI コード / AI フィールド値
- 文字数カウントの任意上限
- QRチケット生成の readonly key textarea
- QRチケット生成のチケットID / 参加者名 / 料金区分

## 検証

- `npm test -- src/components/ui/__tests__/BareInput.test.tsx src/components/ui/__tests__/Select.test.tsx`
- `npm run build`

## 関連

- #533
- #418