### PR TITLE
feat: ReDoS判定/マッチテスト/構造ツリーをDADS準拠デザインに刷新

### DIFF
--- a/.agents/rules/ui-conventions.md
+++ b/.agents/rules/ui-conventions.md
@@ -19,6 +19,9 @@
 | `ToggleGroup<T>`      | 排他選択トグル（モード切替等）                                                                                                                                                                                                                                                      |
 | `ToggleChips<T>`      | 多選択トグルチップ群。`<fieldset>`/`<legend>` で意味付け、各チップは `aria-pressed` ボタン。`count` prop で件数バッジ表示（マスク検出件数等）、`token` prop で文字トークンを等幅バッジ表示（フラグ g/i/m 等）、`legendVisible={false}` で見出しを sr-only 化（a11y ツリーには残す） |
 | `FileInputButton`     | ファイル選択ボタン。label 内包 input 構造で `:focus-within` によるキーボードフォーカス可視化に対応                                                                                                                                                                                  |
+| `NotificationBanner`  | DADS color-chip 型の通知バナー（variant: warning/error/info/success、title + 本文）                                                                                                                                                                                                 |
+| `StatusBadge`         | 状態を表す filled ピルバッジ（tone: error/success/warning/info）。`decorative` prop で `aria-hidden` を付与し、隣接する通知バナー等が意味を担保する文脈での二重読み上げを抑制できる                                                                                                 |
+| `ChipLabel`           | アウトライン型ラベルチップ（tone: error/info/neutral、任意 icon）                                                                                                                                                                                                                   |
 
 ---
 

--- a/src/components/tools/RegexAstTree.tsx
+++ b/src/components/tools/RegexAstTree.tsx
@@ -25,7 +25,7 @@ export function RegexAstTree({ node, hotspot }: Props) {
         <span className={hot ? 'regex-ast-node regex-ast-node-hot' : 'regex-ast-node'}>
           {node.label}
           {hot && (
-            <ChipLabel color="red" className="ml-2">
+            <ChipLabel tone="error" className="ml-2">
               ⚠ ReDoS 危険箇所
             </ChipLabel>
           )}

--- a/src/components/tools/RegexAstTree.tsx
+++ b/src/components/tools/RegexAstTree.tsx
@@ -1,4 +1,5 @@
 import type { RegexAstNode } from '@/utils/regex-visualizer';
+import { ChipLabel } from '@/components/ui/ChipLabel';
 
 interface Props {
   node: RegexAstNode;
@@ -23,7 +24,11 @@ export function RegexAstTree({ node, hotspot }: Props) {
       <li>
         <span className={hot ? 'regex-ast-node regex-ast-node-hot' : 'regex-ast-node'}>
           {node.label}
-          {hot && <span className="caption text-warning"> ⚠ ReDoS 危険箇所</span>}
+          {hot && (
+            <ChipLabel color="red" className="ml-2">
+              ⚠ ReDoS 危険箇所
+            </ChipLabel>
+          )}
         </span>
         {node.children.map((child, i) => (
           <RegexAstTree key={i} node={child} hotspot={hotspot} />

--- a/src/components/tools/RegexMatchTester.tsx
+++ b/src/components/tools/RegexMatchTester.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { InputField } from '@/components/ui/InputField';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { ResultTable, type TableColumn } from '@/components/ui/ResultTable';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { useDebouncedTransform } from '@/hooks/useDebouncedTransform';
 // runMatch は match.ts から直接 import する（barrel 経由にしない）。barrel(index.ts) は
 // parse.ts/redos.ts も re-export しており、それらは CJS（regexp-tree / recheck）依存。
@@ -122,10 +123,10 @@ export function RegexMatchTester({ pattern, flags, redosStatus, regexValid }: Pr
       {!regexValid ? (
         <p className="caption text-muted">有効な正規表現を入力するとマッチを試せます。</p>
       ) : redosStatus === 'vulnerable' ? (
-        <p className="text-warning caption">
-          この正規表現は ReDoS のリスクがあるため、マッチ実行を無効化しています。上の ReDoS
-          判定パネルに表示された攻撃文字列を参照してください。
-        </p>
+        <NotificationBanner variant="info" title="マッチ実行を無効化しています">
+          この正規表現は ReDoS
+          のリスクがあるため、安全のため実行をブロックしています。挙動を確認する場合は、上の判定パネルの攻撃文字列を参照してください。
+        </NotificationBanner>
       ) : (
         <>
           <InputField

--- a/src/components/tools/RegexVisualizer.tsx
+++ b/src/components/tools/RegexVisualizer.tsx
@@ -5,6 +5,8 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { ToggleChips } from '@/components/ui/ToggleChips';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
+import { StatusBadge } from '@/components/ui/StatusBadge';
 import { useDebouncedTransform } from '@/hooks/useDebouncedTransform';
 import type { RegexAstNode, RedosResult, RailNode } from '@/utils/regex-visualizer';
 // 純粋関数のみの module を直接 import（barrel 経由だと recheck/regexp-tree の CJS が
@@ -137,18 +139,33 @@ export function RegexVisualizer() {
         aria-live="polite"
         className="rounded-lg border border-default p-4"
       >
-        <h2 className="body-emphasis text-default mb-2">ReDoS 判定</h2>
+        <div className="flex items-center gap-2 mb-2">
+          <h2 className="body-emphasis text-default">ReDoS 判定</h2>
+          {!analysis.isPending && redos?.status === 'vulnerable' && (
+            <StatusBadge tone="error">脆弱</StatusBadge>
+          )}
+          {!analysis.isPending && redos?.status === 'safe' && (
+            <StatusBadge tone="success">安全</StatusBadge>
+          )}
+          {!analysis.isPending && redos?.status === 'unknown' && (
+            <StatusBadge tone="warning">判定不能</StatusBadge>
+          )}
+        </div>
         {analysis.isPending && <p className="caption text-muted">判定中…</p>}
         {!analysis.isPending && redos?.status === 'safe' && (
-          <p className="alert-success">安全：壊滅的バックトラッキングは検出されませんでした。</p>
+          <NotificationBanner variant="success" title="安全：ReDoS は検出されませんでした">
+            壊滅的バックトラッキングは検出されませんでした。
+          </NotificationBanner>
         )}
         {!analysis.isPending && redos?.status === 'vulnerable' && (
-          <div className="space-y-2">
-            <p className="text-warning body-emphasis">
-              ⚠ 脆弱：ReDoS のリスクがあります（{redos.complexity}）。
-            </p>
+          <div className="space-y-3">
+            <NotificationBanner variant="error" title="脆弱：ReDoS のリスクがあります">
+              入力長に対してマッチ時間が{redos.complexity}
+              に増加します。下の攻撃文字列で再現できます。本番環境では使用しないでください。
+            </NotificationBanner>
             {redos.attackString && attack && (
               <div className="space-y-1">
+                <p className="caption text-muted">攻撃文字列（コピーして検証に使用）</p>
                 <div className="flex items-start gap-2">
                   <code className="bg-subtle rounded px-2 py-1 font-mono break-all">
                     {attack.display}
@@ -167,7 +184,9 @@ export function RegexVisualizer() {
           </div>
         )}
         {!analysis.isPending && redos?.status === 'unknown' && (
-          <p className="text-muted">判定不能（{redos.reason}）：安全とは限りません。</p>
+          <NotificationBanner variant="warning" title="判定不能：安全とは限りません">
+            判定できませんでした（{redos.reason}）。安全とは限らないため注意してください。
+          </NotificationBanner>
         )}
         {!analysis.isPending && !redos && (
           <p className="caption text-muted">正規表現を入力してください。</p>

--- a/src/components/tools/RegexVisualizer.tsx
+++ b/src/components/tools/RegexVisualizer.tsx
@@ -142,13 +142,19 @@ export function RegexVisualizer() {
         <div className="flex items-center gap-2 mb-2">
           <h2 className="body-emphasis text-default">ReDoS 判定</h2>
           {!analysis.isPending && redos?.status === 'vulnerable' && (
-            <StatusBadge tone="error">脆弱</StatusBadge>
+            <StatusBadge tone="error" decorative>
+              脆弱
+            </StatusBadge>
           )}
           {!analysis.isPending && redos?.status === 'safe' && (
-            <StatusBadge tone="success">安全</StatusBadge>
+            <StatusBadge tone="success" decorative>
+              安全
+            </StatusBadge>
           )}
           {!analysis.isPending && redos?.status === 'unknown' && (
-            <StatusBadge tone="warning">判定不能</StatusBadge>
+            <StatusBadge tone="warning" decorative>
+              判定不能
+            </StatusBadge>
           )}
         </div>
         {analysis.isPending && <p className="caption text-muted">判定中…</p>}

--- a/src/components/tools/__tests__/RegexVisualizer.test.tsx
+++ b/src/components/tools/__tests__/RegexVisualizer.test.tsx
@@ -33,13 +33,17 @@ describe('RegexVisualizer', () => {
   it('脆弱な正規表現で危険判定を表示する', async () => {
     render(<RegexVisualizer />);
     setPattern('(a+)+$');
-    expect(await screen.findByText(/脆弱/, undefined, FIND)).toBeTruthy();
+    // StatusBadge（「脆弱」）と NotificationBanner title（「脆弱：ReDoS…」）の両方が表示される
+    const els = await screen.findAllByText(/脆弱/, undefined, FIND);
+    expect(els.length).toBeGreaterThan(0);
   });
 
   it('安全な正規表現で安全判定を表示する', async () => {
     render(<RegexVisualizer />);
     setPattern('^[a-z]+$');
-    expect(await screen.findByText(/安全/, undefined, FIND)).toBeTruthy();
+    // StatusBadge（「安全」）と NotificationBanner title（「安全：ReDoS…」）の両方が表示される
+    const els = await screen.findAllByText(/安全/, undefined, FIND);
+    expect(els.length).toBeGreaterThan(0);
   });
 
   it('鉄道図タブに切り替えると SVG が表示される', async () => {
@@ -55,7 +59,8 @@ describe('RegexVisualizer', () => {
   it('鉄道図タブで脆弱パターンの hotspot が強調される', async () => {
     render(<RegexVisualizer />);
     setPattern('(a+)+$');
-    await screen.findByText(/脆弱/, undefined, FIND);
+    // StatusBadge + NotificationBanner title の両方にマッチするので findAllByText で待機
+    await screen.findAllByText(/脆弱/, undefined, FIND);
     fireEvent.click(screen.getByRole('button', { name: '鉄道図' }));
     const svg = await screen.findByRole('img', { name: '正規表現の鉄道図' }, FIND);
     expect(svg.querySelector('.rr-box-hot')).toBeTruthy();
@@ -64,8 +69,8 @@ describe('RegexVisualizer', () => {
   it('安全な正規表現でテスト文字列を入力するとマッチが集計される', async () => {
     render(<RegexVisualizer />);
     setPattern('\\d+');
-    // safe 判定の確定を待つ（動的 import + debounce 完了の目印）
-    await screen.findByText(/安全/, undefined, FIND);
+    // safe 判定の確定を待つ（StatusBadge + title の両方にマッチするので findAllByText）
+    await screen.findAllByText(/安全/, undefined, FIND);
     fireEvent.change(screen.getByLabelText('テスト文字列'), { target: { value: 'a1 b2' } });
     expect(await screen.findByText(/件マッチ/, undefined, FIND)).toBeTruthy();
   });
@@ -73,7 +78,8 @@ describe('RegexVisualizer', () => {
   it('脆弱な正規表現ではマッチ実行が無効化される', async () => {
     render(<RegexVisualizer />);
     setPattern('(a+)+$');
-    await screen.findByText(/脆弱/, undefined, FIND);
+    // StatusBadge + NotificationBanner title の両方にマッチするので findAllByText で待機
+    await screen.findAllByText(/脆弱/, undefined, FIND);
     expect(await screen.findByText(/マッチ実行を無効化/, undefined, FIND)).toBeTruthy();
   });
 });

--- a/src/components/ui/ChipLabel.tsx
+++ b/src/components/ui/ChipLabel.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  color: 'red' | 'blue' | 'gray';
+  children: ReactNode;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export function ChipLabel({ color, children, icon, className = '' }: Props) {
+  return (
+    <span className={`chip-label chip-label--${color}${className ? ` ${className}` : ''}`}>
+      {icon}
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/ChipLabel.tsx
+++ b/src/components/ui/ChipLabel.tsx
@@ -1,15 +1,15 @@
 import type { ReactNode } from 'react';
 
 interface Props {
-  color: 'red' | 'blue' | 'gray';
+  tone: 'error' | 'info' | 'neutral';
   children: ReactNode;
   icon?: ReactNode;
   className?: string;
 }
 
-export function ChipLabel({ color, children, icon, className = '' }: Props) {
+export function ChipLabel({ tone, children, icon, className = '' }: Props) {
   return (
-    <span className={`chip-label chip-label--${color}${className ? ` ${className}` : ''}`}>
+    <span className={`chip-label chip-label--${tone}${className ? ` ${className}` : ''}`}>
       {icon}
       {children}
     </span>

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { StatusIcon } from '@/components/ui/StatusIcon';
 
-type Variant = 'warning' | 'error';
+type Variant = 'warning' | 'error' | 'info' | 'success';
 
 interface Props {
   variant?: Variant;

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  tone: 'error' | 'success' | 'warning' | 'info';
+  children: ReactNode;
+  className?: string;
+}
+
+export function StatusBadge({ tone, children, className = '' }: Props) {
+  return (
+    <span className={`status-badge status-badge--${tone}${className ? ` ${className}` : ''}`}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -4,11 +4,16 @@ interface Props {
   tone: 'error' | 'success' | 'warning' | 'info';
   children: ReactNode;
   className?: string;
+  /** true のとき aria-hidden="true" を付与し、スクリーンリーダーの読み上げを抑制する */
+  decorative?: boolean;
 }
 
-export function StatusBadge({ tone, children, className = '' }: Props) {
+export function StatusBadge({ tone, children, className = '', decorative = false }: Props) {
   return (
-    <span className={`status-badge status-badge--${tone}${className ? ` ${className}` : ''}`}>
+    <span
+      className={`status-badge status-badge--${tone}${className ? ` ${className}` : ''}`}
+      aria-hidden={decorative || undefined}
+    >
       {children}
     </span>
   );

--- a/src/components/ui/StatusIcon.tsx
+++ b/src/components/ui/StatusIcon.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  variant: 'success' | 'error' | 'warning';
+  variant: 'success' | 'error' | 'warning' | 'info';
   size?: number;
   className?: string;
   /** 塗りつぶしアイコン（地色 + 白抜きシンボル）。通知バナー等で使用 */
@@ -23,8 +23,7 @@ export function StatusIcon({ variant, size = 16, className = '', filled = false 
     strokeLinejoin: 'round' as const,
   };
 
-  if (filled && variant !== 'success') {
-    // 地色（currentColor）で塗りつぶし、シンボルを白抜きで描画する
+  if (filled) {
     const filledCommon = { ...base };
 
     if (variant === 'error') {
@@ -37,10 +36,38 @@ export function StatusIcon({ variant, size = 16, className = '', filled = false 
       );
     }
 
-    // 警告: 三角形に「!」を抜いた塗りつぶし（DADS 公式パス）
+    if (variant === 'warning') {
+      // 三角形に「!」を抜いた塗りつぶし（DADS 公式パス）
+      return (
+        <svg {...filledCommon} fill="currentColor">
+          <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+        </svg>
+      );
+    }
+
+    if (variant === 'success') {
+      // 緑地の円 + 白抜きチェック
+      return (
+        <svg {...filledCommon} fill="currentColor">
+          <circle cx="12" cy="12" r="10" />
+          <polyline
+            points="20 6 9 17 4 12"
+            fill="none"
+            stroke="#fff"
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    }
+
+    // info: 地色の円 + 白抜きの「i」（縦線 + ドット）
     return (
       <svg {...filledCommon} fill="currentColor">
-        <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+        <circle cx="12" cy="12" r="10" />
+        <circle cx="12" cy="8" r="1" fill="#fff" />
+        <line x1="12" y1="11" x2="12" y2="17" stroke="#fff" strokeWidth={2} strokeLinecap="round" />
       </svg>
     );
   }
@@ -62,6 +89,18 @@ export function StatusIcon({ variant, size = 16, className = '', filled = false 
     );
   }
 
+  if (variant === 'info') {
+    // アウトライン: 円 + i（縦線 + ドット）
+    return (
+      <svg {...common} strokeWidth={2}>
+        <circle cx="12" cy="12" r="10" />
+        <circle cx="12" cy="8" r="1" fill="currentColor" />
+        <line x1="12" y1="11" x2="12" y2="17" />
+      </svg>
+    );
+  }
+
+  // warning
   return (
     <svg {...common} strokeWidth={2}>
       <path d="M12 3 L22 20 L2 20 Z" />

--- a/src/components/ui/__tests__/ChipLabel.test.tsx
+++ b/src/components/ui/__tests__/ChipLabel.test.tsx
@@ -7,33 +7,42 @@ afterEach(() => cleanup());
 
 describe('ChipLabel', () => {
   it('children が描画される', () => {
-    const { getByText } = render(<ChipLabel color="red">ReDoS 危険箇所</ChipLabel>);
+    const { getByText } = render(<ChipLabel tone="error">ReDoS 危険箇所</ChipLabel>);
     expect(getByText('ReDoS 危険箇所')).toBeTruthy();
   });
 
-  it('color="red" で chip-label--red クラスが付く', () => {
-    const { container } = render(<ChipLabel color="red">ReDoS 危険箇所</ChipLabel>);
-    expect((container.firstChild as HTMLElement).className).toContain('chip-label--red');
+  it('tone="error" で chip-label--error クラスが付く', () => {
+    const { container } = render(<ChipLabel tone="error">ReDoS 危険箇所</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--error');
   });
 
-  it('color="blue" で chip-label--blue クラスが付く', () => {
-    const { container } = render(<ChipLabel color="blue">情報</ChipLabel>);
-    expect((container.firstChild as HTMLElement).className).toContain('chip-label--blue');
+  it('tone="info" で chip-label--info クラスが付く', () => {
+    const { container } = render(<ChipLabel tone="info">情報</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--info');
   });
 
-  it('color="gray" で chip-label--gray クラスが付く', () => {
-    const { container } = render(<ChipLabel color="gray">その他</ChipLabel>);
-    expect((container.firstChild as HTMLElement).className).toContain('chip-label--gray');
+  it('tone="neutral" で chip-label--neutral クラスが付く', () => {
+    const { container } = render(<ChipLabel tone="neutral">その他</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--neutral');
   });
 
   it('chip-label ベースクラスが常に付く', () => {
-    const { container } = render(<ChipLabel color="red">テスト</ChipLabel>);
+    const { container } = render(<ChipLabel tone="error">テスト</ChipLabel>);
     expect((container.firstChild as HTMLElement).className).toContain('chip-label');
+  });
+
+  it('旧 color prop 由来のクラスが付かない（chip-label--red / --blue / --gray の残留がない）', () => {
+    const { container: e } = render(<ChipLabel tone="error">error</ChipLabel>);
+    const { container: i } = render(<ChipLabel tone="info">info</ChipLabel>);
+    const { container: n } = render(<ChipLabel tone="neutral">neutral</ChipLabel>);
+    expect((e.firstChild as HTMLElement).className).not.toContain('chip-label--red');
+    expect((i.firstChild as HTMLElement).className).not.toContain('chip-label--blue');
+    expect((n.firstChild as HTMLElement).className).not.toContain('chip-label--gray');
   });
 
   it('任意の className が追加される', () => {
     const { container } = render(
-      <ChipLabel color="red" className="ml-2">
+      <ChipLabel tone="error" className="ml-2">
         テスト
       </ChipLabel>
     );
@@ -42,7 +51,7 @@ describe('ChipLabel', () => {
 
   it('icon prop が描画される', () => {
     const { getByText } = render(
-      <ChipLabel color="red" icon={<span>icon</span>}>
+      <ChipLabel tone="error" icon={<span>icon</span>}>
         ラベル
       </ChipLabel>
     );

--- a/src/components/ui/__tests__/ChipLabel.test.tsx
+++ b/src/components/ui/__tests__/ChipLabel.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ChipLabel } from '@/components/ui/ChipLabel';
+
+afterEach(() => cleanup());
+
+describe('ChipLabel', () => {
+  it('children が描画される', () => {
+    const { getByText } = render(<ChipLabel color="red">ReDoS 危険箇所</ChipLabel>);
+    expect(getByText('ReDoS 危険箇所')).toBeTruthy();
+  });
+
+  it('color="red" で chip-label--red クラスが付く', () => {
+    const { container } = render(<ChipLabel color="red">ReDoS 危険箇所</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--red');
+  });
+
+  it('color="blue" で chip-label--blue クラスが付く', () => {
+    const { container } = render(<ChipLabel color="blue">情報</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--blue');
+  });
+
+  it('color="gray" で chip-label--gray クラスが付く', () => {
+    const { container } = render(<ChipLabel color="gray">その他</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--gray');
+  });
+
+  it('chip-label ベースクラスが常に付く', () => {
+    const { container } = render(<ChipLabel color="red">テスト</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label');
+  });
+
+  it('任意の className が追加される', () => {
+    const { container } = render(
+      <ChipLabel color="red" className="ml-2">
+        テスト
+      </ChipLabel>
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('ml-2');
+  });
+
+  it('icon prop が描画される', () => {
+    const { getByText } = render(
+      <ChipLabel color="red" icon={<span>icon</span>}>
+        ラベル
+      </ChipLabel>
+    );
+    expect(getByText('icon')).toBeTruthy();
+    expect(getByText('ラベル')).toBeTruthy();
+  });
+});

--- a/src/components/ui/__tests__/NotificationBanner.test.tsx
+++ b/src/components/ui/__tests__/NotificationBanner.test.tsx
@@ -40,4 +40,44 @@ describe('NotificationBanner', () => {
     const el = getByRole('note');
     expect(el.className).toContain('notification-banner--error');
   });
+
+  it('variant="info" で notification-banner--info クラスが付く', () => {
+    const { getByRole } = render(
+      <NotificationBanner variant="info" title="情報タイトル">
+        情報本文
+      </NotificationBanner>
+    );
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--info');
+  });
+
+  it('variant="success" で notification-banner--success クラスが付く', () => {
+    const { getByRole } = render(
+      <NotificationBanner variant="success" title="成功タイトル">
+        成功本文
+      </NotificationBanner>
+    );
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--success');
+  });
+
+  it('variant="info" で StatusIcon が描画される（aria-hidden SVG が存在する）', () => {
+    const { container } = render(
+      <NotificationBanner variant="info" title="情報">
+        本文
+      </NotificationBanner>
+    );
+    const svg = container.querySelector('svg[aria-hidden="true"]');
+    expect(svg).not.toBeNull();
+  });
+
+  it('variant="success" で StatusIcon が描画される（aria-hidden SVG が存在する）', () => {
+    const { container } = render(
+      <NotificationBanner variant="success" title="成功">
+        本文
+      </NotificationBanner>
+    );
+    const svg = container.querySelector('svg[aria-hidden="true"]');
+    expect(svg).not.toBeNull();
+  });
 });

--- a/src/components/ui/__tests__/StatusBadge.test.tsx
+++ b/src/components/ui/__tests__/StatusBadge.test.tsx
@@ -45,4 +45,27 @@ describe('StatusBadge', () => {
     );
     expect((container.firstChild as HTMLElement).className).toContain('ml-2');
   });
+
+  it('decorative=true で aria-hidden="true" が付く', () => {
+    const { container } = render(
+      <StatusBadge tone="success" decorative>
+        安全
+      </StatusBadge>
+    );
+    expect((container.firstChild as HTMLElement).getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('decorative 未指定でデフォルト false: aria-hidden が付かない', () => {
+    const { container } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect((container.firstChild as HTMLElement).getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('decorative=false 明示でも aria-hidden が付かない', () => {
+    const { container } = render(
+      <StatusBadge tone="info" decorative={false}>
+        情報
+      </StatusBadge>
+    );
+    expect((container.firstChild as HTMLElement).getAttribute('aria-hidden')).toBeNull();
+  });
 });

--- a/src/components/ui/__tests__/StatusBadge.test.tsx
+++ b/src/components/ui/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { StatusBadge } from '@/components/ui/StatusBadge';
+
+afterEach(() => cleanup());
+
+describe('StatusBadge', () => {
+  it('children が描画される', () => {
+    const { getByText } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect(getByText('脆弱')).toBeTruthy();
+  });
+
+  it('tone="error" で status-badge--error クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect(container.firstChild).not.toBeNull();
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--error');
+  });
+
+  it('tone="success" で status-badge--success クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="success">安全</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--success');
+  });
+
+  it('tone="warning" で status-badge--warning クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="warning">判定不能</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--warning');
+  });
+
+  it('tone="info" で status-badge--info クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="info">情報</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--info');
+  });
+
+  it('status-badge ベースクラスが常に付く', () => {
+    const { container } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge');
+  });
+
+  it('任意の className が追加される', () => {
+    const { container } = render(
+      <StatusBadge tone="error" className="ml-2">
+        脆弱
+      </StatusBadge>
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('ml-2');
+  });
+});

--- a/src/components/ui/__tests__/StatusIcon.test.tsx
+++ b/src/components/ui/__tests__/StatusIcon.test.tsx
@@ -83,15 +83,19 @@ describe('StatusIcon', () => {
       expect(svg?.querySelectorAll('line').length).toBe(2);
     });
 
-    it('success filled: filled ガードをスルーし outline success (polyline) にフォールスルーする', () => {
+    it('success filled: 緑地の円 + 白抜き polyline チェックを描画する', () => {
       const { container } = render(<StatusIcon variant="success" filled />);
       const svg = container.querySelector('svg');
       expect(svg).toBeTruthy();
-      // アウトライン success は stroke="currentColor" を持つ
-      expect(svg?.getAttribute('stroke')).toBe('currentColor');
-      expect(svg?.querySelector('polyline')).toBeTruthy();
-      // 塗りつぶし円はない
-      expect(svg?.querySelector('circle')).toBeFalsy();
+      expect(svg?.getAttribute('aria-hidden')).toBe('true');
+      // 塗りつぶし円は fill="currentColor" を SVG ルートに持つ
+      expect(svg?.getAttribute('fill')).toBe('currentColor');
+      // 白抜きチェック (polyline) が存在する
+      const poly = svg?.querySelector('polyline');
+      expect(poly).toBeTruthy();
+      expect(poly?.getAttribute('stroke')).toBe('#fff');
+      // 背景の円が存在する
+      expect(svg?.querySelector('circle')).toBeTruthy();
     });
   });
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,6 +57,8 @@
   --color-error-bg: #fef2f2;
   --color-warning: #854d0e; /* amber-800: amber-600 は白背景で WCAG AA 不合格 */
   --color-warning-bg: #fef3c7; /* amber-100 */
+  --color-info: #1d4ed8; /* blue-700: 白背景でコントラスト 4.5:1 以上 */
+  --color-info-bg: #eff6ff; /* blue-50 */
 
   /* === 機能カラー === */
   --color-link: #2563eb;
@@ -499,6 +501,16 @@
     box-shadow: inset 16px 0 0 0 var(--color-error);
     color: var(--color-error);
   }
+  .notification-banner--info {
+    border-color: var(--color-info);
+    box-shadow: inset 16px 0 0 0 var(--color-info);
+    color: var(--color-info);
+  }
+  .notification-banner--success {
+    border-color: var(--color-success);
+    box-shadow: inset 16px 0 0 0 var(--color-success);
+    color: var(--color-success);
+  }
 
   /* File picker label (VerifyTab upload mode) */
   .qr-file-picker-label {
@@ -830,10 +842,10 @@
     margin: 0.125rem 0;
   }
 
-  /* ReDoS 危険箇所にマッチするノードを警告色で強調 */
+  /* ReDoS 危険箇所にマッチするノードをエラー色（赤）で強調 */
   .regex-ast-node-hot {
-    background: var(--color-warning-bg);
-    color: var(--color-warning);
+    background: var(--color-error-bg);
+    color: var(--color-error);
   }
 
   /* === 汎用トグルチップ（ToggleChips コンポーネント用） === */
@@ -1114,6 +1126,56 @@
       opacity: 1;
       pointer-events: auto;
     }
+  }
+
+  /* === StatusBadge: 小さい filled ピル（地色=semantic 色、文字=白） === */
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    border-radius: var(--radius-md, 0.5rem);
+    font-weight: 700;
+    font-size: 0.875rem;
+    line-height: 1;
+    color: var(--color-text-on-primary, #fff);
+  }
+  .status-badge--error {
+    background: var(--color-error);
+  }
+  .status-badge--success {
+    background: var(--color-success);
+  }
+  .status-badge--warning {
+    background: var(--color-warning);
+  }
+  .status-badge--info {
+    background: var(--color-info);
+  }
+
+  /* === ChipLabel: アウトライン型ピル（白背景 + color ボーダー + color 文字） === */
+  .chip-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: var(--radius-md, 0.5rem);
+    border: 1px solid;
+    background: var(--color-bg, #fff);
+    font-size: 0.875rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+  .chip-label--red {
+    border-color: var(--color-error);
+    color: var(--color-error);
+  }
+  .chip-label--blue {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .chip-label--gray {
+    border-color: var(--color-border);
+    color: var(--color-muted);
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -52,6 +52,7 @@
 
   /* === セマンティックカラー === */
   --color-success: #16a34a;
+  --color-success-strong: #15803d; /* 白文字バッジ用: 白×#15803d ≈ 5.0:1 で WCAG AA 合格 */
   --color-success-bg: #f0fdf4;
   --color-error: #dc2626;
   --color-error-bg: #fef2f2;
@@ -1143,7 +1144,7 @@
     background: var(--color-error);
   }
   .status-badge--success {
-    background: var(--color-success);
+    background: var(--color-success-strong);
   }
   .status-badge--warning {
     background: var(--color-warning);
@@ -1165,15 +1166,15 @@
     font-weight: 700;
     line-height: 1.2;
   }
-  .chip-label--red {
+  .chip-label--error {
     border-color: var(--color-error);
     color: var(--color-error);
   }
-  .chip-label--blue {
+  .chip-label--info {
     border-color: var(--color-info);
     color: var(--color-info);
   }
-  .chip-label--gray {
+  .chip-label--neutral {
     border-color: var(--color-border);
     color: var(--color-muted);
   }


### PR DESCRIPTION
## 概要

正規表現ビジュアライザの **ReDoS判定 / マッチテスト / 構造ツリー** の3領域を、デジタル庁デザインシステム(DADS)準拠のデザインに刷新します。従来はテキスト主体の警告表示でしたが、color-chip型の `NotificationBanner` と `StatusBadge` / `ChipLabel` に統一しました。

## 変更内容

### ツール画面
| 領域 | Before | After |
|---|---|---|
| ReDoS判定 | 見出し + 絵文字付きテキスト | 見出し横に状態別 `StatusBadge`（脆弱=赤 / 安全=緑 / 判定不能=黄）+ color-chip型 `NotificationBanner`。**全3状態でデザイン統一** |
| マッチテスト（脆弱時） | グレーの警告テキスト | 青の info型 `NotificationBanner`「マッチ実行を無効化しています」 |
| 構造ツリー | hotspot をテキスト「⚠ ReDoS 危険箇所」 | 赤の `ChipLabel` 化。ノード強調を警告色→エラー色（赤）へ |

### 共通コンポーネント
- **新規**: `StatusBadge`（filled ピル, tone: error/success/warning/info）, `ChipLabel`（アウトライン型ピル, color: red/blue/gray）を `src/components/ui/` に追加（再利用可能）
- **拡張**: `NotificationBanner` を `warning | error | info | success` の4 variant に対応
- **拡張**: `StatusIcon` に filled success（緑丸+白チェック）/ filled info（青丸+白i）を追加
- `global.css` に `--color-info` トークン + 各 semantic class を `@layer components` に追加

## 検証

- `npx astro check`: エラー0
- `npm run test`: 1944 passed / 1 skipped（StatusBadge / ChipLabel / NotificationBanner のテスト追加含む）
- `npm run build`: 成功、`dist` の CSS に新クラス9種の生成を確認
- `regex-visualizer.spec.ts`（E2E）: 13 passed。E2E依存文字列（`脆弱：ReDoS` / `安全：` / `マッチ実行を無効化` / copy ボタンの aria-label）を維持
- Playwright 実描画で 脆弱(PC/スマホ390px) / 安全(PC) を目視確認済み

## 補足

- 挙動（解析ロジック・対応正規表現）は不変のため `docs/tools.md` の更新は不要と判断
- 判定不能(unknown)状態は同じ `NotificationBanner`(warning variant) を使用、単体テストで網羅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
