### PR TITLE
refactor(ui): text-xs 直書き 4 箇所を semantic class hint-xs へ統一

### DIFF
--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -299,7 +299,7 @@ export function EncodingConverterTool() {
               accept={ACCEPT_ATTR}
             />
           </label>
-          <p className="text-xs text-muted mt-1">
+          <p className="hint-xs text-muted mt-1">
             対応形式: テキストファイル（.txt / .csv / .json / .xml / .yaml / .toml 等）・最大 10 MB
           </p>
           {fileBytes && (

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -45,7 +45,7 @@ function PayloadValue({ k, v }: { k: string; v: unknown }) {
       <span className="jwt-json-key">"{k}"</span>
       <span className="text-default">: </span>
       <span className="jwt-json-value">{JSON.stringify(v)}</span>
-      {isTs && <span className="ml-2 text-xs text-muted">→ {formatTimestamp(v as number)}</span>}
+      {isTs && <span className="ml-2 hint-xs text-muted">→ {formatTimestamp(v as number)}</span>}
     </span>
   );
 }

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -155,7 +155,7 @@ export function QrReaderTool() {
               <FileInputButton accept="image/*" onChange={handleImageUpload} id="qr-image-input">
                 画像を選択
               </FileInputButton>
-              <p className="text-xs text-muted mt-1">
+              <p className="hint-xs text-muted mt-1">
                 対応形式: PNG / JPEG / WebP / GIF / SVG・最大 15 MB
               </p>
             </div>

--- a/src/components/tools/qr-ticket/VerifyTab.tsx
+++ b/src/components/tools/qr-ticket/VerifyTab.tsx
@@ -120,7 +120,7 @@ export function VerifyTab({
                   aria-label="画像を選択"
                 />
               </label>
-              <p className="text-xs text-muted mt-1">
+              <p className="hint-xs text-muted mt-1">
                 対応形式: PNG / JPEG / WebP / GIF / SVG・最大 15 MB
               </p>
               {!verifyPubKeyStr.trim() && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -593,6 +593,14 @@
     opacity: 0.7;
   }
 
+  /* 0.75rem の補足テキスト用 semantic class（Tailwind primitive `text-xs` 直書きの代替）。
+     Tailwind v4 の text-xs (font-size 0.75rem / line-height calc(1/0.75)) を完全再現し、
+     VRT を不変に保ちつつ primitive utility 依存を解消する（issue #399 案B）。 */
+  .hint-xs {
+    font-size: 0.75rem;
+    line-height: calc(1 / 0.75);
+  }
+
   /* === Gs1Databar: バーコードプレビューの sub-pixel anti-alias 抑止 ===
      bwip-js は bar を <path stroke="#000000" stroke-width="N" d="..."> で描く。
      vector だがブラウザは high-DPR / 非整数 scaling 時に raster cache を介して

--- a/tests/meta/no-primitive-text-xs.test.ts
+++ b/tests/meta/no-primitive-text-xs.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+/**
+ * meta test: primitive `text-xs` 直書き禁止ガード (PR #571 レビュー指摘 / issue #399 恒久化)
+ *
+ * PR #571 で `text-xs` 直書き 4 箇所を semantic class `.hint-xs` に統一した。
+ * しかし手作業の置換なので、将来 `src/` に再び `text-xs` が書かれても検知されない。
+ * 本テストを CI (`npm run test`) で走らせることで、primitive `text-xs` の再混入が
+ * merge 前に必ず fail として検知される。
+ *
+ * 許可リスト:
+ *   - `src/components/ui/CopyButton.tsx`: コンパクトボタン内テキストで別用途として
+ *     意図的に維持（PR #399 のスコープ外として除外）。
+ *
+ * 対象: `src/` 配下の tsx / astro ファイル（再帰）
+ * 除外: css ファイル（global.css の `.hint-xs` 説明コメント内の "text-xs" を
+ *        誤検知しないため）/ `tests/` ディレクトリ
+ */
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+/**
+ * 許可リスト。リポジトリ相対パス（`/` 区切り）で指定。
+ * OS 依存しないよう path 区切りを `/` に正規化して比較する。
+ */
+const ALLOWLIST: ReadonlySet<string> = new Set([
+  // CopyButton のコンパクト表示で別用途。#399 のスコープ外として意図的に維持。
+  'src/components/ui/CopyButton.tsx',
+]);
+
+/** `\btext-xs\b` (word boundary) で primitive Tailwind utility を検出する正規表現 */
+const TEXT_XS_RE = /\btext-xs\b/;
+
+/**
+ * ファイル一覧を受け取り、許可リスト外で `text-xs` を使っている違反箇所を返す純粋関数。
+ * 陰性対照（実 src スキャン）と陽性対照（fixture 注入）の両方で共有する。
+ *
+ * @param files - パスとコンテンツのペア配列（path はリポジトリ相対パス、`/` 区切り）
+ * @param allowlist - スキップするリポジトリ相対パスの Set
+ * @returns 違反箇所 { path, line } の配列
+ */
+function findPrimitiveTextXs(
+  files: { path: string; content: string }[],
+  allowlist: ReadonlySet<string>
+): { path: string; line: number }[] {
+  const violations: { path: string; line: number }[] = [];
+  for (const file of files) {
+    // path 区切りを `/` に正規化して OS 依存しない比較を行う
+    const normalizedPath = file.path.replace(/\\/g, '/');
+    if (allowlist.has(normalizedPath)) continue;
+    const lines = file.content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (TEXT_XS_RE.test(lines[i])) {
+        violations.push({ path: normalizedPath, line: i + 1 });
+      }
+    }
+  }
+  return violations;
+}
+
+/** `src/` 配下の `.tsx` / `.astro` ファイルを再帰収集する */
+function collectSrcComponents(root: string, results: string[] = []): string[] {
+  const skipDirs = new Set(['node_modules', '.git', 'dist', '.astro', 'coverage']);
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (skipDirs.has(entry.name)) continue;
+    const fullPath = join(root, entry.name);
+    let isDir = entry.isDirectory();
+    let isFile = entry.isFile();
+    if (entry.isSymbolicLink()) {
+      try {
+        const stat = statSync(fullPath);
+        isDir = stat.isDirectory();
+        isFile = stat.isFile();
+      } catch {
+        continue;
+      }
+    }
+    if (isDir) {
+      collectSrcComponents(fullPath, results);
+    } else if (isFile && (entry.name.endsWith('.tsx') || entry.name.endsWith('.astro'))) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+// --- 陰性対照: 実 src スキャンで違反ゼロを保証 ---
+
+describe('src 配下での primitive text-xs 使用禁止', () => {
+  it('src/**/*.{tsx,astro} に許可リスト外の text-xs が存在しない', () => {
+    const srcRoot = join(REPO_ROOT, 'src');
+    const absolutePaths = collectSrcComponents(srcRoot);
+    const files = absolutePaths.map((absPath) => ({
+      path: relative(REPO_ROOT, absPath).replace(/\\/g, '/'),
+      content: readFileSync(absPath, 'utf-8'),
+    }));
+
+    const violations = findPrimitiveTextXs(files, ALLOWLIST);
+    expect(
+      violations,
+      violations.length > 0
+        ? `primitive text-xs が検出されました:\n${violations.map((v) => `  ${v.path}:${v.line}`).join('\n')}\n→ .hint-xs など semantic class に置き換えてください`
+        : ''
+    ).toEqual([]);
+  });
+});
+
+// --- 陽性対照: 検知機構が空回りしていないことを保証 (test-gates skill 準拠) ---
+
+describe('[陽性対照] primitive text-xs 検知機構', () => {
+  it('許可リスト外のファイルに className="text-xs ..." があると検出される', () => {
+    const files = [
+      {
+        path: 'src/components/tools/FakeTool.tsx',
+        content: 'return <span className="text-xs font-medium">ヒント</span>;',
+      },
+    ];
+    const violations = findPrimitiveTextXs(files, ALLOWLIST);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0].path).toBe('src/components/tools/FakeTool.tsx');
+  });
+
+  it('許可リストに登録されたパスは text-xs があっても検出されない (allowlist が効く)', () => {
+    const files = [
+      {
+        path: 'src/components/ui/CopyButton.tsx',
+        content: 'className="btn-copy text-xs px-2"',
+      },
+    ];
+    const violations = findPrimitiveTextXs(files, ALLOWLIST);
+    expect(violations).toEqual([]);
+  });
+
+  it('違反ファイルと clean ファイルの混在で違反ファイルのみ列挙する (過検知なし)', () => {
+    const files = [
+      {
+        path: 'src/components/tools/ViolatingTool.tsx',
+        content: '<span className="text-xs">bad</span>',
+      },
+      {
+        path: 'src/components/tools/CleanTool.tsx',
+        content: '<span className="hint-xs">good</span>',
+      },
+      {
+        path: 'src/pages/tools/clean-page.astro',
+        content: '<p class="body-sm">no violation here</p>',
+      },
+    ];
+    const violations = findPrimitiveTextXs(files, ALLOWLIST);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].path).toBe('src/components/tools/ViolatingTool.tsx');
+  });
+
+  it('text-xs を含まない clean ファイルのみでは何も検出しない (過検知なし)', () => {
+    const files = [
+      {
+        path: 'src/components/tools/ToolA.tsx',
+        content: '<div className="hint-xs">ヒントテキスト</div>',
+      },
+      {
+        path: 'src/pages/tools/tool-b.astro',
+        content: '<p class="body-sm text-sm">通常テキスト</p>',
+      },
+    ];
+    const violations = findPrimitiveTextXs(files, ALLOWLIST);
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

issue #399 の対応（**案B: semantic class 化**）。typography system では `caption` (0.875rem) が最小本文サイズだが、補足テキスト4箇所で Tailwind primitive utility `text-xs` (0.75rem) を直書きしており system 逸脱になっていた。サイズ (0.75rem) を維持したまま primitive→semantic class へ統一し、再混入を防ぐ回帰ガードも追加する。

案A（`caption` 0.875rem への昇格）ではなく案Bを採用した理由: サイズを変えないことで **視覚変化ゼロ＝VRT baseline 再生成不要** とし、PR #570(#412) と同じく「VRT 全 pass＝視覚不変の証明」として変更の安全性を受動検証できるため。可読性改善（案A）は deferral として #572 に分離。

## 変更内容

- `src/styles/global.css` の `@layer components` に `.hint-xs` を新設
  - Tailwind v4 の `text-xs`（`font-size: 0.75rem; line-height: calc(1 / 0.75)`）を **font-size・line-height の両方** 含めて完全再現。line-height を省くと単一行要素のボックス高が変わり VRT が diff るため両方を一致させている
- `QrReader.tsx` / `EncodingConverter.tsx` / `qr-ticket/VerifyTab.tsx` / `JwtDecoder.tsx` の **補足テキスト4箇所** で `text-xs` → `hint-xs` に置換し、これら4箇所の primitive 依存を解消
- `CopyButton.tsx` の `text-xs` は **スコープ外**（ボタン内テキストで別用途）のため変更なし。したがって本 PR は src 全体の primitive 解消ではなく「補足テキスト4箇所」の局所統一である
- **回帰ガード追加（レビュー指摘 #2）**: `tests/meta/no-primitive-text-xs.test.ts` を新設。`src/**/*.{tsx,astro}` を再帰スキャンし許可リスト外の primitive `text-xs` 再混入を CI で検知。`test-gates` 規約に従い陽性対照4ケースを別 describe に同梱（CopyButton は許可リストで除外）

## 検証

- [x] `astro check` pass（0 errors）
- [x] `npm run build` 後、生成 CSS に `.hint-xs{font-size:.75rem;line-height:1.33333}` が出力されることを確認（= `calc(1/0.75)` = text-xs と一致）
- [x] 対象4ファイルに `text-xs` 残存なし / CopyButton のみ維持
- [x] `npm run test`（新規 meta テスト 5/5 pass 含む。変更起因の失敗なし。残る1件は sandbox 環境依存の既知失敗で変更無関係）
- [x] CI: `visual-regression`（VRT本体）・`test` success ＝「視覚不変＝baseline 再生成不要」を実証
- [ ] 追加コミット後の CI 再実行（`e2e` 含む）の完了確認

## 補足

`.hint-xs` は variant prefix を付けずに使うため、Tailwind v4 の `@layer components` 手書き class の variant 非対応制約（CLAUDE.md 7.1 章）には抵触しない。

Closes #399

https://claude.ai/code/session_016gvUENpeSy8rNvt8s7qcKQ