### PR TITLE
refactor(ui): hero 見出しを .hero-heading semantic class へ切り出し (#565)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,9 +25,7 @@ const jsonLd = {
   <section
     class="text-center px-4 py-8 bg-[var(--color-background)] border-b border-[var(--color-blue-100)]"
   >
-    <h1 class="mb-2 font-bold hero-heading text-default">
-      DevTools
-    </h1>
+    <h1 class="mb-2 font-bold hero-heading text-default">DevTools</h1>
     <p class="text-base leading-[1.7] tracking-[0.02em] text-[var(--color-neutral-600)]">
       ブラウザで完結する無料の開発者ツール集
     </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const jsonLd = {
   <section
     class="text-center px-4 py-8 bg-[var(--color-background)] border-b border-[var(--color-blue-100)]"
   >
-    <h1 class="mb-2 font-bold text-[2rem] leading-[1.4] tracking-[0.01em] text-default">
+    <h1 class="mb-2 font-bold hero-heading text-default">
       DevTools
     </h1>
     <p class="text-base leading-[1.7] tracking-[0.02em] text-[var(--color-neutral-600)]">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -806,6 +806,15 @@
     color: var(--color-neutral-700);
   }
 
+  /* トップページ hero h1 見出し (2rem)。.page-heading (1.75rem) / .section-heading (1.125rem) より
+     一段大きい hero 用見出しスケールの SoT。color は class に含めず consumer 側で text-default を併用
+     (既存 hero h1 は text-default 付き)。(issue #565) */
+  .hero-heading {
+    font-size: 2rem;
+    line-height: 1.4;
+    letter-spacing: 0.01em;
+  }
+
   /* ページ h1 見出し: about/privacy/404 の静的ページ共通 (1.75rem)。
      .section-heading (h2, 1.125rem) より一段大きい page タイトル用。
      color は .section-heading と同様 class に含めず consumer 側で text-default を併用 (issue #535)。 */


### PR DESCRIPTION
## 概要

issue #565 対応。`index.astro` の hero h1 が直書きしていた arbitrary Tailwind 値 `text-[2rem] leading-[1.4] tracking-[0.01em]` を `@layer components` の semantic class `.hero-heading`（2rem）へ切り出し、見出し typography スケールを一元化した。

- `.hero-heading`（2rem）/ `.page-heading`（1.75rem）/ `.section-heading`（1.125rem）が並び、見出し階層の SoT 化を達成
- arbitrary typography 値の残存を解消し、§7 意味クラス方針と整合
- color は他の見出し class と同様 class に含めず、consumer 側で `text-default` を併用（既存 hero h1 と同じ）

## スコープ

issue 記載どおり **index.astro の hero h1 のみ**。他ページの見出し棚卸しや他の arbitrary 値（p タグ等）は対象外（P2・最小スコープ）。

## 変更内容

- `src/styles/global.css`: `.page-heading` 定義の直前に `.hero-heading`（2rem / 1.4 / 0.01em）を追加（日本語コメント付き）
- `src/pages/index.astro`: hero h1 の className から arbitrary 値を除去し `hero-heading` に置換。他クラス（`mb-2 font-bold text-default`）は保持

## 検証

- 値は現状と**完全一致**（2rem / 1.4 / 0.01em）のため**視覚的変化なし**（VRT 差分なし）
- `node_modules/.bin/astro check`: 0 errors / 0 warnings / 0 hints
- `npm run build`: 成功。`dist/_astro/BaseLayout.*.css` に `.hero-heading{letter-spacing:.01em;font-size:2rem;line-height:1.4}` が生成され purge されないことを確認
- `npm run test`: 2260/2261 pass（失敗1件は `codex-git-add-files.test.ts` の git signing server 400 による環境固有問題で本変更と無関係）

Closes #565

https://claude.ai/code/session_01N9R1Ek1yyTKvSxqgU3DWtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9R1Ek1yyTKvSxqgU3DWtc)_