### PR TITLE
fix: SJIS/CRLF変換でダウンロードファイル末尾にNULバイトが混入する不具合を修正

### DIFF
--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { downloadBlob, downloadPngFromSvgElement, svgContentToPngBlob } from '@/utils/download';
+import {
+  downloadBlob,
+  downloadBytes,
+  downloadPngFromSvgElement,
+  svgContentToPngBlob,
+} from '@/utils/download';
 
 /**
  * `src/utils/download.ts` の private const `RETINA_SCALE` の mirror。
@@ -197,6 +202,81 @@ describe('downloadBlob', () => {
   it('生成した ObjectURL は revokeObjectURL で解放される', () => {
     downloadBlob(new Blob(['x']), 'a.txt');
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});
+
+/**
+ * downloadBytes: backing buffer 全体を覆わない Uint8Array ビュー（normalizeNewlines の
+ * CRLF モードが返す subarray など）を渡したとき、NUL バイトが混入しないことを検証する。
+ *
+ * 根本原因: normalizeNewlines() の CRLF モードは `new Uint8Array(bytes.length * 2)` を
+ * 確保して `out.subarray(0, w)` というビューを返す。旧実装が `bytes.buffer`（バッファ全体）
+ * を Blob に渡していたため、ビュー範囲外のゼロ詰めバイトが出力に混入し、VS Code が
+ * 「バイナリか、サポートされていないエンコード」と判定する事故が発生した。
+ *
+ * 陽性対照（oversized buffer ケース）と陰性対照（通常ケース）を別 it() に分離。
+ * URL.createObjectURL に渡される Blob を捕捉して Blob.size を assert する。
+ */
+describe('downloadBytes', () => {
+  let createdAnchor: { href: string; download: string; click: ReturnType<typeof vi.fn> };
+  let capturedBlob: Blob | undefined;
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createdAnchor = { href: '', download: '', click: vi.fn() };
+    capturedBlob = undefined;
+    createObjectURL = vi.fn((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:mock-url';
+    });
+    revokeObjectURL = vi.fn();
+
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => createdAnchor),
+    });
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * 陽性対照: oversized backing buffer の subarray ビューを渡したとき、
+   * Blob.size がビュー長（6）になること。
+   *
+   * 旧実装（`bytes.buffer` 直渡し）に revert すると Blob.size は backing buffer 長（10）
+   * になりこのテストが fail する — これがバグ検知能力の証明（test-gates 鉄則 1）。
+   * normalizeNewlines() の CRLF モードが `bytes.length * 2` のバッファを確保して
+   * `subarray(0, w)` を返すパターンと同じ状況を手動で再現している。
+   */
+  it('陽性対照: oversized buffer の subarray ビューを渡すと Blob.size がビュー長（6）になる', () => {
+    // 10 バイトの backing buffer を作り、先頭 6 バイトだけのビューを作る
+    // (normalizeNewlines CRLF モードの `new Uint8Array(bytes.length * 2)` + `subarray(0, w)` を模倣)
+    const buf = new Uint8Array(10);
+    buf.set([0x83, 0x4a, 0x0d, 0x0a, 0x96, 0xbc]); // SJIS「花」＋CRLF＋SJIS「名」
+    const view = buf.subarray(0, 6); // backing buffer は 10 バイト、ビューは 6 バイト
+
+    downloadBytes(view, 'output.txt');
+
+    expect(capturedBlob).toBeDefined();
+    // 修正版: Blob.size = 6（ビュー長のみ）
+    // 旧実装（bytes.buffer 直渡し）に revert すると size = 10（backing buffer 全体）になり fail
+    expect(capturedBlob!.size).toBe(6);
+  });
+
+  /**
+   * 陰性対照: backing buffer 全体を覆う通常の Uint8Array を渡したとき、
+   * Blob.size が正しくバイト長になること。
+   */
+  it('陰性対照: backing buffer 全体を覆う Uint8Array を渡すと Blob.size がバイト長と一致する', () => {
+    const bytes = new Uint8Array([0x83, 0x4a, 0x0d, 0x0a]); // 4 バイト、buffer 全体をカバー
+
+    downloadBytes(bytes, 'output.txt');
+
+    expect(capturedBlob).toBeDefined();
+    expect(capturedBlob!.size).toBe(4);
   });
 });
 

--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -5,6 +5,7 @@ import {
   downloadPngFromSvgElement,
   svgContentToPngBlob,
 } from '@/utils/download';
+import { normalizeNewlines } from '@/utils/encoding';
 
 /**
  * `src/utils/download.ts` の private const `RETINA_SCALE` の mirror。
@@ -277,6 +278,28 @@ describe('downloadBytes', () => {
 
     expect(capturedBlob).toBeDefined();
     expect(capturedBlob!.size).toBe(4);
+  });
+
+  /**
+   * 陽性対照（実コードパス連結）: normalizeNewlines('crlf') の戻り値（oversized backing
+   * buffer の subarray ビュー）を実際に downloadBytes に流し、Blob.size がビュー長と
+   * 一致することを end-to-end で検証する（#598 レビュー提案 1）。
+   *
+   * 上の手動再構築ケースと違い、normalizeNewlines 側の実装（`new Uint8Array(len*2)` +
+   * `subarray(0, w)`）が将来変わっても本ケースが回帰を直接ガードする。旧 downloadBytes
+   * （`bytes.buffer` 直渡し）に revert すると size がゼロ詰めを含む値になり fail する。
+   */
+  it('陽性対照: normalizeNewlines("crlf") 出力を downloadBytes に流すと Blob.size がビュー長と一致する', () => {
+    // SJIS「花」(83 4a) + LF + SJIS「名」(96 bc): LF を含む現実的なバイト列
+    const input = new Uint8Array([0x83, 0x4a, 0x0a, 0x96, 0xbc]);
+    const crlf = normalizeNewlines(input, 'crlf'); // LF→CRLF で 6 バイトのビュー（裏は 10 バイト）
+    expect(crlf.length).toBe(6);
+    expect(crlf.buffer.byteLength).toBeGreaterThan(crlf.length); // oversized buffer であることを確認
+
+    downloadBytes(crlf, 'output.txt');
+
+    expect(capturedBlob).toBeDefined();
+    expect(capturedBlob!.size).toBe(crlf.length); // ゼロ詰めを含まずビュー長と一致
   });
 });
 

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -23,12 +23,21 @@ export function downloadText(content: string, filename: string, mimeType = 'text
   downloadBlob(new Blob([content], { type: `${mimeType};charset=utf-8` }), filename);
 }
 
-/** バイナリをファイルとしてダウンロードする */
+/**
+ * バイナリをファイルとしてダウンロードする。
+ *
+ * normalizeNewlines() の CRLF モードは `new Uint8Array(bytes.length * 2)` を確保して
+ * `out.subarray(0, w)` というビューを返す。backing buffer には末尾にゼロ詰めが残るため、
+ * 旧実装のように `bytes.buffer`（バッファ全体）を Blob に渡すと NUL バイトが混入し、
+ * VS Code が「バイナリか、サポートされていないエンコード」と判定する事故が起きていた
+ * （issue: SJIS/CRLF 変換）。
+ *
+ * `bytes.slice()` は byteOffset/byteLength の範囲だけを ArrayBuffer 裏の新しい Uint8Array に
+ * コピーして返すため、ビュー範囲外のゼロ詰めバイトが混入せず、かつ ArrayBufferLike
+ * （SharedArrayBuffer 含む）の型問題も回避できる。
+ */
 export function downloadBytes(bytes: Uint8Array, filename: string): void {
-  downloadBlob(
-    new Blob([bytes.buffer as ArrayBuffer], { type: 'application/octet-stream' }),
-    filename
-  );
+  downloadBlob(new Blob([bytes.slice()], { type: 'application/octet-stream' }), filename);
 }
 
 /** SVG文字列をファイルとしてダウンロードする */

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -144,6 +144,11 @@ export const NEWLINE_OPTIONS: Array<{ value: NewlineMode; label: string }> = [
 
 // UTF-8 / SJIS / EUC-JP / JIS / ASCII 向けのバイト単位正規化。
 // UTF-16 は呼び出し元で除外すること（BOM バイトは 0x0A/0x0D を含まないため分離不要）。
+//
+// ⚠️ 返り値は `out.subarray(0, w)` というビューで、backing buffer は実データより大きい
+// （crlf モードは最大 bytes.length * 2 を確保）。末尾にゼロ詰めが残るため、consumer は
+// `.length` / 反復のみを使い、`.buffer` を直接参照してはならない（範囲外バイトが混入する）。
+// 例: downloadBytes は `.buffer` 直渡しでファイル末尾に NUL を混入させる不具合があった（#598）。
 export function normalizeNewlines(bytes: Uint8Array, mode: NewlineMode): Uint8Array {
   if (mode === 'keep' || bytes.length === 0) return bytes;
 


### PR DESCRIPTION
## 概要

文字コード変換ツールで **UTF-8/LF → SJIS/CRLF** に変換すると、ダウンロードしたファイルの末尾に NUL バイト（`0x00`）が混入し、VS Code が「このファイルはバイナリか、サポートされていないテキストエンコードを使用しているため、テキストエディターに表示できません。」と表示して開けなくなる不具合を修正します。

## 根本原因

`src/utils/download.ts` の `downloadBytes()` が Uint8Array の **backing buffer 全体**（`bytes.buffer`）を `Blob` に渡していたことが原因です。

`src/utils/encoding.ts` の `normalizeNewlines()` は CRLF モードでワーストケース用に `new Uint8Array(bytes.length * 2)` を確保し、最後に `out.subarray(0, w)` という**ビュー**を返します。このビューの裏には末尾にゼロ詰めが残った大きなバッファがあり、`bytes.buffer` を渡すと `byteOffset`/`byteLength` を無視してゼロ詰めまで出力されていました。

実機再現（SJIS 2文字＋LF を CRLF 変換）:

```
正しい長さ            : 6
bytes.buffer の長さ   : 10
downloadBytes が書く  : 83 4a 0d 0a 96 bc 00 00 00 00   ← 末尾に NUL×4
```

症状の辻褄:

| 操作 | 結果 |
| :-- | :-- |
| SJIS変換のみ（改行=そのまま） | `keep` はタイトな配列を返す＝padなし → ✅ 成功 |
| LF変換 | バッファ長 = 入力長、LF入力では pad ほぼ無し → たまたま成功 |
| **CRLF変換** | バッファ長 = 入力長×2 で常に大きく余る → **必ず**ゼロ詰め混入 → ❌ 化ける |

## 修正内容

- `downloadBytes()`: `bytes.buffer` ではなく `bytes.slice()`（`byteOffset`/`byteLength` の範囲だけを ArrayBuffer 裏の新しい Uint8Array にコピー）を `Blob` に渡すよう変更。ビュー範囲外のバイト混入を防ぎ、`ArrayBufferLike`（SharedArrayBuffer 含む）の型問題も回避。
- `download.test.ts`: oversized buffer のビューを渡した際に `Blob.size` がビュー長（6）になることを検証する**陽性対照**テストを追加（通常ケースの陰性対照も併設）。

## 検証

- `node_modules/.bin/astro check` → 0 errors
- `npm run test -- src/utils/__tests__/download.test.ts` → 17 passed
- **陽性対照の検知能力を確認**: 旧実装（`bytes.buffer` 直渡し）に revert すると追加テストが `Blob.size` 6 ≠ 10 で **fail** することを確認済み（test-gates 鉄則）。

> 注: フルスイートで `tests/meta/sw-cache-version.test.ts`（`dist/sw.js` ビルド成果物が必要）と `tests/meta/codex-git-add-files.test.ts`（git ヘルパー）の 3 件が fail しますが、いずれも本変更とは無関係の既存・環境依存の失敗です（本 PR は `download.*` のみ変更）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbGjzPRVr16J2sKTpQmJbv)_