### PR TITLE
fix: JSON整形ビューアのツリー結果欄の高さを固定

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1015,8 +1015,7 @@
 
   /* === JsonFormatter: ツリービュー === */
   .json-tree-box {
-    min-height: 22rem;
-    max-height: 34rem;
+    height: 28rem;
     overflow: auto;
   }
   .json-tree-root {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1015,6 +1015,9 @@
 
   /* === JsonFormatter: ツリービュー === */
   .json-tree-box {
+    /* 入力 textarea（rows=18, 実測 446px ≒ 28rem）と外形を揃える固定高。
+       超過分は overflow: auto で枠内スクロールさせる。textarea 側の
+       rows/font-size/line-height を変えた場合はこの値も追従させること。 */
     height: 28rem;
     overflow: auto;
   }


### PR DESCRIPTION
## 問題

JSON整形・ビューア（`/tools/json-formatter`）の「ツリー」表示において、結果パネル（`.json-tree-box`）の高さが `min-height: 22rem; max-height: 34rem` で内容に応じて伸縮していたため、以下の 2 つの問題があった。

1. **JSON 未入力時**: ツリー結果枠の高さが 22rem（352px）となり、入力テキストエリア（rows=18、実測 446px）より低く揃いが崩れる
2. **JSON 多量入力時**: ツリー結果枠が最大 34rem（544px）まで伸びて入力欄を大幅に超える

## 修正内容

`src/styles/global.css` の `.json-tree-box` を以下のように変更した（CSS のみ、React ロジック/JSX 変更なし）。

Before: `min-height: 22rem; max-height: 34rem; overflow: auto;`
After: `height: 28rem; overflow: auto;`

`height: 28rem`（= 448px）の根拠: rows=18・font-size 0.875rem・line-height 1.7 の textarea 実測高さ 446.34px（16px ルートフォントで 27.9rem ≈ 28rem）と一致。差分 1.66px で許容範囲内。

## 検証結果

### 自動テスト（すべて pass）

| テスト種別 | 結果 |
| :--- | :--- |
| ユニットテスト (`npm run test`) | Test Files 108 passed / Tests 1951 passed |
| 型チェック (`astro check`) | 0 errors / 0 warnings / 0 hints（331 files） |
| E2E テスト (`npm run test:e2e`) | 293 passed / 1 skipped |

### Playwright 実機確認（PC 1280×800 / スマホ 390×844）

- **PC 未入力**: ツリー結果枠（448px）が入力欄（446px）とほぼ同じ高さで揃う
- **PC サンプル入力**: ツリー枠が入力欄高さを超えず、コンテンツ超過時は枠内スクロール
- **スマホ 未入力 / サンプル入力**: 縦並びレイアウトで同様に正常動作

### VRT について

`/tools/json-formatter` は VRT 対象ページのため、CI Linux runner で pixel diff が検出される場合があります。baseline 更新は CI 側（`Update Visual Regression Baseline` workflow_dispatch）で対応してください。ローカル baseline は変更しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
