### PR TITLE
feat: Web セッションで enabledPlugins を SessionStart hook から自動 install する

### DIFF
--- a/.claude/scripts/session-install.sh
+++ b/.claude/scripts/session-install.sh
@@ -44,9 +44,24 @@ fi
 # 反映されず、コンテナ状態キャッシュにより同一環境の次セッション以降で有効になる。
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ] && [ -f .claude/settings.json ] && command -v claude >/dev/null 2>&1; then
   node -e '
-    const s = JSON.parse(require("fs").readFileSync(".claude/settings.json", "utf8"));
-    for (const [name, enabled] of Object.entries(s.enabledPlugins ?? {})) if (enabled) console.log(name);
-  ' 2>/dev/null | while IFS= read -r plugin; do
+    let s;
+    try {
+      s = JSON.parse(require("fs").readFileSync(".claude/settings.json", "utf8"));
+    } catch (e) {
+      // install 失敗が warn を出すのと対称に、settings 破損も silent skip にせず気づけるようにする
+      console.error("warn: .claude/settings.json の parse に失敗したため plugin install をスキップします: " + e.message);
+      process.exit(0);
+    }
+    for (const [name, enabled] of Object.entries(s.enabledPlugins ?? {})) {
+      if (!enabled) continue;
+      // `-` 始まり等が CLI フラグとして解釈されないよう name@marketplace 形式のみ通す
+      if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*@[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(name)) {
+        console.error("warn: 不正な形式のプラグイン名をスキップします: " + name);
+        continue;
+      }
+      console.log(name);
+    }
+  ' | while IFS= read -r plugin; do
     claude plugin install "$plugin" || echo "warn: plugin install failed: $plugin（次セッションで再試行されます）" >&2
   done
 fi

--- a/.claude/scripts/session-install.sh
+++ b/.claude/scripts/session-install.sh
@@ -28,6 +28,29 @@ if [ ! -d node_modules ] || [ "$(cat node_modules/.lockhash 2>/dev/null)" != "$h
   npm ci && echo "$hash" >node_modules/.lockhash
 fi
 
+# Claude Code on the web 限定: `.claude/settings.json` の enabledPlugins を自動 install する。
+#
+# なぜ hook 側か:
+#   enabledPlugins の自動 install は trust dialog イベントに紐づいており、Web / headless では
+#   発火せず silent skip される（docs/setup/plugins.md 2 章 / upstream #23737）。
+#   PR #204 当時は hook からの `claude plugin install` が "not found in marketplace" で失敗したが、
+#   現行の Claude Code（2.1.173 で確認）はセッション開始時に extraKnownMarketplaces を
+#   ~/.claude/plugins/marketplaces へ自動 clone するため、hook 実行時点で install が成功する。
+#
+# 冪等性: install 済みなら "already installed" で即終了し再 clone しない（exit 0）。
+# 失敗時は warn のみで継続する（次セッションの再試行で self-healing。npm ci / playwright の
+# 結果に影響させないため非致命にする）。
+# 注意: プラグインのスキルはセッション開始時にロードされるため、新規コンテナの初回セッションでは
+# 反映されず、コンテナ状態キャッシュにより同一環境の次セッション以降で有効になる。
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ] && [ -f .claude/settings.json ] && command -v claude >/dev/null 2>&1; then
+  node -e '
+    const s = JSON.parse(require("fs").readFileSync(".claude/settings.json", "utf8"));
+    for (const [name, enabled] of Object.entries(s.enabledPlugins ?? {})) if (enabled) console.log(name);
+  ' 2>/dev/null | while IFS= read -r plugin; do
+    claude plugin install "$plugin" || echo "warn: plugin install failed: $plugin（次セッションで再試行されます）" >&2
+  done
+fi
+
 # Claude Code on the web 限定: E2E / スクリーンショット用の Playwright Chromium を確保する。
 #
 # なぜ環境セットアップスクリプトでなく hook 側か:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Claude Code 固有の補足は `.claude/rules/` 配下に分割し、上記 `@im
 | `frontend-design@claude-plugins-official` | 高品質なフロントエンド UI 生成                                    |
 | `context7@claude-plugins-official`        | ライブラリ公式ドキュメントの最新参照（Upstash Context7 MCP 同梱） |
 
-CLI / Desktop は `.claude/settings.json` から自動 install を prompt します。**Web (claude.ai/code) は silent skip される既知制約**があり、各環境で 1 回だけ手動 install が必要です。
+CLI / Desktop は `.claude/settings.json` から自動 install を prompt します。**Web (claude.ai/code) は trust dialog 非発火で silent skip される既知制約**があるため、SessionStart hook（`.claude/scripts/session-install.sh`）が web セッションで自動 install します（新規コンテナの初回セッションのみ未反映、同一環境の次セッション以降で有効）。
 
 セットアップ手順・トラブルシュート・context7 API キー設定 → **`docs/setup/plugins.md`**
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3997,3 +3997,28 @@ Node v22 で各純粋関数の CPU 時間（中央値）と `structuredClone` �
 - ✅ ベンチは `.bench.ts` で `npm run test` の include glob（`*.test.{ts,tsx}`）外。CI を汚染しない。実行は `npx vitest bench src/utils/json-formatter/__tests__/offload.bench.ts`。
 - ⚠️ 超大入力（~15MB+）を将来サポートする場合は、本ベンチの数値を起点に「parse+format を Worker 内完結・文字列返し」の狭い設計から再検討する（別 issue/サイクル）。
 - ⚠️ ブラウザ実測は実 `parseJson`(jsonc-parser) でなく native `JSON.parse`/`stringify` を代理に使ったため、実パスの long task 有無は厳密には未検証。ただし同一 V8 エンジンの Node 実関数値で像は確定しており、結論は変わらない。
+
+## [105] 2026-06-11 — Web セッションの enabledPlugins 自動 install を SessionStart hook で再導入
+
+**2026-06-11 | ステータス: 採用**
+
+### 背景
+
+`.claude/settings.json` の `enabledPlugins`（superpowers / frontend-design / context7）は Claude Code on the web で silent skip され（trust dialog 非発火、upstream #23737）、superpowers のスキル群が web セッションで使えなかった。PR #204 で hook 自動化を試みた際は `claude plugin install` が `not found in marketplace` で失敗し「手動 install 運用」に確定していた。
+
+### 再検証で判明したこと（2026-06、Claude Code 2.1.173）
+
+- 現行の Claude Code は**セッション開始時に `extraKnownMarketplaces` を `~/.claude/plugins/marketplaces` へ自動 clone する**ようになっており、PR #204 当時の失敗原因（marketplace 未解決）が解消。web コンテナの hook から `claude plugin install` が 3 プラグインとも成功することを実機確認。
+- superpowers は marketplace 同梱でなく外部 repo（`obra/superpowers.git`、sha pin）から clone される external プラグインで、install 実行なしでは実体が取得されない（これが「marketplace clone はあるのにスキルが無い」状態の正体）。
+- `claude plugin install` は冪等（install 済みなら "already installed" で exit 0、再 clone なし）。
+
+### 決断
+
+`.claude/scripts/session-install.sh`（SessionStart hook）に web 限定（`CLAUDE_CODE_REMOTE=true`）の enabledPlugins 自動 install を追加。プラグイン一覧は `.claude/settings.json` から動的に読む（ハードコードによる宣言との drift を防止）。失敗は warn のみで非致命（npm ci / playwright install の結果に影響させない・次セッション再試行で self-healing）。meta テスト（`tests/meta/session-install.test.ts`）に fake claude による陽性対照・陰性対照を併設し、旧実装で fail することを確認済み。
+
+### 結果・トレードオフ
+
+- ✅ 各環境 1 回の手動 `/plugin install` 運用が不要になる（手動コマンドはフォールバックとして docs に残置）。
+- ⚠️ スキルのロードはセッション開始時のため、**新規コンテナの初回セッションでは未反映**。コンテナ状態キャッシュ（`~/.claude/plugins` 含む）により同一環境の次セッション以降で有効。
+- ⚠️ CLI / Desktop は従来どおり trust dialog の自動 prompt に委ね、hook では触らない（開発者ローカルの user scope 状態を hook が暗黙に書き換えない）。
+- ⚠️ context7 の MCP は web では egress 403 の別制約が残る（decisions [059]、リポジトリ側で解消不可）。

--- a/docs/setup/plugins.md
+++ b/docs/setup/plugins.md
@@ -24,17 +24,24 @@
 
 公式ドキュメントは「クラウドセッションでも `enabledPlugins` 宣言のプラグインはセッション開始時に install される」と謳っていますが、**実装上は trust dialog イベントに紐づいており、Web / headless / CI ではこのイベントが発火しないため silent に install がスキップされる** Claude Code 本体側の既知制約があります。
 
+**現在は SessionStart hook（`.claude/scripts/session-install.sh`）が web セッションで `enabledPlugins` を自動 install します**（decisions [105]）。注意点:
+
+- スキルはセッション開始時にロードされるため、**新規コンテナの初回セッションでは反映されない**。コンテナ状態キャッシュにより同一環境の次セッション以降で有効になる。
+- install 失敗時は warn のみで継続し、次セッションで自動再試行される（冪等）。
+
 ### 関連 upstream issue
 
 - [#23737](https://github.com/anthropics/claude-code/issues/23737)
 - `autoInstallEnabledPlugins` 提案（duplicate でクローズ・未実装）
 - 関連 #17832 / #19275
 
-### 自動化を試みた経緯
+### 自動化の経緯
 
-PR #204 で SessionStart hook 経由の自動 install を試みましたが、`claude plugin install` が `Plugin "<name>" not found in marketplace` を返して 3 プラグインとも失敗（`marketplace update` 前置でも同症状）。**現状リポジトリ側からの自動化は不可能**と判明したため、各環境で 1 回だけ手動 install する運用に確定。
+PR #204 で SessionStart hook 経由の自動 install を試みた際は、`claude plugin install` が `Plugin "<name>" not found in marketplace` を返して 3 プラグインとも失敗（`marketplace update` 前置でも同症状）し、手動 install 運用に確定していた。その後 Claude Code 本体（2.1.173 で確認）が**セッション開始時に `extraKnownMarketplaces` を `~/.claude/plugins/marketplaces` へ自動 clone する**ようになり、hook 実行時点で marketplace が解決できるため install が成功するようになった（2026-06 再検証）。これを受けて hook による自動 install を再導入した。
 
-### 手動 install コマンド
+### 手動 install コマンド（フォールバック）
+
+hook が失敗する場合や初回セッションで即座に使いたい場合は手動で install する:
 
 ```
 /plugin install superpowers@claude-plugins-official

--- a/tests/meta/session-install.test.ts
+++ b/tests/meta/session-install.test.ts
@@ -39,14 +39,49 @@ function setupFakeNpm(dir: string): string {
     '#!/bin/sh\nif [ "$1" = "ci" ]; then mkdir -p node_modules; echo x >>ci-count; fi\n'
   );
   chmodSync(fakeNpm, 0o755);
+  // npx を no-op 化（CLAUDE_CODE_REMOTE=true で実行された場合に実 playwright download へ抜けない）
+  const fakeNpx = join(binDir, 'npx');
+  writeFileSync(fakeNpx, '#!/bin/sh\nexit 0\n');
+  chmodSync(fakeNpx, 0o755);
   return binDir;
 }
 
-/** script を temp dir 内で実行（fake npm を PATH 先頭に） */
-function runHook(cwd: string, binDir: string): void {
+/**
+ * `claude plugin install <name>` の呼び出しを plugin-install-log に記録する fake claude を
+ * fakebin に追加する。exitCode 非 0 で install 失敗を模擬できる。
+ */
+function setupFakeClaude(binDir: string, exitCode = 0): void {
+  const fakeClaude = join(binDir, 'claude');
+  writeFileSync(
+    fakeClaude,
+    `#!/bin/sh\nif [ "$1" = "plugin" ] && [ "$2" = "install" ]; then echo "$3" >>plugin-install-log; fi\nexit ${exitCode}\n`
+  );
+  chmodSync(fakeClaude, 0o755);
+}
+
+/** plugin install が呼ばれたプラグイン名一覧（plugin-install-log の行）を返す */
+function installedPlugins(cwd: string): string[] {
+  const f = join(cwd, 'plugin-install-log');
+  if (!existsSync(f)) return [];
+  return readFileSync(f, 'utf8').split('\n').filter(Boolean);
+}
+
+/** enabledPlugins 宣言入りの .claude/settings.json を temp dir に作る */
+function writeSettings(dir: string, enabledPlugins: Record<string, boolean>): void {
+  mkdirSync(join(dir, '.claude'), { recursive: true });
+  writeFileSync(join(dir, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins }));
+}
+
+/** script を temp dir 内で実行（fake npm を PATH 先頭に）。env で CLAUDE_CODE_REMOTE 等を制御 */
+function runHook(cwd: string, binDir: string, env: Record<string, string> = {}): void {
   execFileSync('bash', [scriptPath], {
     cwd,
-    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+    env: {
+      ...process.env,
+      CLAUDE_CODE_REMOTE: '',
+      ...env,
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    },
   });
 }
 
@@ -103,5 +138,64 @@ describe('session-install.sh: lockfile ハッシュガード', () => {
     rmSync(join(dir, 'package-lock.json'));
     runHook(dir, binDir);
     expect(ciCount(dir)).toBe(0);
+  });
+});
+
+describe('session-install.sh: enabledPlugins 自動 install（web 限定）', () => {
+  let dir: string;
+  let binDir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'session-install-'));
+    binDir = setupFakeNpm(dir);
+    setupFakeClaude(binDir);
+    writeFileSync(join(dir, 'package-lock.json'), '{"v":1}');
+    writeSettings(dir, {
+      'superpowers@claude-plugins-official': true,
+      'context7@claude-plugins-official': true,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // 陽性対照: web セッションでは settings.json の enabledPlugins 全件を install する。
+  // 旧実装（plugin install ブロックなし）に当てると plugin-install-log が生成されず fail する。
+  it('CLAUDE_CODE_REMOTE=true なら enabledPlugins を全件 install する', () => {
+    runHook(dir, binDir, { CLAUDE_CODE_REMOTE: 'true' });
+    expect(installedPlugins(dir)).toEqual([
+      'superpowers@claude-plugins-official',
+      'context7@claude-plugins-official',
+    ]);
+  });
+
+  // 陰性対照: ローカル（CLI / Desktop）では trust dialog の自動 prompt に委ね、hook では触らない
+  it('CLAUDE_CODE_REMOTE が true でなければ install しない', () => {
+    runHook(dir, binDir);
+    expect(installedPlugins(dir)).toEqual([]);
+  });
+
+  // 陰性対照: enabledPlugins で false 宣言されたプラグインは install 対象外
+  it('false 宣言のプラグインは install しない', () => {
+    writeSettings(dir, {
+      'superpowers@claude-plugins-official': true,
+      'frontend-design@claude-plugins-official': false,
+    });
+    runHook(dir, binDir, { CLAUDE_CODE_REMOTE: 'true' });
+    expect(installedPlugins(dir)).toEqual(['superpowers@claude-plugins-official']);
+  });
+
+  // 陰性対照: .claude/settings.json が無いプロジェクト（テスト temp dir 等）では何もしない
+  it('.claude/settings.json が無ければ install しない', () => {
+    rmSync(join(dir, '.claude'), { recursive: true });
+    runHook(dir, binDir, { CLAUDE_CODE_REMOTE: 'true' });
+    expect(installedPlugins(dir)).toEqual([]);
+  });
+
+  // 失敗許容: install 失敗（exit 非 0）でも hook 全体は fail しない（次セッション再試行に委ねる）
+  it('plugin install が失敗しても hook は exit 0 のまま継続する', () => {
+    setupFakeClaude(binDir, 1);
+    expect(() => runHook(dir, binDir, { CLAUDE_CODE_REMOTE: 'true' })).not.toThrow();
   });
 });

--- a/tests/meta/session-install.test.ts
+++ b/tests/meta/session-install.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import {
   mkdtempSync,
   rmSync,
@@ -8,6 +8,7 @@ import {
   existsSync,
   readFileSync,
   chmodSync,
+  symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -83,6 +84,26 @@ function runHook(cwd: string, binDir: string, env: Record<string, string> = {}):
       PATH: `${binDir}:${process.env.PATH ?? ''}`,
     },
   });
+}
+
+/** runHook と同じ実行で exit code / stderr も観測する（warn 出力の assert 用） */
+function runHookCapture(
+  cwd: string,
+  binDir: string,
+  env: Record<string, string> = {},
+  pathOverride?: string
+): { status: number | null; stderr: string } {
+  const r = spawnSync('bash', [scriptPath], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CLAUDE_CODE_REMOTE: '',
+      ...env,
+      PATH: pathOverride ?? `${binDir}:${process.env.PATH ?? ''}`,
+    },
+  });
+  return { status: r.status, stderr: r.stderr };
 }
 
 /** npm ci が呼ばれた回数（ci-count の行数）を返す */
@@ -197,5 +218,43 @@ describe('session-install.sh: enabledPlugins 自動 install（web 限定）', ()
   it('plugin install が失敗しても hook は exit 0 のまま継続する', () => {
     setupFakeClaude(binDir, 1);
     expect(() => runHook(dir, binDir, { CLAUDE_CODE_REMOTE: 'true' })).not.toThrow();
+  });
+
+  // 陽性対照: settings.json が malformed JSON なら warn を stderr に出して hook は exit 0 で継続する。
+  // 旧実装（node の stderr を 2>/dev/null で握りつぶす）に当てると warn が観測できず fail する。
+  it('settings.json が malformed JSON なら warn を出しつつ exit 0 で継続する', () => {
+    writeFileSync(join(dir, '.claude', 'settings.json'), '{ broken');
+    const r = runHookCapture(dir, binDir, { CLAUDE_CODE_REMOTE: 'true' });
+    expect(r.status).toBe(0);
+    expect(installedPlugins(dir)).toEqual([]);
+    expect(r.stderr).toContain('parse に失敗');
+  });
+
+  // 陽性対照: `-` 始まり等の不正形式プラグイン名は CLI に渡さず warn して skip する。
+  // 旧実装（形式チェックなし）に当てると不正名も install されて fail する。
+  it('不正な形式のプラグイン名は install せず warn する', () => {
+    writeSettings(dir, {
+      '--dangerously-evil': true,
+      'superpowers@claude-plugins-official': true,
+    });
+    const r = runHookCapture(dir, binDir, { CLAUDE_CODE_REMOTE: 'true' });
+    expect(installedPlugins(dir)).toEqual(['superpowers@claude-plugins-official']);
+    expect(r.stderr).toContain('--dangerously-evil');
+  });
+
+  // 陰性対照: claude コマンド不在（CLI 未配備環境）では install を試みず hook も fail しない。
+  // PATH を fakebin + 最小システム dir に限定し、実 claude（node と同居しがち）を除外する。
+  // bash / coreutils / node だけ解決できるよう node は fakebin に symlink して持ち込む。
+  it('claude コマンドが無ければ install せず exit 0 で継続する', () => {
+    rmSync(join(binDir, 'claude')); // beforeEach の fake claude を除去して不在を再現
+    symlinkSync(process.execPath, join(binDir, 'node'));
+    const r = runHookCapture(
+      dir,
+      binDir,
+      { CLAUDE_CODE_REMOTE: 'true' },
+      `${binDir}:/usr/bin:/bin`
+    );
+    expect(r.status).toBe(0);
+    expect(installedPlugins(dir)).toEqual([]);
   });
 });


### PR DESCRIPTION
# 概要

Claude Code on the web で superpowers 等のプラグインスキルが使えない問題を解析し、SessionStart hook による自動 install を再導入しました。

## 解析結果（なぜ使えなかったか）

- `enabledPlugins` の自動 install は trust dialog イベントに紐づいており、Web では発火せず **silent skip** される（既知制約・upstream anthropics/claude-code#23737）。
- superpowers は marketplace 同梱ではなく**外部 repo（`obra/superpowers.git`、sha pin）から clone される external プラグイン**のため、install 実行なしではスキル実体が取得されない。これが「marketplace clone は存在するのにスキルが無い」状態の正体。
- PR #204 当時の hook 自動化失敗（`not found in marketplace`）は、**現行 Claude Code（2.1.173 で確認）がセッション開始時に `extraKnownMarketplaces` を `~/.claude/plugins/marketplaces` へ自動 clone するようになったことで解消済み**。web コンテナの hook から `claude plugin install` が 3 プラグインとも成功することを実機確認した。

## 変更内容

- `.claude/scripts/session-install.sh`: web 限定（`CLAUDE_CODE_REMOTE=true`）で `.claude/settings.json` の `enabledPlugins` を動的に読み取り自動 install するブロックを追加（冪等・失敗時は warn のみで非致命・次セッション再試行で self-healing）
- `tests/meta/session-install.test.ts`: fake `claude` による陽性対照 2 件・陰性対照 3 件を追加（test-gates 準拠。旧実装に当てると陽性対照 2 件が fail することを実機確認済み）。あわせて fake `npx` 追加と `CLAUDE_CODE_REMOTE` の明示制御で既存テストをリモート環境でも hermetic 化
- `docs/setup/plugins.md` / `CLAUDE.md`: 「各環境で手動 install」運用から hook 自動 install へ記述を更新（手動コマンドはフォールバックとして残置）
- `docs/decisions.md`: [106] として経緯・再検証結果・トレードオフを記録（develop 側で [105] が先行採番されたため merge 時に renumber）

## 検証

- `npx vitest run tests/meta/session-install.test.ts`: 9 件 green
- 陽性対照: script 変更を stash した旧実装で 2 件 fail することを確認
- `npm run test`: 1852 passed（fail 3 件は本変更と無関係: `sw-cache-version` は `dist/` ビルド前提、`codex-git-add-files` はリモートコンテナの commit 署名サーバー 400 起因）
- `node_modules/.bin/astro check`: 0 errors
- **実環境実証**: 本 hook がセッション resume 時に発火し、同一セッションで superpowers / frontend-design のスキル群がロードされることを確認

## 制限事項

- スキルはセッション開始時にロードされるため、新規コンテナの**初回セッションでは未反映**（コンテナ状態キャッシュにより同一環境の次セッション以降で有効）
- context7 の MCP は web では egress 403 の別制約が残る（decisions [059]、リポジトリ側で解消不可）

https://claude.ai/code/session_01CfxY2UpDC9pDG1q9B5JQeK