### PR TITLE
test(e2e): withProductionCsp ラッパ固有挙動の陽性対照メタテストを追加

### DIFF
--- a/scripts/test-vrt-comment-build.sh
+++ b/scripts/test-vrt-comment-build.sh
@@ -24,8 +24,10 @@
 # 複製元 workflow step（set -euo pipefail）と同一オプションに揃え、未定義変数も早期検知する
 set -euo pipefail
 
-# 一時ディレクトリを作成し、終了時に掃除する
-TMPDIR_WORK=$(mktemp -d)
+# 一時ディレクトリを作成し、終了時に掃除する。
+# macOS の mktemp はテンプレート省略時に TMPDIR を無視して /var/folders を使うため、
+# sandbox 環境 (TMPDIR のみ書込可) でも動くようテンプレートで TMPDIR を明示する。
+TMPDIR_WORK=$(mktemp -d "${TMPDIR:-/tmp}/vrt-comment-build.XXXXXXXX")
 trap 'rm -rf "$TMPDIR_WORK"' EXIT
 
 PASS=0

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -213,6 +213,11 @@ export async function applyProductionCsp(page: Page, options?: ApplyCspOptions):
  * `finally` で `context.close()` のみ実行される。元の例外が伝播しテストが
  * 失敗する (inline pattern と等価)。
  *
+ * **ラッパ固有挙動の陽性対照**: `tests/e2e/with-production-csp.gate.spec.ts`
+ * (issue #281) が「throw 時の context.close」「終端 assertNoViolations の集約」
+ * 「元例外の伝播 (隠蔽されない)」を検証する。本ラッパの制御フローを変更したら
+ * 必ず同 spec を実行すること。
+ *
  * **`skipHydration` オプション**: 静的ページ (`/privacy` / `/about` / `/` 等の
  * React island を含まないページ) では `waitForReactHydration` が
  * `__react*` キーを持つ要素を見つけられず timeout する。これらのページに対しては

--- a/tests/e2e/with-production-csp.gate.spec.ts
+++ b/tests/e2e/with-production-csp.gate.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from '@playwright/test';
+import { withProductionCsp } from './helpers';
+
+/**
+ * 陽性対照: `withProductionCsp` ラッパ固有挙動を検証するメタテスト (issue #281)。
+ *
+ * `applyProductionCsp` 単体の検知能力は `tests/e2e/uuid-v7.spec.ts` /
+ * `tests/e2e/config-converter.spec.ts` の inline pattern メタテストが担保するが、
+ * ラッパが追加する以下の挙動はどの利用テストも明示的に検証していなかった:
+ *
+ * 1. `fn` が throw しても `context.close()` が確実に呼ばれる (`finally` の検証)
+ * 2. `fn` 正常終了後に `guard.assertNoViolations()` が呼ばれ、違反が test failure
+ *    に昇格する (集約の本丸)
+ * 3. `fn` の throw が `assertNoViolations` の失敗に隠蔽されず元例外が伝播する
+ *
+ * いずれも「ラッパの該当行を壊すとこの spec が fail に昇格する」設計
+ * (test-gates skill の陽性対照要件)。陰性対照は withProductionCsp を利用する
+ * 通常テスト群 (`uuid-v7.spec.ts` 等) が兼ねる。
+ */
+
+/** fn 内で意図的に CSP 違反 (外部 origin script 注入) を発生させ、guard に記録されるまで待つ */
+async function injectCspViolation(page: Page, guard: { violations: readonly string[] }) {
+  await page.evaluate(() => {
+    const script = document.createElement('script');
+    script.src = 'https://example.com/violates-csp.js';
+    document.head.appendChild(script);
+  });
+  // console error の到達は非同期のため、fn を抜ける前に記録を確実化して
+  // 「終端 assertNoViolations より違反到達が遅れて素通り」する race を排除する
+  await expect.poll(() => guard.violations.length, { timeout: 5000 }).toBeGreaterThan(0);
+}
+
+test('withProductionCsp: fn が throw しても context.close が呼ばれる', async ({ browser }) => {
+  let capturedPage: Page | undefined;
+  await expect(
+    withProductionCsp(browser, '/tools/uuid-v7', async (page) => {
+      capturedPage = page;
+      throw new Error('intentional-throw');
+    })
+  ).rejects.toThrow('intentional-throw');
+  // context.close() 済みなら配下の page も closed になる (観測可能な振る舞い)
+  expect(capturedPage).toBeDefined();
+  expect(capturedPage!.isClosed()).toBe(true);
+});
+
+test('withProductionCsp: fn 内の CSP 違反は終端 assertNoViolations で fail に昇格する (陽性対照)', async ({
+  browser,
+}) => {
+  await expect(
+    withProductionCsp(browser, '/tools/uuid-v7', async (page, guard) => {
+      // fn 内では assertNoViolations を呼ばず、ラッパの終端呼び出しに任せる
+      await injectCspViolation(page, guard);
+    })
+  ).rejects.toThrow(/CSP 違反/);
+});
+
+test('withProductionCsp: fn の throw は assertNoViolations の失敗に隠蔽されず元例外が伝播する', async ({
+  browser,
+}) => {
+  await expect(
+    withProductionCsp(browser, '/tools/uuid-v7', async (page, guard) => {
+      // 違反を発生させた上で throw する: 仮にラッパが throw 後も
+      // assertNoViolations を呼ぶ実装 (finally 内呼び出し等) に変わると
+      // /CSP 違反/ が伝播してこの assert が fail する
+      await injectCspViolation(page, guard);
+      throw new Error('intentional-original');
+    })
+  ).rejects.toThrow('intentional-original');
+});

--- a/tests/e2e/with-production-csp.gate.spec.ts
+++ b/tests/e2e/with-production-csp.gate.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { withProductionCsp } from './helpers';
+import { withProductionCsp, type CspGuard } from './helpers';
 
 /**
  * 陽性対照: `withProductionCsp` ラッパ固有挙動を検証するメタテスト (issue #281)。
@@ -19,7 +19,7 @@ import { withProductionCsp } from './helpers';
  */
 
 /** fn 内で意図的に CSP 違反 (外部 origin script 注入) を発生させ、guard に記録されるまで待つ */
-async function injectCspViolation(page: Page, guard: { violations: readonly string[] }) {
+async function injectCspViolation(page: Page, guard: CspGuard) {
   await page.evaluate(() => {
     const script = document.createElement('script');
     script.src = 'https://example.com/violates-csp.js';


### PR DESCRIPTION
## 概要

issue #281 対応。`tests/e2e/helpers.ts` の `withProductionCsp` ラッパ固有挙動を検証する陽性対照メタテスト `tests/e2e/with-production-csp.gate.spec.ts` を新規追加する。

これまでラッパの正しさは「利用テスト全てが pass」で間接的に担保されているのみで、以下のラッパ固有挙動はどのテストも明示的に検証していなかった。

## 追加テスト (3 件)

| テスト | 検証対象 |
| --- | --- |
| fn が throw しても context.close が呼ばれる | `finally` によるリソースリーク防止 |
| fn 内の CSP 違反が終端 assertNoViolations で fail に昇格する (陽性対照) | 違反集約の本丸 |
| fn の throw が assertNoViolations の失敗に隠蔽されず元例外が伝播する | 例外マスキング防止 |

## test-gates 陽性対照の実証

実装を意図的に破壊して各テストが対応して fail することをローカルで実機確認済み:

- 破壊 1 (`finally` / `assertNoViolations` 除去) → テスト 1・2 が fail、テスト 3 は pass
- 破壊 2 (`assertNoViolations` を fn の `finally` 内へ移動 = throw 隠蔽) → テスト 3 が fail

console error 到達の非同期性による「終端 assert より違反到達が遅れて素通り」race は、fn 内で `expect.poll` により guard への記録を待ってから抜けることで排除した。

## 付随修正

`scripts/test-vrt-comment-build.sh` の `mktemp -d` にテンプレートで TMPDIR を明示。macOS の mktemp はテンプレート省略時に TMPDIR を無視して `/var/folders` (confstr `_CS_DARWIN_USER_TEMP_DIR`) を使うため、sandbox 環境 (TMPDIR のみ書込可) で meta テストが `Operation not permitted` で fail していた (本 issue とは無関係の環境起因・1 行修正のため規約 6.4 に従い同梱)。

## 検証

- ユニット: 111 files / 1992 passed (script 修正前は 1 failed → 全 green)
- 型チェック: `astro check` 0 errors
- E2E 全体: 298 passed / 1 skipped (新規 3 テスト含む)

## 関連

- closes #281
- 起源: PR #278 review 提案 #4
- 既存の `applyProductionCsp` 単体の陽性対照 (`uuid-v7.spec.ts` / `config-converter.spec.ts`) とはレイヤが異なる (本 PR はラッパ固有挙動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
