### PR TITLE
`gh auth status` コマンドが確認プロンプトなしで実行

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -178,6 +178,7 @@
       "Bash(gh run view*)",
       "Bash(gh run watch*)",
       "Bash(gh workflow list*)",
+      "Bash(gh auth status)",
       "Bash(gh workflow view*)",
       "Bash(bash scripts/rm-tmp.sh *)",
       "Bash(node --version)",


### PR DESCRIPTION
## 変更内容
`.claude/settings.json` の `permissions.allow` に `Bash(gh auth status)` を追加。
これにより `gh auth status` コマンドが確認プロンプトなしで実行できるようになる。
