### PR TITLE
fix: CIDR 計算機のネットワーク情報行で値とコピーボタンを縦中央揃え

### DIFF
--- a/src/components/tools/CidrCalculator.tsx
+++ b/src/components/tools/CidrCalculator.tsx
@@ -105,9 +105,9 @@ function ResultRow({ label, value, copyLabel }: ResultRowData) {
   // モバイル: ラベルを上・値を下に縦積み（狭い横並びによるラベル折返しを回避）
   // デスクトップ (md~): ラベル左・値右の横並び
   return (
-    <div className="flex flex-col gap-1 py-2 border-b border-default last:border-b-0 md:flex-row md:items-start md:justify-between md:gap-3">
+    <div className="flex flex-col gap-1 py-2 border-b border-default last:border-b-0 md:flex-row md:items-center md:justify-between md:gap-3">
       <dt className="caption text-muted md:w-44 md:shrink-0">{label}</dt>
-      <dd className="flex items-start gap-2 min-w-0 md:flex-1 md:justify-end">
+      <dd className="flex items-center gap-2 min-w-0 md:flex-1 md:justify-end">
         <span className="caption font-mono text-default break-all md:text-right">{value}</span>
         <CopyButton text={value} ariaLabel={copyLabel} compact />
       </dd>


### PR DESCRIPTION
## 概要

CIDR/サブネット計算機の「ネットワーク情報」テーブル（計算モード）で、各行の値テキストがコピーボタンに対して上寄りに見え、縦中央に揃っていなかった問題を修正します。

## 原因

`ResultRow`（`src/components/tools/CidrCalculator.tsx`）の縦位置揃え:

- 値の `<span>` は `.caption`（line-height 1.7 ≒ 24px）
- compact な `CopyButton` は `min-h-8` = 32px
- `<dd>` が `items-start` で両者を**上端揃え**していたため、1 行の値グリフがボタンのアイコン中心より上に見えていた

## 変更

`ResultRow` の 2 箇所（`md:` 修飾とベース）のみ:

- 行コンテナ: `md:items-start` → `md:items-center`
- `<dd>`: `items-start` → `items-center`

ラベル・値・コピーボタンを縦中央で揃える。純粋な視覚整列の変更で挙動・出力は不変。

## 検証

- `node_modules/.bin/astro check`: 0 errors（commit hook でも通過）
- `npm run test`: 1906 passed / 1 skipped
- Playwright 実機確認（PC 1280x800 / スマホ 390x844）
  - ネットワーク情報の全 9 行で、値テキストとコピーボタンの縦中心差が `diff: 0`
  - 長い「2 進表記」行・モバイル縦積み（値の左揃え維持）も確認

> ⚠️ VRT baseline はわずかにずれるため、CI Linux runner 側で `Update Visual Regression Baseline` workflow の更新が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
