### PR TITLE
refactor(ui): CopyButton と compact ボタンの角丸を rounded-lg に統一し共有定数化

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3727,3 +3727,25 @@ json-formatter 段階リリースの最終段（クエリ・マスク・型生�
 - ✅ テキスト/マスク/型表示中はツリーを構築しない。巨大入力でも自動凍結しない。
 - ⚠️ 閾値超のツリーは明示操作後に構築するため、強制表示すると依然重い（仮想化は後続）。閾値は整形済み長の単純指標で、ノード数とは厳密一致しない。
 - ツリー仮想化 / Worker オフロードは #512 残として follow-up。
+
+---
+
+## [097] 2026-06-01 — CopyButton と compact ボタンの角丸を rounded-lg に統一（issue #320 / c案）
+
+**2026-06-01 | ステータス: 採用**
+
+### 背景
+
+PR #318 後も `CopyButton`(default) は `rounded`(0.25rem)、`ActionButton`(size="compact") / `DownloadButton` は `rounded-lg`(0.5rem) で border-radius が不一致だった。class 名 assert ベースの unit test では片方だけ変わる silent drift を検出できない問題があった（issue #320）。
+
+### 決断（c案）
+
+- **rounded-lg に統一**: CopyButton 側を 0.25rem → 0.5rem に上げ、ActionButton compact / DownloadButton に揃える。プロジェクトの主流は rounded-lg。
+- **共有定数化**: `src/components/ui/_compactButton.ts` に `COMPACT_BUTTON_SHAPE_CLASSES = 'rounded-lg font-bold px-3 py-2 leading-none'` を切り出し、`ActionButton`(compact 経路) と `CopyButton`(default 経路) の両方から import して使う。
+- **cross-component drift 検知テスト追加**: `src/components/ui/__tests__/compact-button-radius-drift.test.tsx` で両コンポーネントの compact token 集合が一致することを assert。陽性対照テスト（旧実装 rounded に戻すと fail するテスト）を同ファイル内別 describe に併設（test-gates 準拠）。
+
+### 結果・トレードオフ
+
+- ✅ 両コンポーネントの角丸が共有定数で一元管理され、以降の一方の変更は即座に test fail で検知される。
+- ✅ CopyButton 固有（caption / tracking-wide / gap-1.5 / btn-copy 等）・ActionButton 固有（btn-action / variant class 等）のクラスは各自に残し、共有するのは「compact 高さ + 角丸」部分のみ。
+- ⚠️ CopyButton の見た目（角丸）が変わるため VRT baseline 差分が発生する。CI Linux runner の `Update Visual Regression Baseline` workflow を workflow_dispatch で再生成が必要（ローカル不可）。

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { COMPACT_BUTTON_SHAPE_CLASSES } from './_compactButton';
 
 type Variant = 'default' | 'primary' | 'secondary' | 'danger';
 type Size = 'default' | 'compact';
@@ -15,20 +16,21 @@ interface Props extends Omit<
   /**
    * 高さプリセット。
    * - 'default'（既定）: `font-semibold px-4 py-2`、`caption` の line-height 1.7 を継承
-   * - 'compact': `font-bold px-3 py-2 leading-none`、CopyButton (default) と同じ高さ
+   * - 'compact': COMPACT_BUTTON_SHAPE_CLASSES（rounded-lg / font-bold / px-3 py-2 / leading-none）、
+   *   CopyButton (default) と同じ高さ・角丸（issue #320 で統一）
    */
   size?: Size;
 }
 
 const SIZE_CLASS: Record<Size, string> = {
   default: 'font-semibold px-4 py-2',
-  compact: 'font-bold px-3 py-2 leading-none',
+  compact: COMPACT_BUTTON_SHAPE_CLASSES,
 };
 
 /**
  * 汎用アクションボタン。
  * - `variant`: 'default' | 'primary' | 'secondary' | 'danger'
- * - `size`: 'default' | 'compact'（'compact' は CopyButton と同じ高さに揃える）
+ * - `size`: 'default' | 'compact'（'compact' は CopyButton と同じ高さ・角丸に揃える）
  * - `loading`: true のとき `aria-busy="true"` を付与し、disabled 状態にする
  * - ローディング中の子要素はそのまま表示するため、呼び出し元でローディング文言に切り替えること
  *   （例: `{loading ? '生成中…' : '生成'}`）

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -14,8 +14,9 @@ interface Props extends Omit<
   variant?: Variant;
   loading?: boolean;
   /**
-   * 高さプリセット。
-   * - 'default'（既定）: `font-semibold px-4 py-2`、`caption` の line-height 1.7 を継承
+   * 高さプリセット。角丸（rounded-lg）は両サイズとも SIZE_CLASS 経由で供給し、
+   * base className には持たせない（issue #320: 共有定数を角丸の単一の真実源にするため）。
+   * - 'default'（既定）: `rounded-lg font-semibold px-4 py-2`、`caption` の line-height 1.7 を継承
    * - 'compact': COMPACT_BUTTON_SHAPE_CLASSES（rounded-lg / font-bold / px-3 py-2 / leading-none）、
    *   CopyButton (default) と同じ高さ・角丸（issue #320 で統一）
    */
@@ -23,7 +24,7 @@ interface Props extends Omit<
 }
 
 const SIZE_CLASS: Record<Size, string> = {
-  default: 'font-semibold px-4 py-2',
+  default: 'rounded-lg font-semibold px-4 py-2',
   compact: COMPACT_BUTTON_SHAPE_CLASSES,
 };
 
@@ -57,7 +58,7 @@ export function ActionButton({
       onClick={onClick}
       disabled={isDisabled}
       aria-busy={loading ? 'true' : undefined}
-      className={`caption inline-flex items-center rounded-lg whitespace-nowrap btn-action btn-action--${variant} ${SIZE_CLASS[size]}`}
+      className={`caption inline-flex items-center whitespace-nowrap btn-action btn-action--${variant} ${SIZE_CLASS[size]}`}
       {...rest}
     >
       {children}

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { copyToClipboard } from '@/utils/clipboard';
+import { COMPACT_BUTTON_SHAPE_CLASSES } from './_compactButton';
 
 function ClipboardIcon() {
   return (
@@ -66,6 +67,9 @@ interface Props {
  *
  * style: global.css `@layer components` の `.btn-copy` / `.btn-copy.is-copied` /
  * `.btn-copy.is-compact` を参照。状態は `is-copied` / `is-compact` className で切替。
+ *
+ * default 表示の角丸は COMPACT_BUTTON_SHAPE_CLASSES 経由で ActionButton (size="compact") /
+ * DownloadButton と統一（rounded-lg / issue #320）。
  */
 export function CopyButton({
   text,
@@ -114,7 +118,7 @@ export function CopyButton({
       type="button"
       onClick={handleClick}
       aria-label={accessibleName}
-      className={`btn-copy ${stateClass} caption font-bold inline-flex items-center gap-1.5 rounded px-3 py-2 leading-none tracking-wide whitespace-nowrap ${className}`.trim()}
+      className={`btn-copy ${stateClass} caption inline-flex items-center gap-1.5 ${COMPACT_BUTTON_SHAPE_CLASSES} tracking-wide whitespace-nowrap ${className}`.trim()}
     >
       {copied ? <CheckIcon /> : <ClipboardIcon />}
       {label}

--- a/src/components/ui/__tests__/compact-button-radius-drift.test.tsx
+++ b/src/components/ui/__tests__/compact-button-radius-drift.test.tsx
@@ -26,7 +26,13 @@ afterEach(() => {
  * COMPACT_BUTTON_SHAPE_CLASSES から各 utility を抽出するヘルパー。
  * 定数から直接 token を取り出すことで、実装との 1:1 対応を保証する。
  */
-function extractCompactTokens(classStr: string): { borderRadius: string; px: string; py: string; leading: string; fontWeight: string } {
+function extractCompactTokens(classStr: string): {
+  borderRadius: string;
+  px: string;
+  py: string;
+  leading: string;
+  fontWeight: string;
+} {
   const classes = classStr.split(' ');
   const borderRadius = classes.find((c) => c.startsWith('rounded')) ?? '';
   const px = classes.find((c) => c.startsWith('px-')) ?? '';
@@ -47,10 +53,10 @@ describe('compact ボタン border-radius drift 検知 (陰性対照)', () => {
     const tokens = extractCompactTokens(COMPACT_BUTTON_SHAPE_CLASSES);
 
     expect(btn.className).toContain(tokens.borderRadius); // 'rounded-lg'
-    expect(btn.className).toContain(tokens.px);           // 'px-3'
-    expect(btn.className).toContain(tokens.py);           // 'py-2'
-    expect(btn.className).toContain(tokens.leading);      // 'leading-none'
-    expect(btn.className).toContain(tokens.fontWeight);   // 'font-bold'
+    expect(btn.className).toContain(tokens.px); // 'px-3'
+    expect(btn.className).toContain(tokens.py); // 'py-2'
+    expect(btn.className).toContain(tokens.leading); // 'leading-none'
+    expect(btn.className).toContain(tokens.fontWeight); // 'font-bold'
   });
 
   it('ActionButton(size="compact") は COMPACT_BUTTON_SHAPE_CLASSES の全 token を含む', () => {

--- a/src/components/ui/__tests__/compact-button-radius-drift.test.tsx
+++ b/src/components/ui/__tests__/compact-button-radius-drift.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * cross-component メタテスト: CopyButton(default) と ActionButton(size="compact") の
+ * border-radius ・パディング・行高さが共有定数 COMPACT_BUTTON_SHAPE_CLASSES 経由で
+ * 一致していることを検証する drift 検知器。
+ *
+ * 問題の背景: PR #318 後も CopyButton は rounded(0.25rem)、ActionButton compact は
+ * rounded-lg(0.5rem) で不一致が残っていた。class 名 assert ベースの unit test では
+ * 片方だけ変わる silent drift を検出できないため、issue #320 で共有定数化 + 本テストを追加。
+ *
+ * 陽性対照: 下記「陽性対照 (positive control)」テストを参照。
+ * CopyButton か ActionButton compact の角丸を rounded に戻すと必ず fail する設計にしている。
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { ActionButton } from '@/components/ui/ActionButton';
+import { COMPACT_BUTTON_SHAPE_CLASSES } from '@/components/ui/_compactButton';
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * COMPACT_BUTTON_SHAPE_CLASSES から各 utility を抽出するヘルパー。
+ * 定数から直接 token を取り出すことで、実装との 1:1 対応を保証する。
+ */
+function extractCompactTokens(classStr: string): { borderRadius: string; px: string; py: string; leading: string; fontWeight: string } {
+  const classes = classStr.split(' ');
+  const borderRadius = classes.find((c) => c.startsWith('rounded')) ?? '';
+  const px = classes.find((c) => c.startsWith('px-')) ?? '';
+  const py = classes.find((c) => c.startsWith('py-')) ?? '';
+  const leading = classes.find((c) => c.startsWith('leading-')) ?? '';
+  const fontWeight = classes.find((c) => c.startsWith('font-')) ?? '';
+  return { borderRadius, px, py, leading, fontWeight };
+}
+
+// ─── 陰性対照（正常系）: 共有定数の各 token が両コンポーネントに存在する ───────────────
+// ⚠️ これ単独では「検知能力ゼロで green」との区別ができない。
+// 陽性対照（下記）と合わせて初めて drift 検知器として機能する。
+
+describe('compact ボタン border-radius drift 検知 (陰性対照)', () => {
+  it('CopyButton(default) は COMPACT_BUTTON_SHAPE_CLASSES の全 token を含む', () => {
+    render(<CopyButton text="test" label="コピー" />);
+    const btn = screen.getByRole('button', { name: 'コピー' }) as HTMLButtonElement;
+    const tokens = extractCompactTokens(COMPACT_BUTTON_SHAPE_CLASSES);
+
+    expect(btn.className).toContain(tokens.borderRadius); // 'rounded-lg'
+    expect(btn.className).toContain(tokens.px);           // 'px-3'
+    expect(btn.className).toContain(tokens.py);           // 'py-2'
+    expect(btn.className).toContain(tokens.leading);      // 'leading-none'
+    expect(btn.className).toContain(tokens.fontWeight);   // 'font-bold'
+  });
+
+  it('ActionButton(size="compact") は COMPACT_BUTTON_SHAPE_CLASSES の全 token を含む', () => {
+    render(
+      <ActionButton onClick={() => {}} size="compact">
+        ダウンロード
+      </ActionButton>
+    );
+    const btn = screen.getByRole('button', { name: 'ダウンロード' }) as HTMLButtonElement;
+    const tokens = extractCompactTokens(COMPACT_BUTTON_SHAPE_CLASSES);
+
+    expect(btn.className).toContain(tokens.borderRadius); // 'rounded-lg'
+    expect(btn.className).toContain(tokens.px);
+    expect(btn.className).toContain(tokens.py);
+    expect(btn.className).toContain(tokens.leading);
+    expect(btn.className).toContain(tokens.fontWeight);
+  });
+
+  it('CopyButton(default) と ActionButton(compact) の compact 関連 token 集合が一致する', () => {
+    render(<CopyButton text="test" label="コピー" />);
+    const copyBtn = screen.getByRole('button', { name: 'コピー' }) as HTMLButtonElement;
+    cleanup();
+
+    render(
+      <ActionButton onClick={() => {}} size="compact">
+        ダウンロード
+      </ActionButton>
+    );
+    const actionBtn = screen.getByRole('button', { name: 'ダウンロード' }) as HTMLButtonElement;
+
+    const copyTokens = extractCompactTokens(copyBtn.className);
+    const actionTokens = extractCompactTokens(actionBtn.className);
+
+    // 両コンポーネントの compact token が完全一致することを確認する drift 検知
+    expect(copyTokens).toEqual(actionTokens);
+  });
+});
+
+// ─── 陽性対照 (positive control): 旧実装では必ず fail する検知能力の証明 ────────────────
+// test-gates ルール準拠: 検知能力ゼロで green にならないことを保証する。
+//
+// 検証方法: 旧実装（CopyButton が rounded を使用）では copyTokens.borderRadius = 'rounded'、
+// COMPACT_BUTTON_SHAPE_CLASSES には 'rounded-lg' が含まれるため
+// expect(copyTokens.borderRadius).toBe(expectedRadius) が fail する。
+// → 「CopyButton の rounded を rounded-lg に統一した」修正が機能していることを証明する。
+//
+// もし CopyButton の角丸を再び rounded に戻すと、このテストが fail して drift を検知できる。
+
+describe('compact ボタン border-radius drift 検知 (陽性対照)', () => {
+  it('[陽性対照] COMPACT_BUTTON_SHAPE_CLASSES が rounded-lg を指定していることを確認する', () => {
+    // 定数自体が rounded-lg を含む前提。これが変わったら意図的な変更として検知する。
+    const tokens = extractCompactTokens(COMPACT_BUTTON_SHAPE_CLASSES);
+    expect(tokens.borderRadius).toBe('rounded-lg');
+  });
+
+  it('[陽性対照] CopyButton(default) の角丸が rounded-lg であることを確認する (旧実装 rounded では fail)', () => {
+    // 旧実装: CopyButton に 'rounded' が直書きされていた。
+    // → このテストは rounded-lg を assert するため、旧実装に当てると必ず fail する。
+    // → 角丸が再び rounded に戻った場合も検知できる。
+    render(<CopyButton text="test" label="コピー" />);
+    const btn = screen.getByRole('button', { name: 'コピー' }) as HTMLButtonElement;
+
+    // 'rounded-lg' が存在することを assert
+    expect(btn.className).toContain('rounded-lg');
+
+    // 旧実装の 'rounded'（= 0.25rem, rounded-lg 以外の rounded）が単体で含まれないことを確認
+    // ('rounded-lg' は 'rounded' を部分一致で含むため、単体 token として存在しないことを検証)
+    const classes = btn.className.split(' ');
+    const hasPlainRounded = classes.includes('rounded');
+    expect(hasPlainRounded).toBe(false); // 'rounded' のみ（rounded-lgではない）が含まれていたら fail
+  });
+
+  it('[陽性対照] ActionButton(compact) の角丸が rounded-lg であることを確認する', () => {
+    render(
+      <ActionButton onClick={() => {}} size="compact">
+        ダウンロード
+      </ActionButton>
+    );
+    const btn = screen.getByRole('button', { name: 'ダウンロード' }) as HTMLButtonElement;
+    const classes = btn.className.split(' ');
+
+    expect(classes).toContain('rounded-lg');
+    expect(classes).not.toContain('rounded'); // plain 'rounded' (0.25rem) は含まない
+  });
+});

--- a/src/components/ui/_compactButton.ts
+++ b/src/components/ui/_compactButton.ts
@@ -1,0 +1,9 @@
+/**
+ * compact ボタン共通 utility クラス群。
+ * CopyButton (default) と ActionButton (size="compact") / DownloadButton の
+ * 角丸・パディング・行高さを一箇所で管理し、両者の不一致（border-radius drift）を防ぐ。
+ *
+ * 歴史: PR #318 後も CopyButton は rounded(0.25rem) / ActionButton compact は rounded-lg(0.5rem)
+ * で不一致が残っていたため、issue #320 で rounded-lg に統一し本定数として共有化。
+ */
+export const COMPACT_BUTTON_SHAPE_CLASSES = 'rounded-lg font-bold px-3 py-2 leading-none' as const;


### PR DESCRIPTION
## 概要

issue #320 に対応（c案: 共有定数化 + border-radius 統一 + cross-component drift 検知テスト）。

PR #318 後も `CopyButton`(default) は `rounded`(0.25rem)、`DownloadButton`(=`ActionButton` size="compact") は `rounded-lg`(0.5rem) で角丸が不一致のままだった。class 名 assert ベースの unit test では「片方だけ変わる」silent drift を検出できないため、共有定数化とメタテストで構造的に固める。

**統一方向**: `rounded-lg`（プロジェクト主流。CopyButton を 0.25→0.5rem に上げ、DownloadButton/ActionButton compact に揃える）

## 変更内容

- **`src/components/ui/_compactButton.ts`（新規）**: `COMPACT_BUTTON_SHAPE_CLASSES = 'rounded-lg font-bold px-3 py-2 leading-none'` を共有定数として切り出し
- **`ActionButton.tsx`**: 角丸を base className のハードコードから外し、`SIZE_CLASS.default`（`rounded-lg ...`）/ `SIZE_CLASS.compact`（共有定数）の両サイズ経由で供給。共有定数を compact 経路の角丸の単一の真実源にし、base の二重付与を解消（レビュー指摘 (a) 対応）
- **`CopyButton.tsx`**: default 表示の `rounded px-3 py-2 leading-none` を共有定数に置換（CopyButton 固有クラスは保持）
- **`DownloadButton.tsx`**: ActionButton ラッパーのため変更不要（統一を自動享受）
- **`compact-button-radius-drift.test.tsx`（新規）**: CopyButton と ActionButton(compact) の compact 関連 utility 集合を比較する drift 検知メタテスト
- **`docs/decisions.md`**: `[097]` として決定記録を追記

## test-gates（陽性対照）

drift 検知メタテストは陰性対照（両者一致を検証）に加え、**陽性対照**（共有定数の `rounded-lg` を `rounded` に戻すと fail することを別 describe で保証）を併設。検知能力ゼロで green にならないことを保証している。(a) 対応後は CopyButton 側・ActionButton(compact) 側の双方の陽性対照が定数に依存して fail することを実証確認済み（陰性3 + 陽性3 = 6 件 pass）。

## 検証

- `node_modules/.bin/astro check`: pass（0 errors / 0 warnings / 0 hints）
- `npm run test`: pass（drift テスト 6 件含む。無関係な環境起因の pre-existing fail を除く）
- `npm run build`: pass
- CI: test / e2e / visual-regression / visual-regression-report いずれも success

## VRT について

当初は CopyButton の角丸変更で baseline 再生成が必要と想定していたが、**VRT は全 48 件 pass**（角丸 0.25→0.5rem の差分は閾値内に収まり、(a) のリファクタも視覚出力は不変）。**baseline 再生成は不要**。

Closes #320

https://claude.ai/code/session_01LfZEfdXMhzNoc5Vj8Yrx3x