### PR TITLE
feat: SQL整形ツールの警告ボックスを DADS 準拠デザインに刷新

### DIFF
--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -5,6 +5,7 @@ import { InputField } from '@/components/ui/InputField';
 import { OutputField } from '@/components/ui/OutputField';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { formatSql, embedParams, type SqlDialect } from '@/utils/sql';
 import { useCodec } from '@/hooks/useCodec';
 
@@ -95,13 +96,10 @@ export function SqlFormatterTool() {
         </>
       ) : (
         <>
-          <div role="note" className="border border-warning bg-warning-tint rounded-lg p-4">
-            <p className="caption text-warning">
-              ⚠️ この出力はデバッグで内容を確認するための表示用です。文字列連結による値の埋め込みは
-              SQL インジェクションの形そのものであり、生成された SQL をそのまま DB
-              で実行しないでください。
-            </p>
-          </div>
+          <NotificationBanner title="生成された SQL はそのまま実行しないでください">
+            この出力はデバッグで内容を確認するための表示用です。文字列連結による値の埋め込みは SQL
+            インジェクションそのものの形です。
+          </NotificationBanner>
 
           <div className="flex flex-col md:flex-row gap-4 items-stretch">
             <div className="w-full md:flex-1 min-w-0 space-y-4" data-testid="embed-input-column">

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -22,7 +22,12 @@ export function NotificationBanner({ variant = 'warning', title, children, role 
       className={`notification-banner notification-banner--${variant} rounded-lg p-4`}
     >
       <div className="flex items-center gap-2">
-        <StatusIcon variant={variant} size={20} className={`${ICON_COLOR[variant]} shrink-0`} />
+        <StatusIcon
+          variant={variant}
+          size={20}
+          filled
+          className={`${ICON_COLOR[variant]} shrink-0`}
+        />
         <p className="body-emphasis text-default">{title}</p>
       </div>
       <p className="caption text-default mt-2">{children}</p>

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+import { StatusIcon } from '@/components/ui/StatusIcon';
+
+type Variant = 'warning' | 'error';
+
+interface Props {
+  variant?: Variant;
+  title: string;
+  children: ReactNode;
+  role?: string;
+}
+
+const ICON_COLOR: Record<Variant, string> = {
+  warning: 'text-warning',
+  error: 'text-error',
+};
+
+export function NotificationBanner({ variant = 'warning', title, children, role = 'note' }: Props) {
+  return (
+    <div
+      role={role}
+      className={`notification-banner notification-banner--${variant} rounded-lg p-4`}
+    >
+      <div className="flex items-center gap-2">
+        <StatusIcon variant={variant} size={20} className={`${ICON_COLOR[variant]} shrink-0`} />
+        <p className="body-emphasis text-default">{title}</p>
+      </div>
+      <p className="caption text-default mt-2">{children}</p>
+    </div>
+  );
+}

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -19,12 +19,12 @@ export function NotificationBanner({ variant = 'warning', title, children, role 
   return (
     <div
       role={role}
-      className={`notification-banner notification-banner--${variant} rounded-lg p-4`}
+      className={`notification-banner notification-banner--${variant} rounded-xl pt-4 pr-6 pb-6 pl-10`}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
         <StatusIcon
           variant={variant}
-          size={20}
+          size={24}
           filled
           className={`${ICON_COLOR[variant]} shrink-0`}
         />

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -10,11 +10,6 @@ interface Props {
   role?: string;
 }
 
-const ICON_COLOR: Record<Variant, string> = {
-  warning: 'text-warning',
-  error: 'text-error',
-};
-
 export function NotificationBanner({ variant = 'warning', title, children, role = 'note' }: Props) {
   return (
     <div
@@ -22,12 +17,7 @@ export function NotificationBanner({ variant = 'warning', title, children, role 
       className={`notification-banner notification-banner--${variant} rounded-xl pt-4 pr-6 pb-6 pl-10`}
     >
       <div className="flex items-center gap-3">
-        <StatusIcon
-          variant={variant}
-          size={24}
-          filled
-          className={`${ICON_COLOR[variant]} shrink-0`}
-        />
+        <StatusIcon variant={variant} size={24} filled className="shrink-0" />
         <p className="body-emphasis text-default">{title}</p>
       </div>
       <p className="caption text-default mt-2">{children}</p>

--- a/src/components/ui/StatusIcon.tsx
+++ b/src/components/ui/StatusIcon.tsx
@@ -55,25 +55,10 @@ export function StatusIcon({ variant, size = 16, className = '', filled = false 
       );
     }
 
+    // 警告: 三角形に「!」を抜いた塗りつぶし（DADS 公式パス）
     return (
-      <svg
-        {...filledCommon}
-        fill="currentColor"
-        stroke="currentColor"
-        strokeWidth={2}
-        strokeLinejoin="round"
-      >
-        <path d="M12 4 L21 19 L3 19 Z" />
-        <line
-          x1="12"
-          y1="9.5"
-          x2="12"
-          y2="13.5"
-          stroke="#fff"
-          strokeWidth={2}
-          strokeLinecap="round"
-        />
-        <circle cx="12" cy="16.5" r="1.15" fill="#fff" stroke="none" />
+      <svg {...filledCommon} fill="currentColor">
+        <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
       </svg>
     );
   }

--- a/src/components/ui/StatusIcon.tsx
+++ b/src/components/ui/StatusIcon.tsx
@@ -7,43 +7,25 @@ interface Props {
 }
 
 export function StatusIcon({ variant, size = 16, className = '', filled = false }: Props) {
-  const common = {
+  const base = {
     width: size,
     height: size,
     viewBox: '0 0 24 24',
-    fill: 'none',
-    stroke: 'currentColor',
-    strokeLinecap: 'round' as const,
-    strokeLinejoin: 'round' as const,
     'aria-hidden': true,
     className: `inline-block align-middle${className ? ` ${className}` : ''}`,
   };
 
-  if (filled) {
-    // 地色（currentColor）で塗りつぶし、シンボルを白抜きで描画する
-    const filledCommon = {
-      width: size,
-      height: size,
-      viewBox: '0 0 24 24',
-      'aria-hidden': true,
-      className: `inline-block align-middle${className ? ` ${className}` : ''}`,
-    };
+  const common = {
+    ...base,
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  };
 
-    if (variant === 'success') {
-      return (
-        <svg {...filledCommon} fill="currentColor">
-          <circle cx="12" cy="12" r="10" />
-          <polyline
-            points="17 9 10.5 15.5 7 12"
-            fill="none"
-            stroke="#fff"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      );
-    }
+  if (filled && variant !== 'success') {
+    // 地色（currentColor）で塗りつぶし、シンボルを白抜きで描画する
+    const filledCommon = { ...base };
 
     if (variant === 'error') {
       return (

--- a/src/components/ui/StatusIcon.tsx
+++ b/src/components/ui/StatusIcon.tsx
@@ -2,9 +2,11 @@ interface Props {
   variant: 'success' | 'error' | 'warning';
   size?: number;
   className?: string;
+  /** 塗りつぶしアイコン（地色 + 白抜きシンボル）。通知バナー等で使用 */
+  filled?: boolean;
 }
 
-export function StatusIcon({ variant, size = 16, className = '' }: Props) {
+export function StatusIcon({ variant, size = 16, className = '', filled = false }: Props) {
   const common = {
     width: size,
     height: size,
@@ -16,6 +18,65 @@ export function StatusIcon({ variant, size = 16, className = '' }: Props) {
     'aria-hidden': true,
     className: `inline-block align-middle${className ? ` ${className}` : ''}`,
   };
+
+  if (filled) {
+    // 地色（currentColor）で塗りつぶし、シンボルを白抜きで描画する
+    const filledCommon = {
+      width: size,
+      height: size,
+      viewBox: '0 0 24 24',
+      'aria-hidden': true,
+      className: `inline-block align-middle${className ? ` ${className}` : ''}`,
+    };
+
+    if (variant === 'success') {
+      return (
+        <svg {...filledCommon} fill="currentColor">
+          <circle cx="12" cy="12" r="10" />
+          <polyline
+            points="17 9 10.5 15.5 7 12"
+            fill="none"
+            stroke="#fff"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    }
+
+    if (variant === 'error') {
+      return (
+        <svg {...filledCommon} fill="currentColor">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="15" y1="9" x2="9" y2="15" stroke="#fff" strokeWidth={2} strokeLinecap="round" />
+          <line x1="9" y1="9" x2="15" y2="15" stroke="#fff" strokeWidth={2} strokeLinecap="round" />
+        </svg>
+      );
+    }
+
+    return (
+      <svg
+        {...filledCommon}
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinejoin="round"
+      >
+        <path d="M12 4 L21 19 L3 19 Z" />
+        <line
+          x1="12"
+          y1="9.5"
+          x2="12"
+          y2="13.5"
+          stroke="#fff"
+          strokeWidth={2}
+          strokeLinecap="round"
+        />
+        <circle cx="12" cy="16.5" r="1.15" fill="#fff" stroke="none" />
+      </svg>
+    );
+  }
 
   if (variant === 'success') {
     return (

--- a/src/components/ui/__tests__/NotificationBanner.test.tsx
+++ b/src/components/ui/__tests__/NotificationBanner.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
+
+afterEach(() => cleanup());
+
+describe('NotificationBanner', () => {
+  it('title が描画される', () => {
+    const { getByText } = render(
+      <NotificationBanner title="テストタイトル">本文テキスト</NotificationBanner>
+    );
+    expect(getByText('テストタイトル')).toBeTruthy();
+  });
+
+  it('children (本文) が描画される', () => {
+    const { getByText } = render(
+      <NotificationBanner title="タイトル">本文テキスト</NotificationBanner>
+    );
+    expect(getByText('本文テキスト')).toBeTruthy();
+  });
+
+  it('デフォルトで role="note" が付与される', () => {
+    const { getByRole } = render(<NotificationBanner title="タイトル">本文</NotificationBanner>);
+    expect(getByRole('note')).toBeTruthy();
+  });
+
+  it('デフォルト (variant="warning") で notification-banner--warning クラスが付く', () => {
+    const { getByRole } = render(<NotificationBanner title="タイトル">本文</NotificationBanner>);
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--warning');
+  });
+
+  it('variant="error" で notification-banner--error クラスが付く', () => {
+    const { getByRole } = render(
+      <NotificationBanner variant="error" title="タイトル">
+        本文
+      </NotificationBanner>
+    );
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--error');
+  });
+});

--- a/src/components/ui/__tests__/StatusIcon.test.tsx
+++ b/src/components/ui/__tests__/StatusIcon.test.tsx
@@ -58,4 +58,40 @@ describe('StatusIcon', () => {
     expect(cls).toContain('align-middle');
     expect(cls).toContain('custom-cls');
   });
+
+  describe('filled variants', () => {
+    it('warning filled: <path> を持つ塗りつぶし三角形を描画し aria-hidden="true"', () => {
+      const { container } = render(<StatusIcon variant="warning" filled />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('aria-hidden')).toBe('true');
+      expect(svg?.getAttribute('fill')).toBe('currentColor');
+      // 塗りつぶし三角はルートに stroke="currentColor" を持たない
+      expect(svg?.getAttribute('stroke')).toBeNull();
+      expect(svg?.querySelector('path')).toBeTruthy();
+    });
+
+    it('error filled: <circle> と 2 本の <line> を持つ塗りつぶし円を描画し aria-hidden="true"', () => {
+      const { container } = render(<StatusIcon variant="error" filled />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('aria-hidden')).toBe('true');
+      expect(svg?.getAttribute('fill')).toBe('currentColor');
+      // 塗りつぶし円はルートに stroke="currentColor" を持たない
+      expect(svg?.getAttribute('stroke')).toBeNull();
+      expect(svg?.querySelector('circle')).toBeTruthy();
+      expect(svg?.querySelectorAll('line').length).toBe(2);
+    });
+
+    it('success filled: filled ガードをスルーし outline success (polyline) にフォールスルーする', () => {
+      const { container } = render(<StatusIcon variant="success" filled />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      // アウトライン success は stroke="currentColor" を持つ
+      expect(svg?.getAttribute('stroke')).toBe('currentColor');
+      expect(svg?.querySelector('polyline')).toBeTruthy();
+      // 塗りつぶし円はない
+      expect(svg?.querySelector('circle')).toBeFalsy();
+    });
+  });
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -483,6 +483,19 @@
     border-color: var(--color-error);
   }
 
+  /* Notification banner (DADS 通知バナー: 左帯 + 白背景 + 薄い外枠) */
+  .notification-banner {
+    border: 1px solid var(--color-border);
+    border-left-width: 4px;
+    background: var(--color-bg);
+  }
+  .notification-banner--warning {
+    border-left-color: var(--color-warning);
+  }
+  .notification-banner--error {
+    border-left-color: var(--color-error);
+  }
+
   /* File picker label (VerifyTab upload mode) */
   .qr-file-picker-label {
     background: var(--color-bg-surface);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -492,10 +492,12 @@
   .notification-banner--warning {
     border-color: var(--color-warning);
     box-shadow: inset 16px 0 0 0 var(--color-warning);
+    color: var(--color-warning);
   }
   .notification-banner--error {
     border-color: var(--color-error);
     box-shadow: inset 16px 0 0 0 var(--color-error);
+    color: var(--color-error);
   }
 
   /* File picker label (VerifyTab upload mode) */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -483,17 +483,17 @@
     border-color: var(--color-error);
   }
 
-  /* Notification banner (DADS 通知バナー: 左帯 + 白背景 + 薄い外枠) */
+  /* Notification banner (DADS 通知バナー: 左帯 + 白背景 + 全周ボーダー) */
   .notification-banner {
     border: 1px solid var(--color-border);
-    border-left-width: 4px;
+    border-left-width: 6px;
     background: var(--color-bg);
   }
   .notification-banner--warning {
-    border-left-color: var(--color-warning);
+    border-color: var(--color-warning);
   }
   .notification-banner--error {
-    border-left-color: var(--color-error);
+    border-color: var(--color-error);
   }
 
   /* File picker label (VerifyTab upload mode) */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -483,17 +483,19 @@
     border-color: var(--color-error);
   }
 
-  /* Notification banner (DADS 通知バナー: 左帯 + 白背景 + 全周ボーダー) */
+  /* Notification banner (DADS 通知バナー color-chip 型: 全周ボーダー + 左カラーチップ)
+     左帯は inset box-shadow（16px）で表現し、角丸に沿ってクリップされる。 */
   .notification-banner {
-    border: 1px solid var(--color-border);
-    border-left-width: 6px;
+    border: 2px solid;
     background: var(--color-bg);
   }
   .notification-banner--warning {
     border-color: var(--color-warning);
+    box-shadow: inset 16px 0 0 0 var(--color-warning);
   }
   .notification-banner--error {
     border-color: var(--color-error);
+    box-shadow: inset 16px 0 0 0 var(--color-error);
   }
 
   /* File picker label (VerifyTab upload mode) */


### PR DESCRIPTION
## 概要

SQL整形・パラメータ埋め込みツール（`/tools/sql-formatter`）のパラメータ埋め込みモードに表示される警告ボックスを、デジタル庁デザインシステム（DADS）に沿ったデザインへ刷新します。

旧デザインは絵文字 ⚠️ を使い注意文を 1 行べた書きしており、プロジェクトのデザインシステムと整合していませんでした。

## 変更内容

- **再利用可能な `NotificationBanner` コンポーネントを新設**（`src/components/ui/`）
  - 白背景 + 全周ボーダー（深刻度色）+ 太い左帯 + 塗りつぶし三角アイコン + 見出し/本文構造
  - 深刻度 variant（`warning` / `error`）対応
- 絵文字 ⚠️ を廃止。`StatusIcon` に `filled` prop を追加し、塗りつぶしの地色 + 白抜きシンボルを描画
- 1 行べた書きを「太字の見出し + 本文」に分割
- 色・角丸・余白・タイポは全て既存 DADS トークン経由（primitive scale 直書きなし）
- `SqlFormatter` のパラメータ埋め込みモードの警告を新コンポーネントに置換

QrReader / ConfigConverter にある同種の警告ボックスは本 PR では現状維持です（`NotificationBanner` へ将来移行可能な状態）。

## 設計判断

- **深刻度は警告イエロー**: 「表示専用」はツールの仕様としての注意であり runtime エラーではないため、エラーレッドではなく警告イエローを採用。
- アイコン + 左帯/ボーダーで警告を伝え、テキストは高コントラストの `text-default`（DADS「色だけで情報を伝えない」に整合）。

## 検証

- ✅ 型チェック（`astro check`）: 0 errors
- ✅ ユニットテスト: 1916 passed（新規 `NotificationBanner` テスト 5 件含む）
- ✅ E2E（`sql-formatter`）: 13 passed
- ✅ ビルドで `.notification-banner` CSS rule 生成を確認
- ✅ Playwright 実描画確認（PC 1280x800 / スマホ 390x844）

## 補足

- 警告ボックスはパラメータ埋め込みタブを開いて初めて表示される領域で、VRT baseline がキャプチャするデフォルト表示（整形タブ）には変化がないため、**VRT baseline 再生成は不要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
