### PR TITLE
[codex] SQL埋め込み結果欄の高さを揃える

### DIFF
--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -103,8 +103,8 @@ export function SqlFormatterTool() {
             </p>
           </div>
 
-          <div className="flex flex-col md:flex-row gap-4 items-start">
-            <div className="w-full md:flex-1 min-w-0 space-y-4">
+          <div className="flex flex-col md:flex-row gap-4 items-stretch">
+            <div className="w-full md:flex-1 min-w-0 space-y-4" data-testid="embed-input-column">
               <InputField
                 id="embed-sql-input"
                 label="プレースホルダ付き SQL"
@@ -133,13 +133,19 @@ export function SqlFormatterTool() {
               />
               {embed.error && <ErrorMessage message={embed.error} variant="block" />}
             </div>
-            <div className="w-full md:flex-1 min-w-0">
+            <div
+              className="w-full md:flex-1 min-w-0 flex md:self-stretch"
+              data-testid="embed-output-column"
+            >
               <OutputField
                 id="embed-output"
                 label="埋め込み結果"
                 value={embed.output}
                 rows={16}
                 ariaLabel="埋め込み結果"
+                className="md:flex md:h-full md:flex-col"
+                statusClassName="md:flex md:flex-1 md:min-h-0"
+                textareaClassName="md:block md:h-full md:min-h-0"
               />
             </div>
           </div>

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -143,9 +143,7 @@ export function SqlFormatterTool() {
                 value={embed.output}
                 rows={16}
                 ariaLabel="埋め込み結果"
-                className="md:flex md:h-full md:flex-col"
-                statusClassName="md:flex md:flex-1 md:min-h-0"
-                textareaClassName="md:block md:h-full md:min-h-0"
+                fill
               />
             </div>
           </div>

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -134,7 +134,7 @@ export function SqlFormatterTool() {
               {embed.error && <ErrorMessage message={embed.error} variant="block" />}
             </div>
             <div
-              className="w-full md:flex-1 min-w-0 flex md:self-stretch"
+              className="w-full md:flex-1 min-w-0 md:flex md:self-stretch"
               data-testid="embed-output-column"
             >
               <OutputField

--- a/src/components/ui/OutputField.tsx
+++ b/src/components/ui/OutputField.tsx
@@ -22,12 +22,11 @@ interface OutputFieldProps {
   showCopy?: boolean;
   /** ラベル右側に並べる追加要素（ダウンロードボタンなど） */
   rightSlot?: ReactNode;
-  /** 外側コンテナに追加するクラス */
-  className?: string;
-  /** textarea ラッパーに追加するクラス */
-  statusClassName?: string;
-  /** textarea に追加するクラス */
-  textareaClassName?: string;
+  /**
+   * 親 flex コンテナの高さいっぱいに textarea を伸ばす（左右カラムの高さ揃え用）。既定 false。
+   * fill が true のとき手動リサイズは無効化され、managed height が保証される。
+   */
+  fill?: boolean;
 }
 
 /**
@@ -45,15 +44,17 @@ export function OutputField({
   copyLabel = 'コピー',
   showCopy = true,
   rightSlot,
-  className,
-  statusClassName,
-  textareaClassName,
+  fill = false,
 }: OutputFieldProps) {
   const hasValue = value !== '';
   const monoClass = mono ? 'font-mono' : '';
-  const resizeClass = resize ? 'resize-y' : 'resize-none';
+  // fill 時は managed height を保証するため手動リサイズを強制無効化する
+  const resizeClass = fill || !resize ? 'resize-none' : 'resize-y';
+  const fillContainerClass = fill ? 'md:flex md:h-full md:flex-col' : '';
+  const fillStatusClass = fill ? 'md:flex md:flex-1 md:min-h-0' : '';
+  const fillTextareaClass = fill ? 'md:block md:h-full md:min-h-0' : '';
   return (
-    <div className={`w-full ${className ?? ''}`.trim()}>
+    <div className={`w-full ${fillContainerClass}`.trim()}>
       <div className="flex items-center justify-between mb-3 min-h-8">
         <label htmlFor={id} className="body-emphasis text-default">
           {label}
@@ -65,15 +66,18 @@ export function OutputField({
           </div>
         )}
       </div>
-      <div role="status" aria-live="polite" aria-atomic="false" className={statusClassName}>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="false"
+        className={fillStatusClass || undefined}
+      >
         <textarea
           id={id}
           readOnly
           value={value}
           rows={rows}
-          className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide ${
-            textareaClassName ?? ''
-          }`.trim()}
+          className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide ${fillTextareaClass}`.trim()}
           aria-label={ariaLabel ?? label}
         />
       </div>

--- a/src/components/ui/OutputField.tsx
+++ b/src/components/ui/OutputField.tsx
@@ -22,6 +22,12 @@ interface OutputFieldProps {
   showCopy?: boolean;
   /** ラベル右側に並べる追加要素（ダウンロードボタンなど） */
   rightSlot?: ReactNode;
+  /** 外側コンテナに追加するクラス */
+  className?: string;
+  /** textarea ラッパーに追加するクラス */
+  statusClassName?: string;
+  /** textarea に追加するクラス */
+  textareaClassName?: string;
 }
 
 /**
@@ -39,12 +45,15 @@ export function OutputField({
   copyLabel = 'コピー',
   showCopy = true,
   rightSlot,
+  className,
+  statusClassName,
+  textareaClassName,
 }: OutputFieldProps) {
   const hasValue = value !== '';
   const monoClass = mono ? 'font-mono' : '';
   const resizeClass = resize ? 'resize-y' : 'resize-none';
   return (
-    <div className="w-full">
+    <div className={`w-full ${className ?? ''}`.trim()}>
       <div className="flex items-center justify-between mb-3 min-h-8">
         <label htmlFor={id} className="body-emphasis text-default">
           {label}
@@ -56,13 +65,15 @@ export function OutputField({
           </div>
         )}
       </div>
-      <div role="status" aria-live="polite" aria-atomic="false">
+      <div role="status" aria-live="polite" aria-atomic="false" className={statusClassName}>
         <textarea
           id={id}
           readOnly
           value={value}
           rows={rows}
-          className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide`.trim()}
+          className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide ${
+            textareaClassName ?? ''
+          }`.trim()}
           aria-label={ariaLabel ?? label}
         />
       </div>

--- a/src/components/ui/__tests__/OutputField.test.tsx
+++ b/src/components/ui/__tests__/OutputField.test.tsx
@@ -57,3 +57,31 @@ describe('OutputField a11y contract', () => {
     expect(screen.getByRole('button', { name: 'コピー' })).toBeTruthy();
   });
 });
+
+describe('OutputField fill prop', () => {
+  it('fill=true のとき textarea が resize-none クラスを持ち resize-y を持たない', () => {
+    render(<OutputField id="out" label="変換結果" value="Hello" fill />);
+    const textarea = screen.getByLabelText('変換結果');
+    expect(textarea.classList.contains('resize-none')).toBe(true);
+    expect(textarea.classList.contains('resize-y')).toBe(false);
+  });
+
+  it('fill=true のとき textarea が md:h-full クラスを持つ（fill 用クラス付与の確認）', () => {
+    render(<OutputField id="out" label="変換結果" value="Hello" fill />);
+    const textarea = screen.getByLabelText('変換結果');
+    expect(textarea.classList.contains('md:h-full')).toBe(true);
+  });
+
+  it('fill=false（既定）のとき textarea が resize-y クラスを持ち resize-none を持たない（後方互換）', () => {
+    render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const textarea = screen.getByLabelText('変換結果');
+    expect(textarea.classList.contains('resize-y')).toBe(true);
+    expect(textarea.classList.contains('resize-none')).toBe(false);
+  });
+
+  it('fill=false（既定）のとき textarea に md:h-full クラスが付かない（後方互換）', () => {
+    render(<OutputField id="out" label="変換結果" value="Hello" />);
+    const textarea = screen.getByLabelText('変換結果');
+    expect(textarea.classList.contains('md:h-full')).toBe(false);
+  });
+});

--- a/tests/e2e/sql-formatter.spec.ts
+++ b/tests/e2e/sql-formatter.spec.ts
@@ -45,6 +45,56 @@ test.describe('SQL整形（production CSP 適用）', () => {
 });
 
 test.describe('SQLパラメータ埋め込み（production CSP 適用）', () => {
+  test('入力欄と結果欄の表示領域がデスクトップ幅で揃う（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/sql-formatter', async (page) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.getByRole('button', { name: 'パラメータ埋め込み' }).click();
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+
+      const inputColumn = page.getByTestId('embed-input-column');
+      const outputColumn = page.getByTestId('embed-output-column');
+      const sqlInput = page.getByLabel('プレースホルダ付き SQL');
+      const paramsInput = page.getByLabel('パラメータ（JSON）');
+      const output = page.getByRole('textbox', { name: '埋め込み結果' });
+
+      await expect(inputColumn).toBeVisible();
+      await expect(outputColumn).toBeVisible();
+      await expect(output).toBeVisible();
+
+      const inputColumnBox = await inputColumn.boundingBox();
+      const outputColumnBox = await outputColumn.boundingBox();
+      const sqlInputBox = await sqlInput.boundingBox();
+      const paramsInputBox = await paramsInput.boundingBox();
+      const outputBox = await output.boundingBox();
+
+      expect(inputColumnBox).not.toBeNull();
+      expect(outputColumnBox).not.toBeNull();
+      expect(sqlInputBox).not.toBeNull();
+      expect(paramsInputBox).not.toBeNull();
+      expect(outputBox).not.toBeNull();
+
+      expect(outputColumnBox!.x).toBeGreaterThan(inputColumnBox!.x + inputColumnBox!.width - 2);
+      expect(Math.abs(inputColumnBox!.y - outputColumnBox!.y)).toBeLessThanOrEqual(2);
+      expect(Math.abs(sqlInputBox!.y - outputBox!.y)).toBeLessThanOrEqual(2);
+
+      const paramsBottom = paramsInputBox!.y + paramsInputBox!.height;
+      const outputBottom = outputBox!.y + outputBox!.height;
+      expect(Math.abs(paramsBottom - outputBottom)).toBeLessThanOrEqual(6);
+    });
+  });
+
+  test('埋め込み結果欄はモバイル幅でも複数行の高さを保つ（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/sql-formatter', async (page) => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await page.getByRole('button', { name: 'パラメータ埋め込み' }).click();
+
+      const outputBox = await page.getByRole('textbox', { name: '埋め込み結果' }).boundingBox();
+
+      expect(outputBox).not.toBeNull();
+      expect(outputBox!.height).toBeGreaterThan(300);
+    });
+  });
+
   test('? 位置指定パラメータを埋め込める（CSP 違反なし）', async ({ browser }) => {
     await withProductionCsp(browser, '/tools/sql-formatter', async (page) => {
       await page.getByRole('button', { name: 'パラメータ埋め込み' }).click();

--- a/tests/e2e/sql-formatter.spec.ts
+++ b/tests/e2e/sql-formatter.spec.ts
@@ -74,11 +74,14 @@ test.describe('SQLパラメータ埋め込み（production CSP 適用）', () =>
       expect(outputBox).not.toBeNull();
 
       expect(outputColumnBox!.x).toBeGreaterThan(inputColumnBox!.x + inputColumnBox!.width - 2);
+      // サブピクセル丸め誤差の許容
       expect(Math.abs(inputColumnBox!.y - outputColumnBox!.y)).toBeLessThanOrEqual(2);
+      // サブピクセル丸め誤差の許容
       expect(Math.abs(sqlInputBox!.y - outputBox!.y)).toBeLessThanOrEqual(2);
 
       const paramsBottom = paramsInputBox!.y + paramsInputBox!.height;
       const outputBottom = outputBox!.y + outputBox!.height;
+      // label 行高さ + サブピクセル差分の許容
       expect(Math.abs(paramsBottom - outputBottom)).toBeLessThanOrEqual(6);
     });
   });
@@ -143,6 +146,32 @@ test.describe('SQLパラメータ埋め込み（production CSP 適用）', () =>
       await page.getByLabel('プレースホルダ付き SQL').fill('WHERE a = ?');
       await page.getByLabel('パラメータ（JSON）').fill('[1, 2]');
       await expect(page.getByRole('alert')).toBeVisible();
+    });
+  });
+
+  test('エラー表示時も入力カラムと出力カラムの高さが揃う（CSP 違反なし）', async ({ browser }) => {
+    await withProductionCsp(browser, '/tools/sql-formatter', async (page) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.getByRole('button', { name: 'パラメータ埋め込み' }).click();
+
+      // エラーを発生させる（件数不一致: サンプル SQL の ? が 2 つに対してパラメータが 10 個）
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await page.getByLabel('パラメータ（JSON）').fill('[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]');
+
+      // エラーが表示されることを確認してから測定する
+      await expect(page.getByRole('alert')).toBeVisible();
+
+      const inputColumn = page.getByTestId('embed-input-column');
+      const outputColumn = page.getByTestId('embed-output-column');
+
+      const inputColumnBox = await inputColumn.boundingBox();
+      const outputColumnBox = await outputColumn.boundingBox();
+
+      expect(inputColumnBox).not.toBeNull();
+      expect(outputColumnBox).not.toBeNull();
+
+      // items-stretch による高さ揃えを検証（サブピクセル丸め誤差の許容）
+      expect(Math.abs(inputColumnBox!.height - outputColumnBox!.height)).toBeLessThanOrEqual(2);
     });
   });
 });


### PR DESCRIPTION
## 概要

SQL整形・パラメータ埋め込みツールの「パラメータ埋め込み」タブで、右側の埋め込み結果欄が左側の入力スタックと同じ高さになるように調整しました。

## 変更内容

- 埋め込みタブの左右カラムを `items-stretch` で揃えるよう変更
- `OutputField` に高さ揃え用の `fill` prop を追加し、親 flex コンテナいっぱいに textarea を伸ばすレイアウト（外側 / status wrapper / textarea の 3 層へのクラス付与）をコンポーネント内にカプセル化
- `fill` 時は手動リサイズ（`resize-y`）と `h-full` の競合を避けるため `resize-none` を強制し managed height を保証
- SQL formatter E2E にレイアウト回帰テストを追加（デスクトップ幅の揃え・モバイル幅の高さ保持・エラー表示時のカラム高さ揃え）

## 背景

プレースホルダ付き SQL とパラメータ JSON の 2 段入力に対し、右側の埋め込み結果欄だけ高さが揃わず、下端が不一致になっていました。

## 検証

- `npm run pretest:e2e`
- `npx playwright test tests/e2e/sql-formatter.spec.ts --project=e2e` → 13 passed
- `npx vitest run src/components/ui/__tests__/OutputField.test.tsx` → 8 passed
- `node_modules/.bin/astro check` → 0 errors / 0 warnings / 0 hints
- `npx prettier --check src/components/tools/SqlFormatter.tsx src/components/ui/OutputField.tsx tests/e2e/sql-formatter.spec.ts` → pass

## レビュー指摘対応（#2〜#5）

| 指摘 | 対応 |
| :-- | :-- |
| #2 抽象の漏れ | `OutputField` の 3 つの className エスケープハッチを単一の `fill` prop に集約 |
| #3 resize 競合 | `fill` 時は `resize-none` を強制し managed height を保証 |
| #4 エラー時の揃え未検証 | エラー表示時のカラム高さ揃え E2E を追加（旧実装で 114px diff fail を確認した陽性対照） |
| #5 tolerance 根拠不明 | 許容値マジックナンバーに根拠コメントを付与 |
