### PR TITLE
refactor(config-converter): 未使用の detectFormat と関連テストを削除

### DIFF
--- a/src/utils/config-converter/__tests__/convert.test.ts
+++ b/src/utils/config-converter/__tests__/convert.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { convert, detectFormat } from '../index';
+import { convert } from '../index';
 
 describe('convert', () => {
   it('JSONをYAMLに変換する', () => {
@@ -65,35 +65,5 @@ describe('convert', () => {
   it('dotenv→JSONで値の文字列読み込み警告を出す', () => {
     const result = convert('KEY=value', 'dotenv', 'json');
     expect(result.warnings).toContain('値はすべて文字列として読み込まれます');
-  });
-});
-
-describe('detectFormat', () => {
-  it('JSONを検出する ({で始まる)', () => {
-    expect(detectFormat('{"a":1}')).toBe('json');
-  });
-
-  it('JSONを検出する ([で始まる)', () => {
-    expect(detectFormat('[1,2,3]')).toBe('json');
-  });
-
-  it('YAMLを検出する (---で始まる)', () => {
-    expect(detectFormat('---\nkey: value')).toBe('yaml');
-  });
-
-  it('YAMLを検出する (key: value形式)', () => {
-    expect(detectFormat('key: value\nother: 123')).toBe('yaml');
-  });
-
-  it('TOMLを検出する ([section]形式)', () => {
-    expect(detectFormat('[server]\nport = 8080')).toBe('toml');
-  });
-
-  it('dotenvを検出する (KEY=VALUE形式)', () => {
-    expect(detectFormat('KEY=value\nOTHER=test')).toBe('dotenv');
-  });
-
-  it('不明な形式でnullを返す', () => {
-    expect(detectFormat('   ')).toBeNull();
   });
 });

--- a/src/utils/config-converter/index.ts
+++ b/src/utils/config-converter/index.ts
@@ -65,39 +65,3 @@ export function convert(text: string, from: ConfigFormat, to: ConfigFormat): Con
 
   return { output, warnings };
 }
-
-/** テキストのフォーマットをヒューリスティックに検出する */
-export function detectFormat(text: string): ConfigFormat | null {
-  const trimmed = text.trim();
-
-  if (trimmed === '') {
-    return null;
-  }
-
-  // TOML: [section] パターン — JSON の配列より先にチェック
-  if (/^\[[\w.]+\]/m.test(trimmed)) {
-    return 'toml';
-  }
-
-  // JSON: { または [ で始まる
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-    return 'json';
-  }
-
-  // YAML: --- で始まる、または key: value パターンを含む
-  if (trimmed.startsWith('---')) {
-    return 'yaml';
-  }
-
-  // YAML: key: value パターン (TOMLの後にチェック)
-  if (/^[\w-]+\s*:(\s|$)/m.test(trimmed)) {
-    return 'yaml';
-  }
-
-  // dotenv: KEY=VALUE パターン
-  if (/^[A-Z_][A-Z0-9_]*=.*/im.test(trimmed)) {
-    return 'dotenv';
-  }
-
-  return null;
-}


### PR DESCRIPTION
## 概要

issue #138 に対応（B案: YAGNI による dead code 削除）。

`src/utils/config-converter/index.ts` の `detectFormat` 関数は `export` されているものの、`ConfigConverter.tsx` をはじめ UI・他ユーティリティから一切呼ばれておらず、テスト 7 件だけが dead code を支えている状態だった。必要になった時点で再実装する方針で削除する。

## 変更内容

- `src/utils/config-converter/index.ts`: `detectFormat` 関数定義（28行）を削除
- `src/utils/config-converter/__tests__/convert.test.ts`: `detectFormat` の import と専用テスト `describe('detectFormat')` 7 件を削除

`ConfigFormat` / `ConvertResult` 型は `convert` 関数でも使用中のため残置。

## 確認事項

- 全 `.ts`/`.tsx`/`.astro`/`.md` を grep し、削除後の参照が **0 件** であることを確認
- `docs/` / `SPEC.md` / `README.md` への `detectFormat` 記載は無く、更新不要

## 検証

- `node_modules/.bin/astro check`: pass（0 errors / 0 warnings / 0 hints）
- `npm run test`: pass（config-converter 関連 12 件全 pass。無関係な環境起因の pre-existing fail を除く）
- `npm run build`: pass

Closes #138

https://claude.ai/code/session_01LfZEfdXMhzNoc5Vj8Yrx3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfZEfdXMhzNoc5Vj8Yrx3x)_