### PR TITLE
refactor(ui): 静的ページの見出し typography を semantic class へ統一

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,15 +17,13 @@ const featured = FEATURED_404_SLUGS.map((slug) => tools.find((tool) => tool.slug
 >
   <main class="mx-auto max-w-2xl px-6 py-16" id="main-content">
     <div class="text-center">
-      <p class="font-bold text-[4rem] leading-none text-primary">404</p>
-      <h1 class="mt-4 mb-3 font-bold text-[1.75rem] leading-[1.4] tracking-[0.02em] text-default">
-        ページが見つかりません
-      </h1>
+      <p class="font-bold error-code text-primary">404</p>
+      <h1 class="mt-4 mb-3 font-bold page-heading text-default">ページが見つかりません</h1>
       <p class="mb-8 text-body">
         お探しのページは削除されたか、URL が間違っている可能性があります。
       </p>
       <p class="mb-12">
-        <a href="/" class="text-link text-base leading-[1.7] tracking-[0.02em]"> ← ホームに戻る </a>
+        <a href="/" class="text-link link-text"> ← ホームに戻る </a>
       </p>
     </div>
 
@@ -37,10 +35,7 @@ const featured = FEATURED_404_SLUGS.map((slug) => tools.find((tool) => tool.slug
         {
           featured.map((tool) => (
             <li>
-              <a
-                href={`/tools/${tool.slug}`}
-                class="text-link text-base leading-[1.7] tracking-[0.02em]"
-              >
+              <a href={`/tools/${tool.slug}`} class="text-link link-text">
                 {tool.name}
               </a>
               <span class="ml-2 caption text-muted">— {tool.description}</span>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -18,9 +18,7 @@ const jsonLd = {
   jsonLd={jsonLd}
 >
   <main class="mx-auto max-w-2xl px-6 py-12" id="main-content">
-    <h1 class="mb-8 font-bold text-[1.75rem] leading-[1.4] tracking-[0.02em] text-default">
-      About
-    </h1>
+    <h1 class="mb-8 font-bold page-heading text-default">About</h1>
 
     <section class="mb-10">
       <h2 class="mb-3 font-bold section-heading text-default">DevTools とは</h2>
@@ -53,10 +51,7 @@ const jsonLd = {
         {
           tools.map((tool) => (
             <li>
-              <a
-                href={`/tools/${tool.slug}`}
-                class="text-link text-base leading-[1.7] tracking-[0.02em]"
-              >
+              <a href={`/tools/${tool.slug}`} class="text-link link-text">
                 {tool.name}
               </a>
               <span class="ml-2 caption text-muted">— {tool.description}</span>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -19,9 +19,7 @@ const lastUpdated = '2026年4月12日';
   jsonLd={jsonLd}
 >
   <main class="mx-auto max-w-2xl px-6 py-12" id="main-content">
-    <h1 class="mb-2 font-bold text-[1.75rem] leading-[1.4] tracking-[0.02em] text-default">
-      プライバシーポリシー
-    </h1>
+    <h1 class="mb-2 font-bold page-heading text-default">プライバシーポリシー</h1>
     <p class="mb-10 caption text-muted">
       最終更新: {lastUpdated}
     </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -762,6 +762,29 @@
     color: var(--color-neutral-700);
   }
 
+  /* ページ h1 見出し: about/privacy/404 の静的ページ共通 (1.75rem)。
+     .section-heading (h2, 1.125rem) より一段大きい page タイトル用。
+     color は .section-heading と同様 class に含めず consumer 側で text-default を併用 (issue #535)。 */
+  .page-heading {
+    font-size: 1.75rem;
+    line-height: 1.4;
+    letter-spacing: 0.02em;
+  }
+
+  /* 404 ページの装飾的エラーコード (大型数字 "404")。色は text-primary を併用 (issue #535)。 */
+  .error-code {
+    font-size: 4rem;
+    line-height: 1;
+  }
+
+  /* 静的ページのリンクテキスト typography: about/404 のツール/ホームリンク。
+     色は text-link を併用 (typography のみ定義) (issue #535)。 */
+  .link-text {
+    font-size: 1rem;
+    line-height: 1.7;
+    letter-spacing: 0.02em;
+  }
+
   /* Horizontal scroll snap container: index hero carousel (1 occurrence、5 prop)
      注: 単発だが property 数が多く、Tailwind arbitrary 6連
      (`overflow-x-scroll snap-x snap-mandatory scroll-smooth


### PR DESCRIPTION
## 概要

issue #535 に対応。静的ページの見出し・リンク typography の arbitrary Tailwind 値（`text-[1.75rem]` 等）を `@layer components` の semantic class へ統一しました。**値は完全に同一で、視覚変化ゼロの純粋 refactor** です。

## 変更内容

### `src/styles/global.css` — 3 つの semantic class を追加

`.section-heading` / `.text-body`（#289 PR 7b ブロック）の隣に、既存慣習に沿って追加（色は class に含めず consumer 側で `text-default` / `text-link` / `text-primary` を併用）。

| class | 値 | 用途 |
| :-- | :-- | :-- |
| `.page-heading` | `1.75rem` / `1.4` / `0.02em` | 静的ページ h1（`.section-heading` より一段大きい） |
| `.error-code` | `4rem` / `line-height:1` | 404 装飾数字 |
| `.link-text` | `1rem` / `1.7` / `0.02em` | 静的ページのリンク typography |

### arbitrary 値の置換

- `about.astro`: h1 → `page-heading`、ツールリンク → `text-link link-text`
- `privacy.astro`: h1 → `page-heading`（issue 本文の「将来の静的ページ」方針に沿い、同一パターンのため統一対象に含めた）
- `404.astro`: 装飾 "404" → `error-code`、h1 → `page-heading`、リンク 2 箇所 → `text-link link-text`

スコープ外: `index.astro` の段落・タブ（リンクでなく色・文脈が異なるため別途）。

## 検証

- `node_modules/.bin/astro check`: 0 errors / 0 warnings（306 files）
- `npm run format`: 差分なし
- `npm run build`: 成功。`dist/_astro/BaseLayout.*.css` に `page-heading` / `error-code` / `link-text` の 3 class が生成されることを確認
- VRT: 同値置換のため差分ゼロを期待。最終確認は CI に委譲

closes #535

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sek97GamkF3NCX4JtAKqpm)_