### PR TITLE
feat: cert-decoder のアコーディオンを DADS Accordion 準拠に修正

### DIFF
--- a/src/components/tools/CertDecoder.tsx
+++ b/src/components/tools/CertDecoder.tsx
@@ -50,6 +50,38 @@ function certRoleLabel(cert: ParsedCert, chainPosition: number, totalInChain: nu
   return chainPosition === 0 ? '中間 CA' : `中間 CA (${chainPosition})`;
 }
 
+/**
+ * 証明書カード内のアコーディオンセクション（DADS Accordion 準拠）。
+ * 左側に円形ボーダー付き chevron アイコンを置き、開閉時に 180° 回転させる。
+ */
+interface CertSectionProps {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+function CertSection({ title, defaultOpen = false, children }: CertSectionProps) {
+  return (
+    <details open={defaultOpen}>
+      <summary className="px-4 py-3 cursor-pointer hover-bg-subtle summary-no-marker flex items-center gap-2">
+        <span
+          className="cert-chevron shrink-0 inline-flex items-center justify-center size-5 rounded-full border border-current bg-default text-primary"
+          aria-hidden="true"
+        >
+          <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
+            <path
+              d="M16.668 5.5L10.0013 12.1667L3.33464 5.5L2.16797 6.66667L10.0013 14.5L17.8346 6.66667L16.668 5.5Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span className="body-emphasis text-default">{title}</span>
+      </summary>
+      {children}
+    </details>
+  );
+}
+
 function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }: CertCardProps) {
   const positionLabel = certRoleLabel(cert, chainPosition, totalInChain);
 
@@ -93,13 +125,7 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
       {/* カード本体 */}
       <div className="bg-default divide-y divide-subtle">
         {/* 基本情報 */}
-        <details open>
-          <summary className="px-4 py-3 body-emphasis text-default cursor-pointer hover-bg-subtle list-none flex items-center justify-between">
-            <span>基本情報</span>
-            <span className="caption text-muted cert-chevron" aria-hidden="true">
-              ▾
-            </span>
-          </summary>
+        <CertSection title="基本情報" defaultOpen>
           <div className="px-4 pb-4 pt-2 space-y-2">
             <CertField label="サブジェクト (Subject)" value={cert.subject.full} copyable />
             <CertField label="発行者 (Issuer)" value={cert.issuer.full} copyable />
@@ -121,17 +147,11 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
               copyable
             />
           </div>
-        </details>
+        </CertSection>
 
         {/* SAN */}
         {cert.san.length > 0 && (
-          <details open>
-            <summary className="px-4 py-3 body-emphasis text-default cursor-pointer hover-bg-subtle list-none flex items-center justify-between">
-              <span>サブジェクト代替名 (SAN)</span>
-              <span className="caption text-muted" aria-hidden="true">
-                ▾
-              </span>
-            </summary>
+          <CertSection title="サブジェクト代替名 (SAN)" defaultOpen>
             <div className="px-4 pb-4 pt-2">
               <div className="flex items-start gap-2">
                 <div className="font-mono caption text-default break-all flex-1">
@@ -140,20 +160,14 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
                 <CopyButton text={cert.san.join('\n')} label="コピー" />
               </div>
             </div>
-          </details>
+          </CertSection>
         )}
 
         {/* 拡張 */}
         {(cert.keyUsage.length > 0 ||
           cert.extKeyUsage.length > 0 ||
           cert.pathLen !== undefined) && (
-          <details>
-            <summary className="px-4 py-3 body-emphasis text-default cursor-pointer hover-bg-subtle list-none flex items-center justify-between">
-              <span>拡張</span>
-              <span className="caption text-muted" aria-hidden="true">
-                ▾
-              </span>
-            </summary>
+          <CertSection title="拡張">
             <div className="px-4 pb-4 pt-2 space-y-2">
               {cert.keyUsage.length > 0 && (
                 <CertField label="KeyUsage" value={cert.keyUsage.join(', ')} />
@@ -174,17 +188,11 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
                 <CertField label="AuthorityKeyIdentifier" value={cert.authorityKeyId} mono />
               )}
             </div>
-          </details>
+          </CertSection>
         )}
 
         {/* 公開鍵 */}
-        <details>
-          <summary className="px-4 py-3 body-emphasis text-default cursor-pointer hover-bg-subtle list-none flex items-center justify-between">
-            <span>公開鍵</span>
-            <span className="caption text-muted" aria-hidden="true">
-              ▾
-            </span>
-          </summary>
+        <CertSection title="公開鍵">
           <div className="px-4 pb-4 pt-2 space-y-2">
             <CertField label="アルゴリズム" value={cert.publicKey.algorithm} />
             {cert.publicKey.keySizeBits && (
@@ -194,30 +202,18 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
               <CertField label="曲線" value={cert.publicKey.namedCurve} />
             )}
           </div>
-        </details>
+        </CertSection>
 
         {/* 署名 */}
-        <details>
-          <summary className="px-4 py-3 body-emphasis text-default cursor-pointer hover-bg-subtle list-none flex items-center justify-between">
-            <span>署名</span>
-            <span className="caption text-muted" aria-hidden="true">
-              ▾
-            </span>
-          </summary>
+        <CertSection title="署名">
           <div className="px-4 pb-4 pt-2">
             <CertField label="署名アルゴリズム" value={cert.signatureAlgorithm} />
           </div>
-        </details>
+        </CertSection>
 
         {/* SCT */}
         {cert.sct.length > 0 && (
-          <details>
-            <summary className="px-4 py-3 body-emphasis text-default cursor-pointer hover-bg-subtle list-none flex items-center justify-between">
-              <span>SCT（証明書透明性）</span>
-              <span className="caption text-muted" aria-hidden="true">
-                ▾
-              </span>
-            </summary>
+          <CertSection title="SCT（証明書透明性）">
             <div className="px-4 pb-4 pt-2 space-y-3">
               {cert.sct.map((sct, i) => (
                 <div key={i} className="rounded-lg bg-subtle p-3 space-y-1">
@@ -227,7 +223,7 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
                 </div>
               ))}
             </div>
-          </details>
+          </CertSection>
         )}
       </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -692,6 +692,18 @@
     background: var(--color-bg-subtle);
   }
 
+  /* === CertDecoder: アコーディオン chevron アイコン (DADS Accordion 準拠) ===
+     §7.1 の通り `@layer components` 手書き class は Tailwind variant 非対応のため、
+     開閉状態の回転は `details[open]` 状態ルールを直接定義する
+     (`group-open:` 等の Tailwind variant 生成に依存しない)。
+     DADS Accordion は閉時に chevron が下向き、開時に 180° 回転して上向きになる。 */
+  .cert-chevron {
+    transition: transform 0.2s;
+  }
+  details[open] > summary .cert-chevron {
+    transform: rotate(180deg);
+  }
+
   /* === #136: FileInputButton (label 内包 input 構造のファイル選択ボタン) ===
      input を label の子にすることで :focus-within が parent label に効き、
      キーボードフォーカス時に outline ring が可視化される。


### PR DESCRIPTION
## 概要

SSL/TLS証明書デコーダ (cert-decoder) のアコーディオンを、デジタル庁デザインシステム (DADS) の [Accordion パターン](https://github.com/digital-go-jp/design-system-example-components-react/blob/main/src/components/Accordion/Accordion.tsx) に準拠するよう修正しました。

## 背景

既存実装は DADS Accordion と次の点で乖離していました。

| 項目 | 修正前 | 修正後 (DADS準拠) |
| :-- | :-- | :-- |
| アイコン | 右側のテキスト `▾` | 左側の**円形ボーダー付き chevron アイコン** (青基調 SVG) |
| 開閉回転 | なし | 開いたとき **180° 回転** (閉=下向き / 開=上向き) |
| 配色 | グレー文字 | 青基調 (`text-primary` + `border-current`) |

## あわせて修正した不具合

`cert-chevron` クラスは **global.css に未定義の silent no-op** で回転が一切効いておらず、しかも 6 セクション中 1 つ (基本情報) にしか付与されていませんでした。`global.css` に正式定義し、全セクションで回転するようにしました。

## 変更内容

- `CertDecoder.tsx`: 重複していた 6 つの `details`/`summary` を `CertSection` コンポーネントに集約 (DADS の `Accordion` 構成にならう)。chevron を左側の円形アイコンに変更。
- `global.css`: `cert-chevron` を実定義。§7.1 (Tailwind v4 の `@layer components` 手書き class は variant 非対応) に従い、回転は `details[open] > summary .cert-chevron` の状態ルールを直書き (`group-open:` の Tailwind variant 生成に依存しない)。

## 規約への適合

- DADS 参照実装は `@digital-go-jp/tailwind-theme-plugin` 前提 (`text-blue-1000` 等) だが本プロジェクトには未導入のため、semantic class / `@theme` auto-utility に翻訳 (primitive scale 直書き・inline `style` は不使用)。

## 検証

- `npm run test` (ユニット): 2201 passed / 1 skipped ✅
- `node_modules/.bin/astro check` (型): 0 errors ✅
- `npm run test:e2e`: cert-decoder 関連を含む 319 passed ✅
  - `dsn-builder.spec.ts` の 7 failed は **クリーンな develop でも同様に発生する pre-existing な失敗**で本 PR とは無関係 (確認済み)
- Playwright 実機 (PC 1280 / スマホ 390): 円形アイコン表示・開閉回転を目視確認。computed transform が open 時に `matrix(-1,0,0,-1,0,0)` (= 180°) になることを確認。

## 補足

純粋な視覚変更で `<details>` のネイティブ挙動のままのため新規 E2E は追加していません。`/tools/cert-decoder` は VRT 登録済みのため、**VRT baseline は CI 側で更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
