### PR TITLE
fix(a11y): index.astro のタブボタンに type="button" を付与

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -116,6 +116,7 @@ const jsonLd = {
         class="mb-6 flex gap-1 border-b border-default overflow-x-auto"
       >
         <button
+          type="button"
           role="tab"
           id="tab-0"
           aria-selected="true"
@@ -128,6 +129,7 @@ const jsonLd = {
         {
           categories.map((cat, i) => (
             <button
+              type="button"
               role="tab"
               id={`tab-${i + 1}`}
               aria-selected="false"


### PR DESCRIPTION
## 概要

issue #271 の一部に対応。`src/pages/index.astro` 内の `role="tab"` を持つ `<button>` 要素 2 件に `type="button"` 属性を追加した。

- 「すべて」タブの固定 `<button role="tab">`
- `categories.map()` で生成される各カテゴリタブの `<button role="tab">`

`<button>` の `type` 省略時のデフォルトは `submit` のため、フォーム内に置かれた場合に意図しないサブミットを誘発しうる。HTML 仕様準拠と a11y 改善のため明示する。視覚・動作の変化はなし。

## スコープ外（#271 残課題）

ESLint `react/button-has-type` の導入は本 PR に含めない。本プロジェクトには現状 ESLint 自体が未導入で、新規依存追加・config 作成・CI 連携判断を伴い規模が大きいため。ESLint 導入は #271 に残課題として残置する。

## 検証

- `node_modules/.bin/astro check`: pass（0 errors / 0 warnings / 0 hints）
- `npm run test`: pass（無関係な環境起因の既存 fail 1 件 `codex-git-add-files.test.ts` を除く）
- `npm run build`: pass
- VRT baseline 更新: 不要（属性追加のみで視覚差なし）

関連: #271

https://claude.ai/code/session_01LfZEfdXMhzNoc5Vj8Yrx3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfZEfdXMhzNoc5Vj8Yrx3x)_