### PR TITLE
fix: 正規表現ビジュアライザの攻撃文字列コピーボタンをアイコンのみ表示に変更

### DIFF
--- a/src/components/tools/RegexVisualizer.tsx
+++ b/src/components/tools/RegexVisualizer.tsx
@@ -154,11 +154,7 @@ export function RegexVisualizer() {
                     {attack.display}
                     {attack.truncated && '…'}
                   </code>
-                  <CopyButton
-                    text={redos.attackString}
-                    label="コピー"
-                    ariaLabel="攻撃文字列をコピー"
-                  />
+                  <CopyButton text={redos.attackString} ariaLabel="攻撃文字列をコピー" compact />
                 </div>
                 {attack.truncated && (
                   <p className="caption text-muted">

--- a/tests/e2e/regex-visualizer.spec.ts
+++ b/tests/e2e/regex-visualizer.spec.ts
@@ -35,13 +35,13 @@ test.describe('正規表現ビジュアライザ', () => {
       await expect(
         page.getByRole('region', { name: 'ReDoS 判定' }).getByText(/脆弱：ReDoS/)
       ).toBeVisible();
-      // ボタンのアクセシブル名は説明的な「攻撃文字列をコピー」（aria-label）のまま、
-      // 可視テキストはスマホ向けに「コピー」へ短縮されていること（label/ariaLabel 分離の陽性対照）
+      // ボタンはアイコンのみ（可視テキストなし）で、アクセシブル名は説明的な
+      // 「攻撃文字列をコピー」（aria-label）のまま保持されること（icon-only + aria-label の陽性対照）
       const copyBtn = page
         .getByRole('region', { name: 'ReDoS 判定' })
         .getByRole('button', { name: '攻撃文字列をコピー', exact: true });
       await expect(copyBtn).toBeVisible();
-      await expect(copyBtn).toHaveText('コピー');
+      await expect(copyBtn).toHaveText('');
     });
   });
 
@@ -61,10 +61,10 @@ test.describe('正規表現ビジュアライザ', () => {
         .toBeLessThanOrEqual(ATTACK_STRING_DISPLAY_MAX + 1);
       // truncate 発生時の文字数キャプションが表示される
       await expect(region.getByText(/全 \d+ 文字/)).toBeVisible();
-      // 全文取得用のコピーボタンは従来どおり存在する（アクセシブル名は説明的・可視は短縮）
+      // 全文取得用のコピーボタンは従来どおり存在する（アイコンのみ・アクセシブル名は説明的）
       const copyBtn = region.getByRole('button', { name: '攻撃文字列をコピー', exact: true });
       await expect(copyBtn).toBeVisible();
-      await expect(copyBtn).toHaveText('コピー');
+      await expect(copyBtn).toHaveText('');
     });
   });
 


### PR DESCRIPTION
## 概要

正規表現ビジュアライザの「ReDoS 判定」パネルにある攻撃文字列コピーボタンで、可視テキスト「コピー」が攻撃文字列の表示と並んで邪魔になっていたため、アイコンのみの表示（`compact`）に変更しました。

## 変更内容

- `RegexVisualizer.tsx`: 攻撃文字列コピーボタンを `CopyButton` の `compact` 表示に変更（アイコンのみ）。`aria-label="攻撃文字列をコピー"` は保持し、スクリーンリーダー対応を維持。
- `regex-visualizer.spec.ts`: 該当 2 箇所のアサーションを `toHaveText('コピー')` → `toHaveText('')` に更新。
  - ボタンは `getByRole('button', { name: '攻撃文字列をコピー' })` で特定するため、aria-label が消えれば `toBeVisible()` が落ちる（アクセシブル名保持の保証）
  - `toHaveText('')` でアイコンのみ（可視ラベル無し）を保証
  - 旧実装（`label="コピー"`）に当てると fail する正しい方向の陽性対照

## 検証

- `npm run test`: 1906 passed
- `astro check`: 0 errors
- `npm run test:e2e`（regex-visualizer.spec.ts）: 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
