### PR TITLE
feat: GS1 DataBar 生成に A4 印刷機能を追加

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3749,3 +3749,41 @@ PR #318 後も `CopyButton`(default) は `rounded`(0.25rem)、`ActionButton`(siz
 - ✅ 両コンポーネントの角丸が共有定数で一元管理され、以降の一方の変更は即座に test fail で検知される。
 - ✅ CopyButton 固有（caption / tracking-wide / gap-1.5 / btn-copy 等）・ActionButton 固有（btn-action / variant class 等）のクラスは各自に残し、共有するのは「compact 高さ + 角丸」部分のみ。
 - ⚠️ CopyButton の見た目（角丸）が変わるため VRT baseline 差分が発生する。CI Linux runner の `Update Visual Regression Baseline` workflow を workflow_dispatch で再生成が必要（ローカル不可）。
+
+---
+
+## [098] 2026-06-05 — GS1 DataBar 印刷実寸を SVG 属性で指定（CSP style-src 撤去と両立）
+
+**2026-06-05 | ステータス: 採用**
+
+### 背景
+
+GS1 DataBar 生成ツールに A4 印刷機能を追加するにあたり、バーコードを mm 実寸で印刷する必要がある。プリンタ DPI に依存しない実寸指定が必須だが、本プロジェクトは CSP `style-src 'unsafe-inline'` を撤去済み（issue #176）のため、JSX の `style={{}}` や `el.style.setProperty` による動的サイズ指定は使用できない。
+
+### 決断
+
+- **SVG ルート要素の presentation attribute（`width`/`height` 属性）で mm 値を指定する**（例: `<svg width="52.14mm" height="13.20mm" ...>`）。SVG presentation attribute は CSS inline style ではなく HTML 属性であるため、CSP `style-src` の制約対象外。
+- `setSvgPrintSize(svg, xdimMm, scale=3)` 関数を `src/utils/gs1-databar.ts` に追加。bwip-js の `scale: 3`（1 モジュール = 3px）を基準に `factor = xdimMm / scale` で mm/px 換算し、viewBox の W/H にかけて width/height 属性を mm 値に置換する。
+- 列数（1/2/3）は静的 CSS クラス `.print-grid--cols-1/2/3` を `className` で切替えるだけにし、動的 inline style を一切使用しない。
+
+### X-dimension プリセット根拠（GS1 General Specifications 準拠）
+
+| プリセット | X-dim (mm) | 用途                                     |
+| ---------- | ---------- | ---------------------------------------- |
+| 小         | 0.330      | GS1 DataBar target X-dim（密集配置向け） |
+| 中         | 0.495      | 標準的な流通用途                         |
+| 大         | 0.660      | 一般流通の上限付近（カメラ距離向け）     |
+
+全体を同一 factor で拡大するため、合成シンボルの text/quiet zone を含んでもリニア部のモジュール幅は常に xdimMm に一致する。
+
+### 却下した選択肢
+
+- **CSS custom property (`--print-width: 52.14mm`) を `@layer components` に動的注入**: `useDynamicStyleSheet` 経由で constructable stylesheet に書き込む手法（ToggleGroup の実装と同様）も CSP 準拠だが、印刷用途では SVG 自体が寸法を持つほうがシンプルで外部依存が少ない。
+- **`style={{}}` JSX inline style**: CSP 違反（`style-src 'unsafe-inline'` 不在）のため却下。
+
+### 結果・トレードオフ
+
+- ✅ CSP `style-src 'unsafe-inline'` なしで mm 実寸印刷が実現できる。
+- ✅ `setSvgPrintSize` の出力は画面表示用 SVG とは別物であり、`svgContentToPngBlob`（`width="(\d+)" height="(\d+)"` px 隣接 contract）には渡さない設計を JSDoc で明記。
+- ⚠️ 大サイズ（0.660mm）× 3 列は A4 印刷可能幅（約 186mm）を超過し得る。UI に「大サイズは 1〜2 列を推奨」ヒントを表示するがハードな制限は設けない（MVP）。
+- ⚠️ 操作バーに印刷コントロールが追加されるため VRT baseline の更新が必要。CI Linux runner の `Update Visual Regression Baseline` workflow を明示承認後に dispatch すること（ローカル不可）。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3780,10 +3780,12 @@ GS1 DataBar 生成ツールに A4 印刷機能を追加するにあたり、バ�
 
 - **CSS custom property (`--print-width: 52.14mm`) を `@layer components` に動的注入**: `useDynamicStyleSheet` 経由で constructable stylesheet に書き込む手法（ToggleGroup の実装と同様）も CSP 準拠だが、印刷用途では SVG 自体が寸法を持つほうがシンプルで外部依存が少ない。
 - **`style={{}}` JSX inline style**: CSP 違反（`style-src 'unsafe-inline'` 不在）のため却下。
+- **`position: absolute; inset: 0` + `body * { visibility: hidden }` の単ページ前提パターン**: 印刷の定番パターンだが、絶対配置コンテナは Chrome 等で **2 ページ目以降がクリップされ印刷されない既知挙動**がある。`MAX_CARDS = 10` × 大サイズ（0.66mm）× 1 列だと A4 印刷可能高さ（約 273mm）を超え多ページになるため、10 件バッチ印刷で末尾がサイレントに欠落する。これを避けるため、印刷コンテナを `createPortal` で `document.body` 直下へ出し、`@media print` で `body > *:not(.print-area) { display: none }` により兄弟（ページ chrome）を隠して `.print-area` を**通常フロー配置（position:static）**でページ送りさせる方式に変更した（PR レビュー指摘で修正）。`createPortal` は Astro `client:load` の SSR で `document` 不在で落ちるため、`mounted` フラグで mount 後に限定する。
 
 ### 結果・トレードオフ
 
 - ✅ CSP `style-src 'unsafe-inline'` なしで mm 実寸印刷が実現できる。
 - ✅ `setSvgPrintSize` の出力は画面表示用 SVG とは別物であり、`svgContentToPngBlob`（`width="(\d+)" height="(\d+)"` px 隣接 contract）には渡さない設計を JSDoc で明記。
-- ⚠️ 大サイズ（0.660mm）× 3 列は A4 印刷可能幅（約 186mm）を超過し得る。UI に「大サイズは 1〜2 列を推奨」ヒントを表示するがハードな制限は設けない（MVP）。
+- ✅ 印刷コンテナを `createPortal` で body 直下へ出し通常フロー配置にしたことで、**複数ページ印刷でも 2 ページ目以降がクリップされない**（10 件バッチ印刷の正当利用に対応）。
+- ⚠️ 大サイズ（0.660mm）× 3 列は A4 印刷可能**幅**（約 186mm）を超過し得る。これは幅方向の別問題で portal では解決しない。UI に「大サイズは 1〜2 列を推奨」ヒントを表示するがハードな制限は設けない（MVP）。
 - ⚠️ 操作バーに印刷コントロールが追加されるため VRT baseline の更新が必要。CI Linux runner の `Update Visual Regression Baseline` workflow を明示承認後に dispatch すること（ローカル不可）。

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -152,10 +152,21 @@ GTIN-14 と任意のアプリケーション識別子（AI）から GS1 DataBar 
 - GS1 General Specifications（GS1 DataBar Limited / GS1 Composite Component、アプリケーション識別子）。
 - GTIN-14。
 
+#### A4 印刷機能
+
+有効なバーコード（`svg` と `gtin` が揃ったカード）を A4 用紙に印刷する。
+
+1. **実寸変換**: bwip-js は `scale: 3`（1 モジュール = 3px）で SVG を生成する。印刷時は `setSvgPrintSize(svg, xdimMm)` が `factor = xdimMm / 3` を計算し、SVG ルート要素の `width`/`height` 属性を mm 値に置換する。これにより **X-dimension（モジュール幅）が xdimMm に一致した mm 実寸**で印刷される（プリンタ DPI 非依存）。
+2. **CSP 両立**: `style-src 'unsafe-inline'` を撤去済みのため、SVG の presentation attribute（`width="52.14mm"`）で実寸を指定する。CSS inline style や `el.style.setProperty` は使用しない。詳細は `docs/decisions.md` [098] を参照。
+3. **レイアウト**: 列数（1/2/3、デフォルト 2）と X-dimension プリセット（小=0.330mm / 中=0.495mm / 大=0.660mm、デフォルト 中）を ToggleGroup で切替。`@page { size: A4; margin: 12mm }` + `.print-cell { border: 1px dashed #000 }` で破線カット線付きグリッドを構成する。
+4. **印刷起動**: in-page `window.print()` を呼ぶ。ブラウザ印刷ダイアログから「PDF に保存」も利用可能。
+
 #### 制限・エッジケース
 
 - GS1 DataBar Limited の入力は 13 桁、**先頭桁は 0 または 1 のみ**（仕様上の制約）。
 - PNG ダウンロード時は白背景での描画が必須（透明背景だと一部リーダーでデコードできない）。合成シンボル上の AI テキスト描画の経緯・トレードオフは `docs/decisions.md` [067] / [082] / [083] を参照。
+- **大サイズ × 3 列は A4 印刷可能幅（約 186mm）を超過し得る**。UI にヒント注記を表示するが、ハードな組合せ制限は設けていない。印刷プレビューで確認すること。
+- 印刷用 SVG（`setSvgPrintSize` 出力）は mm 値の width/height を持つため、`svgContentToPngBlob` に渡すと canvas サイズ抽出が失敗する。両者は別経路で使用すること。
 
 ### QRチケット
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -160,6 +160,7 @@ GTIN-14 と任意のアプリケーション識別子（AI）から GS1 DataBar 
 2. **CSP 両立**: `style-src 'unsafe-inline'` を撤去済みのため、SVG の presentation attribute（`width="52.14mm"`）で実寸を指定する。CSS inline style や `el.style.setProperty` は使用しない。詳細は `docs/decisions.md` [098] を参照。
 3. **レイアウト**: 列数（1/2/3、デフォルト 2）と X-dimension プリセット（小=0.330mm / 中=0.495mm / 大=0.660mm、デフォルト 中）を ToggleGroup で切替。`@page { size: A4; margin: 12mm }` + `.print-cell { border: 1px dashed #000 }` で破線カット線付きグリッドを構成する。
 4. **印刷起動**: in-page `window.print()` を呼ぶ。ブラウザ印刷ダイアログから「PDF に保存」も利用可能。
+5. **複数ページ対応**: 印刷コンテナは `createPortal` で `document.body` 直下へ出し、通常フロー配置で複数ページ印刷に対応する（`position: absolute` 配置は Chrome 等で 2 ページ目以降がクリップされる既知挙動があるため）。10 件 × 大サイズ等で A4 高さを超えてもページ送りされる。詳細は `docs/decisions.md` [098] を参照。
 
 #### 制限・エッジケース
 

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useId, useRef, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { getErrorMessage } from '@/utils/errors';
 import bwipjs from 'bwip-js';
 import { CopyButton } from '@/components/ui/CopyButton';
@@ -435,6 +436,10 @@ export function Gs1DatabarTool() {
   const [zipError, setZipError] = useState('');
   const [printCols, setPrintCols] = useState<PrintColsValue>('2');
   const [printXdim, setPrintXdim] = useState<PrintXdimValue>('medium');
+  // Astro client:load で SSR されるため、document.body 参照 (createPortal) は
+  // mount 後に限定する。SSR 時に createPortal を呼ぶと document 不在で落ちる。
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   const addCard = () => {
     if (cards.length >= MAX_CARDS) return;
@@ -580,18 +585,25 @@ export function Gs1DatabarTool() {
 
       {zipError && <ErrorMessage message={`ZIP ダウンロードエラー: ${zipError}`} variant="block" />}
 
-      {/* 印刷コンテナ（画面では非表示・@media print で可視化） */}
-      <div className="print-area" aria-hidden="true">
-        <div className={`print-grid print-grid--cols-${printCols}`}>
-          {printEntries.map((e) => (
-            <div
-              key={e.gtin}
-              className="print-cell"
-              dangerouslySetInnerHTML={{ __html: e.printSvg }}
-            />
-          ))}
-        </div>
-      </div>
+      {/* 印刷コンテナ（画面では非表示・@media print で可視化）。
+          createPortal で document.body 直下へ出し通常フロー配置にすることで、
+          複数ページ印刷でも 2 ページ目以降がクリップされない
+          (position:absolute コンテナは Chrome 等で多ページがクリップされる既知挙動)。 */}
+      {mounted &&
+        createPortal(
+          <div className="print-area" aria-hidden="true">
+            <div className={`print-grid print-grid--cols-${printCols}`}>
+              {printEntries.map((e) => (
+                <div
+                  key={e.gtin}
+                  className="print-cell"
+                  dangerouslySetInnerHTML={{ __html: e.printSvg }}
+                />
+              ))}
+            </div>
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -8,9 +8,11 @@ import {
   buildBwipText,
   addSvgDimensions,
   injectCompositeText,
+  setSvgPrintSize,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
+import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { InputField } from '@/components/ui/InputField';
 import { BareInput } from '@/components/ui/BareInput';
 import { Select } from '@/components/ui/Select';
@@ -400,6 +402,28 @@ interface CardSvgState {
   gtin: string;
 }
 
+// X-dimension プリセット（GS1 General Specifications 準拠）
+type PrintColsValue = '1' | '2' | '3';
+type PrintXdimValue = 'small' | 'medium' | 'large';
+
+const PRINT_COLS_OPTIONS: { value: PrintColsValue; label: string }[] = [
+  { value: '1', label: '1列' },
+  { value: '2', label: '2列' },
+  { value: '3', label: '3列' },
+];
+
+const PRINT_XDIM_OPTIONS: { value: PrintXdimValue; label: string }[] = [
+  { value: 'small', label: '小' },
+  { value: 'medium', label: '中' },
+  { value: 'large', label: '大' },
+];
+
+const XDIM_MM: Record<PrintXdimValue, number> = {
+  small: 0.33,
+  medium: 0.495,
+  large: 0.66,
+};
+
 export function Gs1DatabarTool() {
   // useId は SSR/CSR で同じ値を返すため hydration mismatch を避けられる。
   // 複数 card 用に incremental counter で suffix を付与する (crypto.randomUUID() は SSR/CSR で値が割れるため不可)。
@@ -409,6 +433,8 @@ export function Gs1DatabarTool() {
   const [cardSvgs, setCardSvgs] = useState<Record<string, CardSvgState>>({});
   const [isZipping, setIsZipping] = useState(false);
   const [zipError, setZipError] = useState('');
+  const [printCols, setPrintCols] = useState<PrintColsValue>('2');
+  const [printXdim, setPrintXdim] = useState<PrintXdimValue>('medium');
 
   const addCard = () => {
     if (cards.length >= MAX_CARDS) return;
@@ -431,6 +457,21 @@ export function Gs1DatabarTool() {
 
   const validEntries = Object.entries(cardSvgs).filter(([, v]) => v.svg && v.gtin);
   const canDownloadAll = validEntries.length >= 2;
+  const canPrint = validEntries.length >= 1;
+
+  // 印刷用 SVG: 各エントリを setSvgPrintSize で mm 実寸に変換。
+  // 画面表示用の cardSvgs（px 寸法）とは別物。svgContentToPngBlob には渡さない。
+  const printEntries = useMemo(
+    () =>
+      validEntries.map(([, { svg, gtin }]) => ({
+        gtin,
+        printSvg: setSvgPrintSize(svg, XDIM_MM[printXdim]),
+      })),
+    // cardSvgs が変わるたびに validEntries も変わるため cardSvgs を依存に含める。
+    // printXdim が変わると factor が変わるため明示。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cardSvgs, printXdim]
+  );
 
   // svgContentToPngBlob / downloadZip は reject 可能。旧実装は try/finally のみで
   // unhandled promise rejection を発生させていた (issue #338)。catch を追加し
@@ -505,9 +546,52 @@ export function Gs1DatabarTool() {
             variant="primary"
           />
         )}
+
+        {/* 印刷コントロール（有効バーコードが 1 件以上のとき表示） */}
+        {canPrint && (
+          <>
+            <ToggleGroup<PrintColsValue>
+              options={PRINT_COLS_OPTIONS}
+              value={printCols}
+              onChange={setPrintCols}
+              ariaLabel="列数"
+              size="sm"
+            />
+            <ToggleGroup<PrintXdimValue>
+              options={PRINT_XDIM_OPTIONS}
+              value={printXdim}
+              onChange={setPrintXdim}
+              ariaLabel="サイズ 小/中/大"
+              size="sm"
+            />
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="rounded px-4 py-2 caption font-bold border border-primary bg-transparent text-primary hover-bg-active"
+            >
+              印刷
+            </button>
+            {printXdim === 'large' && (
+              <span className="caption text-muted">大サイズは 1〜2 列を推奨</span>
+            )}
+          </>
+        )}
       </div>
 
       {zipError && <ErrorMessage message={`ZIP ダウンロードエラー: ${zipError}`} variant="block" />}
+
+      {/* 印刷コンテナ（画面では非表示・@media print で可視化） */}
+      <div className="print-area" aria-hidden="true">
+        <div className={`print-grid print-grid--cols-${printCols}`}>
+          {printEntries.map((e) => (
+            <div
+              key={e.gtin}
+              className="print-cell"
+              dangerouslySetInnerHTML={{ __html: e.printSvg }}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1066,24 +1066,25 @@
 /* ────────────────────────────────────────────────────────────
    A4 印刷（GS1 DataBar 生成ツール）
    画面では非表示。@media print のみ可視化する。
+   印刷コンテナは createPortal で document.body 直下へ出し通常フロー配置にする。
+   position:absolute コンテナは Chrome 等で複数ページがクリップされる既知挙動が
+   あるため、body 直下 chrome を display:none で隠し .print-area を通常フローで
+   ページ送りさせる方式に変更した（docs/decisions.md [098]）。
    variant prefix（hover: 等）は使わない（Tailwind v4 @layer components 制約）。
    印刷専用色は #000 固定（黒インクが適切）。
    ──────────────────────────────────────────────────────────── */
 .print-area {
-  display: none;
+  display: none; /* 画面では非表示 */
 }
 
 @media print {
-  body * {
-    visibility: hidden;
-  }
-  .print-area,
-  .print-area * {
-    visibility: visible;
+  /* body 直下の chrome（header/main/footer/script 等）を隠し、portal した
+     .print-area のみ通常フローで表示する。absolute 配置を使わないため
+     複数ページ印刷でもページ送りが正常に機能する。 */
+  body > *:not(.print-area) {
+    display: none !important;
   }
   .print-area {
-    position: absolute;
-    inset: 0;
     display: block;
     color: #000;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1063,6 +1063,57 @@
   }
 }
 
+/* ────────────────────────────────────────────────────────────
+   A4 印刷（GS1 DataBar 生成ツール）
+   画面では非表示。@media print のみ可視化する。
+   variant prefix（hover: 等）は使わない（Tailwind v4 @layer components 制約）。
+   印刷専用色は #000 固定（黒インクが適切）。
+   ──────────────────────────────────────────────────────────── */
+.print-area {
+  display: none;
+}
+
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  .print-area,
+  .print-area * {
+    visibility: visible;
+  }
+  .print-area {
+    position: absolute;
+    inset: 0;
+    display: block;
+    color: #000;
+  }
+  @page {
+    size: A4;
+    margin: 12mm;
+  }
+  .print-grid {
+    display: grid;
+    gap: 10mm;
+  }
+  .print-grid--cols-1 {
+    grid-template-columns: repeat(1, 1fr);
+  }
+  .print-grid--cols-2 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .print-grid--cols-3 {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .print-cell {
+    border: 1px dashed #000;
+    padding: 4mm;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    break-inside: avoid;
+  }
+}
+
 /* 前庭障害ユーザー向けに transition / animation を抑止する。
    特定 selector のみで `transition` を上書きしても layer 順や specificity で
    silent regression するため、`!important` でグローバル reset する。 */

--- a/src/utils/__tests__/gs1-databar.test.ts
+++ b/src/utils/__tests__/gs1-databar.test.ts
@@ -6,6 +6,7 @@ import {
   addSvgDimensions,
   escapeHtml,
   injectCompositeText,
+  setSvgPrintSize,
   AI_DEFS,
   type AiCode,
 } from '@/utils/gs1-databar';
@@ -355,5 +356,50 @@ describe('injectCompositeText', () => {
     // svg root には元々 width 属性が無いため anchor 付き regex は no-op (注入もしない)。
     // viewBox は別 regex で更新される (anchor 無関係)。
     expect(out).toMatch(/viewBox="0 0 124\.0 74\.0"/);
+  });
+});
+
+// ────────────────────────────────────────────
+// setSvgPrintSize
+// ────────────────────────────────────────────
+describe('setSvgPrintSize', () => {
+  // viewBox="0 0 237 60"、scale=3、Xdim=0.66 のとき
+  // factor = 0.66 / 3 = 0.22
+  // width = 237 * 0.22 = 52.14 → "52.14mm"
+  // height = 60 * 0.22 = 13.20 → "13.20mm"
+  it('viewBox 0 0 237 60 + Xdim=0.66 → width="52.14mm" height="13.20mm"', () => {
+    const svg =
+      '<svg width="237" height="60" shape-rendering="crispEdges" viewBox="0 0 237 60"><rect/></svg>';
+    const result = setSvgPrintSize(svg, 0.66);
+    expect(result).toMatch(/width="52\.14mm"/);
+    expect(result).toMatch(/height="13\.20mm"/);
+  });
+
+  it('viewBox なし入力はそのまま返す（パススルー）', () => {
+    const svg = '<svg width="237" height="60"><rect/></svg>';
+    const result = setSvgPrintSize(svg, 0.66);
+    expect(result).toBe(svg);
+  });
+
+  it('Xdim を変えると width が変わる（0.33 vs 0.495）', () => {
+    const svg =
+      '<svg width="237" height="60" shape-rendering="crispEdges" viewBox="0 0 237 60"><rect/></svg>';
+    const small = setSvgPrintSize(svg, 0.33);
+    const medium = setSvgPrintSize(svg, 0.495);
+    // factor_small = 0.33/3 = 0.11 → width = 237*0.11 = 26.07mm
+    expect(small).toMatch(/width="26\.07mm"/);
+    // factor_medium = 0.495/3 = 0.165 → width = 237*0.165 = 39.11mm
+    expect(medium).toMatch(/width="39\.11mm"/);
+  });
+
+  it('子要素の width 属性を誤置換しない（ルート anchor 保護）', () => {
+    const svg =
+      '<svg width="237" height="60" shape-rendering="crispEdges" viewBox="0 0 237 60">' +
+      '<rect width="10" height="20"/></svg>';
+    const result = setSvgPrintSize(svg, 0.66);
+    // ルート SVG は mm 値に置換される
+    expect(result).toMatch(/width="52\.14mm"/);
+    // 子 rect の width は変わらない
+    expect(result).toMatch(/<rect width="10" height="20"/);
   });
 });

--- a/src/utils/gs1-databar.ts
+++ b/src/utils/gs1-databar.ts
@@ -198,6 +198,43 @@ export function addSvgDimensions(svg: string): string {
 }
 
 /**
+ * A4 印刷用に SVG ルート要素の `width`/`height` 属性を mm 実寸に置換する。
+ *
+ * bwip-js は `scale: 3`（1 モジュール = 3px）で生成し、`addSvgDimensions` が
+ * viewBox の W/H から px 整数の width/height 属性を注入済み。本関数はその px 値を
+ * `factor = xdimMm / scale`（mm per px）で mm 値に変換し、X-dimension が xdimMm に
+ * 一致した印刷用 SVG を返す。
+ *
+ * 置換は `injectCompositeText` と同じルート開始タグへの anchor 手法を使用し、
+ * 子要素の width/height 属性を誤置換しない。
+ *
+ * viewBox 属性が見つからない場合は入力 svg をそのまま返す（防御的フォールバック）。
+ *
+ * @param svg - `addSvgDimensions` 済みの SVG 文字列（ルートに viewBox が必要）。
+ * @param xdimMm - 目標 X-dimension（モジュール幅）の mm 値。
+ * @param scale - bwip-js の scale 値（デフォルト 3）。
+ * @returns width/height 属性を mm 値に置換した SVG 文字列。
+ *
+ * @remarks
+ * この出力は PNG 変換経路 `svgContentToPngBlob` に渡さないこと。
+ * `svgContentToPngBlob` は `width="(\d+)" height="(\d+)"` の px 整数隣接 contract に
+ * 依存しており（`utils/download.ts:183-186`）、mm 値を渡すと canvas サイズ抽出が失敗する。
+ */
+export function setSvgPrintSize(svg: string, xdimMm: number, scale = 3): string {
+  const vbMatch = svg.match(/viewBox="0 0 ([\d.]+) ([\d.]+)"/);
+  if (!vbMatch) return svg;
+  const W = parseFloat(vbMatch[1]);
+  const H = parseFloat(vbMatch[2]);
+  const factor = xdimMm / scale;
+  const wMm = (W * factor).toFixed(2);
+  const hMm = (H * factor).toFixed(2);
+  // ルート <svg ...> 開始タグにのみ anchor して置換（子要素の width/height を誤置換しない）
+  return svg
+    .replace(/(<svg\s[^>]*?)width="[\d.]+"/, `$1width="${wMm}mm"`)
+    .replace(/(<svg\s[^>]*?)height="[\d.]+"/, `$1height="${hMm}mm"`);
+}
+
+/**
  * HTML/XML 特殊文字をエスケープする (`injectCompositeText` の安全な text 注入用)。
  */
 export function escapeHtml(text: string): string {

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -503,5 +503,24 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
         await expect(page.getByText('大サイズは 1〜2 列を推奨')).toBeHidden();
       });
     });
+
+    test('印刷コンテナは createPortal で document.body 直下に配置される', async ({ browser }) => {
+      await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+        await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+        await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+        // .print-area が document.body の直接の子要素として存在することを検証。
+        // createPortal が body 直下へ出すことで @media print の通常フロー配置
+        // （複数ページ印刷でクリップしない）が成立する。
+        // aria-hidden な印刷専用要素のため role/text を持たず、構造検証は evaluate で行う。
+        const isDirectBodyChild = await page.evaluate(() => {
+          const printAreas = Array.from(document.body.children).filter((el) =>
+            el.classList.contains('print-area')
+          );
+          return printAreas.length === 1;
+        });
+        expect(isDirectBodyChild).toBe(true);
+      });
+    });
   });
 });

--- a/tests/e2e/gs1-databar.spec.ts
+++ b/tests/e2e/gs1-databar.spec.ts
@@ -388,4 +388,120 @@ test.describe('GS1 DataBar 生成（production CSP 適用）', () => {
       }
     });
   });
+
+  // ─────────────────────────────────────────────
+  // A4 印刷機能
+  // ─────────────────────────────────────────────
+  test.describe('A4 印刷機能', () => {
+    test('有効バーコード 0 件では印刷コントロールが非表示', async ({ browser }) => {
+      await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+        // 初期状態: バーコード未生成。印刷ボタンは表示されない。
+        await expect(page.getByRole('button', { name: '印刷' })).toBeHidden();
+        // 列数・サイズ ToggleGroup も非表示
+        await expect(page.getByRole('group', { name: '列数' })).toBeHidden();
+        await expect(page.getByRole('group', { name: 'サイズ 小/中/大' })).toBeHidden();
+      });
+    });
+
+    test('有効バーコード 1 件以上で印刷コントロールが表示される', async ({ browser }) => {
+      await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+        // GTIN を入力してバーコード生成
+        await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+        await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+        // 印刷コントロールが表示される
+        await expect(page.getByRole('button', { name: '印刷' })).toBeVisible();
+        await expect(page.getByRole('group', { name: '列数' })).toBeVisible();
+        await expect(page.getByRole('group', { name: 'サイズ 小/中/大' })).toBeVisible();
+      });
+    });
+
+    test('列数 ToggleGroup 切替で印刷コンテナの grid クラスが更新される', async ({ browser }) => {
+      await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+        await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+        await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+        // デフォルト 2列
+        const printGrid = page.locator('.print-grid');
+        await expect(printGrid).toHaveClass(/print-grid--cols-2/);
+
+        // 3列に切替
+        await page.getByRole('group', { name: '列数' }).getByText('3列').click();
+        await expect(printGrid).toHaveClass(/print-grid--cols-3/);
+
+        // 1列に切替
+        await page.getByRole('group', { name: '列数' }).getByText('1列').click();
+        await expect(printGrid).toHaveClass(/print-grid--cols-1/);
+      });
+    });
+
+    test('サイズ ToggleGroup 切替で .print-area 内 SVG の width 属性が mm 値で更新される', async ({
+      browser,
+    }) => {
+      await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+        await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+        await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+        // デフォルト「中」: print-area 内 SVG の width が mm 値を持つ
+        const getPrintSvgWidth = () =>
+          page.evaluate(() => {
+            const svg = document.querySelector('.print-area svg');
+            return svg?.getAttribute('width') ?? '';
+          });
+
+        const widthMedium = await getPrintSvgWidth();
+        expect(widthMedium).toMatch(/mm$/);
+
+        // 「大」に切替
+        await page.getByRole('group', { name: 'サイズ 小/中/大' }).getByText('大').click();
+        const widthLarge = await getPrintSvgWidth();
+        expect(widthLarge).toMatch(/mm$/);
+        // 大は中より数値が大きい
+        expect(parseFloat(widthLarge)).toBeGreaterThan(parseFloat(widthMedium));
+
+        // 「小」に切替
+        await page.getByRole('group', { name: 'サイズ 小/中/大' }).getByText('小').click();
+        const widthSmall = await getPrintSvgWidth();
+        expect(widthSmall).toMatch(/mm$/);
+        // 小は中より数値が小さい
+        expect(parseFloat(widthSmall)).toBeLessThan(parseFloat(widthMedium));
+      });
+    });
+
+    test('「印刷」ボタン click で例外が出ない（window.print をスタブ化）', async ({ browser }) => {
+      await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+        await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+        await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+        // window.print をスタブ化してダイアログが開かないようにする
+        await page.evaluate(() => {
+          window.print = () => {};
+        });
+
+        // クリックして例外が出ないことを確認
+        await expect(page.getByRole('button', { name: '印刷' })).toBeVisible();
+        await page.getByRole('button', { name: '印刷' }).click();
+        // エラーメッセージが表示されないことを確認
+        await expect(page.getByRole('alert')).toBeHidden();
+      });
+    });
+
+    test('大サイズ選択時に推奨ヒントが表示される', async ({ browser }) => {
+      await withProductionCsp(browser, '/tools/gs1-databar', async (page) => {
+        await page.getByLabel('GTIN-14（先頭13桁）').fill('0498700000001');
+        await expect(page.getByLabel(/GS1 DataBar.*のバーコード/)).toBeVisible();
+
+        // デフォルト「中」ではヒント非表示
+        await expect(page.getByText('大サイズは 1〜2 列を推奨')).toBeHidden();
+
+        // 「大」に切替するとヒント表示
+        await page.getByRole('group', { name: 'サイズ 小/中/大' }).getByText('大').click();
+        await expect(page.getByText('大サイズは 1〜2 列を推奨')).toBeVisible();
+
+        // 「中」に戻すとヒント非表示
+        await page.getByRole('group', { name: 'サイズ 小/中/大' }).getByText('中').click();
+        await expect(page.getByText('大サイズは 1〜2 列を推奨')).toBeHidden();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 概要

「GS1 DataBar 生成」ツールに **A4 用紙への印刷機能** を追加します。

利用シーンはカメラによるスキャン。近接して印刷されたバーコードはカメラの画角に複数入り込んで誤読される恐れがあるため、**切り取って個別利用** する前提で、各バーコードを破線カット線で囲み十分な余白を設けました。またカメラスキャンの成否は印刷物理サイズに直結するため、プリンタ DPI に依存しない **mm 実寸固定** で印刷します。

devtools の全ツールで印刷機能（`window.print()` / `@media print` / `@page`）は初導入です。

## 主な変更

- **`setSvgPrintSize()`**（`src/utils/gs1-databar.ts`）: bwip-js の `scale: 3`（1 モジュール = 3px）を基準に `factor = xdimMm / 3` を計算し、SVG ルート要素の `width`/`height` **属性** を mm 値に置換。X-dimension が指定 mm に一致した実寸で印刷されます。
- **CSP 両立**: `style-src 'unsafe-inline'` を撤去済み（#176）のため、`style={{}}` / `el.style.setProperty` を使わず **SVG presentation attribute**（CSS inline style ではない）で実寸指定。列数は静的クラス `.print-grid--cols-1/2/3` の切替のみ。設計判断は `docs/decisions.md` [098] を参照。
- **UI**: 操作バーに 列数（1/2/3、デフォルト 2）と X-dimension プリセット（小=0.330 / 中=0.495 / 大=0.660mm、デフォルト 中）の ToggleGroup、「印刷」ボタンを追加。大サイズ時は「1〜2 列を推奨」ヒントを表示。
- **印刷スタイル**（`global.css`）: `@page { size: A4; margin: 12mm }` + 破線カット線付きグリッド。`@media print` でツール以外を非表示化。
- 単体テスト4件・E2E6件・docs（tools.md / decisions.md）を追加。

## 確定仕様（実装前にユーザー確認済み）

- レイアウト: 列数を選べるグリッド + 広い余白
- 物理サイズ: mm 実寸固定（X-dimension プリセット 小・中・大）
- 用途: 切り取って個別利用（破線カット線あり）

## 検証

- 型チェック: `astro check` → **0 errors**
- 単体: `Test Files 100 passed` / `Tests 1729 passed | 1 skipped`
- E2E: 新規6件すべて pass（**production CSP 下** で実行 → SVG 属性方式に CSP 違反なしを実証）
- 実機目視（Playwright, PC 1280×800 / スマホ 390×844）:
  - 操作バーは PC 1行 / スマホ2行に折り返し、重なりなし
  - 印刷プレビューで 2列グリッド・破線カット線・十分な間隔を確認

## 留意点

- ⚠️ 操作バー UI が変わるため **VRT baseline の更新が必要**。CI Linux runner の `Update Visual Regression Baseline` workflow を **明示承認後に** dispatch してください（mac ローカル生成は font 差で不可）。
- ⚠️ 大サイズ × 3 列は A4 印刷可能幅（約 186mm）を超過し得ます。UI にヒントを表示しますがハードな組合せ制限は設けていません（MVP）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
