### PR TITLE
fix: 文字コード変換の元/変換後セレクトを横並びに変更

### DIFF
--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -352,28 +352,30 @@ export function EncodingConverterTool() {
       {/* 変換設定 */}
       {mode === 'convert' && (
         <div className="space-y-3">
-          <div>
-            <label htmlFor="enc-source" className="caption text-muted mb-2 block">
-              元の文字コード:
-            </label>
-            <Select
-              id="enc-source"
-              options={SOURCE_ENCODINGS}
-              value={sourceEnc}
-              onChange={(v) => setSourceEnc(v as SourceEncoding)}
-            />
-          </div>
+          <div className="flex flex-col md:flex-row gap-4 items-start">
+            <div className="w-full md:flex-1 min-w-0">
+              <label htmlFor="enc-source" className="caption text-muted mb-2 block">
+                元の文字コード:
+              </label>
+              <Select
+                id="enc-source"
+                options={SOURCE_ENCODINGS}
+                value={sourceEnc}
+                onChange={(v) => setSourceEnc(v as SourceEncoding)}
+              />
+            </div>
 
-          <div>
-            <label htmlFor="enc-target" className="caption text-muted mb-2 block">
-              変換後の文字コード:
-            </label>
-            <Select
-              id="enc-target"
-              options={TARGET_ENCODINGS}
-              value={targetEnc}
-              onChange={(v) => setTargetEnc(v as EncodingName)}
-            />
+            <div className="w-full md:flex-1 min-w-0">
+              <label htmlFor="enc-target" className="caption text-muted mb-2 block">
+                変換後の文字コード:
+              </label>
+              <Select
+                id="enc-target"
+                options={TARGET_ENCODINGS}
+                value={targetEnc}
+                onChange={(v) => setTargetEnc(v as EncodingName)}
+              />
+            </div>
           </div>
 
           {UTF16_ENCODINGS.has(targetEnc) ? (


### PR DESCRIPTION
## 変更概要

`EncodingConverter.tsx` の変換モードにある「元の文字コード」と「変換後の文字コード」の select 要素を、横並びレスポンシブレイアウトに変更。

## Before / After

**Before**: 2 つの select が縦に積み重なった状態（PC 幅でも縦並び）

**After**: `flex flex-col md:flex-row gap-4 items-start` コンテナでラップし、各 select に `w-full md:flex-1 min-w-0` を付与。PC 幅（`md:` ブレークポイント以上）では横並び、スマホ幅では縦並びに自動折り返し。

## 他ツールとの一貫性

ConfigConverter / JsonCsv / Base64Codec 等が採用している `flex flex-col md:flex-row gap-4` パターンと同一。既存 ID（`enc-source` / `enc-target`）・ラベルテキスト・ロジックは一切変更なし。

## 検証結果

| 検証項目 | 結果 |
| :------- | :--- |
| 型チェック (`astro check`) | 0 errors / 0 warnings / 0 hints |
| ユニットテスト (`npm run test`) | Test Files 108 passed (108) / Tests 1951 passed \| 1 skipped (1952) |
| E2E テスト (`test:e2e -- encoding-converter`) | 16 passed (26.6s) |

VRT はローカル mac では baseline 不在のため CI に委任。
