### PR TITLE
fix: 正規表現 d フラグ選択時の Invalid flags エラーを修正

### DIFF
--- a/src/utils/regex-visualizer/__tests__/flags.test.ts
+++ b/src/utils/regex-visualizer/__tests__/flags.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { stripUnsupportedFlags } from '../flags';
 
 describe('stripUnsupportedFlags', () => {
-  // 陽性対照: d フラグが除去されることを直接確認（旧実装は flags.replace を使わないため fail する）
+  // 陽性対照: d が除去されることを確認（ヘルパーが d を除去しないと fail する）
   it('陽性対照: d フラグを除去する', () => {
     expect(stripUnsupportedFlags('d')).toBe('');
   });

--- a/src/utils/regex-visualizer/__tests__/flags.test.ts
+++ b/src/utils/regex-visualizer/__tests__/flags.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { stripUnsupportedFlags } from '../flags';
+
+describe('stripUnsupportedFlags', () => {
+  // 陽性対照: d フラグが除去されることを直接確認（旧実装は flags.replace を使わないため fail する）
+  it('陽性対照: d フラグを除去する', () => {
+    expect(stripUnsupportedFlags('d')).toBe('');
+  });
+
+  it('陽性対照: gid など複合フラグから d のみ除去する', () => {
+    expect(stripUnsupportedFlags('gid')).toBe('gi');
+  });
+
+  // 陰性対照: d 以外のフラグは保持されること
+  it('d を含まないフラグはそのまま返す', () => {
+    expect(stripUnsupportedFlags('gimsuy')).toBe('gimsuy');
+  });
+
+  it('空文字列はそのまま空文字列を返す', () => {
+    expect(stripUnsupportedFlags('')).toBe('');
+  });
+});

--- a/src/utils/regex-visualizer/__tests__/parse.test.ts
+++ b/src/utils/regex-visualizer/__tests__/parse.test.ts
@@ -88,3 +88,18 @@ describe('parseToRegExpTree', () => {
     expect(() => parseToRegExpTree('(', '')).toThrow();
   });
 });
+
+// 回帰防止 #609: d フラグ（hasIndices, ES2022）選択時に regexp-tree が "Invalid flags: d" を throw するバグ
+describe('d フラグ（hasIndices）対応', () => {
+  it('d フラグを受理し例外を投げない', () => {
+    expect(() => parseRegex('(a)b', 'd')).not.toThrow();
+  });
+
+  it('d フラグ有無で AST 構造が一致する', () => {
+    expect(parseRegex('(a)b', 'd')).toEqual(parseRegex('(a)b', ''));
+  });
+
+  it('d フラグと他フラグの組み合わせを受理する', () => {
+    expect(() => parseRegex('(a)', 'gid')).not.toThrow();
+  });
+});

--- a/src/utils/regex-visualizer/__tests__/redos.test.ts
+++ b/src/utils/regex-visualizer/__tests__/redos.test.ts
@@ -22,4 +22,16 @@ describe('analyzeRedos', () => {
     const r = analyzeRedos('(a+)+$', '');
     expect(Array.isArray(r.hotspot)).toBe(true);
   });
+
+  // 回帰防止 #609: d フラグ（hasIndices）選択時に recheck が unknown を返していたバグ
+  // 陽性対照: 旧実装では d フラグを recheck に直渡し → unknown に倒れていた
+  it('陽性対照: d フラグ付きでも vulnerable を判定できる（unknown に倒れない）', () => {
+    const r = analyzeRedos('(a+)+$', 'd');
+    expect(r.status).toBe('vulnerable');
+  });
+
+  it('d フラグ付きでも safe を判定できる', () => {
+    const r = analyzeRedos('^[a-z]+$', 'd');
+    expect(r.status).toBe('safe');
+  });
 });

--- a/src/utils/regex-visualizer/flags.ts
+++ b/src/utils/regex-visualizer/flags.ts
@@ -1,0 +1,8 @@
+/**
+ * regexp-tree / recheck が未対応のフラグを除去して返す。
+ * 'd'（hasIndices, ES2022）は両ライブラリが未対応のため除外する。
+ * AST 構造・ReDoS 解析には影響しない metadata フラグのため除去して渡して問題ない。
+ */
+export function stripUnsupportedFlags(flags: string): string {
+  return [...flags].filter((f) => f !== 'd').join('');
+}

--- a/src/utils/regex-visualizer/parse.ts
+++ b/src/utils/regex-visualizer/parse.ts
@@ -1,5 +1,6 @@
 import { parse as parseRegExpTree } from 'regexp-tree';
 import { getErrorMessage } from '@/utils/errors';
+import { stripUnsupportedFlags } from './flags';
 
 export interface RegexAstNode {
   /** regexp-tree のノード種別（'Char' | 'Repetition' | 'Group' | 'Disjunction' | 'Alternative' | 'CharacterClass' | 'Assertion' | 'Backreference' | 'Root' 等） */
@@ -99,9 +100,8 @@ function toRenderNode(node: RegExpTreeNode): RegexAstNode {
  * native `new RegExp` で構文・フラグを検証（不正なら throw）し、captureLocations 付き AST を返す。
  */
 export function parseToRegExpTree(pattern: string, flags: string) {
-  // 'd' フラグ（hasIndices）は regexp-tree が未対応のため除外して渡す
-  new RegExp(pattern, flags); // 構文・フラグ検証（d フラグも含む完全フラグで）
-  const re = new RegExp(pattern, flags.replace('d', ''));
+  void new RegExp(pattern, flags); // 構文・フラグ検証（d フラグも含む完全フラグで）
+  const re = new RegExp(pattern, stripUnsupportedFlags(flags));
   return parseRegExpTree(re, { captureLocations: true });
 }
 

--- a/src/utils/regex-visualizer/parse.ts
+++ b/src/utils/regex-visualizer/parse.ts
@@ -99,7 +99,9 @@ function toRenderNode(node: RegExpTreeNode): RegexAstNode {
  * native `new RegExp` で構文・フラグを検証（不正なら throw）し、captureLocations 付き AST を返す。
  */
 export function parseToRegExpTree(pattern: string, flags: string) {
-  const re = new RegExp(pattern, flags);
+  // 'd' フラグ（hasIndices）は regexp-tree が未対応のため除外して渡す
+  new RegExp(pattern, flags); // 構文・フラグ検証（d フラグも含む完全フラグで）
+  const re = new RegExp(pattern, flags.replace('d', ''));
   return parseRegExpTree(re, { captureLocations: true });
 }
 

--- a/src/utils/regex-visualizer/redos.ts
+++ b/src/utils/regex-visualizer/redos.ts
@@ -31,7 +31,7 @@ export function analyzeRedos(pattern: string, flags: string): RedosResult {
   // 取り違えて「正規表現が不正」と誤表示しないため）。「不明」を「安全」と混同しないこと。
   let d;
   try {
-    d = checkSync(pattern, flags, { timeout: 1000 });
+    d = checkSync(pattern, flags.replace('d', ''), { timeout: 1000 });
   } catch {
     return { status: 'unknown', reason: 'error' };
   }

--- a/src/utils/regex-visualizer/redos.ts
+++ b/src/utils/regex-visualizer/redos.ts
@@ -1,4 +1,5 @@
 import { checkSync } from 'recheck';
+import { stripUnsupportedFlags } from './flags';
 
 export type RedosStatus = 'safe' | 'vulnerable' | 'unknown';
 
@@ -31,7 +32,7 @@ export function analyzeRedos(pattern: string, flags: string): RedosResult {
   // 取り違えて「正規表現が不正」と誤表示しないため）。「不明」を「安全」と混同しないこと。
   let d;
   try {
-    d = checkSync(pattern, flags.replace('d', ''), { timeout: 1000 });
+    d = checkSync(pattern, stripUnsupportedFlags(flags), { timeout: 1000 });
   } catch {
     return { status: 'unknown', reason: 'error' };
   }


### PR DESCRIPTION
## 概要

正規表現ビジュアライザで `d`（マッチ位置取得 / hasIndices）フラグを選択すると `正規表現が不正です: Invalid flags: d` エラーが出るバグを修正。

## 原因

| ライブラリ | 問題 |
|---|---|
| `regexp-tree` | `validFlags = 'gimsuxy'` に `d` が含まれていない |
| `recheck` | `d` フラグを不明フラグとして扱いエラーを返す |

`d` フラグ（ES2022 `hasIndices`）は正規表現の **マッチ結果の `.indices` プロパティ**を有効化するもので、AST の構造・ReDoS 解析には一切影響しない。

## 修正内容

### `src/utils/regex-visualizer/parse.ts`

`parseToRegExpTree` 内でネイティブ `new RegExp` による構文・フラグ検証（`d` 含む）を先行し、`regexp-tree` に渡す RegExp からは `d` を除去。

### `src/utils/regex-visualizer/redos.ts`

`recheck` の `checkSync` に渡す flags から `d` を除去。

`railroad.ts` の `buildRailroad` は `parseToRegExpTree` 経由のため追加変更不要。

## テスト確認

- 型チェック（`astro check`）: ✅ 0 errors
- コミット前フック: ✅ pass

## スクリーンショット（修正前）

`d` フラグ選択 → `正規表現が不正です: Invalid flags: d` が表示されていた。

修正後は `d` フラグ選択時もエラーなく構造ツリー・鉄道図・ReDoS 判定が動作する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhfhkyX4V7DvLBpteGn1eQ)_