### PR TITLE
refactor: QrReader / ConfigConverter の警告を NotificationBanner に統一 (#595)

### DIFF
--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -6,6 +6,7 @@ import { DownloadButton } from '@/components/ui/DownloadButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { StatusIcon } from '@/components/ui/StatusIcon';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { useCodecWithMeta } from '@/hooks/useCodec';
 import { convert } from '@/utils/config-converter';
 import type { ConfigFormat } from '@/utils/config-converter';
@@ -199,13 +200,13 @@ export function ConfigConverterTool() {
       </div>
 
       {warnings.length > 0 && (
-        <div className="rounded-lg p-3 border border-warning bg-warning-tint">
-          <ul className="caption text-default m-0 pl-5">
+        <NotificationBanner title="変換に関する警告">
+          <ul className="m-0 pl-5">
             {warnings.map((w, i) => (
               <li key={i}>{w}</li>
             ))}
           </ul>
-        </div>
+        </NotificationBanner>
       )}
 
       <div>

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -4,6 +4,7 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { Section } from '@/components/ui/Section';
 import { FileInputButton } from '@/components/ui/FileInputButton';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { useQrCamera } from '@/hooks/useQrCamera';
 import { useAbortableEffect } from '@/hooks/useAbortableEffect';
 import { detectQrContent, decodeQrFromFile, DEFAULT_QR_MAX_DIM } from '@/utils/qr-reader';
@@ -191,20 +192,20 @@ export function QrReaderTool() {
 
             {/* URLの場合のフィッシング警告 */}
             {content.kind === 'url' && (
-              <div className="rounded-lg p-4 space-y-2 border border-warning bg-warning-tint">
-                <p className="caption text-default">
+              <NotificationBanner title="外部リンクが含まれています">
+                <p className="m-0">
                   <strong className="text-default">{content.hostname}</strong>{' '}
-                  への外部リンクが含まれています。URLをよく確認してから開いてください。
+                  への外部リンクです。URL をよく確認してから開いてください。
                 </p>
                 <a
                   href={content.raw}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="caption font-semibold inline-flex items-center px-3.5 py-1.5 rounded-md border border-warning bg-default text-default no-underline"
+                  className="caption font-semibold inline-flex items-center mt-2 px-3.5 py-1.5 rounded-md border border-warning bg-default text-default no-underline"
                 >
                   URLを開く
                 </a>
-              </div>
+              </NotificationBanner>
             )}
           </div>
         </Section>

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -20,7 +20,7 @@ export function NotificationBanner({ variant = 'warning', title, children, role 
         <StatusIcon variant={variant} size={24} filled className="shrink-0" />
         <p className="body-emphasis text-default">{title}</p>
       </div>
-      <p className="caption text-default mt-2">{children}</p>
+      <div className="caption text-default mt-2">{children}</div>
     </div>
   );
 }

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -340,6 +340,12 @@ test.describe('設定ファイル相互変換', () => {
 
     // convert() が push する warning が画面に描画される
     await expect(page.getByText('値はすべて文字列に変換されます')).toBeVisible();
+
+    // 警告は NotificationBanner (role="note") でラップされている
+    // （素の div へ戻るリグレッションを検知する。旧実装に当てると fail することを確認済み）
+    const note = page.getByRole('note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('変換に関する警告');
   });
 
   test('warning の出ないフォーマットへ切替えると warning が消える', async ({ page }) => {

--- a/tests/e2e/qr-reader.spec.ts
+++ b/tests/e2e/qr-reader.spec.ts
@@ -151,6 +151,12 @@ test.describe('QRリーダー（production CSP 適用）', () => {
       await expect(page.getByText(url)).toBeVisible({ timeout: 10000 });
       await expect(page.getByRole('link', { name: 'URLを開く' })).toBeVisible();
       await expect(page.getByText('example.com', { exact: true })).toBeVisible();
+
+      // 警告は NotificationBanner (role="note") でラップされている
+      // （素の div へ戻るリグレッションを検知する）
+      const note = page.getByRole('note');
+      await expect(note).toBeVisible();
+      await expect(note.getByRole('link', { name: 'URLを開く' })).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## 概要

PR #594 で導入した再利用可能な `NotificationBanner`（DADS color-chip デザイン）へ、他ツールに残っていた同種の警告ボックス（`border border-warning bg-warning-tint` 直書き）を移行し、警告 UI の見た目を統一します。

issue #595 の対応です。

## 変更内容

- **`NotificationBanner`**: 本文ラッパを `<p>` → `<div>` に変更。`<ul>` 等のブロック要素を `children` に渡せるようにするため（`<p>` 内に `<ul>` は不正）。表示は不変。
- **`QrReader`**: URL QR 読取時のフィッシング警告を `NotificationBanner`（`title="外部リンクが含まれています"`）に置換。
  - E2E が依存する **hostname の `<strong>` ノード**（`getByText(hostname, {exact:true})`）と **「URLを開く」リンクの属性**（`href` / `target=_blank` / `rel=noopener noreferrer`）は維持。
- **`ConfigConverter`**: 変換警告リストを `NotificationBanner`（`title="変換に関する警告"`）に置換。SR 用 live region（`data-testid="config-converter-warning-announcement"`）は変更なし。

## 検証

- ✅ 型チェック（`astro check`）: 0 errors
- ✅ ユニットテスト: 1918 passed / 1 skipped
- ✅ E2E（qr-reader + config-converter）: 26 passed
- ✅ Playwright 実描画確認（PC 1280x800 / スマホ 390x844）: 両ツールとも color-chip バナーに統一されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
