### PR TITLE
feat: VRT スライダーレポートの差分ファイル一覧を折りたたみ可能にする

### DIFF
--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -211,12 +211,19 @@ export function generateHTML(comparisons) {
   ${cards}
 </main>
 <script>
-  // スマホ幅では画像表示スペースを優先するため、ファイル一覧を初期状態で折りたたむ。
+  // スマホ幅では画像表示スペースを優先するため、ファイル一覧を折りたたむ。
   // (open 属性は media query で切り替えられないため JS で制御する)
-  if (window.matchMedia('(max-width: 767px)').matches) {
+  // リサイズにも追従し、スマホ幅では閉じ・デスクトップ幅では開く。
+  (function () {
     const nav = document.querySelector('.nav-details');
-    if (nav) nav.open = false;
-  }
+    if (!nav) return;
+    const mq = window.matchMedia('(max-width: 767px)');
+    const apply = () => {
+      nav.open = !mq.matches;
+    };
+    apply();
+    mq.addEventListener('change', apply);
+  })();
 </script>
 </body>
 </html>`;

--- a/scripts/generate-vrt-slider.mjs
+++ b/scripts/generate-vrt-slider.mjs
@@ -170,10 +170,14 @@ export function generateHTML(comparisons) {
     header{background:#1e3a8a;color:#fff;padding:1rem 1.5rem}
     header h1{margin:0;font-size:1.2rem}
     header p{margin:.25rem 0 0;font-size:.85rem;opacity:.85}
-    nav{background:#fff;border-bottom:1px solid #e5e7eb;padding:.6rem 1.5rem;position:sticky;top:0;z-index:10}
-    nav ul{margin:0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:.4rem}
+    nav{background:#fff;border-bottom:1px solid #e5e7eb;padding:.6rem 1.5rem;position:sticky;top:0;z-index:10;max-height:50vh;overflow-y:auto}
+    nav ul{margin:.5rem 0 0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:.4rem}
     nav a{font-size:.75rem;color:#1e40af;text-decoration:none;background:#eff6ff;padding:.2rem .45rem;border-radius:4px}
     nav a:hover{background:#dbeafe}
+    .nav-details>summary{cursor:pointer;color:#374151;font-size:.8rem;font-weight:600;list-style:none;display:flex;align-items:center;gap:.35rem}
+    .nav-details>summary::-webkit-details-marker{display:none}
+    .nav-details>summary::before{content:"▼";font-size:.65rem;color:#6b7280;transition:transform .15s ease}
+    .nav-details:not([open])>summary::before{transform:rotate(-90deg)}
     main{max-width:1200px;margin:0 auto;padding:1.5rem}
     .badge{display:inline-block;background:#dc2626;color:#fff;font-size:.75rem;font-weight:600;padding:.2rem .5rem;border-radius:4px;margin-bottom:1rem}
     .card{background:#fff;border-radius:8px;padding:1.5rem;margin-bottom:1.5rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
@@ -195,14 +199,25 @@ export function generateHTML(comparisons) {
   <p>中央の <strong>⇆ ハンドル</strong> を左右に drag して比較 &nbsp;|&nbsp; 左半分: <strong>Baseline（期待値）</strong> &nbsp; 右半分: <strong>Actual（実際）</strong></p>
 </header>
 <nav>
-  <ul>
+  <details class="nav-details" open>
+    <summary>差分ファイル一覧（${comparisons.length} 件）</summary>
+    <ul>
       ${navItems}
-  </ul>
+    </ul>
+  </details>
 </nav>
 <main>
   <p class="badge">${comparisons.length} 件の差分</p>
   ${cards}
 </main>
+<script>
+  // スマホ幅では画像表示スペースを優先するため、ファイル一覧を初期状態で折りたたむ。
+  // (open 属性は media query で切り替えられないため JS で制御する)
+  if (window.matchMedia('(max-width: 767px)').matches) {
+    const nav = document.querySelector('.nav-details');
+    if (nav) nav.open = false;
+  }
+</script>
 </body>
 </html>`;
 }

--- a/tests/meta/vrt-slider-report.test.ts
+++ b/tests/meta/vrt-slider-report.test.ts
@@ -115,6 +115,31 @@ describe('generateHTML (slider lib 参照経路)', () => {
   });
 });
 
+/**
+ * generateHTML: 差分ファイル一覧を折りたためる nav（スマホで画像表示スペースを確保するため）。
+ */
+describe('generateHTML (折りたたみ可能な nav)', () => {
+  const sample = [
+    { label: '[desktop 1280x800] /tools/foo', id: 'foo', hasDiff: false },
+    { label: '[mobile 390x844] /tools/bar', id: 'bar', hasDiff: true },
+  ];
+
+  it('ファイル一覧を <details class="nav-details"> でラップする', () => {
+    const html = generateHTML(sample);
+    expect(html).toContain('<details class="nav-details" open>');
+  });
+
+  it('summary に差分件数を表示する', () => {
+    const html = generateHTML(sample);
+    expect(html).toContain('<summary>差分ファイル一覧（2 件）</summary>');
+  });
+
+  it('スマホ幅で初期折りたたみする制御スクリプトを含む', () => {
+    const html = generateHTML(sample);
+    expect(html).toContain("window.matchMedia('(max-width: 767px)')");
+  });
+});
+
 // 陽性対照: CDN 参照検知 assertion が「常に green」化していないことを確認する。
 // もし将来 generateHTML が unpkg URL を再導入してしまった時、上の `.not.toContain` が
 // 確実に fail することを、CDN URL を含む synthetic HTML 文字列で能動検知できることで証明する。


### PR DESCRIPTION
## 概要

VRT スライダーレポート（`scripts/generate-vrt-slider.mjs` が生成する `vrt-slider-report/index.html`）で、差分が多い場合にスマホ幅で差分ファイル名の列挙が画面の大半を占有し、比較画像を表示するスペースがほとんど無い問題を修正する。

## 変更内容

- ナビゲーションのファイル一覧を `<details class="nav-details">` でラップし、折りたためるようにした
- `summary` に差分件数（例: `差分ファイル一覧（29 件）`）を表示
- スマホ幅（`max-width: 767px`）では初期状態で折りたたむよう JS で制御（`open` 属性は media query で切替不可のため）
- `nav` に `max-height:50vh; overflow-y:auto` を付与し、展開時でも画面を占有しすぎないようにした
- meta テストに折りたたみ nav 構造の検証を追加

## テスト

- `npx vitest run tests/meta/vrt-slider-report.test.ts` → 23 件 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjxKKPFLWfgdb7UqkZAFs4)_