### PR TITLE
test: serializeTicket に timestamp 境界値テストを追加（0・負値）

### DIFF
--- a/src/utils/__tests__/qr-ticket.test.ts
+++ b/src/utils/__tests__/qr-ticket.test.ts
@@ -80,13 +80,13 @@ describe('serializeTicket', () => {
   });
 
   it('timestamp が 0 の場合は "0" として連結される（serializeTicket 自体は検証しない）', () => {
-    const payload: TicketPayload = { e: 'ev', t: 'T-1', timestamp: 0 };
-    expect(serializeTicket(payload)).toBe('ev|T-1|0||');
+    const payload: TicketPayload = { ...base, timestamp: 0 };
+    expect(serializeTicket(payload)).toBe('event-01|T-00001|0||');
   });
 
   it('timestamp が負値の場合も文字列として連結される（検証は verifyTicket に委譲）', () => {
-    const payload: TicketPayload = { e: 'ev', t: 'T-1', timestamp: -3600 };
-    expect(serializeTicket(payload)).toBe('ev|T-1|-3600||');
+    const payload: TicketPayload = { ...base, timestamp: -3600 };
+    expect(serializeTicket(payload)).toBe('event-01|T-00001|-3600||');
   });
 });
 

--- a/src/utils/__tests__/qr-ticket.test.ts
+++ b/src/utils/__tests__/qr-ticket.test.ts
@@ -78,6 +78,16 @@ describe('serializeTicket', () => {
     const payload: TicketPayload = { ...base, n: '', p: '' };
     expect(serializeTicket(payload)).toBe('event-01|T-00001|1735689540||');
   });
+
+  it('timestamp が 0 の場合は "0" として連結される（serializeTicket 自体は検証しない）', () => {
+    const payload: TicketPayload = { e: 'ev', t: 'T-1', timestamp: 0 };
+    expect(serializeTicket(payload)).toBe('ev|T-1|0||');
+  });
+
+  it('timestamp が負値の場合も文字列として連結される（検証は verifyTicket に委譲）', () => {
+    const payload: TicketPayload = { e: 'ev', t: 'T-1', timestamp: -3600 };
+    expect(serializeTicket(payload)).toBe('ev|T-1|-3600||');
+  });
 });
 
 // ────────────────────────────────────────────


### PR DESCRIPTION
## 概要

`serializeTicket` 関数に timestamp の境界値テスト（0 および負値）を追加します。

- timestamp が `0` の場合、`"0"` として文字列連結されることを確認
- timestamp が負値（例: `-3600`）の場合も文字列として連結され、検証は `verifyTicket` に委譲されることを確認

## 変更内容

- `src/utils/__tests__/qr-ticket.test.ts`: `serializeTicket` describe ブロックに境界値テスト 2 件を追加

## テスト結果

`npm run test` および `node_modules/.bin/astro check` がともに成功することを確認済み。

Closes #574

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkrnodaRf4RXPJx9EJBNw)_