### PR TITLE
refactor(tools): 動的 className 構築を cx ヘルパーで統一 (#658)

### DIFF
--- a/src/components/tools/CertDecoder.tsx
+++ b/src/components/tools/CertDecoder.tsx
@@ -154,7 +154,10 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
         </div>
         {signatureValid !== null && (
           <span
-            className={cx('caption font-medium px-2 py-0.5 rounded-full', signatureValid ? 'bg-success-tint text-success' : 'bg-error-tint text-error-text')}
+            className={cx(
+              'caption font-medium px-2 py-0.5 rounded-full',
+              signatureValid ? 'bg-success-tint text-success' : 'bg-error-tint text-error-text'
+            )}
           >
             {signatureValid ? '✓ 署名有効' : '✗ 署名無効'}
           </span>
@@ -283,7 +286,13 @@ function CertField({ label, value, mono, copyable, tone }: CertFieldProps) {
     <div className="flex flex-col gap-0.5">
       <dt className="caption text-muted">{label}</dt>
       <dd
-        className={cx('flex items-start gap-2', mono && 'font-mono', 'caption', tone === 'error' ? 'text-error' : 'text-default', 'break-all')}
+        className={cx(
+          'flex items-start gap-2',
+          mono && 'font-mono',
+          'caption',
+          tone === 'error' ? 'text-error' : 'text-default',
+          'break-all'
+        )}
       >
         <span className="flex-1">{value}</span>
         {copyable && <CopyButton text={value} label="コピー" />}

--- a/src/components/tools/CertDecoder.tsx
+++ b/src/components/tools/CertDecoder.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { cx } from '@/utils/cx';
 import { InputField } from '@/components/ui/InputField';
 import { FileInputButton } from '@/components/ui/FileInputButton';
 import { CopyButton } from '@/components/ui/CopyButton';
@@ -153,9 +154,7 @@ function CertCard({ cert, signatureValid, expired, chainPosition, totalInChain }
         </div>
         {signatureValid !== null && (
           <span
-            className={`caption font-medium px-2 py-0.5 rounded-full ${
-              signatureValid ? 'bg-success-tint text-success' : 'bg-error-tint text-error-text'
-            }`}
+            className={cx('caption font-medium px-2 py-0.5 rounded-full', signatureValid ? 'bg-success-tint text-success' : 'bg-error-tint text-error-text')}
           >
             {signatureValid ? '✓ 署名有効' : '✗ 署名無効'}
           </span>
@@ -284,7 +283,7 @@ function CertField({ label, value, mono, copyable, tone }: CertFieldProps) {
     <div className="flex flex-col gap-0.5">
       <dt className="caption text-muted">{label}</dt>
       <dd
-        className={`flex items-start gap-2 ${mono ? 'font-mono' : ''} caption ${tone === 'error' ? 'text-error' : 'text-default'} break-all`}
+        className={cx('flex items-start gap-2', mono && 'font-mono', 'caption', tone === 'error' ? 'text-error' : 'text-default', 'break-all')}
       >
         <span className="flex-1">{value}</span>
         {copyable && <CopyButton text={value} label="コピー" />}

--- a/src/components/tools/CharCount.tsx
+++ b/src/components/tools/CharCount.tsx
@@ -173,7 +173,10 @@ export function CharCountTool() {
           <dd className="caption font-mono text-right">{lines.longestGraphemes}</dd>
           <dt className="caption text-muted">改行コード</dt>
           <dd
-            className={cx('caption font-mono text-right', lines.newline === 'mixed' && 'text-warning')}
+            className={cx(
+              'caption font-mono text-right',
+              lines.newline === 'mixed' && 'text-warning'
+            )}
           >
             {lines.newline === 'lf' && 'LF'}
             {lines.newline === 'crlf' && 'CRLF'}

--- a/src/components/tools/CharCount.tsx
+++ b/src/components/tools/CharCount.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, type ReactNode } from 'react';
+import { cx } from '@/utils/cx';
 import { Section } from '@/components/ui/Section';
 import { InputField } from '@/components/ui/InputField';
 import { ClearButton } from '@/components/ui/ClearButton';
@@ -70,7 +71,7 @@ function SnsCard({
         <p className="caption text-muted">{method}</p>
       </div>
       <div className="flex items-baseline gap-2">
-        <span className={`font-mono${isOver ? ' text-error' : ''}`}>{current}</span>
+        <span className={cx('font-mono', isOver && 'text-error')}>{current}</span>
         <span className="text-muted">/</span>
         {limitNode ?? <span className="font-mono text-muted">{limit}</span>}
         {isOver && <span className="sr-only"> 上限超過</span>}
@@ -172,7 +173,7 @@ export function CharCountTool() {
           <dd className="caption font-mono text-right">{lines.longestGraphemes}</dd>
           <dt className="caption text-muted">改行コード</dt>
           <dd
-            className={`caption font-mono text-right${lines.newline === 'mixed' ? ' text-warning' : ''}`}
+            className={cx('caption font-mono text-right', lines.newline === 'mixed' && 'text-warning')}
           >
             {lines.newline === 'lf' && 'LF'}
             {lines.newline === 'crlf' && 'CRLF'}

--- a/src/components/tools/ClipboardInspector.tsx
+++ b/src/components/tools/ClipboardInspector.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { cx } from '@/utils/cx';
 import { Section } from '@/components/ui/Section';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
@@ -213,9 +214,7 @@ export function ClipboardInspectorTool() {
           setIsDragOver(true);
         }}
         onDragLeave={() => setIsDragOver(false)}
-        className={`caret-transparent rounded-xl border-2 border-dashed border-default p-8 text-center ${
-          isDragOver ? 'bg-subtle' : ''
-        }`}
+        className={cx('caret-transparent rounded-xl border-2 border-dashed border-default p-8 text-center', isDragOver && 'bg-subtle')}
       >
         <p className="body-emphasis text-default m-0">
           このページで Ctrl+V / Cmd+V

--- a/src/components/tools/ClipboardInspector.tsx
+++ b/src/components/tools/ClipboardInspector.tsx
@@ -214,7 +214,10 @@ export function ClipboardInspectorTool() {
           setIsDragOver(true);
         }}
         onDragLeave={() => setIsDragOver(false)}
-        className={cx('caret-transparent rounded-xl border-2 border-dashed border-default p-8 text-center', isDragOver && 'bg-subtle')}
+        className={cx(
+          'caret-transparent rounded-xl border-2 border-dashed border-default p-8 text-center',
+          isDragOver && 'bg-subtle'
+        )}
       >
         <p className="body-emphasis text-default m-0">
           このページで Ctrl+V / Cmd+V

--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { cx } from '@/utils/cx';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { InputField } from '@/components/ui/InputField';
 import { OutputField } from '@/components/ui/OutputField';
@@ -219,7 +220,7 @@ export function ConfigConverterTool() {
         >
           <span
             aria-hidden="true"
-            className={`inline-block transition-transform duration-200 ${schemaOpen ? 'rotate-90' : ''}`}
+            className={cx('inline-block transition-transform duration-200', schemaOpen && 'rotate-90')}
           >
             ▶
           </span>
@@ -262,7 +263,7 @@ export function ConfigConverterTool() {
             </div>
             {validationResult && (
               <div
-                className={`rounded-lg p-3 border ${validationResult.valid ? 'alert-success' : 'alert-error'}`}
+                className={cx('rounded-lg p-3 border', validationResult.valid ? 'alert-success' : 'alert-error')}
               >
                 {validationResult.valid ? (
                   <p className="caption text-default inline-flex items-center gap-1">

--- a/src/components/tools/ConfigConverter.tsx
+++ b/src/components/tools/ConfigConverter.tsx
@@ -220,7 +220,10 @@ export function ConfigConverterTool() {
         >
           <span
             aria-hidden="true"
-            className={cx('inline-block transition-transform duration-200', schemaOpen && 'rotate-90')}
+            className={cx(
+              'inline-block transition-transform duration-200',
+              schemaOpen && 'rotate-90'
+            )}
           >
             ▶
           </span>
@@ -263,7 +266,10 @@ export function ConfigConverterTool() {
             </div>
             {validationResult && (
               <div
-                className={cx('rounded-lg p-3 border', validationResult.valid ? 'alert-success' : 'alert-error')}
+                className={cx(
+                  'rounded-lg p-3 border',
+                  validationResult.valid ? 'alert-success' : 'alert-error'
+                )}
               >
                 {validationResult.valid ? (
                   <p className="caption text-default inline-flex items-center gap-1">

--- a/src/components/tools/Gs1Databar.tsx
+++ b/src/components/tools/Gs1Databar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useId, useRef, useMemo } from 'react';
+import { cx } from '@/utils/cx';
 import { createPortal } from 'react-dom';
 import { getErrorMessage } from '@/utils/errors';
 import bwipjs from 'bwip-js';
@@ -585,7 +586,7 @@ export function Gs1DatabarTool() {
       {mounted &&
         createPortal(
           <div className="print-area" aria-hidden="true">
-            <div className={`print-grid print-grid--cols-${printCols}`}>
+            <div className={cx('print-grid', `print-grid--cols-${printCols}`)}>
               {printEntries.map((e) => (
                 <div
                   key={e.gtin}

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -216,7 +216,10 @@ export function JwtDecoderTool() {
         <div className="flex flex-wrap items-center gap-2">
           {verifyExp && (
             <span
-              className={cx('rounded-full px-3 py-0.5 caption font-medium', expBadge[parsed.expStatus].badgeClass)}
+              className={cx(
+                'rounded-full px-3 py-0.5 caption font-medium',
+                expBadge[parsed.expStatus].badgeClass
+              )}
             >
               {expBadge[parsed.expStatus].label}
               {parsed.expStatus === 'valid' && parsed.remainingMs !== undefined && (
@@ -226,7 +229,10 @@ export function JwtDecoderTool() {
           )}
           {sigBadge[sigStatus] && (
             <span
-              className={cx('rounded-full px-3 py-0.5 caption font-medium', sigBadge[sigStatus]!.badgeClass)}
+              className={cx(
+                'rounded-full px-3 py-0.5 caption font-medium',
+                sigBadge[sigStatus]!.badgeClass
+              )}
             >
               {sigBadge[sigStatus]!.label}
             </span>

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
+import { cx } from '@/utils/cx';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ClearButton } from '@/components/ui/ClearButton';
 import { InputField } from '@/components/ui/InputField';
@@ -69,7 +70,7 @@ interface SectionProps {
 function Section({ title, variant, data, renderValue, 'data-testid': testId }: SectionProps) {
   const json = JSON.stringify(data, null, 2);
   return (
-    <div className={`rounded-lg p-4 bg-subtle ${SECTION_CLASSES[variant]}`} data-testid={testId}>
+    <div className={cx('rounded-lg p-4 bg-subtle', SECTION_CLASSES[variant])} data-testid={testId}>
       <div className="mb-2 flex items-center justify-between">
         <h3 className="body-emphasis text-default">{title}</h3>
         <CopyButton text={json} label="コピー" />
@@ -215,7 +216,7 @@ export function JwtDecoderTool() {
         <div className="flex flex-wrap items-center gap-2">
           {verifyExp && (
             <span
-              className={`rounded-full px-3 py-0.5 caption font-medium ${expBadge[parsed.expStatus].badgeClass}`}
+              className={cx('rounded-full px-3 py-0.5 caption font-medium', expBadge[parsed.expStatus].badgeClass)}
             >
               {expBadge[parsed.expStatus].label}
               {parsed.expStatus === 'valid' && parsed.remainingMs !== undefined && (
@@ -225,7 +226,7 @@ export function JwtDecoderTool() {
           )}
           {sigBadge[sigStatus] && (
             <span
-              className={`rounded-full px-3 py-0.5 caption font-medium ${sigBadge[sigStatus]!.badgeClass}`}
+              className={cx('rounded-full px-3 py-0.5 caption font-medium', sigBadge[sigStatus]!.badgeClass)}
             >
               {sigBadge[sigStatus]!.label}
             </span>

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
+import { cx } from '@/utils/cx';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
@@ -133,7 +134,7 @@ export function QrReaderTool() {
                 ref={camera.videoRef}
                 playsInline
                 muted
-                className={`w-full max-w-[400px] rounded-lg qr-video-preview ${camera.cameraActive ? '' : 'hidden'}`}
+                className={cx('w-full max-w-[400px] rounded-lg qr-video-preview', !camera.cameraActive && 'hidden')}
                 aria-label="カメラプレビュー"
               />
               {camera.cameraActive && (

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -134,7 +134,10 @@ export function QrReaderTool() {
                 ref={camera.videoRef}
                 playsInline
                 muted
-                className={cx('w-full max-w-[400px] rounded-lg qr-video-preview', !camera.cameraActive && 'hidden')}
+                className={cx(
+                  'w-full max-w-[400px] rounded-lg qr-video-preview',
+                  !camera.cameraActive && 'hidden'
+                )}
                 aria-label="カメラプレビュー"
               />
               {camera.cameraActive && (

--- a/src/components/tools/RegexMatchTester.tsx
+++ b/src/components/tools/RegexMatchTester.tsx
@@ -44,7 +44,12 @@ function highlight(
     nodes.push(
       <mark
         key={`m-${i}`}
-        className={cx('match-highlight text-default', colorClass, selected === i && 'match-highlight-active', m.value === '' && 'match-highlight-empty')}
+        className={cx(
+          'match-highlight text-default',
+          colorClass,
+          selected === i && 'match-highlight-active',
+          m.value === '' && 'match-highlight-empty'
+        )}
         onClick={() => onSelect(i)}
         title={`マッチ ${i + 1}`}
       >

--- a/src/components/tools/RegexMatchTester.tsx
+++ b/src/components/tools/RegexMatchTester.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { cx } from '@/utils/cx';
 import type { ReactNode } from 'react';
 import { InputField } from '@/components/ui/InputField';
 import { ActionButton } from '@/components/ui/ActionButton';
@@ -40,12 +41,10 @@ function highlight(
       nodes.push(<span key={`t-${i}`}>{input.slice(cursor, m.start)}</span>);
     }
     const colorClass = i % 2 === 0 ? 'match-highlight-a' : 'match-highlight-b';
-    const activeClass = selected === i ? ' match-highlight-active' : '';
-    const emptyClass = m.value === '' ? ' match-highlight-empty' : '';
     nodes.push(
       <mark
         key={`m-${i}`}
-        className={`match-highlight text-default ${colorClass}${activeClass}${emptyClass}`}
+        className={cx('match-highlight text-default', colorClass, selected === i && 'match-highlight-active', m.value === '' && 'match-highlight-empty')}
         onClick={() => onSelect(i)}
         title={`マッチ ${i + 1}`}
       >

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -78,7 +78,10 @@ function FieldBreakdownPanel({ uuid }: { uuid: string }) {
               {f.key} <span className="uuid-field-bits">({f.bits})</span>
             </span>
             <code
-              className={cx('font-mono whitespace-nowrap rounded px-1.5 py-0.5 bg-default border border-default caption', f.className)}
+              className={cx(
+                'font-mono whitespace-nowrap rounded px-1.5 py-0.5 bg-default border border-default caption',
+                f.className
+              )}
             >
               {f.value}
             </code>

--- a/src/components/tools/UuidV7Generator.tsx
+++ b/src/components/tools/UuidV7Generator.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { cx } from '@/utils/cx';
 import { v7 as uuidv7 } from 'uuid';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { ToggleGroup } from '@/components/ui/ToggleGroup';
@@ -77,7 +78,7 @@ function FieldBreakdownPanel({ uuid }: { uuid: string }) {
               {f.key} <span className="uuid-field-bits">({f.bits})</span>
             </span>
             <code
-              className={`font-mono whitespace-nowrap rounded px-1.5 py-0.5 bg-default border border-default caption ${f.className}`}
+              className={cx('font-mono whitespace-nowrap rounded px-1.5 py-0.5 bg-default border border-default caption', f.className)}
             >
               {f.value}
             </code>

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -1,3 +1,4 @@
+import { cx } from '@/utils/cx';
 import { ChevronIcon } from '@/components/ui/ChevronIcon';
 import { CloseIcon } from '@/components/ui/CloseIcon';
 import { CopyButton } from '@/components/ui/CopyButton';
@@ -234,9 +235,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
               return (
                 <div
                   key={row._key}
-                  className={`flex flex-col md:flex-row gap-2 items-stretch md:items-center mb-6 md:mb-0 pb-4 md:pb-0 border-b border-(--color-border) md:border-b-0 ${
-                    i === tickets.length - 1 ? 'border-none' : ''
-                  }`}
+                  className={cx('flex flex-col md:flex-row gap-2 items-stretch md:items-center mb-6 md:mb-0 pb-4 md:pb-0 border-b border-(--color-border) md:border-b-0', i === tickets.length - 1 && 'border-none')}
                 >
                   <div className="flex-1 min-w-0 flex flex-col gap-1">
                     <span className="md:hidden caption text-muted font-semibold leading-none">
@@ -278,7 +277,7 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
                   <div className="flex items-center justify-between md:justify-end gap-2 mt-2 md:mt-0">
                     <span className="md:hidden caption text-muted font-semibold">合計データ量</span>
                     <span
-                      className={`w-auto md:w-15 caption text-right ${isOver ? 'text-error font-semibold' : 'text-muted'}`}
+                      className={cx('w-auto md:w-15 caption text-right', isOver ? 'text-error font-semibold' : 'text-muted')}
                       title="QRコードに埋め込まれる全データ（署名・時間含む）の合計バイト数"
                     >
                       {byteSize} B

--- a/src/components/tools/qr-ticket/GenerateTab.tsx
+++ b/src/components/tools/qr-ticket/GenerateTab.tsx
@@ -235,7 +235,10 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
               return (
                 <div
                   key={row._key}
-                  className={cx('flex flex-col md:flex-row gap-2 items-stretch md:items-center mb-6 md:mb-0 pb-4 md:pb-0 border-b border-(--color-border) md:border-b-0', i === tickets.length - 1 && 'border-none')}
+                  className={cx(
+                    'flex flex-col md:flex-row gap-2 items-stretch md:items-center mb-6 md:mb-0 pb-4 md:pb-0 border-b border-(--color-border) md:border-b-0',
+                    i === tickets.length - 1 && 'border-none'
+                  )}
                 >
                   <div className="flex-1 min-w-0 flex flex-col gap-1">
                     <span className="md:hidden caption text-muted font-semibold leading-none">
@@ -277,7 +280,10 @@ export function GenerateTab({ keyPair, generation }: GenerateTabProps) {
                   <div className="flex items-center justify-between md:justify-end gap-2 mt-2 md:mt-0">
                     <span className="md:hidden caption text-muted font-semibold">合計データ量</span>
                     <span
-                      className={cx('w-auto md:w-15 caption text-right', isOver ? 'text-error font-semibold' : 'text-muted')}
+                      className={cx(
+                        'w-auto md:w-15 caption text-right',
+                        isOver ? 'text-error font-semibold' : 'text-muted'
+                      )}
                       title="QRコードに埋め込まれる全データ（署名・時間含む）の合計バイト数"
                     >
                       {byteSize} B

--- a/src/components/tools/qr-ticket/TicketDetail.tsx
+++ b/src/components/tools/qr-ticket/TicketDetail.tsx
@@ -1,4 +1,5 @@
 import { formatTimestamp, type TicketPayload } from '@/utils/qr-ticket';
+import { cx } from '@/utils/cx';
 
 const MONO_LABELS = ['チケットID', 'イベントID'];
 
@@ -18,7 +19,7 @@ export function TicketDetail({ ticket }: { ticket: TicketPayload }) {
           <tr key={label}>
             <td className="caption text-muted pr-4 pb-1 whitespace-nowrap">{label}</td>
             <td
-              className={`caption text-default ${MONO_LABELS.includes(label) ? 'font-mono' : ''}`}
+              className={cx('caption text-default', MONO_LABELS.includes(label) && 'font-mono')}
             >
               {value}
             </td>

--- a/src/components/tools/qr-ticket/TicketDetail.tsx
+++ b/src/components/tools/qr-ticket/TicketDetail.tsx
@@ -18,9 +18,7 @@ export function TicketDetail({ ticket }: { ticket: TicketPayload }) {
         {rows.map(({ label, value }) => (
           <tr key={label}>
             <td className="caption text-muted pr-4 pb-1 whitespace-nowrap">{label}</td>
-            <td
-              className={cx('caption text-default', MONO_LABELS.includes(label) && 'font-mono')}
-            >
+            <td className={cx('caption text-default', MONO_LABELS.includes(label) && 'font-mono')}>
               {value}
             </td>
           </tr>

--- a/src/components/tools/qr-ticket/VerifyTab.tsx
+++ b/src/components/tools/qr-ticket/VerifyTab.tsx
@@ -6,6 +6,7 @@ import { Section } from '@/components/ui/Section';
 import { ActionButton } from '@/components/ui/ActionButton';
 import type { VerificationResult } from '@/utils/qr-ticket';
 import { TicketDetail } from './TicketDetail';
+import { cx } from '@/utils/cx';
 import { SCAN_OPTIONS } from './index';
 
 interface CameraProps {
@@ -152,10 +153,10 @@ export function VerifyTab({
             ) : verificationResult ? (
               <div className="space-y-3">
                 <div
-                  className={`rounded-lg p-4 border ${verificationResult.valid ? 'alert-success' : 'alert-error'}`}
+                  className={cx('rounded-lg p-4 border', verificationResult.valid ? 'alert-success' : 'alert-error')}
                 >
                   <p
-                    className={`body-emphasis ${verificationResult.valid ? 'text-success' : 'text-error'} ${verificationResult.ticket ? 'mb-3' : ''}`}
+                    className={cx('body-emphasis', verificationResult.valid ? 'text-success' : 'text-error', verificationResult.ticket && 'mb-3')}
                   >
                     {verificationResult.valid ? (
                       <span className="inline-flex items-center gap-2">

--- a/src/components/tools/qr-ticket/VerifyTab.tsx
+++ b/src/components/tools/qr-ticket/VerifyTab.tsx
@@ -153,10 +153,17 @@ export function VerifyTab({
             ) : verificationResult ? (
               <div className="space-y-3">
                 <div
-                  className={cx('rounded-lg p-4 border', verificationResult.valid ? 'alert-success' : 'alert-error')}
+                  className={cx(
+                    'rounded-lg p-4 border',
+                    verificationResult.valid ? 'alert-success' : 'alert-error'
+                  )}
                 >
                   <p
-                    className={cx('body-emphasis', verificationResult.valid ? 'text-success' : 'text-error', verificationResult.ticket && 'mb-3')}
+                    className={cx(
+                      'body-emphasis',
+                      verificationResult.valid ? 'text-success' : 'text-error',
+                      verificationResult.ticket && 'mb-3'
+                    )}
                   >
                     {verificationResult.valid ? (
                       <span className="inline-flex items-center gap-2">


### PR DESCRIPTION
## 概要

issue #658 対応。`src/components/tools/*` 配下に残っていた template literal + 条件付き className 構築を、`src/utils/cx.ts` の `cx` ヘルパーへ統一する純粋リファクタ。#260 / PR #657 で `src/components/ui/` に導入済みの方式を `tools/` 配下へ横展開した。

`CertDecoder.tsx` の `mono===false` 時に発生していた `gap-2  caption` の二重空白など、中間・末尾の二重空白が `cx`（falsy 除去 + 単一スペース join）により解消される。

## 変更内容

12 ファイルの動的 className を `cx(...)` 化:

- `qr-ticket/VerifyTab.tsx` / `qr-ticket/TicketDetail.tsx` / `qr-ticket/GenerateTab.tsx`
- `QrReader.tsx` / `CertDecoder.tsx` / `RegexMatchTester.tsx` / `UuidV7Generator.tsx`
- `JwtDecoder.tsx` / `Gs1Databar.tsx` / `ClipboardInspector.tsx` / `CharCount.tsx` / `ConfigConverter.tsx`

変換時の方針:

- `` `a ${cond ? 'x' : ''}` `` → `cx('a', cond && 'x')`
- `QrReader` の `${cameraActive ? '' : 'hidden'}` は条件を反転し `!cameraActive && 'hidden'` に正規化
- `RegexMatchTester` の先頭スペース付き変数（`activeClass` / `emptyClass`）は変数定義を廃し `cond && 'class'` に正規化
- `Gs1Databar` の動的クラストークン `print-grid--cols-${printCols}` は分割せず template literal のまま `cx` 引数へ
- 各ファイルに `import { cx } from '@/utils/cx';` を追加

**クラス名・記述順序は一切変更していない**（DOM 出力は二重空白の解消を除き不変）。

## 検証

- `node_modules/.bin/astro check`: 0 errors, 0 warnings, 0 hints
- `npm run test`: 2086 passed（既存の環境依存メタテスト 3 件のみ失敗 — `sw-cache-version` は `npm run build` 未実行、`codex-git-add-files` はシェルスクリプト系で、本リファクタとは無関係）
- 挙動不変の純粋リファクタのため E2E は既存 baseline で担保

Closes #658

https://claude.ai/code/session_01JJ4cmWufJ2neXFSogggxJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJ4cmWufJ2neXFSogggxJB)_