### PR TITLE
refactor: className 構築を cx ヘルパーで統一 (#260)

### DIFF
--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -1,5 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { COMPACT_BUTTON_SHAPE_CLASSES } from './_compactButton';
+import { cx } from '@/utils/cx';
 
 type Variant = 'default' | 'primary' | 'secondary' | 'danger';
 type Size = 'default' | 'compact';
@@ -58,7 +59,11 @@ export function ActionButton({
       onClick={onClick}
       disabled={isDisabled}
       aria-busy={loading ? 'true' : undefined}
-      className={`caption inline-flex items-center whitespace-nowrap btn-action btn-action--${variant} ${SIZE_CLASS[size]}`}
+      className={cx(
+        'caption inline-flex items-center whitespace-nowrap btn-action',
+        `btn-action--${variant}`,
+        SIZE_CLASS[size]
+      )}
       {...rest}
     >
       {children}

--- a/src/components/ui/BareInput.tsx
+++ b/src/components/ui/BareInput.tsx
@@ -1,4 +1,5 @@
 import type { InputHTMLAttributes } from 'react';
+import { cx } from '@/utils/cx';
 
 interface Props extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
@@ -38,7 +39,13 @@ export function BareInput({
     <input
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className={`caption rounded-md border ${borderClass} ${monoClass} bg-default text-default w-full px-2 py-1.5 ${extraClass}`.trim()}
+      className={cx(
+        'caption rounded-md border',
+        borderClass,
+        monoClass,
+        'bg-default text-default w-full px-2 py-1.5',
+        extraClass
+      )}
       {...rest}
     />
   );

--- a/src/components/ui/ChevronIcon.tsx
+++ b/src/components/ui/ChevronIcon.tsx
@@ -1,3 +1,5 @@
+import { cx } from '@/utils/cx';
+
 interface Props {
   /** 開状態 (true なら 180° 回転して上向き ▲) */
   open?: boolean;
@@ -22,9 +24,11 @@ export function ChevronIcon({ open = false, size = 14, className = '' }: Props) 
       strokeLinecap="round"
       strokeLinejoin="round"
       aria-hidden="true"
-      className={`inline-block align-middle transition-transform duration-150 ease-in-out${
-        open ? ' rotate-180' : ''
-      }${className ? ` ${className}` : ''}`}
+      className={cx(
+        'inline-block align-middle transition-transform duration-150 ease-in-out',
+        open && 'rotate-180',
+        className
+      )}
     >
       <polyline points="6 9 12 15 18 9" />
     </svg>

--- a/src/components/ui/ChipLabel.tsx
+++ b/src/components/ui/ChipLabel.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { cx } from '@/utils/cx';
 
 interface Props {
   tone: 'error' | 'info' | 'neutral';
@@ -9,7 +10,7 @@ interface Props {
 
 export function ChipLabel({ tone, children, icon, className = '' }: Props) {
   return (
-    <span className={`chip-label chip-label--${tone}${className ? ` ${className}` : ''}`}>
+    <span className={cx('chip-label', `chip-label--${tone}`, className)}>
       {icon}
       {children}
     </span>

--- a/src/components/ui/ClearButton.tsx
+++ b/src/components/ui/ClearButton.tsx
@@ -1,3 +1,5 @@
+import { cx } from '@/utils/cx';
+
 interface Props {
   onClick: () => void;
   className?: string;
@@ -14,7 +16,10 @@ export function ClearButton({ onClick, className = '' }: Props) {
     <button
       type="button"
       onClick={onClick}
-      className={`caption text-muted btn-clear rounded-lg px-3 py-1.5 whitespace-nowrap border-0 ${className}`.trim()}
+      className={cx(
+        'caption text-muted btn-clear rounded-lg px-3 py-1.5 whitespace-nowrap border-0',
+        className
+      )}
     >
       クリア
     </button>

--- a/src/components/ui/CloseIcon.tsx
+++ b/src/components/ui/CloseIcon.tsx
@@ -1,3 +1,5 @@
+import { cx } from '@/utils/cx';
+
 interface Props {
   size?: number;
   className?: string;
@@ -15,7 +17,7 @@ export function CloseIcon({ size = 16, className = '' }: Props) {
       strokeLinecap="round"
       strokeLinejoin="round"
       aria-hidden="true"
-      className={`inline-block align-middle${className ? ` ${className}` : ''}`}
+      className={cx('inline-block align-middle', className)}
     >
       <line x1="18" y1="6" x2="6" y2="18" />
       <line x1="6" y1="6" x2="18" y2="18" />

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { copyToClipboard } from '@/utils/clipboard';
 import { COMPACT_BUTTON_SHAPE_CLASSES } from './_compactButton';
+import { cx } from '@/utils/cx';
 
 function ClipboardIcon() {
   return (
@@ -105,7 +106,11 @@ export function CopyButton({
         type="button"
         onClick={handleClick}
         aria-label={accessibleName}
-        className={`btn-copy is-compact ${stateClass} rounded-md inline-flex items-center justify-center text-xs px-2 py-1 min-w-8 min-h-8 whitespace-nowrap`.trim()}
+        className={cx(
+          'btn-copy is-compact',
+          stateClass,
+          'rounded-md inline-flex items-center justify-center text-xs px-2 py-1 min-w-8 min-h-8 whitespace-nowrap'
+        )}
       >
         {copied ? <CheckIcon /> : <ClipboardIcon />}
         <CopyAnnounce copied={copied} />
@@ -118,7 +123,14 @@ export function CopyButton({
       type="button"
       onClick={handleClick}
       aria-label={accessibleName}
-      className={`btn-copy ${stateClass} caption inline-flex items-center gap-1.5 ${COMPACT_BUTTON_SHAPE_CLASSES} tracking-wide whitespace-nowrap ${className}`.trim()}
+      className={cx(
+        'btn-copy',
+        stateClass,
+        'caption inline-flex items-center gap-1.5',
+        COMPACT_BUTTON_SHAPE_CLASSES,
+        'tracking-wide whitespace-nowrap',
+        className
+      )}
     >
       {copied ? <CheckIcon /> : <ClipboardIcon />}
       {label}

--- a/src/components/ui/FileInputButton.tsx
+++ b/src/components/ui/FileInputButton.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent, ReactNode } from 'react';
+import { cx } from '@/utils/cx';
 
 interface Props {
   /** 許可する MIME タイプ / 拡張子 (例: "image/*") */
@@ -38,10 +39,7 @@ export function FileInputButton({
   disabled = false,
 }: Props) {
   return (
-    <label
-      className={`btn-file-input${className ? ` ${className}` : ''}`}
-      aria-disabled={disabled ? true : undefined}
-    >
+    <label className={cx('btn-file-input', className)} aria-disabled={disabled ? true : undefined}>
       <input
         type="file"
         className="sr-only"

--- a/src/components/ui/OutputField.tsx
+++ b/src/components/ui/OutputField.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { CopyButton } from '@/components/ui/CopyButton';
+import { cx } from '@/utils/cx';
 
 interface OutputFieldProps {
   /** textarea の id（label との関連付けに使用） */
@@ -54,7 +55,7 @@ export function OutputField({
   const fillStatusClass = fill ? 'md:flex md:flex-1 md:min-h-0' : '';
   const fillTextareaClass = fill ? 'md:block md:h-full md:min-h-0' : '';
   return (
-    <div className={`w-full ${fillContainerClass}`.trim()}>
+    <div className={cx('w-full', fillContainerClass)}>
       <div className="flex items-center justify-between mb-3 min-h-8">
         <label htmlFor={id} className="body-emphasis text-default">
           {label}
@@ -77,7 +78,13 @@ export function OutputField({
           readOnly
           value={value}
           rows={rows}
-          className={`caption ${monoClass} ${resizeClass} w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide ${fillTextareaClass}`.trim()}
+          className={cx(
+            'caption',
+            monoClass,
+            resizeClass,
+            'w-full rounded-lg border border-default bg-subtle text-default px-3 py-2 tracking-wide',
+            fillTextareaClass
+          )}
           aria-label={ariaLabel ?? label}
         />
       </div>

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -1,4 +1,5 @@
 import { useDynamicStyleSheet } from '@/hooks/useDynamicStyleSheet';
+import { cx } from '@/utils/cx';
 
 type ProgressBarProps = {
   current: number;
@@ -57,7 +58,7 @@ export function ProgressBar({ current, max, 'aria-describedby': describedBy }: P
       aria-valuenow={valuenow}
       aria-valuetext={valuetext}
       aria-describedby={describedBy}
-      className={`progress-track ${dynClassName}`}
+      className={cx('progress-track', dynClassName)}
     >
       <span className="progress-fill" aria-hidden="true" />
       {isOver && <span className="progress-overflow" aria-hidden="true" />}

--- a/src/components/ui/ResultTable.tsx
+++ b/src/components/ui/ResultTable.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useDynamicStyleSheet } from '@/hooks/useDynamicStyleSheet';
 import { assertCssLength } from '@/utils/css-length';
+import { cx } from '@/utils/cx';
 
 export interface TableColumn<T> {
   key: string;
@@ -86,7 +87,7 @@ export function ResultTable<T>({
         </div>
       )}
       <div className="overflow-x-auto">
-        <table className={`w-full border-collapse result-table ${dynClassName}`}>
+        <table className={cx('w-full border-collapse result-table', dynClassName)}>
           <colgroup>
             {columns.map((col) => (
               <col key={col.key} />
@@ -98,7 +99,11 @@ export function ResultTable<T>({
                 <th
                   key={col.key}
                   scope="col"
-                  className={`caption text-muted font-semibold whitespace-nowrap ${paddingClass()} ${alignClass(col.headerAlign)}`}
+                  className={cx(
+                    'caption text-muted font-semibold whitespace-nowrap',
+                    paddingClass(),
+                    alignClass(col.headerAlign)
+                  )}
                 >
                   {col.header}
                 </th>
@@ -132,7 +137,12 @@ export function ResultTable<T>({
                   {columns.map((col) => (
                     <td
                       key={col.key}
-                      className={`caption text-default ${paddingClass(col.cellPadding)} ${alignClass(col.cellAlign)} ${col.className ?? ''}`}
+                      className={cx(
+                        'caption text-default',
+                        paddingClass(col.cellPadding),
+                        alignClass(col.cellAlign),
+                        col.className
+                      )}
                     >
                       {col.render(row, i)}
                     </td>

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,4 +1,5 @@
 import type { AriaAttributes, ReactNode } from 'react';
+import { cx } from '@/utils/cx';
 
 interface Props extends AriaAttributes {
   title?: ReactNode;
@@ -34,7 +35,10 @@ export function Section({
     <div role={role} {...ariaProps} className="rounded-xl border border-default overflow-hidden">
       {hasHeader && (
         <div
-          className={`body-emphasis text-default bg-subtle border-b border-default px-4 py-3 m-0${headerSlot ? ' flex items-center justify-between flex-wrap gap-2' : ''}`}
+          className={cx(
+            'body-emphasis text-default bg-subtle border-b border-default px-4 py-3 m-0',
+            headerSlot != null && 'flex items-center justify-between flex-wrap gap-2'
+          )}
         >
           {title != null && (
             <span role="heading" aria-level={headingLevel}>

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -37,7 +37,7 @@ export function Section({
         <div
           className={cx(
             'body-emphasis text-default bg-subtle border-b border-default px-4 py-3 m-0',
-            headerSlot != null && 'flex items-center justify-between flex-wrap gap-2'
+            !!headerSlot && 'flex items-center justify-between flex-wrap gap-2'
           )}
         >
           {title != null && (

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { cx } from '@/utils/cx';
 
 interface Props {
   tone: 'error' | 'success' | 'warning' | 'info';
@@ -11,7 +12,7 @@ interface Props {
 export function StatusBadge({ tone, children, className = '', decorative = false }: Props) {
   return (
     <span
-      className={`status-badge status-badge--${tone}${className ? ` ${className}` : ''}`}
+      className={cx('status-badge', `status-badge--${tone}`, className)}
       aria-hidden={decorative || undefined}
     >
       {children}

--- a/src/components/ui/ToggleGroup.tsx
+++ b/src/components/ui/ToggleGroup.tsx
@@ -1,4 +1,5 @@
 import { useDynamicStyleSheet } from '@/hooks/useDynamicStyleSheet';
+import { cx } from '@/utils/cx';
 
 interface Option<T> {
   value: T;
@@ -43,7 +44,7 @@ export function ToggleGroup<T extends string>({
 
   const containerClass = isWrap
     ? 'bg-subtle rounded-lg border border-input p-1 flex flex-wrap gap-1 w-max max-w-full'
-    : `bg-subtle rounded-lg border border-input p-1 toggle-grid ${dynClassName}`;
+    : cx('bg-subtle rounded-lg border border-input p-1 toggle-grid', dynClassName);
   const buttonSizeClass = size === 'sm' ? 'px-2.5 py-0.5' : 'px-3 py-1.5';
 
   return (
@@ -54,7 +55,10 @@ export function ToggleGroup<T extends string>({
           type="button"
           onClick={() => onChange(opt.value)}
           aria-pressed={value === opt.value}
-          className={`caption font-semibold btn-toggle rounded-lg whitespace-nowrap ${buttonSizeClass}`}
+          className={cx(
+            'caption font-semibold btn-toggle rounded-lg whitespace-nowrap',
+            buttonSizeClass
+          )}
         >
           {opt.label}
         </button>

--- a/src/utils/__tests__/cx.test.ts
+++ b/src/utils/__tests__/cx.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { cx } from '@/utils/cx';
+
+describe('cx — 基本結合', () => {
+  it('複数の文字列を単一スペースで結合する', () => {
+    expect(cx('a', 'b', 'c')).toBe('a b c');
+  });
+
+  it('1 つの文字列はそのまま返す', () => {
+    expect(cx('foo')).toBe('foo');
+  });
+});
+
+describe('cx — falsy 値の除去', () => {
+  it('false を除去する（条件 false のクラスが消える）', () => {
+    expect(cx('btn', false, 'active')).toBe('btn active');
+  });
+
+  it('null を除去する', () => {
+    expect(cx('btn', null, 'active')).toBe('btn active');
+  });
+
+  it('undefined を除去する', () => {
+    expect(cx('btn', undefined, 'active')).toBe('btn active');
+  });
+
+  it('空文字列を除去する', () => {
+    expect(cx('btn', '', 'active')).toBe('btn active');
+  });
+
+  it('0 を除去する（falsy）', () => {
+    expect(cx('btn', 0, 'active')).toBe('btn active');
+  });
+});
+
+describe('cx — 連続空白を生成しない', () => {
+  it('条件 falsy が中間にあっても二重空白が出ない', () => {
+    expect(cx('a', '', 'b')).toBe('a b');
+  });
+
+  it('複数の falsy が連続しても二重空白が出ない', () => {
+    expect(cx('a', '', false, null, 'b')).toBe('a b');
+  });
+});
+
+describe('cx — 前後空白なし', () => {
+  it('先頭の falsy がある場合に前置スペースが付かない', () => {
+    expect(cx(false, 'btn')).toBe('btn');
+  });
+
+  it('末尾の falsy がある場合に後置スペースが付かない', () => {
+    expect(cx('btn', false)).toBe('btn');
+  });
+});
+
+describe('cx — 全 falsy', () => {
+  it('全て falsy なら空文字列を返す', () => {
+    expect(cx(false, null, undefined, '')).toBe('');
+  });
+
+  it('引数なしでも空文字列を返す', () => {
+    expect(cx()).toBe('');
+  });
+});
+
+describe('cx — 数値', () => {
+  it('0 は除去される（falsy）', () => {
+    expect(cx('btn', 0)).toBe('btn');
+  });
+
+  it('正の数値は文字列化して残る', () => {
+    expect(cx('w-', 4)).toBe('w- 4');
+  });
+});

--- a/src/utils/cx.ts
+++ b/src/utils/cx.ts
@@ -1,0 +1,13 @@
+/**
+ * className を組み立てる小さなヘルパー。
+ * falsy 値（false / null / undefined / '' / 0）を除去し、残りを単一スペースで結合する。
+ * template literal + `.trim()` 方式で発生していた連続空白・前後空白を防ぐ（issue #260）。
+ *
+ * @example
+ * cx('btn', isActive && 'is-active', className)
+ */
+export type ClassValue = string | number | false | null | undefined;
+
+export function cx(...values: ClassValue[]): string {
+  return values.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## 概要

issue #260 対応。`template literal + .trim()` 方式では条件付き className が空文字になると**連続空白（二重空白）**が残る問題があった（`CopyButton.tsx` 等）。`.trim()` は前後のみで中間空白は除去されない。

falsy 値を除去し単一スペースで結合する内部ヘルパー `cx`（`src/utils/cx.ts`）を新設し、`src/components/ui/` 配下で動的に className を組み立てている箇所を統一した。

> 方式は issue 記載の 2 案のうち**内部ヘルパー**を採用。プロジェクトの依存最小方針（CLAUDE.md §4 のライブラリ追加に伴う SPEC/decisions/lock 更新負荷の回避）と整合するため、`clsx` の追加は見送った。対象範囲も issue 主旨どおり `src/components/ui` に限定。

## 変更点

- **新設**: `src/utils/cx.ts` ＋ 単体テスト `src/utils/__tests__/cx.test.ts`（15 ケース: 結合 / falsy 除去 / 連続空白なし / 前後空白なし / 全 falsy / 数値）
- **移行**: ActionButton / BareInput / ChevronIcon / ChipLabel / ClearButton / CloseIcon / CopyButton / FileInputButton / OutputField / ProgressBar / ResultTable / Section / StatusBadge / ToggleGroup
- **対象外（仕様どおり）**: `NotificationBanner`（`--${variant}` 補間のみ・条件なし）、`CountInput` / `Select` / `ErrorMessage`（静的文字列のみ）は連続空白リスクがないため変更なし

クラス名・順序は一切変えない純粋リファクタで、視覚変化なし（連続空白の除去のみ）。VRT baseline 更新は不要。

## 補足

- `Section.tsx` は cx の `ClassValue` 型（ReactNode を含まない）に合わせ、条件部を `!!headerSlot && '…'` とした（boolean 化で型互換）。`!!headerSlot` は旧実装の truthy 判定（`headerSlot ?`）を完全保存するため、`headerSlot={cond && <X/>}` で `cond===false` / `0` / `''` のときも元と同一挙動（flex レイアウトを付けない）。

## 検証

- `node_modules/.bin/astro check`: **0 errors / 0 warnings / 0 hints**（401 files）
- `npm run test`: `cx.test.ts` 15 件含む 2086 件 pass
  - 既存の環境依存 3 件のみ fail（`sw-cache-version` ×2 は `dist/sw.js` 未生成で要 `npm run build`、`codex-git-add-files` ×1 は git shell スクリプトのサンドボックス差）。いずれも本変更と無関係。

## フォローアップ

- `src/components/tools/*` への `cx` 横展開（同型の二重空白パターンが残存）: #658

Closes #260

https://claude.ai/code/session_01GEXKuG45NXc9tHZP2SBjr4