### PR TITLE
release: develop の変更を main へ反映（#594 / #596 / #597 / #598）

### DIFF
--- a/.agents/rules/ui-conventions.md
+++ b/.agents/rules/ui-conventions.md
@@ -19,6 +19,9 @@
 | `ToggleGroup<T>`      | 排他選択トグル（モード切替等）                                                                                                                                                                                                                                                      |
 | `ToggleChips<T>`      | 多選択トグルチップ群。`<fieldset>`/`<legend>` で意味付け、各チップは `aria-pressed` ボタン。`count` prop で件数バッジ表示（マスク検出件数等）、`token` prop で文字トークンを等幅バッジ表示（フラグ g/i/m 等）、`legendVisible={false}` で見出しを sr-only 化（a11y ツリーには残す） |
 | `FileInputButton`     | ファイル選択ボタン。label 内包 input 構造で `:focus-within` によるキーボードフォーカス可視化に対応                                                                                                                                                                                  |
+| `NotificationBanner`  | DADS color-chip 型の通知バナー（variant: warning/error/info/success、title + 本文）                                                                                                                                                                                                 |
+| `StatusBadge`         | 状態を表す filled ピルバッジ（tone: error/success/warning/info）。`decorative` prop で `aria-hidden` を付与し、隣接する通知バナー等が意味を担保する文脈での二重読み上げを抑制できる                                                                                                 |
+| `ChipLabel`           | アウトライン型ラベルチップ（tone: error/info/neutral、任意 icon）                                                                                                                                                                                                                   |
 
 ---
 

--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -6,6 +6,7 @@ import { DownloadButton } from '@/components/ui/DownloadButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { StatusIcon } from '@/components/ui/StatusIcon';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { useCodecWithMeta } from '@/hooks/useCodec';
 import { convert } from '@/utils/config-converter';
 import type { ConfigFormat } from '@/utils/config-converter';
@@ -199,13 +200,13 @@ export function ConfigConverterTool() {
       </div>
 
       {warnings.length > 0 && (
-        <div className="rounded-lg p-3 border border-warning bg-warning-tint">
-          <ul className="caption text-default m-0 pl-5">
+        <NotificationBanner title="変換に関する警告">
+          <ul className="m-0 pl-5">
             {warnings.map((w, i) => (
               <li key={i}>{w}</li>
             ))}
           </ul>
-        </div>
+        </NotificationBanner>
       )}
 
       <div>

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -4,6 +4,7 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { Section } from '@/components/ui/Section';
 import { FileInputButton } from '@/components/ui/FileInputButton';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { useQrCamera } from '@/hooks/useQrCamera';
 import { useAbortableEffect } from '@/hooks/useAbortableEffect';
 import { detectQrContent, decodeQrFromFile, DEFAULT_QR_MAX_DIM } from '@/utils/qr-reader';
@@ -191,20 +192,20 @@ export function QrReaderTool() {
 
             {/* URLの場合のフィッシング警告 */}
             {content.kind === 'url' && (
-              <div className="rounded-lg p-4 space-y-2 border border-warning bg-warning-tint">
-                <p className="caption text-default">
+              <NotificationBanner title="外部リンクが含まれています">
+                <p className="m-0">
                   <strong className="text-default">{content.hostname}</strong>{' '}
-                  への外部リンクが含まれています。URLをよく確認してから開いてください。
+                  への外部リンクです。URL をよく確認してから開いてください。
                 </p>
                 <a
                   href={content.raw}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="caption font-semibold inline-flex items-center px-3.5 py-1.5 rounded-md border border-warning bg-default text-default no-underline"
+                  className="caption font-semibold inline-flex items-center mt-2 px-3.5 py-1.5 rounded-md border border-warning bg-default text-default no-underline"
                 >
                   URLを開く
                 </a>
-              </div>
+              </NotificationBanner>
             )}
           </div>
         </Section>

--- a/src/components/tools/RegexAstTree.tsx
+++ b/src/components/tools/RegexAstTree.tsx
@@ -1,4 +1,5 @@
 import type { RegexAstNode } from '@/utils/regex-visualizer';
+import { ChipLabel } from '@/components/ui/ChipLabel';
 
 interface Props {
   node: RegexAstNode;
@@ -23,7 +24,11 @@ export function RegexAstTree({ node, hotspot }: Props) {
       <li>
         <span className={hot ? 'regex-ast-node regex-ast-node-hot' : 'regex-ast-node'}>
           {node.label}
-          {hot && <span className="caption text-warning"> ⚠ ReDoS 危険箇所</span>}
+          {hot && (
+            <ChipLabel tone="error" className="ml-2">
+              ⚠ ReDoS 危険箇所
+            </ChipLabel>
+          )}
         </span>
         {node.children.map((child, i) => (
           <RegexAstTree key={i} node={child} hotspot={hotspot} />

--- a/src/components/tools/RegexMatchTester.tsx
+++ b/src/components/tools/RegexMatchTester.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { InputField } from '@/components/ui/InputField';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { ResultTable, type TableColumn } from '@/components/ui/ResultTable';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { useDebouncedTransform } from '@/hooks/useDebouncedTransform';
 // runMatch は match.ts から直接 import する（barrel 経由にしない）。barrel(index.ts) は
 // parse.ts/redos.ts も re-export しており、それらは CJS（regexp-tree / recheck）依存。
@@ -122,10 +123,10 @@ export function RegexMatchTester({ pattern, flags, redosStatus, regexValid }: Pr
       {!regexValid ? (
         <p className="caption text-muted">有効な正規表現を入力するとマッチを試せます。</p>
       ) : redosStatus === 'vulnerable' ? (
-        <p className="text-warning caption">
-          この正規表現は ReDoS のリスクがあるため、マッチ実行を無効化しています。上の ReDoS
-          判定パネルに表示された攻撃文字列を参照してください。
-        </p>
+        <NotificationBanner variant="info" title="マッチ実行を無効化しています">
+          この正規表現は ReDoS
+          のリスクがあるため、安全のため実行をブロックしています。挙動を確認する場合は、上の判定パネルの攻撃文字列を参照してください。
+        </NotificationBanner>
       ) : (
         <>
           <InputField

--- a/src/components/tools/RegexVisualizer.tsx
+++ b/src/components/tools/RegexVisualizer.tsx
@@ -5,6 +5,8 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { ToggleChips } from '@/components/ui/ToggleChips';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
+import { StatusBadge } from '@/components/ui/StatusBadge';
 import { useDebouncedTransform } from '@/hooks/useDebouncedTransform';
 import type { RegexAstNode, RedosResult, RailNode } from '@/utils/regex-visualizer';
 // 純粋関数のみの module を直接 import（barrel 経由だと recheck/regexp-tree の CJS が
@@ -137,18 +139,39 @@ export function RegexVisualizer() {
         aria-live="polite"
         className="rounded-lg border border-default p-4"
       >
-        <h2 className="body-emphasis text-default mb-2">ReDoS 判定</h2>
+        <div className="flex items-center gap-2 mb-2">
+          <h2 className="body-emphasis text-default">ReDoS 判定</h2>
+          {!analysis.isPending && redos?.status === 'vulnerable' && (
+            <StatusBadge tone="error" decorative>
+              脆弱
+            </StatusBadge>
+          )}
+          {!analysis.isPending && redos?.status === 'safe' && (
+            <StatusBadge tone="success" decorative>
+              安全
+            </StatusBadge>
+          )}
+          {!analysis.isPending && redos?.status === 'unknown' && (
+            <StatusBadge tone="warning" decorative>
+              判定不能
+            </StatusBadge>
+          )}
+        </div>
         {analysis.isPending && <p className="caption text-muted">判定中…</p>}
         {!analysis.isPending && redos?.status === 'safe' && (
-          <p className="alert-success">安全：壊滅的バックトラッキングは検出されませんでした。</p>
+          <NotificationBanner variant="success" title="安全：ReDoS は検出されませんでした">
+            壊滅的バックトラッキングは検出されませんでした。
+          </NotificationBanner>
         )}
         {!analysis.isPending && redos?.status === 'vulnerable' && (
-          <div className="space-y-2">
-            <p className="text-warning body-emphasis">
-              ⚠ 脆弱：ReDoS のリスクがあります（{redos.complexity}）。
-            </p>
+          <div className="space-y-3">
+            <NotificationBanner variant="error" title="脆弱：ReDoS のリスクがあります">
+              入力長に対してマッチ時間が{redos.complexity}
+              に増加します。下の攻撃文字列で再現できます。本番環境では使用しないでください。
+            </NotificationBanner>
             {redos.attackString && attack && (
               <div className="space-y-1">
+                <p className="caption text-muted">攻撃文字列（コピーして検証に使用）</p>
                 <div className="flex items-start gap-2">
                   <code className="bg-subtle rounded px-2 py-1 font-mono break-all">
                     {attack.display}
@@ -167,7 +190,9 @@ export function RegexVisualizer() {
           </div>
         )}
         {!analysis.isPending && redos?.status === 'unknown' && (
-          <p className="text-muted">判定不能（{redos.reason}）：安全とは限りません。</p>
+          <NotificationBanner variant="warning" title="判定不能：安全とは限りません">
+            判定できませんでした（{redos.reason}）。安全とは限らないため注意してください。
+          </NotificationBanner>
         )}
         {!analysis.isPending && !redos && (
           <p className="caption text-muted">正規表現を入力してください。</p>

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -5,6 +5,7 @@ import { InputField } from '@/components/ui/InputField';
 import { OutputField } from '@/components/ui/OutputField';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
 import { formatSql, embedParams, type SqlDialect } from '@/utils/sql';
 import { useCodec } from '@/hooks/useCodec';
 
@@ -95,13 +96,10 @@ export function SqlFormatterTool() {
         </>
       ) : (
         <>
-          <div role="note" className="border border-warning bg-warning-tint rounded-lg p-4">
-            <p className="caption text-warning">
-              ⚠️ この出力はデバッグで内容を確認するための表示用です。文字列連結による値の埋め込みは
-              SQL インジェクションの形そのものであり、生成された SQL をそのまま DB
-              で実行しないでください。
-            </p>
-          </div>
+          <NotificationBanner title="生成された SQL はそのまま実行しないでください">
+            この出力はデバッグで内容を確認するための表示用です。文字列連結による値の埋め込みは SQL
+            インジェクションそのものの形です。
+          </NotificationBanner>
 
           <div className="flex flex-col md:flex-row gap-4 items-stretch">
             <div className="w-full md:flex-1 min-w-0 space-y-4" data-testid="embed-input-column">

--- a/src/components/tools/__tests__/RegexVisualizer.test.tsx
+++ b/src/components/tools/__tests__/RegexVisualizer.test.tsx
@@ -33,13 +33,17 @@ describe('RegexVisualizer', () => {
   it('脆弱な正規表現で危険判定を表示する', async () => {
     render(<RegexVisualizer />);
     setPattern('(a+)+$');
-    expect(await screen.findByText(/脆弱/, undefined, FIND)).toBeTruthy();
+    // StatusBadge（「脆弱」）と NotificationBanner title（「脆弱：ReDoS…」）の両方が表示される
+    const els = await screen.findAllByText(/脆弱/, undefined, FIND);
+    expect(els.length).toBeGreaterThan(0);
   });
 
   it('安全な正規表現で安全判定を表示する', async () => {
     render(<RegexVisualizer />);
     setPattern('^[a-z]+$');
-    expect(await screen.findByText(/安全/, undefined, FIND)).toBeTruthy();
+    // StatusBadge（「安全」）と NotificationBanner title（「安全：ReDoS…」）の両方が表示される
+    const els = await screen.findAllByText(/安全/, undefined, FIND);
+    expect(els.length).toBeGreaterThan(0);
   });
 
   it('鉄道図タブに切り替えると SVG が表示される', async () => {
@@ -55,7 +59,8 @@ describe('RegexVisualizer', () => {
   it('鉄道図タブで脆弱パターンの hotspot が強調される', async () => {
     render(<RegexVisualizer />);
     setPattern('(a+)+$');
-    await screen.findByText(/脆弱/, undefined, FIND);
+    // StatusBadge + NotificationBanner title の両方にマッチするので findAllByText で待機
+    await screen.findAllByText(/脆弱/, undefined, FIND);
     fireEvent.click(screen.getByRole('button', { name: '鉄道図' }));
     const svg = await screen.findByRole('img', { name: '正規表現の鉄道図' }, FIND);
     expect(svg.querySelector('.rr-box-hot')).toBeTruthy();
@@ -64,8 +69,8 @@ describe('RegexVisualizer', () => {
   it('安全な正規表現でテスト文字列を入力するとマッチが集計される', async () => {
     render(<RegexVisualizer />);
     setPattern('\\d+');
-    // safe 判定の確定を待つ（動的 import + debounce 完了の目印）
-    await screen.findByText(/安全/, undefined, FIND);
+    // safe 判定の確定を待つ（StatusBadge + title の両方にマッチするので findAllByText）
+    await screen.findAllByText(/安全/, undefined, FIND);
     fireEvent.change(screen.getByLabelText('テスト文字列'), { target: { value: 'a1 b2' } });
     expect(await screen.findByText(/件マッチ/, undefined, FIND)).toBeTruthy();
   });
@@ -73,7 +78,8 @@ describe('RegexVisualizer', () => {
   it('脆弱な正規表現ではマッチ実行が無効化される', async () => {
     render(<RegexVisualizer />);
     setPattern('(a+)+$');
-    await screen.findByText(/脆弱/, undefined, FIND);
+    // StatusBadge + NotificationBanner title の両方にマッチするので findAllByText で待機
+    await screen.findAllByText(/脆弱/, undefined, FIND);
     expect(await screen.findByText(/マッチ実行を無効化/, undefined, FIND)).toBeTruthy();
   });
 });

--- a/src/components/ui/ChipLabel.tsx
+++ b/src/components/ui/ChipLabel.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  tone: 'error' | 'info' | 'neutral';
+  children: ReactNode;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export function ChipLabel({ tone, children, icon, className = '' }: Props) {
+  return (
+    <span className={`chip-label chip-label--${tone}${className ? ` ${className}` : ''}`}>
+      {icon}
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -20,7 +20,7 @@ export function NotificationBanner({ variant = 'warning', title, children, role 
         <StatusIcon variant={variant} size={24} filled className="shrink-0" />
         <p className="body-emphasis text-default">{title}</p>
       </div>
-      <p className="caption text-default mt-2">{children}</p>
+      <div className="caption text-default mt-2">{children}</div>
     </div>
   );
 }

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { StatusIcon } from '@/components/ui/StatusIcon';
 
-type Variant = 'warning' | 'error';
+type Variant = 'warning' | 'error' | 'info' | 'success';
 
 interface Props {
   variant?: Variant;

--- a/src/components/ui/NotificationBanner.tsx
+++ b/src/components/ui/NotificationBanner.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { StatusIcon } from '@/components/ui/StatusIcon';
+
+type Variant = 'warning' | 'error';
+
+interface Props {
+  variant?: Variant;
+  title: string;
+  children: ReactNode;
+  role?: string;
+}
+
+export function NotificationBanner({ variant = 'warning', title, children, role = 'note' }: Props) {
+  return (
+    <div
+      role={role}
+      className={`notification-banner notification-banner--${variant} rounded-xl pt-4 pr-6 pb-6 pl-10`}
+    >
+      <div className="flex items-center gap-3">
+        <StatusIcon variant={variant} size={24} filled className="shrink-0" />
+        <p className="body-emphasis text-default">{title}</p>
+      </div>
+      <p className="caption text-default mt-2">{children}</p>
+    </div>
+  );
+}

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  tone: 'error' | 'success' | 'warning' | 'info';
+  children: ReactNode;
+  className?: string;
+  /** true のとき aria-hidden="true" を付与し、スクリーンリーダーの読み上げを抑制する */
+  decorative?: boolean;
+}
+
+export function StatusBadge({ tone, children, className = '', decorative = false }: Props) {
+  return (
+    <span
+      className={`status-badge status-badge--${tone}${className ? ` ${className}` : ''}`}
+      aria-hidden={decorative || undefined}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/StatusIcon.tsx
+++ b/src/components/ui/StatusIcon.tsx
@@ -2,20 +2,48 @@ interface Props {
   variant: 'success' | 'error' | 'warning';
   size?: number;
   className?: string;
+  /** 塗りつぶしアイコン（地色 + 白抜きシンボル）。通知バナー等で使用 */
+  filled?: boolean;
 }
 
-export function StatusIcon({ variant, size = 16, className = '' }: Props) {
-  const common = {
+export function StatusIcon({ variant, size = 16, className = '', filled = false }: Props) {
+  const base = {
     width: size,
     height: size,
     viewBox: '0 0 24 24',
+    'aria-hidden': true,
+    className: `inline-block align-middle${className ? ` ${className}` : ''}`,
+  };
+
+  const common = {
+    ...base,
     fill: 'none',
     stroke: 'currentColor',
     strokeLinecap: 'round' as const,
     strokeLinejoin: 'round' as const,
-    'aria-hidden': true,
-    className: `inline-block align-middle${className ? ` ${className}` : ''}`,
   };
+
+  if (filled && variant !== 'success') {
+    // 地色（currentColor）で塗りつぶし、シンボルを白抜きで描画する
+    const filledCommon = { ...base };
+
+    if (variant === 'error') {
+      return (
+        <svg {...filledCommon} fill="currentColor">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="15" y1="9" x2="9" y2="15" stroke="#fff" strokeWidth={2} strokeLinecap="round" />
+          <line x1="9" y1="9" x2="15" y2="15" stroke="#fff" strokeWidth={2} strokeLinecap="round" />
+        </svg>
+      );
+    }
+
+    // 警告: 三角形に「!」を抜いた塗りつぶし（DADS 公式パス）
+    return (
+      <svg {...filledCommon} fill="currentColor">
+        <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+      </svg>
+    );
+  }
 
   if (variant === 'success') {
     return (

--- a/src/components/ui/StatusIcon.tsx
+++ b/src/components/ui/StatusIcon.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  variant: 'success' | 'error' | 'warning';
+  variant: 'success' | 'error' | 'warning' | 'info';
   size?: number;
   className?: string;
   /** 塗りつぶしアイコン（地色 + 白抜きシンボル）。通知バナー等で使用 */
@@ -23,8 +23,7 @@ export function StatusIcon({ variant, size = 16, className = '', filled = false 
     strokeLinejoin: 'round' as const,
   };
 
-  if (filled && variant !== 'success') {
-    // 地色（currentColor）で塗りつぶし、シンボルを白抜きで描画する
+  if (filled) {
     const filledCommon = { ...base };
 
     if (variant === 'error') {
@@ -37,10 +36,38 @@ export function StatusIcon({ variant, size = 16, className = '', filled = false 
       );
     }
 
-    // 警告: 三角形に「!」を抜いた塗りつぶし（DADS 公式パス）
+    if (variant === 'warning') {
+      // 三角形に「!」を抜いた塗りつぶし（DADS 公式パス）
+      return (
+        <svg {...filledCommon} fill="currentColor">
+          <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+        </svg>
+      );
+    }
+
+    if (variant === 'success') {
+      // 緑地の円 + 白抜きチェック
+      return (
+        <svg {...filledCommon} fill="currentColor">
+          <circle cx="12" cy="12" r="10" />
+          <polyline
+            points="20 6 9 17 4 12"
+            fill="none"
+            stroke="#fff"
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    }
+
+    // info: 地色の円 + 白抜きの「i」（縦線 + ドット）
     return (
       <svg {...filledCommon} fill="currentColor">
-        <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+        <circle cx="12" cy="12" r="10" />
+        <circle cx="12" cy="8" r="1" fill="#fff" />
+        <line x1="12" y1="11" x2="12" y2="17" stroke="#fff" strokeWidth={2} strokeLinecap="round" />
       </svg>
     );
   }
@@ -62,6 +89,18 @@ export function StatusIcon({ variant, size = 16, className = '', filled = false 
     );
   }
 
+  if (variant === 'info') {
+    // アウトライン: 円 + i（縦線 + ドット）
+    return (
+      <svg {...common} strokeWidth={2}>
+        <circle cx="12" cy="12" r="10" />
+        <circle cx="12" cy="8" r="1" fill="currentColor" />
+        <line x1="12" y1="11" x2="12" y2="17" />
+      </svg>
+    );
+  }
+
+  // warning
   return (
     <svg {...common} strokeWidth={2}>
       <path d="M12 3 L22 20 L2 20 Z" />

--- a/src/components/ui/__tests__/ChipLabel.test.tsx
+++ b/src/components/ui/__tests__/ChipLabel.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ChipLabel } from '@/components/ui/ChipLabel';
+
+afterEach(() => cleanup());
+
+describe('ChipLabel', () => {
+  it('children が描画される', () => {
+    const { getByText } = render(<ChipLabel tone="error">ReDoS 危険箇所</ChipLabel>);
+    expect(getByText('ReDoS 危険箇所')).toBeTruthy();
+  });
+
+  it('tone="error" で chip-label--error クラスが付く', () => {
+    const { container } = render(<ChipLabel tone="error">ReDoS 危険箇所</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--error');
+  });
+
+  it('tone="info" で chip-label--info クラスが付く', () => {
+    const { container } = render(<ChipLabel tone="info">情報</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--info');
+  });
+
+  it('tone="neutral" で chip-label--neutral クラスが付く', () => {
+    const { container } = render(<ChipLabel tone="neutral">その他</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label--neutral');
+  });
+
+  it('chip-label ベースクラスが常に付く', () => {
+    const { container } = render(<ChipLabel tone="error">テスト</ChipLabel>);
+    expect((container.firstChild as HTMLElement).className).toContain('chip-label');
+  });
+
+  it('旧 color prop 由来のクラスが付かない（chip-label--red / --blue / --gray の残留がない）', () => {
+    const { container: e } = render(<ChipLabel tone="error">error</ChipLabel>);
+    const { container: i } = render(<ChipLabel tone="info">info</ChipLabel>);
+    const { container: n } = render(<ChipLabel tone="neutral">neutral</ChipLabel>);
+    expect((e.firstChild as HTMLElement).className).not.toContain('chip-label--red');
+    expect((i.firstChild as HTMLElement).className).not.toContain('chip-label--blue');
+    expect((n.firstChild as HTMLElement).className).not.toContain('chip-label--gray');
+  });
+
+  it('任意の className が追加される', () => {
+    const { container } = render(
+      <ChipLabel tone="error" className="ml-2">
+        テスト
+      </ChipLabel>
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('ml-2');
+  });
+
+  it('icon prop が描画される', () => {
+    const { getByText } = render(
+      <ChipLabel tone="error" icon={<span>icon</span>}>
+        ラベル
+      </ChipLabel>
+    );
+    expect(getByText('icon')).toBeTruthy();
+    expect(getByText('ラベル')).toBeTruthy();
+  });
+});

--- a/src/components/ui/__tests__/NotificationBanner.test.tsx
+++ b/src/components/ui/__tests__/NotificationBanner.test.tsx
@@ -40,4 +40,44 @@ describe('NotificationBanner', () => {
     const el = getByRole('note');
     expect(el.className).toContain('notification-banner--error');
   });
+
+  it('variant="info" で notification-banner--info クラスが付く', () => {
+    const { getByRole } = render(
+      <NotificationBanner variant="info" title="情報タイトル">
+        情報本文
+      </NotificationBanner>
+    );
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--info');
+  });
+
+  it('variant="success" で notification-banner--success クラスが付く', () => {
+    const { getByRole } = render(
+      <NotificationBanner variant="success" title="成功タイトル">
+        成功本文
+      </NotificationBanner>
+    );
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--success');
+  });
+
+  it('variant="info" で StatusIcon が描画される（aria-hidden SVG が存在する）', () => {
+    const { container } = render(
+      <NotificationBanner variant="info" title="情報">
+        本文
+      </NotificationBanner>
+    );
+    const svg = container.querySelector('svg[aria-hidden="true"]');
+    expect(svg).not.toBeNull();
+  });
+
+  it('variant="success" で StatusIcon が描画される（aria-hidden SVG が存在する）', () => {
+    const { container } = render(
+      <NotificationBanner variant="success" title="成功">
+        本文
+      </NotificationBanner>
+    );
+    const svg = container.querySelector('svg[aria-hidden="true"]');
+    expect(svg).not.toBeNull();
+  });
 });

--- a/src/components/ui/__tests__/NotificationBanner.test.tsx
+++ b/src/components/ui/__tests__/NotificationBanner.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NotificationBanner } from '@/components/ui/NotificationBanner';
+
+afterEach(() => cleanup());
+
+describe('NotificationBanner', () => {
+  it('title が描画される', () => {
+    const { getByText } = render(
+      <NotificationBanner title="テストタイトル">本文テキスト</NotificationBanner>
+    );
+    expect(getByText('テストタイトル')).toBeTruthy();
+  });
+
+  it('children (本文) が描画される', () => {
+    const { getByText } = render(
+      <NotificationBanner title="タイトル">本文テキスト</NotificationBanner>
+    );
+    expect(getByText('本文テキスト')).toBeTruthy();
+  });
+
+  it('デフォルトで role="note" が付与される', () => {
+    const { getByRole } = render(<NotificationBanner title="タイトル">本文</NotificationBanner>);
+    expect(getByRole('note')).toBeTruthy();
+  });
+
+  it('デフォルト (variant="warning") で notification-banner--warning クラスが付く', () => {
+    const { getByRole } = render(<NotificationBanner title="タイトル">本文</NotificationBanner>);
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--warning');
+  });
+
+  it('variant="error" で notification-banner--error クラスが付く', () => {
+    const { getByRole } = render(
+      <NotificationBanner variant="error" title="タイトル">
+        本文
+      </NotificationBanner>
+    );
+    const el = getByRole('note');
+    expect(el.className).toContain('notification-banner--error');
+  });
+});

--- a/src/components/ui/__tests__/StatusBadge.test.tsx
+++ b/src/components/ui/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { StatusBadge } from '@/components/ui/StatusBadge';
+
+afterEach(() => cleanup());
+
+describe('StatusBadge', () => {
+  it('children が描画される', () => {
+    const { getByText } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect(getByText('脆弱')).toBeTruthy();
+  });
+
+  it('tone="error" で status-badge--error クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect(container.firstChild).not.toBeNull();
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--error');
+  });
+
+  it('tone="success" で status-badge--success クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="success">安全</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--success');
+  });
+
+  it('tone="warning" で status-badge--warning クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="warning">判定不能</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--warning');
+  });
+
+  it('tone="info" で status-badge--info クラスが付く', () => {
+    const { container } = render(<StatusBadge tone="info">情報</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge--info');
+  });
+
+  it('status-badge ベースクラスが常に付く', () => {
+    const { container } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain('status-badge');
+  });
+
+  it('任意の className が追加される', () => {
+    const { container } = render(
+      <StatusBadge tone="error" className="ml-2">
+        脆弱
+      </StatusBadge>
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('ml-2');
+  });
+
+  it('decorative=true で aria-hidden="true" が付く', () => {
+    const { container } = render(
+      <StatusBadge tone="success" decorative>
+        安全
+      </StatusBadge>
+    );
+    expect((container.firstChild as HTMLElement).getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('decorative 未指定でデフォルト false: aria-hidden が付かない', () => {
+    const { container } = render(<StatusBadge tone="error">脆弱</StatusBadge>);
+    expect((container.firstChild as HTMLElement).getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('decorative=false 明示でも aria-hidden が付かない', () => {
+    const { container } = render(
+      <StatusBadge tone="info" decorative={false}>
+        情報
+      </StatusBadge>
+    );
+    expect((container.firstChild as HTMLElement).getAttribute('aria-hidden')).toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/StatusIcon.test.tsx
+++ b/src/components/ui/__tests__/StatusIcon.test.tsx
@@ -83,15 +83,19 @@ describe('StatusIcon', () => {
       expect(svg?.querySelectorAll('line').length).toBe(2);
     });
 
-    it('success filled: filled ガードをスルーし outline success (polyline) にフォールスルーする', () => {
+    it('success filled: 緑地の円 + 白抜き polyline チェックを描画する', () => {
       const { container } = render(<StatusIcon variant="success" filled />);
       const svg = container.querySelector('svg');
       expect(svg).toBeTruthy();
-      // アウトライン success は stroke="currentColor" を持つ
-      expect(svg?.getAttribute('stroke')).toBe('currentColor');
-      expect(svg?.querySelector('polyline')).toBeTruthy();
-      // 塗りつぶし円はない
-      expect(svg?.querySelector('circle')).toBeFalsy();
+      expect(svg?.getAttribute('aria-hidden')).toBe('true');
+      // 塗りつぶし円は fill="currentColor" を SVG ルートに持つ
+      expect(svg?.getAttribute('fill')).toBe('currentColor');
+      // 白抜きチェック (polyline) が存在する
+      const poly = svg?.querySelector('polyline');
+      expect(poly).toBeTruthy();
+      expect(poly?.getAttribute('stroke')).toBe('#fff');
+      // 背景の円が存在する
+      expect(svg?.querySelector('circle')).toBeTruthy();
     });
   });
 });

--- a/src/components/ui/__tests__/StatusIcon.test.tsx
+++ b/src/components/ui/__tests__/StatusIcon.test.tsx
@@ -58,4 +58,40 @@ describe('StatusIcon', () => {
     expect(cls).toContain('align-middle');
     expect(cls).toContain('custom-cls');
   });
+
+  describe('filled variants', () => {
+    it('warning filled: <path> を持つ塗りつぶし三角形を描画し aria-hidden="true"', () => {
+      const { container } = render(<StatusIcon variant="warning" filled />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('aria-hidden')).toBe('true');
+      expect(svg?.getAttribute('fill')).toBe('currentColor');
+      // 塗りつぶし三角はルートに stroke="currentColor" を持たない
+      expect(svg?.getAttribute('stroke')).toBeNull();
+      expect(svg?.querySelector('path')).toBeTruthy();
+    });
+
+    it('error filled: <circle> と 2 本の <line> を持つ塗りつぶし円を描画し aria-hidden="true"', () => {
+      const { container } = render(<StatusIcon variant="error" filled />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('aria-hidden')).toBe('true');
+      expect(svg?.getAttribute('fill')).toBe('currentColor');
+      // 塗りつぶし円はルートに stroke="currentColor" を持たない
+      expect(svg?.getAttribute('stroke')).toBeNull();
+      expect(svg?.querySelector('circle')).toBeTruthy();
+      expect(svg?.querySelectorAll('line').length).toBe(2);
+    });
+
+    it('success filled: filled ガードをスルーし outline success (polyline) にフォールスルーする', () => {
+      const { container } = render(<StatusIcon variant="success" filled />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      // アウトライン success は stroke="currentColor" を持つ
+      expect(svg?.getAttribute('stroke')).toBe('currentColor');
+      expect(svg?.querySelector('polyline')).toBeTruthy();
+      // 塗りつぶし円はない
+      expect(svg?.querySelector('circle')).toBeFalsy();
+    });
+  });
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -52,11 +52,14 @@
 
   /* === セマンティックカラー === */
   --color-success: #16a34a;
+  --color-success-strong: #15803d; /* 白文字バッジ用: 白×#15803d ≈ 5.0:1 で WCAG AA 合格 */
   --color-success-bg: #f0fdf4;
   --color-error: #dc2626;
   --color-error-bg: #fef2f2;
   --color-warning: #854d0e; /* amber-800: amber-600 は白背景で WCAG AA 不合格 */
   --color-warning-bg: #fef3c7; /* amber-100 */
+  --color-info: #1d4ed8; /* blue-700: 白背景でコントラスト 4.5:1 以上 */
+  --color-info-bg: #eff6ff; /* blue-50 */
 
   /* === 機能カラー === */
   --color-link: #2563eb;
@@ -499,6 +502,16 @@
     box-shadow: inset 16px 0 0 0 var(--color-error);
     color: var(--color-error);
   }
+  .notification-banner--info {
+    border-color: var(--color-info);
+    box-shadow: inset 16px 0 0 0 var(--color-info);
+    color: var(--color-info);
+  }
+  .notification-banner--success {
+    border-color: var(--color-success);
+    box-shadow: inset 16px 0 0 0 var(--color-success);
+    color: var(--color-success);
+  }
 
   /* File picker label (VerifyTab upload mode) */
   .qr-file-picker-label {
@@ -830,10 +843,10 @@
     margin: 0.125rem 0;
   }
 
-  /* ReDoS 危険箇所にマッチするノードを警告色で強調 */
+  /* ReDoS 危険箇所にマッチするノードをエラー色（赤）で強調 */
   .regex-ast-node-hot {
-    background: var(--color-warning-bg);
-    color: var(--color-warning);
+    background: var(--color-error-bg);
+    color: var(--color-error);
   }
 
   /* === 汎用トグルチップ（ToggleChips コンポーネント用） === */
@@ -1114,6 +1127,56 @@
       opacity: 1;
       pointer-events: auto;
     }
+  }
+
+  /* === StatusBadge: 小さい filled ピル（地色=semantic 色、文字=白） === */
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    border-radius: var(--radius-md, 0.5rem);
+    font-weight: 700;
+    font-size: 0.875rem;
+    line-height: 1;
+    color: var(--color-text-on-primary, #fff);
+  }
+  .status-badge--error {
+    background: var(--color-error);
+  }
+  .status-badge--success {
+    background: var(--color-success-strong);
+  }
+  .status-badge--warning {
+    background: var(--color-warning);
+  }
+  .status-badge--info {
+    background: var(--color-info);
+  }
+
+  /* === ChipLabel: アウトライン型ピル（白背景 + color ボーダー + color 文字） === */
+  .chip-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: var(--radius-md, 0.5rem);
+    border: 1px solid;
+    background: var(--color-bg, #fff);
+    font-size: 0.875rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+  .chip-label--error {
+    border-color: var(--color-error);
+    color: var(--color-error);
+  }
+  .chip-label--info {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .chip-label--neutral {
+    border-color: var(--color-border);
+    color: var(--color-muted);
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -483,6 +483,23 @@
     border-color: var(--color-error);
   }
 
+  /* Notification banner (DADS 通知バナー color-chip 型: 全周ボーダー + 左カラーチップ)
+     左帯は inset box-shadow（16px）で表現し、角丸に沿ってクリップされる。 */
+  .notification-banner {
+    border: 2px solid;
+    background: var(--color-bg);
+  }
+  .notification-banner--warning {
+    border-color: var(--color-warning);
+    box-shadow: inset 16px 0 0 0 var(--color-warning);
+    color: var(--color-warning);
+  }
+  .notification-banner--error {
+    border-color: var(--color-error);
+    box-shadow: inset 16px 0 0 0 var(--color-error);
+    color: var(--color-error);
+  }
+
   /* File picker label (VerifyTab upload mode) */
   .qr-file-picker-label {
     background: var(--color-bg-surface);

--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { downloadBlob, downloadPngFromSvgElement, svgContentToPngBlob } from '@/utils/download';
+import {
+  downloadBlob,
+  downloadBytes,
+  downloadPngFromSvgElement,
+  svgContentToPngBlob,
+} from '@/utils/download';
+import { normalizeNewlines } from '@/utils/encoding';
 
 /**
  * `src/utils/download.ts` の private const `RETINA_SCALE` の mirror。
@@ -197,6 +203,103 @@ describe('downloadBlob', () => {
   it('生成した ObjectURL は revokeObjectURL で解放される', () => {
     downloadBlob(new Blob(['x']), 'a.txt');
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});
+
+/**
+ * downloadBytes: backing buffer 全体を覆わない Uint8Array ビュー（normalizeNewlines の
+ * CRLF モードが返す subarray など）を渡したとき、NUL バイトが混入しないことを検証する。
+ *
+ * 根本原因: normalizeNewlines() の CRLF モードは `new Uint8Array(bytes.length * 2)` を
+ * 確保して `out.subarray(0, w)` というビューを返す。旧実装が `bytes.buffer`（バッファ全体）
+ * を Blob に渡していたため、ビュー範囲外のゼロ詰めバイトが出力に混入し、VS Code が
+ * 「バイナリか、サポートされていないエンコード」と判定する事故が発生した。
+ *
+ * 陽性対照（oversized buffer ケース）と陰性対照（通常ケース）を別 it() に分離。
+ * URL.createObjectURL に渡される Blob を捕捉して Blob.size を assert する。
+ */
+describe('downloadBytes', () => {
+  let createdAnchor: { href: string; download: string; click: ReturnType<typeof vi.fn> };
+  let capturedBlob: Blob | undefined;
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createdAnchor = { href: '', download: '', click: vi.fn() };
+    capturedBlob = undefined;
+    createObjectURL = vi.fn((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:mock-url';
+    });
+    revokeObjectURL = vi.fn();
+
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => createdAnchor),
+    });
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * 陽性対照: oversized backing buffer の subarray ビューを渡したとき、
+   * Blob.size がビュー長（6）になること。
+   *
+   * 旧実装（`bytes.buffer` 直渡し）に revert すると Blob.size は backing buffer 長（10）
+   * になりこのテストが fail する — これがバグ検知能力の証明（test-gates 鉄則 1）。
+   * normalizeNewlines() の CRLF モードが `bytes.length * 2` のバッファを確保して
+   * `subarray(0, w)` を返すパターンと同じ状況を手動で再現している。
+   */
+  it('陽性対照: oversized buffer の subarray ビューを渡すと Blob.size がビュー長（6）になる', () => {
+    // 10 バイトの backing buffer を作り、先頭 6 バイトだけのビューを作る
+    // (normalizeNewlines CRLF モードの `new Uint8Array(bytes.length * 2)` + `subarray(0, w)` を模倣)
+    const buf = new Uint8Array(10);
+    buf.set([0x83, 0x4a, 0x0d, 0x0a, 0x96, 0xbc]); // SJIS「花」＋CRLF＋SJIS「名」
+    const view = buf.subarray(0, 6); // backing buffer は 10 バイト、ビューは 6 バイト
+
+    downloadBytes(view, 'output.txt');
+
+    expect(capturedBlob).toBeDefined();
+    // 修正版: Blob.size = 6（ビュー長のみ）
+    // 旧実装（bytes.buffer 直渡し）に revert すると size = 10（backing buffer 全体）になり fail
+    expect(capturedBlob!.size).toBe(6);
+  });
+
+  /**
+   * 陰性対照: backing buffer 全体を覆う通常の Uint8Array を渡したとき、
+   * Blob.size が正しくバイト長になること。
+   */
+  it('陰性対照: backing buffer 全体を覆う Uint8Array を渡すと Blob.size がバイト長と一致する', () => {
+    const bytes = new Uint8Array([0x83, 0x4a, 0x0d, 0x0a]); // 4 バイト、buffer 全体をカバー
+
+    downloadBytes(bytes, 'output.txt');
+
+    expect(capturedBlob).toBeDefined();
+    expect(capturedBlob!.size).toBe(4);
+  });
+
+  /**
+   * 陽性対照（実コードパス連結）: normalizeNewlines('crlf') の戻り値（oversized backing
+   * buffer の subarray ビュー）を実際に downloadBytes に流し、Blob.size がビュー長と
+   * 一致することを end-to-end で検証する（#598 レビュー提案 1）。
+   *
+   * 上の手動再構築ケースと違い、normalizeNewlines 側の実装（`new Uint8Array(len*2)` +
+   * `subarray(0, w)`）が将来変わっても本ケースが回帰を直接ガードする。旧 downloadBytes
+   * （`bytes.buffer` 直渡し）に revert すると size がゼロ詰めを含む値になり fail する。
+   */
+  it('陽性対照: normalizeNewlines("crlf") 出力を downloadBytes に流すと Blob.size がビュー長と一致する', () => {
+    // SJIS「花」(83 4a) + LF + SJIS「名」(96 bc): LF を含む現実的なバイト列
+    const input = new Uint8Array([0x83, 0x4a, 0x0a, 0x96, 0xbc]);
+    const crlf = normalizeNewlines(input, 'crlf'); // LF→CRLF で 6 バイトのビュー（裏は 10 バイト）
+    expect(crlf.length).toBe(6);
+    expect(crlf.buffer.byteLength).toBeGreaterThan(crlf.length); // oversized buffer であることを確認
+
+    downloadBytes(crlf, 'output.txt');
+
+    expect(capturedBlob).toBeDefined();
+    expect(capturedBlob!.size).toBe(crlf.length); // ゼロ詰めを含まずビュー長と一致
   });
 });
 

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -23,12 +23,21 @@ export function downloadText(content: string, filename: string, mimeType = 'text
   downloadBlob(new Blob([content], { type: `${mimeType};charset=utf-8` }), filename);
 }
 
-/** バイナリをファイルとしてダウンロードする */
+/**
+ * バイナリをファイルとしてダウンロードする。
+ *
+ * normalizeNewlines() の CRLF モードは `new Uint8Array(bytes.length * 2)` を確保して
+ * `out.subarray(0, w)` というビューを返す。backing buffer には末尾にゼロ詰めが残るため、
+ * 旧実装のように `bytes.buffer`（バッファ全体）を Blob に渡すと NUL バイトが混入し、
+ * VS Code が「バイナリか、サポートされていないエンコード」と判定する事故が起きていた
+ * （issue: SJIS/CRLF 変換）。
+ *
+ * `bytes.slice()` は byteOffset/byteLength の範囲だけを ArrayBuffer 裏の新しい Uint8Array に
+ * コピーして返すため、ビュー範囲外のゼロ詰めバイトが混入せず、かつ ArrayBufferLike
+ * （SharedArrayBuffer 含む）の型問題も回避できる。
+ */
 export function downloadBytes(bytes: Uint8Array, filename: string): void {
-  downloadBlob(
-    new Blob([bytes.buffer as ArrayBuffer], { type: 'application/octet-stream' }),
-    filename
-  );
+  downloadBlob(new Blob([bytes.slice()], { type: 'application/octet-stream' }), filename);
 }
 
 /** SVG文字列をファイルとしてダウンロードする */

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -144,6 +144,11 @@ export const NEWLINE_OPTIONS: Array<{ value: NewlineMode; label: string }> = [
 
 // UTF-8 / SJIS / EUC-JP / JIS / ASCII 向けのバイト単位正規化。
 // UTF-16 は呼び出し元で除外すること（BOM バイトは 0x0A/0x0D を含まないため分離不要）。
+//
+// ⚠️ 返り値は `out.subarray(0, w)` というビューで、backing buffer は実データより大きい
+// （crlf モードは最大 bytes.length * 2 を確保）。末尾にゼロ詰めが残るため、consumer は
+// `.length` / 反復のみを使い、`.buffer` を直接参照してはならない（範囲外バイトが混入する）。
+// 例: downloadBytes は `.buffer` 直渡しでファイル末尾に NUL を混入させる不具合があった（#598）。
 export function normalizeNewlines(bytes: Uint8Array, mode: NewlineMode): Uint8Array {
   if (mode === 'keep' || bytes.length === 0) return bytes;
 

--- a/tests/e2e/config-converter.spec.ts
+++ b/tests/e2e/config-converter.spec.ts
@@ -340,6 +340,12 @@ test.describe('設定ファイル相互変換', () => {
 
     // convert() が push する warning が画面に描画される
     await expect(page.getByText('値はすべて文字列に変換されます')).toBeVisible();
+
+    // 警告は NotificationBanner (role="note") でラップされている
+    // （素の div へ戻るリグレッションを検知する。旧実装に当てると fail することを確認済み）
+    const note = page.getByRole('note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('変換に関する警告');
   });
 
   test('warning の出ないフォーマットへ切替えると warning が消える', async ({ page }) => {

--- a/tests/e2e/qr-reader.spec.ts
+++ b/tests/e2e/qr-reader.spec.ts
@@ -151,6 +151,12 @@ test.describe('QRリーダー（production CSP 適用）', () => {
       await expect(page.getByText(url)).toBeVisible({ timeout: 10000 });
       await expect(page.getByRole('link', { name: 'URLを開く' })).toBeVisible();
       await expect(page.getByText('example.com', { exact: true })).toBeVisible();
+
+      // 警告は NotificationBanner (role="note") でラップされている
+      // （素の div へ戻るリグレッションを検知する）
+      const note = page.getByRole('note');
+      await expect(note).toBeVisible();
+      await expect(note.getByRole('link', { name: 'URLを開く' })).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## リリース概要

前回リリース（#592）以降に develop へマージされた変更を main へ反映します。

## 含まれる変更

| PR | 種別 | 概要 |
| :-- | :-- | :-- |
| #594 | feat | SQL整形ツールの警告ボックスを DADS 準拠デザインに刷新（`NotificationBanner` 新設・`StatusIcon` に filled prop 追加） |
| #596 | refactor | QrReader / ConfigConverter の警告を `NotificationBanner` に統一（role="note" ラップの回帰ガード E2E 追加） |
| #597 | feat | ReDoS判定 / マッチテスト / 構造ツリーを DADS 準拠デザインに刷新（`StatusBadge` / `ChipLabel` 新設・WCAG AA コントラスト準拠） |
| #598 | fix | SJIS/CRLF 変換でダウンロードファイル末尾に NUL バイトが混入する不具合を修正（`downloadBytes` のビュー範囲外バイト混入を防止） |

## 備考

- マージ方式は release PR の運用に従い **merge commit**（squash ではない）。
- 各 PR は develop マージ時点で CI（test / e2e / VRT）green を確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JbGjzPRVr16J2sKTpQmJbv)_