### PR TITLE
release: develop の変更を main へ反映

### DIFF
--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -352,28 +352,30 @@ export function EncodingConverterTool() {
       {/* 変換設定 */}
       {mode === 'convert' && (
         <div className="space-y-3">
-          <div>
-            <label htmlFor="enc-source" className="caption text-muted mb-2 block">
-              元の文字コード:
-            </label>
-            <Select
-              id="enc-source"
-              options={SOURCE_ENCODINGS}
-              value={sourceEnc}
-              onChange={(v) => setSourceEnc(v as SourceEncoding)}
-            />
-          </div>
+          <div className="flex flex-col md:flex-row gap-4 items-start">
+            <div className="w-full md:flex-1 min-w-0">
+              <label htmlFor="enc-source" className="caption text-muted mb-2 block">
+                元の文字コード:
+              </label>
+              <Select
+                id="enc-source"
+                options={SOURCE_ENCODINGS}
+                value={sourceEnc}
+                onChange={(v) => setSourceEnc(v as SourceEncoding)}
+              />
+            </div>
 
-          <div>
-            <label htmlFor="enc-target" className="caption text-muted mb-2 block">
-              変換後の文字コード:
-            </label>
-            <Select
-              id="enc-target"
-              options={TARGET_ENCODINGS}
-              value={targetEnc}
-              onChange={(v) => setTargetEnc(v as EncodingName)}
-            />
+            <div className="w-full md:flex-1 min-w-0">
+              <label htmlFor="enc-target" className="caption text-muted mb-2 block">
+                変換後の文字コード:
+              </label>
+              <Select
+                id="enc-target"
+                options={TARGET_ENCODINGS}
+                value={targetEnc}
+                onChange={(v) => setTargetEnc(v as EncodingName)}
+              />
+            </div>
           </div>
 
           {UTF16_ENCODINGS.has(targetEnc) ? (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1015,8 +1015,10 @@
 
   /* === JsonFormatter: ツリービュー === */
   .json-tree-box {
-    min-height: 22rem;
-    max-height: 34rem;
+    /* 入力 textarea（rows=18, 実測 446px ≒ 28rem）と外形を揃える固定高。
+       超過分は overflow: auto で枠内スクロールさせる。textarea 側の
+       rows/font-size/line-height を変えた場合はこの値も追従させること。 */
+    height: 28rem;
     overflow: auto;
   }
   .json-tree-root {


### PR DESCRIPTION
## リリース内容（develop → main）

以下の修正を本番へ反映します。

- **fix: JSON整形ビューアのツリー結果欄の高さを固定 (#602)**
  ツリー表示の結果パネルが内容に応じて伸縮していたのを `height: 28rem` 固定に変更。未入力時は入力欄より短く・入力時は入力欄を超える揃いの崩れを解消。
- **fix: 文字コード変換の元/変換後セレクトを横並びに変更 (#601)**

## マージ方法

release PR のため `--merge`（マージコミット）で取り込む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
