### PR TITLE
test: VRT レポート nav のリサイズ追従リスナー存在を検証するテストを追加

### DIFF
--- a/tests/meta/vrt-slider-report.test.ts
+++ b/tests/meta/vrt-slider-report.test.ts
@@ -141,7 +141,9 @@ describe('generateHTML (折りたたみ可能な nav)', () => {
 
   it('リサイズ追従用に matchMedia の change リスナーを登録する', () => {
     const html = generateHTML(sample);
-    expect(html).toContain("addEventListener('change'");
+    // レシーバを mq に束縛し「リサイズ追従の意図」まで検証する
+    // (mq 以外への change リスナー追加で false negative になるのを防ぐ)
+    expect(html).toContain("mq.addEventListener('change'");
   });
 });
 

--- a/tests/meta/vrt-slider-report.test.ts
+++ b/tests/meta/vrt-slider-report.test.ts
@@ -138,6 +138,11 @@ describe('generateHTML (折りたたみ可能な nav)', () => {
     const html = generateHTML(sample);
     expect(html).toContain("window.matchMedia('(max-width: 767px)')");
   });
+
+  it('リサイズ追従用に matchMedia の change リスナーを登録する', () => {
+    const html = generateHTML(sample);
+    expect(html).toContain("addEventListener('change'");
+  });
 });
 
 // 陽性対照: CDN 参照検知 assertion が「常に green」化していないことを確認する。


### PR DESCRIPTION
## 概要

PR #649（VRT スライダーレポートの nav 折りたたみ）のレビューで任意指摘として挙がった、リサイズ追従用 `matchMedia` の `change` リスナーの存在を検証するテストを追加する。本テストはマージ直前に push したためタイミング上 #649 の squash マージに含まれず develop に未反映だったものを切り出した。

## 変更内容

- `tests/meta/vrt-slider-report.test.ts` に 1 ケース追加: `generateHTML` 出力に `addEventListener('change'` が含まれることを assert
- リスナーが将来削除された場合に CI で検知できるようにする静的出力のリグレッションガード

## 検知能力の確認

リスナーを除去した出力に対しては `toContain` が `false` となり fail することを実機確認済み（現行 `true` / 除去時 `false`）。

## テスト

- `npx vitest run tests/meta/vrt-slider-report.test.ts` → 24 件 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjxKKPFLWfgdb7UqkZAFs4)_