### PR TITLE
docs: squash マージ時の --subject/--body-file 指定を必須ルールとして明記

### DIFF
--- a/.agents/rules/common.md
+++ b/.agents/rules/common.md
@@ -12,8 +12,7 @@
   - 例: ✅ `feat: 新しいツールを追加` / ❌ `feat: Add new tool`（英語） / ❌ `update: ...`（プレフィックス不正）
   - `Merge`, `Revert`, `fixup!`, `squash!` で始まるコミットはチェックをスキップ
   - **squash マージで develop に乗るコミット件名も同じ規約に従う**。GitHub の squash は件名のデフォルトが PR タイトルで、`.githooks/commit-msg` は GitHub 上の squash には効かない（prefix なしコミットが素通りする事故あり）。手順・対策 → `docs/playbooks/pr-creation.md` 6 章
-  - **マージ方法**: feature PR（→ develop）は `--squash`、release PR（develop → main）は `--merge`。
-  - **`--squash` 時は `--subject` と `--body-file` を必ず指定**（省略禁止）。例: `gh pr merge <N> --squash --delete-branch --subject "fix: 〇〇 (#N)" --body-file /tmp/claude/squash_body.md`
+
 - **コード内コメント**: 日本語を基本とする。
 
 ---
@@ -120,6 +119,11 @@ gh pr create --base develop --title "..." --body-file <tmpdir>/pr_body.md   # <t
 **`main` 向けはリリース PR のみ**。通常の機能追加・バグ修正・refactor・docs は全て develop ベース。リリース時は別途 `develop → main` の release PR を切る運用 (release-only branch policy)。
 
 PR 作成・親 push 前チェックリスト・親向けレビュー取得手順 → **`docs/playbooks/pr-creation.md` 3〜5 章**
+
+### 6.3.1 マージ方法の使い分け
+
+- **feature PR（→ develop）**: `--squash`。**`--subject` と `--body-file` を必ず指定**（省略すると全コミットが自動連結されノイズになる）。詳細手順 → `docs/playbooks/pr-creation.md` 6 章
+- **release PR（develop → main）**: `--merge`。
 
 ### 6.4 先送り（deferral）時は必ず issue 化する
 

--- a/.agents/rules/common.md
+++ b/.agents/rules/common.md
@@ -12,6 +12,7 @@
   - 例: ✅ `feat: 新しいツールを追加` / ❌ `feat: Add new tool`（英語） / ❌ `update: ...`（プレフィックス不正）
   - `Merge`, `Revert`, `fixup!`, `squash!` で始まるコミットはチェックをスキップ
   - **squash マージで develop に乗るコミット件名も同じ規約に従う**。GitHub の squash は件名のデフォルトが PR タイトルで、`.githooks/commit-msg` は GitHub 上の squash には効かない（prefix なしコミットが素通りする事故あり）。手順・対策 → `docs/playbooks/pr-creation.md` 6 章
+  - ⚠️ **`gh pr merge --squash` は必ず `--subject` と `--body-file` を同時指定**。省略すると GitHub がブランチ内全コミットを自動連結した本文を生成し、レビュー往復の途中経過が git log に永続残留する。`--subject` なしでの実行は禁止。
 - **コード内コメント**: 日本語を基本とする。
 
 ---

--- a/.agents/rules/common.md
+++ b/.agents/rules/common.md
@@ -122,8 +122,10 @@ PR 作成・親 push 前チェックリスト・親向けレビュー取得手�
 
 ### 6.3.1 マージ方法の使い分け
 
-- **feature PR（→ develop）**: `--squash`。**`--subject` と `--body-file` を必ず指定**（省略すると全コミットが自動連結されノイズになる）。詳細手順 → `docs/playbooks/pr-creation.md` 6 章
-- **release PR（develop → main）**: `--merge`。
+> ⚠️ **PR 作成・編集・マージ時は必ず `docs/playbooks/pr-creation.md` を参照すること。**
+
+- **feature PR（→ develop）**: `--squash`
+- **release PR（develop → main）**: `--merge`
 
 ### 6.4 先送り（deferral）時は必ず issue 化する
 

--- a/.agents/rules/common.md
+++ b/.agents/rules/common.md
@@ -12,7 +12,8 @@
   - 例: ✅ `feat: 新しいツールを追加` / ❌ `feat: Add new tool`（英語） / ❌ `update: ...`（プレフィックス不正）
   - `Merge`, `Revert`, `fixup!`, `squash!` で始まるコミットはチェックをスキップ
   - **squash マージで develop に乗るコミット件名も同じ規約に従う**。GitHub の squash は件名のデフォルトが PR タイトルで、`.githooks/commit-msg` は GitHub 上の squash には効かない（prefix なしコミットが素通りする事故あり）。手順・対策 → `docs/playbooks/pr-creation.md` 6 章
-  - ⚠️ **`gh pr merge --squash` は必ず `--subject` と `--body-file` を同時指定**。省略すると GitHub がブランチ内全コミットを自動連結した本文を生成し、レビュー往復の途中経過が git log に永続残留する。`--subject` なしでの実行は禁止。
+  - **マージ方法**: feature PR（→ develop）は `--squash`、release PR（develop → main）は `--merge`。
+  - **`--squash` 時は `--subject` と `--body-file` を必ず指定**（省略禁止）。例: `gh pr merge <N> --squash --delete-branch --subject "fix: 〇〇 (#N)" --body-file /tmp/claude/squash_body.md`
 - **コード内コメント**: 日本語を基本とする。
 
 ---

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -176,7 +176,7 @@ prefix_rule(
     pattern = ["gh", "pr", "merge"],
     decision = "prompt",
     justification = "Do not rely on the default merge method. Use --squash for develop-bound PRs and --merge for release PRs to main.",
-    match = ["gh pr merge <pr-number> --squash --delete-branch", "gh pr merge <pr-number> --merge --delete-branch"],
+    match = ["gh pr merge <pr-number> --squash --delete-branch --subject \"<prefix>: <日本語要約> (#<pr-number>)\" --body-file /tmp/codex/squash_body.md", "gh pr merge <pr-number> --merge --delete-branch"],
 )
 
 prefix_rule(

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -155,6 +155,16 @@ gh pr merge <PR> --squash --delete-branch \
 
 `--body-file` を使うのは、本文がほぼ常に複数行になるため（理由は `.agents/rules/common.md` 6.1 と同じ）。
 
+### リリース PR のマージ（develop → main）
+
+release PR（develop → main）は **`--merge`** を使う（squash しない）。develop に積み上げた squash コミット群をそのまま main に引き継ぐため。
+
+```bash
+gh pr merge <PR> --merge --delete-branch
+```
+
+squash merge と異なり `--subject` / `--body-file` の指定は不要（merge commit のメッセージは GitHub が自動生成する `Merge pull request #N ...` で十分）。
+
 ## 7. マージ後の worktree 後始末
 
 `gh pr merge --delete-branch` を打つ前に worktree を unlock + remove する。`worktree-agent-<id>` の内部 branch も別途 `git branch -D` で削除（記憶: feedback_worktree_merge_order）。

--- a/tests/meta/codex-rules-not-match.test.ts
+++ b/tests/meta/codex-rules-not-match.test.ts
@@ -14,6 +14,7 @@ import {
   commandMatchesPrefix,
   matchViolations,
   notMatchViolations,
+  parseMatch,
   prefixRuleBlocks,
 } from './helpers/codexRules.js';
 
@@ -142,6 +143,37 @@ describe('Codex gh pr merge policy', () => {
     expect(mergePolicyViolations(broken)).toContain(
       'merge guidance must mention develop and main targets'
     );
+  });
+});
+
+describe('Codex gh pr merge squash match フォーマット検証', () => {
+  function squashMatchFlags(source: string): string {
+    const block = prefixRuleBlocks(source).find((b) =>
+      b.includes('pattern = ["gh", "pr", "merge"]')
+    );
+    const matches = block ? (parseMatch(block) ?? []) : [];
+    return matches.find((m) => m.includes('--squash')) ?? '';
+  }
+
+  it('陰性対照: squash match 例に --subject と --body-file が含まれる', () => {
+    const rules = readFileSync(codexRules, 'utf8');
+    const squashExample = squashMatchFlags(rules);
+    expect(squashExample).toContain('--subject');
+    expect(squashExample).toContain('--body-file');
+  });
+
+  it('陽性対照: --subject/--body-file を欠く squash match 例の欠落を検知する', () => {
+    const broken = [
+      'prefix_rule(',
+      '    pattern = ["gh", "pr", "merge"],',
+      '    decision = "prompt",',
+      '    justification = "...",',
+      '    match = ["gh pr merge <pr-number> --squash --delete-branch"],',
+      ')',
+    ].join('\n');
+    const squashExample = squashMatchFlags(broken);
+    expect(squashExample).not.toContain('--subject');
+    expect(squashExample).not.toContain('--body-file');
   });
 });
 


### PR DESCRIPTION
## 概要

- `gh pr merge --squash` 実行時は `--subject` と `--body-file` の両方を必須とするルールを `.agents/rules/common.md` に明記
- 省略すると GitHub が全コミットを自動連結した本文を生成し git log にノイズが永続残留する事故を防ぐ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
