### PR TITLE
test: テスト陽性対照（test-gates）3 件を強化 — meta-csp dist 直読化 / VRT comment build / baseline secret audit (#316 #324 #334)

### DIFF
--- a/.github/workflows/test-baseline-audit.yml
+++ b/.github/workflows/test-baseline-audit.yml
@@ -54,19 +54,19 @@ jobs:
       # -----------------------------------------------------------------------
       # Step 2: 陰性対照 — allow list が GH Actions runtime 由来 env を除外することを確認
       #
-      # FAKE_API_KEY を step env から除外した状態で同 pipeline を実行。
+      # FAKE_API_KEY を shell で unset した状態で同 pipeline を実行。
       # GH Actions runtime 由来の env（GITHUB_TOKEN / RUNNER_* 等）は allow list で
       # 除外されるため SUSPECT が空になることを assert（false positive の防止）。
       # allow list が過剰に絞られている場合は本番 audit が常時 fail する。
       # -----------------------------------------------------------------------
       - name: 陰性対照 — allow list が runtime env を除外し false positive がないことを確認
-        # FAKE_API_KEY を step env に持たない独立 step として実行することで、
-        # FAKE_API_KEY が env に存在しない状態を再現する（job env は step env で上書き可能）。
-        env:
-          FAKE_API_KEY: ''
         shell: bash
         run: |
           set -euo pipefail
+          # job env の FAKE_API_KEY を shell から unset し「env に存在しない」状態を再現する。
+          # 注意: step env で `FAKE_API_KEY: ''` と空文字上書きしても env 出力に
+          # `FAKE_API_KEY=` が残って detect パターンにマッチするため、unset が必須。
+          unset FAKE_API_KEY
           # update-visual-baseline.yml L51 と一字一句同一のパターン
           SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(GITHUB_TOKEN=|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
           if [ -n "$SUSPECT" ]; then

--- a/.github/workflows/test-baseline-audit.yml
+++ b/.github/workflows/test-baseline-audit.yml
@@ -1,0 +1,78 @@
+name: Test Baseline Secret Audit
+
+# baseline secret env audit step（update-visual-baseline.yml L39-58）の
+# 陽性対照ワークフロー（issue #334 / 案 1 採用）。
+#
+# 目的: audit step の grep パターンが壊れていないかを定期的に自動確認する。
+# 陽性対照: FAKE_API_KEY（sentinel 値）が audit pattern に検知されることを assert。
+# 陰性対照: allow list が GH Actions runtime 由来 env を除外することを assert。
+#
+# 参照: docs/decisions.md [100] / PR #333 / issue #334
+
+on:
+  # 手動 trigger: audit step 修正後などに即時確認できる
+  workflow_dispatch:
+  # 週次自動確認: grep パターンの silent drift を防ぐ
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  test-baseline-audit:
+    runs-on: ubuntu-latest
+    # sentinel 値を job env に注入。実際の secret ではなく、
+    # audit パターンに検知されるべき命名規則（*_KEY）を持つダミー値。
+    env:
+      FAKE_API_KEY: sentinel-value-not-a-real-secret
+    steps:
+      - uses: actions/checkout@v6
+
+      # -----------------------------------------------------------------------
+      # Step 1: 陽性対照 — FAKE_API_KEY が audit pattern に検知されることを確認
+      #
+      # update-visual-baseline.yml の audit pipeline（grep パターン 2 本）を
+      # 一字一句同一で inline 複製し、FAKE_API_KEY が SUSPECT 変数に入ることを assert。
+      # FAKE_API_KEY が検知されない場合 → audit step の grep pattern が壊れている可能性。
+      # -----------------------------------------------------------------------
+      - name: 陽性対照 — FAKE_API_KEY が audit step で検知されることを確認
+        shell: bash
+        run: |
+          set -euo pipefail
+          # update-visual-baseline.yml L51 と一字一句同一のパターン（drift は meta テストが検知）
+          SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(GITHUB_TOKEN=|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
+          if [ -z "$SUSPECT" ]; then
+            echo "::error::POSITIVE CONTROL FAILED — FAKE_API_KEY が検知されなかった。audit step の grep pattern が壊れている可能性がある。"
+            echo "::error::update-visual-baseline.yml の audit step と本 workflow の grep パターンが一致しているか確認すること。"
+            exit 1
+          fi
+          echo "OK: FAKE_API_KEY が正しく検知された（audit step が機能している）"
+          # 値は redact してキー名のみ表示
+          echo "$SUSPECT" | sed 's/=.*$/=<redacted>/'
+
+      # -----------------------------------------------------------------------
+      # Step 2: 陰性対照 — allow list が GH Actions runtime 由来 env を除外することを確認
+      #
+      # FAKE_API_KEY を step env から除外した状態で同 pipeline を実行。
+      # GH Actions runtime 由来の env（GITHUB_TOKEN / RUNNER_* 等）は allow list で
+      # 除外されるため SUSPECT が空になることを assert（false positive の防止）。
+      # allow list が過剰に絞られている場合は本番 audit が常時 fail する。
+      # -----------------------------------------------------------------------
+      - name: 陰性対照 — allow list が runtime env を除外し false positive がないことを確認
+        # FAKE_API_KEY を step env に持たない独立 step として実行することで、
+        # FAKE_API_KEY が env に存在しない状態を再現する（job env は step env で上書き可能）。
+        env:
+          FAKE_API_KEY: ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          # update-visual-baseline.yml L51 と一字一句同一のパターン
+          SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(GITHUB_TOKEN=|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
+          if [ -n "$SUSPECT" ]; then
+            echo "::warning::allow list に含まれない secret-like env var が検出された（false positive の可能性）:"
+            echo "$SUSPECT" | sed 's/=.*$/=<redacted>/'
+            echo "allow list の更新が必要かもしれない。update-visual-baseline.yml の grep -vE パターンを確認すること。"
+            exit 1
+          fi
+          echo "OK: false positive なし（runtime env は allow list で正しく除外された）"

--- a/.github/workflows/test-baseline-audit.yml
+++ b/.github/workflows/test-baseline-audit.yml
@@ -26,9 +26,9 @@ jobs:
     # audit パターンに検知されるべき命名規則（*_KEY）を持つダミー値。
     env:
       FAKE_API_KEY: sentinel-value-not-a-real-secret
+    # checkout 不要: 両 step とも `env | grep` のみで repo ファイルを一切読まない。
+    # 除去により実行時間と攻撃表面を最小化する（PR #616 review 指摘）。
     steps:
-      - uses: actions/checkout@v6
-
       # -----------------------------------------------------------------------
       # Step 1: 陽性対照 — FAKE_API_KEY が audit pattern に検知されることを確認
       #

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3857,4 +3857,4 @@ IPv4（32bit）と IPv6（128bit）のアドレス演算を、安全かつブラ
 - ✅ #316: dist HTML から直接 hash を計算する設計で定数の二重管理を排除。Astro の inline style 変更を自動検知。
 - ✅ #324: pipeline の `|| true` 有無の違いをケース C が実証し、regression クラス全体をテストハーネスが検知できることを証明。
 - ✅ #334: 週次 cron と `workflow_dispatch` の両建てで、audit step の silent drift を定期自動確認。meta テストで grep パターンの inline 複製 drift を CI から検知。
-- ⚠️ #334: `test-baseline-audit.yml` の陰性対照（Step 2）は `FAKE_API_KEY: ''` で job env を上書きする設計。GH Actions が step env の空文字列で `FAKE_API_KEY=` を env に出すかどうかはランナー実装依存であるため、本番 audit 同様の「env に存在しない」状態と厳密に等価ではない。ただし FAKE_API_KEY のデフォルト検知が Step 1 で保証されているため、Step 2 の陰性対照は false positive の有無を確認する補助的な役割として許容する。
+- ⚠️ #334: `test-baseline-audit.yml` の陰性対照（Step 2）は shell の `unset FAKE_API_KEY` で「env に存在しない」状態を再現する。step env で `FAKE_API_KEY: ''` と空文字上書きする案はレビューで却下した — GH Actions は空文字でも env var を set するため `env` 出力に `FAKE_API_KEY=` が残り、detect パターン（`...KEY=` 接尾辞マッチ）に必ずマッチして陰性対照が常時 fail する。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3818,3 +3818,43 @@ IPv4（32bit）と IPv6（128bit）のアドレス演算を、安全かつブラ
 - ✅ IPv4/IPv6 を BigInt で統一的に扱い、シンプルなロジックで正確なネットワーク計算を実現。
 - ✅ 外部依存ゼロでブラウザ完結を維持。
 - ⚠️ IPv4-mapped IPv6（`::ffff:x.x.x.x`）は BigInt にパースできるが、フォーマット時に IPv4 形式には戻さない（表示は純 IPv6）。
+
+---
+
+## [100] 2026-06-10 — テスト陽性対照強化 (#316/#324/#334)（issue #533）
+
+### 課題
+
+以下の 3 つのテスト / CI 設定に「検知機構が壊れても green が継続する」陰性対照のみの設計が残っていた:
+
+- **#316**: `meta-csp.test.ts` の Astro island inline style hash 整合性テストが、定数 `ASTRO_ISLAND_INLINE_CONTENT` を hardcode して比較する 2 段構造だったため、Astro が inline style 文字列を変更しても旧 hash を `_headers` に残したまま陰性対照で素通りする危険があった。
+- **#324**: `visual-regression.yml` の「PR comment 本文を組み立て」step は VRT 失敗時のみ通る経路で CI 実証手段がなく、`( ... ) || true` による regression 修正が正しいかを手元で確認する手段がなかった。
+- **#334**: `update-visual-baseline.yml` の secret env audit step は陰性対照のみで、grep パターンが壊れても silent pass するリスクがあった（`FAKE_API_KEY` を注入して検知を確認する陽性対照が欠如）。
+
+### 決断
+
+**#316（dist 直読化）**: `meta-csp.test.ts` の integrity テストを dist HTML から `<style>` 中身を全件抽出して sha256 を計算する 1 段構造に書き換え。dist と `_headers` を直接比較する設計で定数の二重管理を排除。「dist に inline style が少なくとも 1 件存在する」assert を陽性対照として追加し、抽出 regex が 0 件で空回りする偽 green を防止。
+
+**#324（陽性対照スクリプト）**: `scripts/test-vrt-comment-build.sh` を新設し、workflow 内の失敗 spec 抽出 pipeline を bash 環境で再現。陰性対照 2 件（空 log / fixture log）に加え、`|| true` を外した旧実装で空 log を流したとき pipeline が確実に中断することを assert するケース C（陽性対照）を追加。`tests/meta/vrt-comment-build-script.test.ts` で `npm run test` に自動組み込み。
+
+**#334（案 1: 別 workflow + 週次 cron）**: `.github/workflows/test-baseline-audit.yml` を新設し、`FAKE_API_KEY=sentinel-value-not-a-real-secret` を job env に注入した状態で audit pipeline を実行。FAKE_API_KEY が検知されなければ `::error::` で fail させる（陽性対照）。さらに FAKE_API_KEY を除外した step で GH Actions runtime 由来 env が allow list で正しく除外されることを確認（陰性対照）。inline 複製した grep パターンの drift は `tests/meta/baseline-audit-positive-control.test.ts` が `npm run test` で自動検知する。
+
+### 案 2・案 3 を却下した理由（#334）
+
+- **案 2（composite action 化）**: action の抽象化により grep パターンを DRY にできるが、workflow のステップを action でラップすると `env:` コンテキストが変わり sentinel 注入の設計が複雑化する。メンテナンスコストが案 1 を上回ると判断。
+- **案 3（bats 導入）**: bash 専用テストフレームワークを導入すれば表現力が上がるが、npm 管理の vitest と二重管理になる。小規模な検証に対してオーバーエンジニアリング。
+
+### inline 複製を meta テストで drift guard する判断
+
+`test-baseline-audit.yml` は `update-visual-baseline.yml` の grep パターンを「一字一句同一」で inline 複製している。DRY でないことは意図的なトレードオフで、以下の理由から許容する:
+
+- grep パターンは短く変更頻度が低い（audit 対象の secret 命名規則が変わった場合のみ更新）。
+- `tests/meta/baseline-audit-positive-control.test.ts` が両 workflow のパターンを抽出して完全一致を assert するため、drift は `npm run test` で即時検知できる。
+- composite action 化より運用が単純で、CI 設定追加の安全性も高い（`permissions: contents: read` のみ、sentinel は実 secret でない）。
+
+### 結果・トレードオフ
+
+- ✅ #316: dist HTML から直接 hash を計算する設計で定数の二重管理を排除。Astro の inline style 変更を自動検知。
+- ✅ #324: pipeline の `|| true` 有無の違いをケース C が実証し、regression クラス全体をテストハーネスが検知できることを証明。
+- ✅ #334: 週次 cron と `workflow_dispatch` の両建てで、audit step の silent drift を定期自動確認。meta テストで grep パターンの inline 複製 drift を CI から検知。
+- ⚠️ #334: `test-baseline-audit.yml` の陰性対照（Step 2）は `FAKE_API_KEY: ''` で job env を上書きする設計。GH Actions が step env の空文字列で `FAKE_API_KEY=` を env に出すかどうかはランナー実装依存であるため、本番 audit 同様の「env に存在しない」状態と厳密に等価ではない。ただし FAKE_API_KEY のデフォルト検知が Step 1 で保証されているため、Step 2 の陰性対照は false positive の有無を確認する補助的な役割として許容する。

--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -279,6 +279,15 @@ regex `^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=` は接尾辞の�
 
 false positive 増加とのトレードオフで現状は acceptable な ROI 判断。secret naming convention が拡張された際は本 docs を再評価。
 
+**audit step を修正したときの確認手順**:
+
+audit step（`update-visual-baseline.yml` の grep パターン / allow list）を修正した場合は、
+以下の手順で陽性対照が引き続き機能することを確認する:
+
+1. `.github/workflows/test-baseline-audit.yml` を GitHub Actions UI から `workflow_dispatch` で trigger する。
+2. Step 1「陽性対照 — FAKE_API_KEY が audit step で検知されることを確認」が pass することを確認。
+3. `grep -iE` と `grep -vE` の両パターンを `update-visual-baseline.yml` と `test-baseline-audit.yml` の両方で同じ文字列に更新すること（`tests/meta/baseline-audit-positive-control.test.ts` が drift を検知し `npm run test` で fail させる）。
+
 **contributor への注意**:
 
 - spec に `localStorage.setItem(...)` / `sessionStorage.setItem(...)` を追加する場合、

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,3 +77,41 @@ npm run test -- tests/meta/rm-tmp.test.ts
 
 - `.claude/rules/git-and-fs.md`（Claude Code での使用方法）
 - `.codex/rules/default.rules`（Codex での allow ルール）
+
+---
+
+## test-vrt-comment-build.sh
+
+VRT の「PR comment 本文を組み立て」step（`.github/workflows/visual-regression.yml`）の
+失敗 spec 抽出 pipeline を bash 環境下で再現し、3 つのケースを検証する。
+
+この step は VRT 失敗時のみ通る経路で CI 実証手段がないため、スクリプトで再現する（issue #324）。
+
+### ケース
+
+- **ケース A（陰性対照）**: ✘ 0 件の空 log を入力 → sentinel 行まで到達し exit 0 することを確認
+- **ケース B（陰性対照）**: ✘ 行 + `(retry` 行を含む fixture log を入力 → 期待形式の行が出力されることを確認
+- **ケース C（陽性対照）**: `|| true` を外した旧実装で空 log → 途中で中断して exit non-zero になることを確認
+
+### 使い方
+
+```bash
+bash scripts/test-vrt-comment-build.sh
+```
+
+### 終了コード
+
+- `0`: 全ケース pass
+- `1`: いずれかのケース fail
+
+### テスト
+
+```bash
+npm run test -- vrt-comment-build-script
+```
+
+### 関連
+
+- `.github/workflows/visual-regression.yml`（L184-245: 対象 step）
+- `tests/meta/vrt-comment-build-script.test.ts`（CI 組み込みテスト）
+- issue #324

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -112,6 +112,6 @@ npm run test -- vrt-comment-build-script
 
 ### 関連
 
-- `.github/workflows/visual-regression.yml`（L184-245: 対象 step）
-- `tests/meta/vrt-comment-build-script.test.ts`（CI 組み込みテスト）
+- `.github/workflows/visual-regression.yml`（対象 step: `PR comment 本文を組み立て（失敗 spec 名込み）`）
+- `tests/meta/vrt-comment-build-script.test.ts`（CI 組み込みテスト + workflow との pipeline drift 検知）
 - issue #324

--- a/scripts/test-vrt-comment-build.sh
+++ b/scripts/test-vrt-comment-build.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# scripts/test-vrt-comment-build.sh
+#
+# visual-regression.yml の「PR comment 本文を組み立て」step の
+# pipeline ロジックを bash 環境下で再現し、3 つのケースを検証する。
+#
+# ケース A（陰性対照・早期失敗再現）:
+#   ✘ 0 件の空 log → pipeline の後段まで到達し、sentinel 行まで出力されることを assert。
+#
+# ケース B（通常失敗再現）:
+#   ✘ 行 + (retry 行を含む fixture log → 期待形式の行が出力されることを assert。
+#   awk の -F'›' 抽出ロジックが正しく動作することを検証。
+#
+# ケース C（陽性対照）:
+#   `|| true` を外した旧実装相当の pipeline を空 log で実行。
+#   途中で中断して sentinel 行に到達しない（exit non-zero）ことを assert。
+#   「テストハーネスがこの regression クラスを検知できる」証明。
+#
+# issue #324 / PR #333 参照。
+#
+# 使い方: bash scripts/test-vrt-comment-build.sh
+# 終了コード: 0=全ケース pass / 1=いずれか fail
+
+set -eo pipefail
+
+# 一時ディレクトリを作成し、終了時に掃除する
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+# ヘルパー: ケース結果を出力する
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+# ===========================================================================
+# ケース A（陰性対照）: ✘ 0 件の空 log → sentinel 行まで到達することを assert
+# 空 log で pipeline が中断しないことを確認する（|| true による回帰修正の検証）
+# ===========================================================================
+echo "ケース A: 空 log（✘ 0 件）→ sentinel 行まで到達"
+
+LOG_A="$TMPDIR_WORK/log_a.txt"
+touch "$LOG_A"  # 空ファイル
+
+OUTPUT_A="$TMPDIR_WORK/output_a.txt"
+
+# workflow 内の step を bash -eo pipefail 環境で再現
+bash -eo pipefail <<SCRIPT_A > "$OUTPUT_A" 2>&1
+LOG_FILE="$LOG_A"
+{
+  echo "body<<MARKDOWN_EOF"
+  echo "## VRT 結果"
+  if [ -f "\$LOG_FILE" ]; then
+    # workflow の実物と同じ pipeline（|| true で包む形）
+    ( grep -E '^[[:space:]]+✘' "\$LOG_FILE" \
+      | grep -v '(retry' \
+      | awk -F'›' '{
+          n = NF
+          spec = \$n
+          sub(/^[ \t]+/, "", spec)
+          sub(/[ \t]*\([0-9.]+m?s\)[ \t]*\$/, "", spec)
+          vp = \$(n - 1)
+          sub(/^[ \t]+/, "", vp)
+          sub(/[ \t]+\$/, "", vp)
+          print "- [" vp "] " spec
+        }' \
+      | sort -u \
+      | head -30 ) || true
+  fi
+  echo "SENTINEL_LINE"
+  echo "MARKDOWN_EOF"
+}
+SCRIPT_A
+
+if grep -q "SENTINEL_LINE" "$OUTPUT_A"; then
+  pass "sentinel 行まで到達した（pipeline が中断しなかった）"
+else
+  fail "sentinel 行に到達しなかった"
+  echo "    stdout/stderr: $(cat "$OUTPUT_A")"
+fi
+
+# ===========================================================================
+# ケース B（陰性対照）: ✘ 行 + (retry 行を含む fixture log → 期待形式の行が出力される
+# awk の -F'›' 抽出ロジックが正しく動作することを検証
+# ===========================================================================
+echo ""
+echo "ケース B: ✘ 行 + retry 行のある fixture log → 期待形式の行を出力"
+
+LOG_B="$TMPDIR_WORK/log_b.txt"
+cat > "$LOG_B" <<'FIXTURE'
+  ✘ home page › desktop › スナップショット (12.3s)
+  ✘ home page › desktop › スナップショット (retry 1) (11.8s)
+  ✘ tools/qr-code › mobile › スナップショット (8.4s)
+  ✓ about › desktop › スナップショット (2.1s)
+FIXTURE
+
+OUTPUT_B="$TMPDIR_WORK/output_b.txt"
+
+bash -eo pipefail <<SCRIPT_B > "$OUTPUT_B" 2>&1
+LOG_FILE="$LOG_B"
+( grep -E '^[[:space:]]+✘' "\$LOG_FILE" \
+  | grep -v '(retry' \
+  | awk -F'›' '{
+      n = NF
+      spec = \$n
+      sub(/^[ \t]+/, "", spec)
+      sub(/[ \t]*\([0-9.]+m?s\)[ \t]*\$/, "", spec)
+      vp = \$(n - 1)
+      sub(/^[ \t]+/, "", vp)
+      sub(/[ \t]+\$/, "", vp)
+      print "- [" vp "] " spec
+    }' \
+  | sort -u \
+  | head -30 ) || true
+SCRIPT_B
+
+# retry 行が除外されていることを確認
+if grep -q "(retry" "$OUTPUT_B"; then
+  fail "retry 行が除外されていない"
+  echo "    output: $(cat "$OUTPUT_B")"
+else
+  pass "retry 行が正しく除外された"
+fi
+
+# 期待形式の行が含まれているかを確認
+if grep -q "^\- \[" "$OUTPUT_B"; then
+  pass "期待形式 '- [viewport] spec名' の行が出力された"
+else
+  fail "期待形式の行が出力されなかった"
+  echo "    output: $(cat "$OUTPUT_B")"
+fi
+
+# desktop viewport の spec が含まれているかを確認
+if grep -q "\[desktop\]" "$OUTPUT_B"; then
+  pass "desktop viewport の spec が出力された"
+else
+  fail "desktop viewport の spec が出力されなかった"
+  echo "    output: $(cat "$OUTPUT_B")"
+fi
+
+# ===========================================================================
+# ケース C（陽性対照）: || true を外した旧実装で空 log → 途中で中断することを assert
+# この regression クラスをテストハーネスが検知できることを証明する
+# ===========================================================================
+echo ""
+echo "ケース C: 旧実装（|| true なし）+ 空 log → 中断して exit non-zero"
+
+LOG_C="$TMPDIR_WORK/log_c.txt"
+touch "$LOG_C"
+
+OUTPUT_C="$TMPDIR_WORK/output_c.txt"
+
+# 旧実装相当: ( ... ) || true の || true を外したパイプライン
+# bash -eo pipefail 環境下では grep がマッチ 0 件のとき exit 1 を返し、
+# set -e により即座にスクリプトが中断する。
+# 意図的に失敗させるため、スクリプト全体の exit code を期待する。
+# 外側の set -e による途中終了を防ぐため || EXIT_C=$? で exit code を捕捉する。
+EXIT_C=0
+bash -eo pipefail <<SCRIPT_C > "$OUTPUT_C" 2>&1 || EXIT_C=$?
+LOG_FILE="$LOG_C"
+{
+  echo "BEFORE_PIPELINE"
+  # 旧実装: || true なし。空 log では grep が exit 1 → set -e で中断する。
+  grep -E '^[[:space:]]+✘' "\$LOG_FILE" \
+    | grep -v '(retry' \
+    | awk -F'›' '{
+        n = NF
+        spec = \$n
+        sub(/^[ \t]+/, "", spec)
+        sub(/[ \t]*\([0-9.]+m?s\)[ \t]*\$/, "", spec)
+        vp = \$(n - 1)
+        sub(/^[ \t]+/, "", vp)
+        sub(/[ \t]+\$/, "", vp)
+        print "- [" vp "] " spec
+      }' \
+    | sort -u \
+    | head -30
+  echo "SENTINEL_LINE"
+}
+SCRIPT_C
+
+if [ "$EXIT_C" -ne 0 ]; then
+  pass "旧実装は exit $EXIT_C で中断した（regression が検知可能であることを確認）"
+else
+  fail "旧実装が exit 0 で完了した（陽性対照が機能していない）"
+fi
+
+if ! grep -q "SENTINEL_LINE" "$OUTPUT_C"; then
+  pass "sentinel 行に到達しなかった（pipeline が正しく中断した）"
+else
+  fail "sentinel 行まで到達してしまった（中断を検知できていない）"
+  echo "    output: $(cat "$OUTPUT_C")"
+fi
+
+# ===========================================================================
+# 結果サマリ
+# ===========================================================================
+echo ""
+echo "==============================="
+echo "結果: ${PASS} passed, ${FAIL} failed"
+echo "==============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/scripts/test-vrt-comment-build.sh
+++ b/scripts/test-vrt-comment-build.sh
@@ -21,7 +21,8 @@
 # 使い方: bash scripts/test-vrt-comment-build.sh
 # 終了コード: 0=全ケース pass / 1=いずれか fail
 
-set -eo pipefail
+# 複製元 workflow step（set -euo pipefail）と同一オプションに揃え、未定義変数も早期検知する
+set -euo pipefail
 
 # 一時ディレクトリを作成し、終了時に掃除する
 TMPDIR_WORK=$(mktemp -d)

--- a/src/utils/__tests__/meta-csp.test.ts
+++ b/src/utils/__tests__/meta-csp.test.ts
@@ -96,51 +96,65 @@ describe('dist/*.html の <meta> CSP（Astro security.csp 由来 / #176 A-1 / #2
 });
 
 /**
- * Astro island runtime の inline style hash 整合性検出網 (#176 B 案完了 / [068]).
+ * dist HTML 全ページの inline style hash と `_headers` の完全同期検証 (#316 / #176 B 案完了 / [068]).
  *
- * Astro が各ページに injection する固定 inline style:
- *   <style>astro-island,astro-slot,astro-static-slot{display:contents}</style>
- * の sha256 hash を `_headers` の style-src に hardcoded fingerprint として
- * 取り込む handcoded 戦略 (option α、`docs/decisions.md [068]` 参照)。
+ * ### 設計変更 (#316)
+ * 旧実装は定数 ASTRO_ISLAND_INLINE_CONTENT を hardcode して hash していたため、
+ * Astro が inline style の文字列を変更しても旧 hash を `_headers` に残すと陰性対照で素通りしていた。
  *
- * 本検出網は以下を assert する:
- * 1. dist HTML 内に Astro island inline style literal が含まれること
- * 2. dist HTML inline style content の sha256 が `_headers` の hash 値と一致すること
+ * 新実装は dist HTML から `<style>...</style>` の中身を全件抽出して sha256 を計算し、
+ * **全 hash** が `public/_headers` の style-src に含まれることを 1 段で直接 assert する。
+ * dist と _headers の「直接同期検証」であり、定数の二重管理を排除する。
  *
- * Astro が当該 inline style 文字列を変更すると検出 1 / 2 が連鎖的に fail し、
- * silent regression を防ぐ陽性対照メタテスト。
+ * ### 陽性対照の維持
+ * - dist のどこかに inline style が少なくとも 1 件存在することを assert（抽出 regex が 0 件で
+ *   空回りして全 hash assert が偽 green になるのを防止）。
+ * - 空 `<style></style>` が将来出現した場合、空文字列の hash (47DEQpj...) が _headers に
+ *   無いため自動 fail する（意図しない空 style 追加を能動検知）。
+ *
+ * Astro が inline style 文字列を変更すると新 hash が _headers に存在せず fail → silent regression を防ぐ。
  */
-describe('Astro island runtime style hash 整合性 (#176 B 案完了 / [068])', () => {
+describe('dist HTML 全 inline style hash の _headers 含有検証 (#316 / #176 B 案完了 / [068])', () => {
   if (distPages.length === 0) {
     it.skip("dist/*.html が無い → 'npm run build' 後に再実行", () => {});
     return;
   }
 
-  const ASTRO_ISLAND_INLINE_STYLE =
-    '<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>';
-  const ASTRO_ISLAND_INLINE_CONTENT = 'astro-island,astro-slot,astro-static-slot{display:contents}';
+  // dist 全 HTML から inline style の中身を全件収集（重複含む）
+  const INLINE_STYLE_REGEX = /<style[^>]*>([^<]*)<\/style>/g;
 
-  it('dist HTML 内に Astro island inline style literal が含まれる (React island ありページ)', () => {
-    // Astro は React island を含むページにのみ astro-island inline style を注入する。
-    // about / privacy 等の純 Astro ページには含まれないため、distPages 全体で
-    // 少なくとも 1 ページに含まれることを assert (some パターン)。
-    const hasInlineStyle = distPages.some((page) =>
-      readFileSync(page, 'utf-8').includes(ASTRO_ISLAND_INLINE_STYLE)
-    );
+  // 全ページから inline style content を収集し、distinct set にまとめる
+  const allInlineStyleContents = new Set<string>();
+  for (const page of distPages) {
+    const html = readFileSync(page, 'utf-8');
+    for (const match of html.matchAll(INLINE_STYLE_REGEX)) {
+      allInlineStyleContents.add(match[1]);
+    }
+  }
+
+  it('dist HTML に inline style が少なくとも 1 件存在する（陽性対照の空回り防止）', () => {
+    // Astro は React island を含むページに astro-island inline style を注入する。
+    // 0 件の場合は抽出 regex がマッチしておらず、下記の全 hash assert が偽 green になる。
+    // このチェックで「テスト自体が機能しているか」を保証する（test-gates 陽性対照原則）。
     expect(
-      hasInlineStyle,
-      'dist のどのページにも Astro island inline style literal が見つからない'
-    ).toBe(true);
+      allInlineStyleContents.size,
+      'dist のどのページにも inline style が見つからない。Astro の出力構造が変わった可能性がある'
+    ).toBeGreaterThan(0);
   });
 
-  it('dist HTML inline style の sha256 が _headers の hash と一致する (陽性対照メタテスト)', async () => {
+  it('dist の全 inline style sha256 hash が _headers の style-src に含まれる（dist と _headers の直接同期検証）', async () => {
     const { createHash } = await import('node:crypto');
-    const computedHash = createHash('sha256').update(ASTRO_ISLAND_INLINE_CONTENT).digest('base64');
-    const expectedToken = `'sha256-${computedHash}'`;
-
     const headersPath = path.resolve(process.cwd(), 'public', '_headers');
     const headersContent = readFileSync(headersPath, 'utf-8');
 
-    expect(headersContent).toContain(expectedToken);
+    for (const content of allInlineStyleContents) {
+      const hash = createHash('sha256').update(content).digest('base64');
+      const token = `'sha256-${hash}'`;
+      expect(
+        headersContent,
+        `inline style content の hash ${token} が _headers の style-src に含まれない。\n` +
+          `対象 content (先頭 80 文字): ${content.slice(0, 80)}`
+      ).toContain(token);
+    }
   });
 });

--- a/src/utils/__tests__/meta-csp.test.ts
+++ b/src/utils/__tests__/meta-csp.test.ts
@@ -104,6 +104,8 @@ describe('dist/*.html の <meta> CSP（Astro security.csp 由来 / #176 A-1 / #2
  *
  * 新実装は dist HTML から `<style>...</style>` の中身を全件抽出して sha256 を計算し、
  * **全 hash** が `public/_headers` の style-src に含まれることを 1 段で直接 assert する。
+ * さらに逆方向（_headers の style-src 内 sha256 token ⊆ dist の hash 集合）も assert し、
+ * 旧 hash の残置（CSP 許可面の不要な広がり）も検知する完全同期検証とする。
  * dist と _headers の「直接同期検証」であり、定数の二重管理を排除する。
  *
  * ### 陽性対照の維持
@@ -120,8 +122,10 @@ describe('dist HTML 全 inline style hash の _headers 含有検証 (#316 / #176
     return;
   }
 
-  // dist 全 HTML から inline style の中身を全件収集（重複含む）
-  const INLINE_STYLE_REGEX = /<style[^>]*>([^<]*)<\/style>/g;
+  // dist 全 HTML から inline style の中身を全件収集（重複含む）。
+  // `[^<]*` ではなく `[\s\S]*?` を使う: CSS が `<` を含む場合（content: "<" 等）に
+  // その <style> が抽出から漏れて hash 未検証のまま素通りするのを防ぐ（PR #616 review 指摘）。
+  const INLINE_STYLE_REGEX = /<style[^>]*>([\s\S]*?)<\/style>/g;
 
   // 全ページから inline style content を収集し、distinct set にまとめる
   const allInlineStyleContents = new Set<string>();
@@ -155,6 +159,45 @@ describe('dist HTML 全 inline style hash の _headers 含有検証 (#316 / #176
         `inline style content の hash ${token} が _headers の style-src に含まれない。\n` +
           `対象 content (先頭 80 文字): ${content.slice(0, 80)}`
       ).toContain(token);
+    }
+  });
+
+  it('_headers の style-src 内 sha256 token がすべて dist の inline style hash に対応する（逆方向同期 / 旧 hash 残置検知）', async () => {
+    // dist → _headers の片方向だけでは、Astro の inline style 変更後に旧 hash が
+    // _headers に残置されても検知できない（CSP 許可面が不要に広いまま残る）。
+    // 逆方向も assert して dist ⇔ _headers の完全同期にする（PR #616 review 指摘）。
+    const { createHash } = await import('node:crypto');
+    const headersPath = path.resolve(process.cwd(), 'public', '_headers');
+    const headersContent = readFileSync(headersPath, 'utf-8');
+
+    // コメント行にも "style-src" の語が出現するため、実ヘッダ行に限定してから抽出する
+    const cspLineMatch = headersContent.match(/^\s*Content-Security-Policy:(.*)$/m);
+    expect(
+      cspLineMatch,
+      '_headers に Content-Security-Policy ヘッダ行が見つからない'
+    ).not.toBeNull();
+    const styleSrcMatch = (cspLineMatch?.[1] ?? '').match(/style-src ([^;]*)/);
+    expect(styleSrcMatch, '_headers に style-src ディレクティブが見つからない').not.toBeNull();
+
+    const headerTokens = [
+      ...(styleSrcMatch?.[1] ?? '').matchAll(/'sha256-([A-Za-z0-9+/=]+)'/g),
+    ].map((m) => m[1]);
+    // _headers 側に hash が 1 件も無い場合は token 抽出の空回りを疑って明示 fail
+    expect(
+      headerTokens.length,
+      '_headers の style-src に sha256 token が 1 件も無い'
+    ).toBeGreaterThan(0);
+
+    const distHashes = new Set(
+      [...allInlineStyleContents].map((content) =>
+        createHash('sha256').update(content).digest('base64')
+      )
+    );
+    for (const token of headerTokens) {
+      expect(
+        distHashes.has(token),
+        `_headers の style-src にある 'sha256-${token}' に対応する inline style が dist に存在しない（旧 hash の残置）`
+      ).toBe(true);
     }
   });
 });

--- a/tests/meta/baseline-audit-positive-control.test.ts
+++ b/tests/meta/baseline-audit-positive-control.test.ts
@@ -6,31 +6,29 @@ import { describe, expect, it } from 'vitest';
 //
 // inline 複製したパターンが drift すると陽性対照が壊れて silent に通過し続けるため、
 // この meta テストで CI から自動検知する（issue #334 / docs/decisions.md [100]）。
+// test-baseline-audit.yml は pipeline を陽性対照 / 陰性対照の 2 step で複製しているため、
+// 先頭 1 出現だけでなく **全出現** を抽出して相互一致を assert する（2 箇所目の drift 見逃し防止）。
 
 const BASELINE_WORKFLOW_PATH = '.github/workflows/update-visual-baseline.yml';
 const AUDIT_WORKFLOW_PATH = '.github/workflows/test-baseline-audit.yml';
 
 /**
- * ワークフロー YAML のテキストから audit step で使われる grep パターン 2 本を抽出する。
+ * ワークフロー YAML のテキストから audit step で使われる grep パターンを全出現抽出する。
  * 抽出対象:
  *   - grep -iE の引数（suspicious env var の検出パターン）
  *   - grep -vE の引数（allow list パターン）
  *
- * 0 件マッチなら明示 fail させるため、配列を返す（呼び出し側で長さを assert）。
+ * 0 件マッチなら空配列を返す（呼び出し側で長さを assert して空回りを防止する）。
  */
 export function extractAuditGrepPatterns(yamlText: string): {
-  detectPattern: string | null;
-  allowPattern: string | null;
+  detectPatterns: string[];
+  allowPatterns: string[];
 } {
-  // grep -iE '...' のシングルクォート内を抽出
-  const detectMatch = yamlText.match(/grep -iE '([^']+)'/);
-  // grep -vE '...' のシングルクォート内を抽出
-  const allowMatch = yamlText.match(/grep -vE '([^']+)'/);
+  // grep -iE '...' / grep -vE '...' のシングルクォート内を全出現抽出
+  const detectPatterns = [...yamlText.matchAll(/grep -iE '([^']+)'/g)].map((m) => m[1]);
+  const allowPatterns = [...yamlText.matchAll(/grep -vE '([^']+)'/g)].map((m) => m[1]);
 
-  return {
-    detectPattern: detectMatch ? detectMatch[1] : null,
-    allowPattern: allowMatch ? allowMatch[1] : null,
-  };
+  return { detectPatterns, allowPatterns };
 }
 
 describe('baseline audit grep パターンの drift 検知', () => {
@@ -40,41 +38,46 @@ describe('baseline audit grep パターンの drift 検知', () => {
   const baselinePatterns = extractAuditGrepPatterns(baselineText);
   const auditPatterns = extractAuditGrepPatterns(auditText);
 
-  it('update-visual-baseline.yml から detectPattern を抽出できる（空回り防止）', () => {
+  it('update-visual-baseline.yml から detect / allow パターンを抽出できる（空回り防止）', () => {
     expect(
-      baselinePatterns.detectPattern,
+      baselinePatterns.detectPatterns.length,
       `${BASELINE_WORKFLOW_PATH} に grep -iE パターンが見つからない。audit step の構造が変わった可能性がある`
-    ).not.toBeNull();
-  });
-
-  it('update-visual-baseline.yml から allowPattern を抽出できる（空回り防止）', () => {
+    ).toBeGreaterThan(0);
     expect(
-      baselinePatterns.allowPattern,
+      baselinePatterns.allowPatterns.length,
       `${BASELINE_WORKFLOW_PATH} に grep -vE パターンが見つからない。audit step の構造が変わった可能性がある`
-    ).not.toBeNull();
+    ).toBeGreaterThan(0);
   });
 
-  it('test-baseline-audit.yml から detectPattern を抽出できる（空回り防止）', () => {
+  it('test-baseline-audit.yml から detect / allow パターンを抽出できる（空回り防止）', () => {
     expect(
-      auditPatterns.detectPattern,
+      auditPatterns.detectPatterns.length,
       `${AUDIT_WORKFLOW_PATH} に grep -iE パターンが見つからない。陽性対照 workflow の audit pipeline が欠落している可能性がある`
-    ).not.toBeNull();
-  });
-
-  it('test-baseline-audit.yml から allowPattern を抽出できる（空回り防止）', () => {
+    ).toBeGreaterThan(0);
     expect(
-      auditPatterns.allowPattern,
+      auditPatterns.allowPatterns.length,
       `${AUDIT_WORKFLOW_PATH} に grep -vE パターンが見つからない。陽性対照 workflow の audit pipeline が欠落している可能性がある`
-    ).not.toBeNull();
+    ).toBeGreaterThan(0);
   });
 
-  it('両 workflow の detectPattern が完全一致する（drift 検知）', () => {
-    // どちらかが null の場合は上記 it で既に fail しているが、安全のため両方確認
-    expect(auditPatterns.detectPattern).toBe(baselinePatterns.detectPattern);
+  it('全出現の detectPattern が両 workflow 間で完全一致する（drift 検知）', () => {
+    const reference = baselinePatterns.detectPatterns[0];
+    // 正本（update-visual-baseline.yml）内の全出現 + 陽性対照 workflow 内の全出現が
+    // すべて同一文字列であることを assert。どれか 1 箇所だけ書き換わった drift も検知する。
+    for (const p of [...baselinePatterns.detectPatterns, ...auditPatterns.detectPatterns]) {
+      expect(p, 'detect パターンが workflow 間（または同一 workflow 内）で drift している').toBe(
+        reference
+      );
+    }
   });
 
-  it('両 workflow の allowPattern が完全一致する（drift 検知）', () => {
-    expect(auditPatterns.allowPattern).toBe(baselinePatterns.allowPattern);
+  it('全出現の allowPattern が両 workflow 間で完全一致する（drift 検知）', () => {
+    const reference = baselinePatterns.allowPatterns[0];
+    for (const p of [...baselinePatterns.allowPatterns, ...auditPatterns.allowPatterns]) {
+      expect(p, 'allow パターンが workflow 間（または同一 workflow 内）で drift している').toBe(
+        reference
+      );
+    }
   });
 });
 
@@ -89,10 +92,10 @@ describe('[陽性対照] extractAuditGrepPatterns — パターン変異を検�
     const originalPatterns = extractAuditGrepPatterns(originalYaml);
     const mutatedPatterns = extractAuditGrepPatterns(mutatedYaml);
 
-    // 変異させたパターンはオリジナルと一致しないことを assert
+    // 変異させたパターンはオリジナルと一致しないことを assert。
     // この test が fail するなら extractAuditGrepPatterns が正しく動作していない
-    expect(mutatedPatterns.detectPattern).not.toBeNull();
-    expect(mutatedPatterns.detectPattern).not.toBe(originalPatterns.detectPattern);
+    expect(mutatedPatterns.detectPatterns).toHaveLength(1);
+    expect(mutatedPatterns.detectPatterns[0]).not.toBe(originalPatterns.detectPatterns[0]);
   });
 
   it('allowPattern が変異した文字列を比較すると不一致を検知する', () => {
@@ -104,7 +107,7 @@ describe('[陽性対照] extractAuditGrepPatterns — パターン変異を検�
     const originalPatterns = extractAuditGrepPatterns(originalYaml);
     const mutatedPatterns = extractAuditGrepPatterns(mutatedYaml);
 
-    expect(mutatedPatterns.allowPattern).not.toBeNull();
-    expect(mutatedPatterns.allowPattern).not.toBe(originalPatterns.allowPattern);
+    expect(mutatedPatterns.allowPatterns).toHaveLength(1);
+    expect(mutatedPatterns.allowPatterns[0]).not.toBe(originalPatterns.allowPatterns[0]);
   });
 });

--- a/tests/meta/baseline-audit-positive-control.test.ts
+++ b/tests/meta/baseline-audit-positive-control.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// update-visual-baseline.yml と test-baseline-audit.yml の audit grep パターンが
+// 一字一句同一であることを assert する drift 検知 meta テスト。
+//
+// inline 複製したパターンが drift すると陽性対照が壊れて silent に通過し続けるため、
+// この meta テストで CI から自動検知する（issue #334 / docs/decisions.md [100]）。
+
+const BASELINE_WORKFLOW_PATH = '.github/workflows/update-visual-baseline.yml';
+const AUDIT_WORKFLOW_PATH = '.github/workflows/test-baseline-audit.yml';
+
+/**
+ * ワークフロー YAML のテキストから audit step で使われる grep パターン 2 本を抽出する。
+ * 抽出対象:
+ *   - grep -iE の引数（suspicious env var の検出パターン）
+ *   - grep -vE の引数（allow list パターン）
+ *
+ * 0 件マッチなら明示 fail させるため、配列を返す（呼び出し側で長さを assert）。
+ */
+export function extractAuditGrepPatterns(yamlText: string): {
+  detectPattern: string | null;
+  allowPattern: string | null;
+} {
+  // grep -iE '...' のシングルクォート内を抽出
+  const detectMatch = yamlText.match(/grep -iE '([^']+)'/);
+  // grep -vE '...' のシングルクォート内を抽出
+  const allowMatch = yamlText.match(/grep -vE '([^']+)'/);
+
+  return {
+    detectPattern: detectMatch ? detectMatch[1] : null,
+    allowPattern: allowMatch ? allowMatch[1] : null,
+  };
+}
+
+describe('baseline audit grep パターンの drift 検知', () => {
+  const baselineText = readFileSync(BASELINE_WORKFLOW_PATH, 'utf-8');
+  const auditText = readFileSync(AUDIT_WORKFLOW_PATH, 'utf-8');
+
+  const baselinePatterns = extractAuditGrepPatterns(baselineText);
+  const auditPatterns = extractAuditGrepPatterns(auditText);
+
+  it('update-visual-baseline.yml から detectPattern を抽出できる（空回り防止）', () => {
+    expect(
+      baselinePatterns.detectPattern,
+      `${BASELINE_WORKFLOW_PATH} に grep -iE パターンが見つからない。audit step の構造が変わった可能性がある`
+    ).not.toBeNull();
+  });
+
+  it('update-visual-baseline.yml から allowPattern を抽出できる（空回り防止）', () => {
+    expect(
+      baselinePatterns.allowPattern,
+      `${BASELINE_WORKFLOW_PATH} に grep -vE パターンが見つからない。audit step の構造が変わった可能性がある`
+    ).not.toBeNull();
+  });
+
+  it('test-baseline-audit.yml から detectPattern を抽出できる（空回り防止）', () => {
+    expect(
+      auditPatterns.detectPattern,
+      `${AUDIT_WORKFLOW_PATH} に grep -iE パターンが見つからない。陽性対照 workflow の audit pipeline が欠落している可能性がある`
+    ).not.toBeNull();
+  });
+
+  it('test-baseline-audit.yml から allowPattern を抽出できる（空回り防止）', () => {
+    expect(
+      auditPatterns.allowPattern,
+      `${AUDIT_WORKFLOW_PATH} に grep -vE パターンが見つからない。陽性対照 workflow の audit pipeline が欠落している可能性がある`
+    ).not.toBeNull();
+  });
+
+  it('両 workflow の detectPattern が完全一致する（drift 検知）', () => {
+    // どちらかが null の場合は上記 it で既に fail しているが、安全のため両方確認
+    expect(auditPatterns.detectPattern).toBe(baselinePatterns.detectPattern);
+  });
+
+  it('両 workflow の allowPattern が完全一致する（drift 検知）', () => {
+    expect(auditPatterns.allowPattern).toBe(baselinePatterns.allowPattern);
+  });
+});
+
+describe('[陽性対照] extractAuditGrepPatterns — パターン変異を検知できること', () => {
+  it('detectPattern が変異した文字列を比較すると不一致を検知する', () => {
+    // FAKE: 検出パターンを意図的に変異させた YAML 断片
+    const mutatedYaml = `
+      SUSPECT=$(env | grep -iE '^MUTATED_PATTERN_THAT_WONT_MATCH=' | grep -vE '^(GITHUB_TOKEN=|RUNNER_|GITHUB_RUN_|ACTIONS_|GH_|PIP_|PYPI_)' || true)
+    `;
+
+    const originalYaml = readFileSync(BASELINE_WORKFLOW_PATH, 'utf-8');
+    const originalPatterns = extractAuditGrepPatterns(originalYaml);
+    const mutatedPatterns = extractAuditGrepPatterns(mutatedYaml);
+
+    // 変異させたパターンはオリジナルと一致しないことを assert
+    // この test が fail するなら extractAuditGrepPatterns が正しく動作していない
+    expect(mutatedPatterns.detectPattern).not.toBeNull();
+    expect(mutatedPatterns.detectPattern).not.toBe(originalPatterns.detectPattern);
+  });
+
+  it('allowPattern が変異した文字列を比較すると不一致を検知する', () => {
+    const mutatedYaml = `
+      SUSPECT=$(env | grep -iE '^[A-Z][A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)=' | grep -vE '^(MUTATED_ALLOW_LIST=)' || true)
+    `;
+
+    const originalYaml = readFileSync(BASELINE_WORKFLOW_PATH, 'utf-8');
+    const originalPatterns = extractAuditGrepPatterns(originalYaml);
+    const mutatedPatterns = extractAuditGrepPatterns(mutatedYaml);
+
+    expect(mutatedPatterns.allowPattern).not.toBeNull();
+    expect(mutatedPatterns.allowPattern).not.toBe(originalPatterns.allowPattern);
+  });
+});

--- a/tests/meta/vrt-comment-build-script.test.ts
+++ b/tests/meta/vrt-comment-build-script.test.ts
@@ -1,22 +1,59 @@
 import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 // VRT PR comment build step の陽性対照スクリプトの健全性検証
 // issue #324 参照: visual-regression.yml の失敗 spec 抽出 pipeline は
 // VRT 失敗時のみ通る経路で CI 実証手段がないため、スクリプトで再現して検証する。
+//
+// さらにスクリプトは workflow の pipeline（grep + awk）を inline 複製しているため、
+// 複製元 workflow との drift を検知する meta テストを併設する（PR #616 review 指摘）。
+// workflow 側の抽出ロジックだけが修正されると、スクリプトは旧 pipeline を検証し続けて
+// green のまま — 「検知機構が壊れても green」クラスの残存を防ぐ。
 
-const script = 'scripts/test-vrt-comment-build.sh';
+const SCRIPT_PATH = 'scripts/test-vrt-comment-build.sh';
+const WORKFLOW_PATH = '.github/workflows/visual-regression.yml';
+
+/**
+ * テキストから失敗 spec 抽出 pipeline の構成要素を全出現抽出する。
+ * 抽出対象:
+ *   - grep -E の引数（✘ 行の検出パターン）
+ *   - grep -v の引数（retry 行の除外パターン）
+ *   - awk -F'›' の program body（spec 名 / viewport の抽出ロジック）
+ *
+ * awk body は表記揺れを吸収するため正規化する:
+ *   - heredoc エスケープ `\$` → `$`（スクリプト側は bash heredoc 内で `$` をエスケープしている）
+ *   - 連続空白 / 改行 → 単一スペース（インデント差を無視）
+ *
+ * 0 件マッチなら空配列を返す（呼び出し側で長さを assert して空回りを防止する）。
+ */
+export function extractPipelineParts(text: string): {
+  detectGreps: string[];
+  retryGreps: string[];
+  awkBodies: string[];
+} {
+  const detectGreps = [...text.matchAll(/grep -E '([^']+)'/g)].map((m) => m[1]);
+  const retryGreps = [...text.matchAll(/grep -v '([^']+)'/g)].map((m) => m[1]);
+  const awkBodies = [...text.matchAll(/awk -F'›' '(\{[\s\S]*?\})'/g)].map((m) =>
+    normalizeAwkBody(m[1])
+  );
+  return { detectGreps, retryGreps, awkBodies };
+}
+
+function normalizeAwkBody(body: string): string {
+  return body.replace(/\\\$/g, '$').replace(/\s+/g, ' ').trim();
+}
 
 describe('scripts/test-vrt-comment-build.sh', () => {
   it('スクリプトが bash で解釈できる構文を持つ', () => {
     // bash -n で構文チェックのみ実行（副作用なし）
-    expect(() => execFileSync('bash', ['-n', script], { cwd: process.cwd() })).not.toThrow();
+    expect(() => execFileSync('bash', ['-n', SCRIPT_PATH], { cwd: process.cwd() })).not.toThrow();
   });
 
   it('3 ケース（陰性 A・陰性 B・陽性 C）が全て pass する', () => {
     // スクリプト本体実行。exit 0 = 全ケース green。
     // タイムアウトは 30 秒（bash サブプロセスが複数起動するため余裕を持たせる）。
-    const result = spawnSync('bash', [script], {
+    const result = spawnSync('bash', [SCRIPT_PATH], {
       cwd: process.cwd(),
       encoding: 'utf8',
       timeout: 30000,
@@ -29,5 +66,87 @@ describe('scripts/test-vrt-comment-build.sh', () => {
     }
 
     expect(result.status, 'スクリプトが非 0 で終了した').toBe(0);
+  });
+});
+
+describe('スクリプトと visual-regression.yml の pipeline drift 検知', () => {
+  const scriptText = readFileSync(SCRIPT_PATH, 'utf-8');
+  const workflowText = readFileSync(WORKFLOW_PATH, 'utf-8');
+
+  const scriptParts = extractPipelineParts(scriptText);
+  const workflowParts = extractPipelineParts(workflowText);
+
+  it('workflow から pipeline 構成要素を抽出できる（空回り防止）', () => {
+    expect(
+      workflowParts.detectGreps.length,
+      `${WORKFLOW_PATH} に grep -E パターンが見つからない。comment build step の構造が変わった可能性がある`
+    ).toBeGreaterThan(0);
+    expect(workflowParts.retryGreps.length).toBeGreaterThan(0);
+    expect(workflowParts.awkBodies.length).toBeGreaterThan(0);
+  });
+
+  it('スクリプトから pipeline 構成要素を抽出できる（空回り防止）', () => {
+    // スクリプトはケース A / B / C で pipeline を 3 回複製している
+    expect(
+      scriptParts.detectGreps.length,
+      `${SCRIPT_PATH} に grep -E パターンが見つからない。再現 pipeline が欠落している可能性がある`
+    ).toBeGreaterThan(0);
+    expect(scriptParts.retryGreps.length).toBeGreaterThan(0);
+    expect(scriptParts.awkBodies.length).toBeGreaterThan(0);
+  });
+
+  it('全出現の grep 検出パターンが workflow と一致する（drift 検知）', () => {
+    const reference = workflowParts.detectGreps[0];
+    for (const p of [...workflowParts.detectGreps, ...scriptParts.detectGreps]) {
+      expect(p, '✘ 行検出の grep -E パターンが workflow とスクリプト間で drift している').toBe(
+        reference
+      );
+    }
+  });
+
+  it('全出現の grep retry 除外パターンが workflow と一致する（drift 検知）', () => {
+    const reference = workflowParts.retryGreps[0];
+    for (const p of [...workflowParts.retryGreps, ...scriptParts.retryGreps]) {
+      expect(p, 'retry 除外の grep -v パターンが workflow とスクリプト間で drift している').toBe(
+        reference
+      );
+    }
+  });
+
+  it('全出現の awk body が workflow と一致する（drift 検知 / 正規化後比較）', () => {
+    const reference = workflowParts.awkBodies[0];
+    for (const b of [...workflowParts.awkBodies, ...scriptParts.awkBodies]) {
+      expect(b, 'awk 抽出ロジックが workflow とスクリプト間で drift している').toBe(reference);
+    }
+  });
+});
+
+describe('[陽性対照] extractPipelineParts — pipeline 変異を検知できること', () => {
+  it('awk body が変異した断片を比較すると不一致を検知する', () => {
+    // FAKE: spec 抽出の awk body を意図的に変異させた断片
+    const mutatedFragment = `
+      | awk -F'›' '{ print "MUTATED" }' \\
+    `;
+
+    const workflowText = readFileSync(WORKFLOW_PATH, 'utf-8');
+    const original = extractPipelineParts(workflowText);
+    const mutated = extractPipelineParts(mutatedFragment);
+
+    // この test が fail するなら extractPipelineParts が正しく動作していない
+    expect(mutated.awkBodies).toHaveLength(1);
+    expect(mutated.awkBodies[0]).not.toBe(original.awkBodies[0]);
+  });
+
+  it('grep 検出パターンが変異した断片を比較すると不一致を検知する', () => {
+    const mutatedFragment = `
+      ( grep -E '^MUTATED_PATTERN' "\$LOG_FILE" | grep -v '(retry' ) || true
+    `;
+
+    const workflowText = readFileSync(WORKFLOW_PATH, 'utf-8');
+    const original = extractPipelineParts(workflowText);
+    const mutated = extractPipelineParts(mutatedFragment);
+
+    expect(mutated.detectGreps).toHaveLength(1);
+    expect(mutated.detectGreps[0]).not.toBe(original.detectGreps[0]);
   });
 });

--- a/tests/meta/vrt-comment-build-script.test.ts
+++ b/tests/meta/vrt-comment-build-script.test.ts
@@ -1,0 +1,33 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+// VRT PR comment build step の陽性対照スクリプトの健全性検証
+// issue #324 参照: visual-regression.yml の失敗 spec 抽出 pipeline は
+// VRT 失敗時のみ通る経路で CI 実証手段がないため、スクリプトで再現して検証する。
+
+const script = 'scripts/test-vrt-comment-build.sh';
+
+describe('scripts/test-vrt-comment-build.sh', () => {
+  it('スクリプトが bash で解釈できる構文を持つ', () => {
+    // bash -n で構文チェックのみ実行（副作用なし）
+    expect(() => execFileSync('bash', ['-n', script], { cwd: process.cwd() })).not.toThrow();
+  });
+
+  it('3 ケース（陰性 A・陰性 B・陽性 C）が全て pass する', () => {
+    // スクリプト本体実行。exit 0 = 全ケース green。
+    // タイムアウトは 30 秒（bash サブプロセスが複数起動するため余裕を持たせる）。
+    const result = spawnSync('bash', [script], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+
+    // 失敗時に stdout/stderr を表示してデバッグしやすくする
+    if (result.status !== 0) {
+      console.error('stdout:', result.stdout);
+      console.error('stderr:', result.stderr);
+    }
+
+    expect(result.status, 'スクリプトが非 0 で終了した').toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要

issue #533「D. テスト陽性対照（test-gates）」の 3 件をまとめて対応する。いずれも「検知機構が壊れても green が続く」陰性対照のみの設計を、陽性対照（意図的に違反を起こして捕捉できることの証明）併設へ強化するもの。

Closes #316
Closes #324
Closes #334

refs #533（D テーマ 3 件）

## 変更内容

### #316: meta-csp integrity テストの dist 直読化（コミット 1）

- `src/utils/__tests__/meta-csp.test.ts` の inline style hash 整合性テストを、定数 hardcode の 2 段構造から **dist HTML の全 `<style>` 中身を抽出して sha256 を計算し、全 hash が `public/_headers` の style-src に含まれることを直接 assert する 1 段構造**へ書き換え
- 「dist に inline style が 1 件以上存在する」assert を併設し、抽出 regex 0 件マッチによる偽 green（空回り）を防止
- 空 `<style></style>` が将来出現した場合も空文字 hash が `_headers` に無いため自動 fail（issue 記載の観察事項を能動検知）
- dist 実態調査: 現状の distinct inline style は Astro island runtime の 1 種類のみで、hash は `_headers` と一致することを確認済み

### #324: VRT PR comment build step の陽性対照スクリプト（コミット 2）

- `scripts/test-vrt-comment-build.sh` 新設。`visual-regression.yml` の失敗 spec 抽出 pipeline（VRT 失敗時のみ通り CI 実証手段がない経路）を bash で再現
  - ケース A（陰性対照）: 空 log で sentinel 行まで到達（`( ... ) || true` 修正の検証）
  - ケース B（陰性対照）: ✘ + retry 行 fixture で awk 抽出ロジックを検証
  - ケース C（**陽性対照**）: `|| true` を外した旧実装が空 log で中断することを assert（regression クラスの検知能力証明）
- `tests/meta/vrt-comment-build-script.test.ts` で `bash -n` + 本体実行を `npm run test` に組み込み（CI 自動実行）
- `scripts/README.md` にエントリ追記

### #334: baseline secret env audit の陽性対照 workflow（コミット 3 + 4）

- issue 推奨の**案 1** を採用: `.github/workflows/test-baseline-audit.yml` 新設（`workflow_dispatch` + 週次 cron、`permissions: contents: read`）
  - Step 1（陽性対照）: `FAKE_API_KEY=sentinel-value-not-a-real-secret` を job env に注入し、audit pipeline が検知しなければ exit 1
  - Step 2（陰性対照）: `unset FAKE_API_KEY` 後に同 pipeline を実行し、runtime env が allow list で除外され false positive がないことを assert
- inline 複製した grep パターンの drift は `tests/meta/baseline-audit-positive-control.test.ts` が**全出現の完全一致**で検知（`npm run test` で自動実行）。抽出ヘルパ自体の陽性対照（変異 YAML で不一致検知）も同梱
- `docs/playbooks/e2e-validation.md` 7.6 に audit step 修正時の確認手順を追記
- `docs/decisions.md` [100] に決定記録（案 2/3 却下理由・inline 複製許容の判断・CI 追加の安全性）

## レビュー指摘と修正（コミット 4）

Sonnet サブエージェント実装を親レビューし、2 件を修正:

1. **陰性対照 step の設計バグ**: 当初実装は step env `FAKE_API_KEY: ''` で「env 不在」を再現しようとしていたが、GH Actions は空文字でも env var を set するため `env` 出力に `FAKE_API_KEY=` が残り detect パターン（`...KEY=` 接尾辞マッチ）に必ずマッチ → **陰性対照が常時 fail** する。bash で実機再現して確認し、`unset FAKE_API_KEY` 方式に修正
2. **drift 検知の抽出漏れ**: meta テストが grep パターンの先頭 1 出現しか見ておらず、`test-baseline-audit.yml` 内 2 箇所目（Step 2）の drift を見逃す穴があった。`matchAll` による全出現抽出 + 相互一致 assert に強化

## test-gates チェックリスト（陽性対照の実機確認）

- [x] #316: `public/_headers` の hash を 1 文字変異 → テスト fail を確認 → 復元
- [x] #324: ケース C で `|| true` なし旧実装が exit non-zero で中断し sentinel 行に到達しないことを実行確認
- [x] #334: `test-baseline-audit.yml` の **2 箇所目**の grep パターンを変異 → meta テスト fail（1 failed / 5 passed）を確認 → 復元。audit pipeline 自体も bash で sentinel あり=検知 / unset=非検知を実機確認

## 検証

- [x] `npm run format:check` pass
- [x] `npx astro check` 0 errors / 0 warnings / 0 hints
- [x] `npm run build` pass（27 pages）
- [x] `npm test` 1984 passed / 1 failed — fail は `codex-git-add-files.test.ts` のみで、remote 実行環境の git commit 署名サーバー都合（signing server 400）による環境起因。本変更とは無関係（変更前から同様に fail）
- [x] `npm run test:e2e` 293 passed / 1 skipped（既知 skip）

## CI 設定追加の安全性

- 新 workflow は `permissions: contents: read` のみ、sentinel は実 secret ではないダミー値
- 既存 workflow（`update-visual-baseline.yml` / `visual-regression.yml`）は無変更

https://claude.ai/code/session_0117GbddNgkv6E4bLWeoVpCi

---
_Generated by [Claude Code](https://claude.ai/code/session_0117GbddNgkv6E4bLWeoVpCi)_