### PR TITLE
refactor: リンク用クラス .text-link-color を .text-link-plain に改名 (#119)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3888,3 +3888,37 @@ Claude Code on the web で Playwright スクリーンショット / E2E を使�
 
 - ✅ web セッションで Playwright スクリーンショット撮影・E2E 実行が再現可能に。
 - ⚠️ 環境側のセットアップスクリプト（`npx -y playwright install chromium`）は不要になるため削除してよい。
+
+---
+
+## [102] リンク用ユーティリティクラスを semantic 命名に統一（.text-link-color → .text-link-plain）（2026-06-10）
+
+### 課題
+
+PR #116 で新設した `.text-link-color` クラスは「色のみを制御する」という **属性ベース命名** であり、クラス名を見ただけでは「下線なし」という利用意図が読み取りにくかった。また、既存の `.text-link`（下線あり汎用リンク）との命名上の対比が不明確だった。
+
+### 決断
+
+`.text-link-color` を **`.text-link-plain`** に改名する。
+
+- `.text-link`（下線あり）と `.text-link-plain`（下線なし）で **用途ベースの一貫したペア** が成立する。
+- BEM modifier 形式（例: `.text-link--no-underline`）ではなく独立クラス名にした理由: 実態として `.text-link` と `.text-link-plain` は**併用されず単独で使われている**。modifier 表記は「base クラスとの併用」を示唆するため、用途を誤解させる可能性がある。
+
+### 変更対象
+
+- `src/styles/global.css`（セレクタ 3 件 + コメント）
+- `src/components/ui/InputField.tsx`
+- `src/components/ui/ToolCard.astro`
+- `src/components/tools/JsonFormatter.tsx`（2 件）
+- `src/components/tools/JsonTreeResult.tsx`
+- `src/components/tools/ConfigConverter.tsx`
+- `src/components/tools/TotpHotpGenerator.tsx`（3 件）
+- `src/components/tools/Gs1Databar.tsx`
+- `src/components/tools/qr-ticket/GenerateTab.tsx`
+- `tests/e2e/link-styles.spec.ts`
+
+### 結果・トレードオフ
+
+- ✅ 命名規則が用途ベースで一貫し、新規実装者が `.text-link` / `.text-link-plain` のどちらを使うべきか直感的に判断できる。
+- ✅ 挙動・見た目は不変（純粋な rename）。
+- ℹ️ `docs/superpowers/plans/` / `docs/superpowers/specs/` 配下の point-in-time 履歴記録は変更対象外（旧名が残るが意図的）。

--- a/docs/projects/issue-176-b-plan-progress.md
+++ b/docs/projects/issue-176-b-plan-progress.md
@@ -205,7 +205,7 @@ PR 5 を **PR 5a / PR 5b** に分割する根拠と各 PR のスコープ。新�
 | [#281](https://github.com/fumtas1k/devtools/issues/281) | `withProductionCsp` 自体の挙動を検証する meta-test 追加                                    | **PR 5 着手前に再確認**                         | PR #278 由来 (review 提案 #4)。`fn` throw 時の `context.close` 確実呼出 / `assertNoViolations` 自動呼出 を assert。PR 5 完了後 or #280 着手時に併設候補 |
 | [#284](https://github.com/fumtas1k/devtools/issues/284) | ラベル最小幅 `min-w-10` の集約検討 (`.label-prefix` 専用 class 化)                         | **PR 5b / PR 6 で類似 pattern 確認**            | PR 5a (#283) self-review NIT #1。出なければ close、blocking なし                                                                                        |
 | [#285](https://github.com/fumtas1k/devtools/issues/285) | カメラボタン等の utility 列挙を `.btn-action--*-fill` variant に集約検討                   | **PR 5b / PR 6 で類似 pattern 確認**            | PR 5a (#283) self-review NIT #2。`bg-error-tint` 派 danger fill の新 variant 必要、出なければ close                                                     |
-| [#119](https://github.com/fumtas1k/devtools/issues/119) | .text-link-color 命名規則統一                                                              | 独立 (低優先)                                   | PR 1.5 で消費パターン定着、改名は all-files rename になる時期まで保留                                                                                   |
+| [#119](https://github.com/fumtas1k/devtools/issues/119) | .text-link-color → .text-link-plain 改名完了                                               | ✅ 完了                                         | 2026-06-10 に全ファイル rename 実施。decisions.md [102] に記録。docs/superpowers/ 履歴記録は意図的に変更対象外                                          |
 
 ## B 案接近系 issue（独立判断）
 

--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -215,7 +215,7 @@ export function ConfigConverterTool() {
           onClick={() => setSchemaOpen((o) => !o)}
           aria-expanded={schemaOpen}
           aria-controls="config-converter-schema-panel"
-          className="flex items-center gap-1 caption text-link-color btn-link-plain"
+          className="flex items-center gap-1 caption text-link-plain btn-link-plain"
         >
           <span
             aria-hidden="true"

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -289,7 +289,7 @@ function BarcodeCard({ cardId, index, canRemove, onRemove, onSvgChange }: Barcod
               <button
                 type="button"
                 onClick={addAiField}
-                className="caption text-link-color hover:underline"
+                className="caption text-link-plain hover:underline"
               >
                 + フィールド追加
               </button>

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -256,14 +256,14 @@ export function JsonFormatter() {
           <div className="flex items-center gap-2">
             <button
               type="button"
-              className="caption text-link-color btn-link-plain"
+              className="caption text-link-plain btn-link-plain"
               onClick={expandAll}
             >
               全展開
             </button>
             <button
               type="button"
-              className="caption text-link-color btn-link-plain"
+              className="caption text-link-plain btn-link-plain"
               onClick={collapseAll}
             >
               全折りたたみ

--- a/src/components/tools/JsonTreeResult.tsx
+++ b/src/components/tools/JsonTreeResult.tsx
@@ -52,7 +52,7 @@ export function JsonTreeResult({
             </p>
             <button
               type="button"
-              className="caption text-link-color btn-link-plain"
+              className="caption text-link-plain btn-link-plain"
               onClick={onForceRender}
             >
               ツリーを表示

--- a/src/components/tools/TotpHotpGenerator.tsx
+++ b/src/components/tools/TotpHotpGenerator.tsx
@@ -293,7 +293,7 @@ export function TotpHotpGeneratorTool() {
                 <button
                   type="button"
                   onClick={handleRegenerateSecret}
-                  className="caption text-link-color btn-link-plain"
+                  className="caption text-link-plain btn-link-plain"
                   aria-label="ランダム生成（新しいシークレット）"
                 >
                   ランダム生成
@@ -301,7 +301,7 @@ export function TotpHotpGeneratorTool() {
                 <button
                   type="button"
                   onClick={() => setShowSecret((v) => !v)}
-                  className="caption text-link-color btn-link-plain"
+                  className="caption text-link-plain btn-link-plain"
                   aria-label={showSecret ? 'シークレットを隠す' : 'シークレットを表示する'}
                 >
                   {showSecret ? '隠す' : '表示'}
@@ -536,7 +536,7 @@ export function TotpHotpGeneratorTool() {
           {otpauthUri && (
             <p className="caption text-muted">
               このURIをコピーして{' '}
-              <a href="/tools/qr-code" className="text-link-color hover:underline">
+              <a href="/tools/qr-code" className="text-link-plain hover:underline">
                 QRコード生成ツール
               </a>{' '}
               に貼り付けると、Google Authenticator 等で読み取れます。

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -117,7 +117,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
               onClick={onToggleImport}
               aria-expanded={showImport}
               aria-controls="qr-ticket-import-panel"
-              className="caption text-link-color btn-link-plain inline-flex items-center gap-1"
+              className="caption text-link-plain btn-link-plain inline-flex items-center gap-1"
             >
               <ChevronIcon open={showImport} />
               {showImport ? '秘密鍵インポートを閉じる' : '既存の秘密鍵をインポート'}

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -63,7 +63,7 @@ export function InputField({
           <button
             type="button"
             onClick={onSampleClick}
-            className="caption text-link-color btn-link-plain"
+            className="caption text-link-plain btn-link-plain"
           >
             サンプルを入力
           </button>

--- a/src/components/ui/ToolCard.astro
+++ b/src/components/ui/ToolCard.astro
@@ -25,7 +25,7 @@ const searchText = buildSearchText(tool, categoryLabel);
     {tool.name}
   </h2>
   <p class="mb-4 caption text-muted">{tool.description}</p>
-  <span class="text-link-color caption">開く &rsaquo;</span>
+  <span class="text-link-plain caption">開く &rsaquo;</span>
 </a>
 
 <style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -160,17 +160,17 @@
   color: var(--color-text);
 }
 
-/* リンクの色のみを制御するクラス（下線なし） */
-.text-link-color {
+/* 下線なしのプレーンリンク色クラス */
+.text-link-plain {
   color: var(--color-link);
   transition: color 0.2s;
 }
 
-.text-link-color:hover {
+.text-link-plain:hover {
   color: var(--color-primary);
 }
 
-.text-link-color:visited {
+.text-link-plain:visited {
   color: var(--color-link-visited);
 }
 

--- a/tests/e2e/link-styles.spec.ts
+++ b/tests/e2e/link-styles.spec.ts
@@ -80,7 +80,7 @@ test.describe('Link Styles（production CSP 適用）', () => {
         // 最初のツールカードを取得
         const card = page.getByRole('main').getByRole('link').first();
         const title = card.getByRole('heading', { level: 2 });
-        const link = card.locator('.text-link-color');
+        const link = card.locator('.text-link-plain');
 
         await expect(card).toBeVisible();
 
@@ -143,8 +143,8 @@ test.describe('Link Styles（production CSP 適用）', () => {
         // .text-link の :visited 定義確認
         expectVisitedColor(await getVisitedColor('text-link'));
 
-        // .text-link-color の :visited 定義確認
-        expectVisitedColor(await getVisitedColor('text-link-color'));
+        // .text-link-plain の :visited 定義確認
+        expectVisitedColor(await getVisitedColor('text-link-plain'));
       },
       { skipHydration: true }
     );


### PR DESCRIPTION
## 背景

PR #116 で新設した `.text-link-color` クラスは「色のみを制御する」という**属性ベース命名**であり、クラス名から「下線なし」という利用意図が読み取りにくかった。また既存の `.text-link`（下線あり）との命名対比も不明確だった（issue #119）。

## 変更内容

`.text-link-color` を `.text-link-plain` に全ファイルで rename。

| ファイル | 変更箇所 |
|---|---|
| `src/styles/global.css` | セレクタ 3 件 + コメント更新 |
| `src/components/ui/InputField.tsx` | 1 件 |
| `src/components/ui/ToolCard.astro` | 1 件 |
| `src/components/tools/JsonFormatter.tsx` | 2 件 |
| `src/components/tools/JsonTreeResult.tsx` | 1 件 |
| `src/components/tools/ConfigConverter.tsx` | 1 件 |
| `src/components/tools/TotpHotpGenerator.tsx` | 3 件 |
| `src/components/tools/Gs1Databar.tsx` | 1 件 |
| `src/components/tools/qr-ticket/GenerateTab.tsx` | 1 件 |
| `tests/e2e/link-styles.spec.ts` | locator・コメント・`getVisitedColor` 引数 |
| `docs/decisions.md` | [102] に改名の背景・決断・結果を記録 |
| `docs/projects/issue-176-b-plan-progress.md` | #119 の保留 note を完了に更新 |

**挙動・見た目は不変（純粋な rename）。**

rename 後は `.text-link`（下線あり）と `.text-link-plain`（下線なし）の用途ベースペアが成立する。BEM modifier ではなく独立クラスにした理由は実態として両クラスが併用されず単独使用されているため。

## 検証結果

```
# 1. astro check（型）
Result (335 files): 0 errors, 0 warnings, 0 hints

# 2. npm run test（ユニット）
Test Files  1 failed | 110 passed (111)  ← vrt-comment-build-script の既存 sandbox 失敗（develop 上でも同じ 1 失敗で今回の変更と無関係）
Tests  1 failed | 1991 passed | 1 skipped (1993)

# 3. npm run build + CSS grep
text-link-plain: BaseLayout.*.css に 1 件出力 ✅
text-link-color: dist/_astro/*.css に 0 件 ✅

# 4. E2E link-styles
5 passed (18.6s) ✅
```

## grep 残存確認

```
grep -rn "text-link-color" src tests  → 0 件 ✅
```

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
