### PR TITLE
refactor: qr-ticket.ts の buildPayload 非公開化と PAYLOAD_FIELD_COUNT dead export 削除 (#222)

### DIFF
--- a/src/utils/__tests__/qr-ticket.test.ts
+++ b/src/utils/__tests__/qr-ticket.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-  buildPayload,
   serializeTicket,
   parseQrString,
   generateKeyPair,
@@ -13,7 +12,6 @@ import {
   generateQrSvg,
   generateTicketId,
   estimateTicketByteSize,
-  PAYLOAD_FIELD_COUNT,
   type TicketPayload,
   type SignedTicket,
 } from '@/utils/qr-ticket';
@@ -53,65 +51,32 @@ describe('estimateTicketByteSize', () => {
 });
 
 // ────────────────────────────────────────────
-// buildPayload
+// serializeTicket
 // ────────────────────────────────────────────
-describe('buildPayload', () => {
+describe('serializeTicket', () => {
   const base: TicketPayload = { e: 'event-01', t: 'T-00001', timestamp: 1735689540 }; // 2024-12-31T23:59:00Z
 
   it('必須フィールドのみでパイプ区切りの文字列を返す', () => {
-    const result = buildPayload(base);
-    expect(result).toBe('event-01|T-00001|1735689540||');
+    expect(serializeTicket(base)).toBe('event-01|T-00001|1735689540||');
   });
 
   it('任意フィールド n, p を含む場合も正しくパイプで連結される', () => {
     const payload: TicketPayload = { ...base, n: '山田 太郎', p: 'VIP' };
-    const result = buildPayload(payload);
-    expect(result).toBe('event-01|T-00001|1735689540|山田 太郎|VIP');
+    expect(serializeTicket(payload)).toBe('event-01|T-00001|1735689540|山田 太郎|VIP');
   });
 
   it('フィールド内に | が含まれる場合は throw する', () => {
     const payload: TicketPayload = { ...base, n: '山田|太郎', p: 'VIP|A' };
-    expect(() => buildPayload(payload)).toThrow('|');
+    expect(() => serializeTicket(payload)).toThrow('|');
   });
 
   it('同一入力で常に同一の出力を返す（決定論性）', () => {
-    expect(buildPayload(base)).toBe(buildPayload(base));
+    expect(serializeTicket(base)).toBe(serializeTicket(base));
   });
 
   it('任意フィールドが空文字の場合は空として連結される', () => {
     const payload: TicketPayload = { ...base, n: '', p: '' };
-    const result = buildPayload(payload);
-    expect(result).toBe('event-01|T-00001|1735689540||');
-  });
-});
-
-// ────────────────────────────────────────────
-// PAYLOAD_FIELD_COUNT
-// ────────────────────────────────────────────
-describe('PAYLOAD_FIELD_COUNT', () => {
-  it('6 であること（ペイロード 5 フィールド + 署名 1）', () => {
-    expect(PAYLOAD_FIELD_COUNT).toBe(6);
-  });
-});
-
-// ────────────────────────────────────────────
-// serializeTicket
-// ────────────────────────────────────────────
-describe('serializeTicket', () => {
-  const base: TicketPayload = { e: 'event-01', t: 'T-00001', timestamp: 1735689540 };
-
-  it('buildPayload と同一のパイプ区切り文字列を返す', () => {
-    expect(serializeTicket(base)).toBe(buildPayload(base));
-  });
-
-  it('任意フィールドを含む場合も正しくシリアライズされる', () => {
-    const payload: TicketPayload = { ...base, n: '山田 太郎', p: 'VIP' };
-    expect(serializeTicket(payload)).toBe('event-01|T-00001|1735689540|山田 太郎|VIP');
-  });
-
-  it('フィールドに | が含まれる場合は throw する', () => {
-    const payload: TicketPayload = { ...base, n: 'bad|name' };
-    expect(() => serializeTicket(payload)).toThrow('|');
+    expect(serializeTicket(payload)).toBe('event-01|T-00001|1735689540||');
   });
 });
 

--- a/src/utils/qr-ticket.ts
+++ b/src/utils/qr-ticket.ts
@@ -94,7 +94,7 @@ export function parseQrString(raw: string): { payload: string; signature: string
   const payload = raw.slice(0, lastPipe);
   const signature = raw.slice(lastPipe + 1);
   if (!signature) return null;
-  // ペイロード部のフィールド数チェック（PAYLOAD_FIELDS.length フィールド分のパイプ区切り）
+  // ペイロードが PAYLOAD_FIELDS.length 個のフィールドに分解できることを確認
   const payloadParts = payload.split('|');
   if (payloadParts.length !== PAYLOAD_FIELDS.length) return null;
   return { payload, signature };

--- a/src/utils/qr-ticket.ts
+++ b/src/utils/qr-ticket.ts
@@ -19,9 +19,6 @@ export const MAX_QR_BYTE_SIZE = 250;
 /** ペイロードのフィールド名リスト（シリアライズ順） */
 const PAYLOAD_FIELDS = ['e', 't', 'timestamp', 'n', 'p'] as const;
 
-/** QRコードに含まれるパイプ区切りフィールドの数 (eventId|ticketId|timestamp|name|category|signature) */
-export const PAYLOAD_FIELD_COUNT = PAYLOAD_FIELDS.length + 1; // +1 は signature 分
-
 // ─── 型定義 ───────────────────────────────────────────────
 
 export interface TicketPayload {
@@ -63,7 +60,7 @@ function sanitizeField(value: string | undefined): string {
 }
 
 /** 署名対象のペイロード文字列を構築（パイプ区切り形式） */
-export function buildPayload(ticket: TicketPayload): string {
+function buildPayload(ticket: TicketPayload): string {
   const e = sanitizeField(ticket.e);
   const t = sanitizeField(ticket.t);
   const ts = String(ticket.timestamp);
@@ -97,7 +94,7 @@ export function parseQrString(raw: string): { payload: string; signature: string
   const payload = raw.slice(0, lastPipe);
   const signature = raw.slice(lastPipe + 1);
   if (!signature) return null;
-  // ペイロード部のフィールド数チェック（PAYLOAD_FIELD_COUNT - 1 個のパイプ区切り = PAYLOAD_FIELDS.length フィールド）
+  // ペイロード部のフィールド数チェック（PAYLOAD_FIELDS.length フィールド分のパイプ区切り）
   const payloadParts = payload.split('|');
   if (payloadParts.length !== PAYLOAD_FIELDS.length) return null;
   return { payload, signature };


### PR DESCRIPTION
## 概要

issue #222 の items 2・4（qr-ticket.ts 公開 API 整理）を対応。  
items 1・3 は既対応済みのため、本 PR で #222 をクローズ。

## 変更内容

### `src/utils/qr-ticket.ts`

- `buildPayload` の `export` を削除（内部実装として非公開化）
- `PAYLOAD_FIELD_COUNT` 定数を削除  
  → `parseQrString` はすでに `PAYLOAD_FIELDS.length` を直接参照しており実コード参照ゼロ
- `serializeTicket` を公開シリアライズ API として維持
- L94 の JSDoc コメントから `PAYLOAD_FIELD_COUNT` への言及を除去

### `src/utils/__tests__/qr-ticket.test.ts`

- `buildPayload` / `PAYLOAD_FIELD_COUNT` の import を削除
- `buildPayload` describe ブロックを `serializeTicket` に統合（同一動作のため置き換え）
- `PAYLOAD_FIELD_COUNT` describe ブロックを削除

## テスト結果

- `npm run test`: 1562 passed（sw-cache-version 3 件はビルド成果物不在による既存 skip）
- `node_modules/.bin/astro check`: 0 errors, 0 warnings

## 関連 issue

closes #222

https://claude.ai/code/session_01SFkrnodaRf4RXPJx9EJBNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkrnodaRf4RXPJx9EJBNw)_