### PR TITLE
chore(vrt): dead code 化した crypto.randomUUID mock を VRT spec から削除

### DIFF
--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -189,7 +189,7 @@ npm run test:vrt
 ### 7.4 VRT 自体の architecture 変更（rare ops）
 
 - spec は `tests/e2e/visual-regression.spec.ts`
-- mock は `addInitScript` で `Math.random` / `crypto.randomUUID` / `Date.now` を固定（spec 上部参照）
+- mock は `addInitScript` で `Math.random` / `Date.now` を固定（spec 上部参照）
 - 新 page を VRT 対象に追加: spec の `PAGES` 配列に path 追記 → baseline 再生成
 - 新 viewport 追加: `VIEWPORTS` 配列に追記 → baseline 再生成
 - 詳細: `docs/decisions.md` [066]

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -7,7 +7,7 @@ import { PAGES, STATIC_PAGES } from './visual-regression-pages';
  *
  * 全 18 ページ × 2 viewport (Desktop 1280×800 / Mobile 390×844) = 36 screenshot を
  * baseline 比較する。production code には一切手を入れず、`addInitScript` で
- * `Math.random` / `crypto.randomUUID` / `Date.now` を deterministic に固定して non-determinism を排除。
+ * `Math.random` / `Date.now` を deterministic に固定して non-determinism を排除。
  *
  * 運用:
  * - baseline は CI Linux runner で生成（mac とのフォントレンダリング差を回避）
@@ -48,17 +48,6 @@ for (const viewport of VIEWPORTS) {
             seed = (seed * 1103515245 + 12345) & 0x7fffffff;
             return seed / 0x7fffffff;
           };
-
-          // Incremental UUID counter: 00000000-0000-0000-0000-NNNNNNNNNNNN 形式に
-          let uuidCounter = 0;
-          if (window.crypto) {
-            const fixedUuid = (): `${string}-${string}-${string}-${string}-${string}` => {
-              uuidCounter++;
-              const n = uuidCounter.toString().padStart(12, '0');
-              return `00000000-0000-0000-0000-${n}` as `${string}-${string}-${string}-${string}-${string}`;
-            };
-            window.crypto.randomUUID = fixedUuid;
-          }
 
           // Fixed Date: 2026-01-01T00:00:00Z で固定
           // Date.now() に加え `new Date()` (引数なし) も FIXED_NOW を返すよう constructor も mock


### PR DESCRIPTION
## 概要

issue #412 の対応。PR #408 で Gs1Databar が `crypto.randomUUID()` を呼ばなくなった（`useId()` + monotonic counter に置換、SSR/CSR 同一 id を保証して hydration mismatch を解消）結果、production code で `crypto.randomUUID()` を呼ぶ箇所がゼロになり、VRT spec に注入されていた `crypto.randomUUID` mock が **dead code** 化していた。これを削除する。

## 変更内容

- `tests/e2e/visual-regression.spec.ts`
  - `addInitScript` 内の「Incremental UUID counter」mock ブロック（`uuidCounter` / `fixedUuid` / `window.crypto.randomUUID` 代入）を削除
  - 冒頭 doc コメントの mock 列挙から `crypto.randomUUID` を除去
  - **`Math.random`（seeded LCG）と `Date.now`/`Date` constructor の mock は引き続き必要なので維持**。`localStorage`/`sessionStorage` clear ブロックも維持
- `docs/playbooks/e2e-validation.md`（7.4 節）の mock 列挙から `crypto.randomUUID` を除去

issue 記載の通り `docs/superpowers/**`（historical snapshot）および `docs/decisions.md`（決定記録の履歴）は対象外として変更していない。

## 受け入れ基準

- [x] `crypto.randomUUID` mock ブロック削除（未使用変数の残存なし）
- [x] `docs/playbooks/e2e-validation.md` から `crypto.randomUUID` 言及を削除
- [x] `node_modules/.bin/astro check` pass（0 errors）
- [ ] CI Linux runner の VRT が pass し baseline 再生成不要であること（= dead mock 削除で screenshot 不変 = production code で誰も呼んでいなかった証明）

## 備考

VRT baseline はあえて再生成していない。screenshot が変わらなければ「mock が dead だった」ことの証明になるため、CI Linux runner の VRT 結果で確認する想定。

Closes #412

https://claude.ai/code/session_016gvUENpeSy8rNvt8s7qcKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016gvUENpeSy8rNvt8s7qcKQ)_