### PR TITLE
fix(security): validateFile に画像 magic-byte 検証を追加 (#398)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -205,6 +205,7 @@ ECDSA 署名付きチケットを生成し、公開鍵でオフライン検証�
 カメラまたは画像ファイルから QR コードを読み取る。デコードは `jsQR`。
 
 - **画像ファイル**: `URL.createObjectURL` → `Image` → `<canvas>` に描画 → `getImageData` → `jsQR` でデコードする（`decodeQrFromFile`）。長辺が `maxDim`（既定 1600px）を超える画像はアスペクト比を保ってダウンスケールしてから処理する。各 `await` ポイントで `AbortSignal` を確認し、処理中のキャンセルに対応する。
+- **ファイル検証**: アップロード前に `validateFile`（`@/utils/file-validation`）で検証する。画像判定は `file.type`（OS / browser 由来の advisory 値で拡張子偽装を検知できない）に依存せず、先頭バイトの magic number（PNG / JPEG / GIF / WebP）で行う。SVG はバイナリ magic を持たないため先頭テキストを sniff（`<svg>` 始まり、または `<?xml>` 始まり かつ `<svg>` 出現）する。拡張子だけ画像に偽装した非画像ファイルは canvas 到達前に拒否される。
 - **カメラ**: `useQrCamera` フックでライブ映像から読み取る。
 - **結果判定**: デコード文字列を `detectQrContent` で解析し、`http:` / `https:` の URL ならホスト名付きの URL として、それ以外はテキストとして表示する。
 

--- a/src/components/tools/EncodingConverter.tsx
+++ b/src/components/tools/EncodingConverter.tsx
@@ -171,7 +171,7 @@ export function EncodingConverterTool() {
     e.target.value = '';
     if (!file) return;
 
-    const validation = validateFile(file, {
+    const validation = await validateFile(file, {
       kind: 'text',
       maxBytes: 10 * 1024 * 1024,
       acceptExtensions: ACCEPTED_EXTENSIONS,

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -51,7 +51,7 @@ export function QrReaderTool() {
     // 同名ファイルを再選択できるよう値をクリア（File 自体は file 変数で参照済み）
     e.target.value = '';
 
-    const validation = validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
+    const validation = await validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
     if (!validation.ok) {
       setDecodeError(validation.message);
       return;

--- a/src/components/tools/qr-ticket/__tests__/useTicketVerification.test.tsx
+++ b/src/components/tools/qr-ticket/__tests__/useTicketVerification.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/utils/qr-ticket', () => ({
 }));
 
 vi.mock('@/utils/file-validation', () => ({
-  validateFile: vi.fn(() => ({ ok: true, message: '' })),
+  validateFile: vi.fn(async () => ({ ok: true, message: '' })),
 }));
 
 vi.mock('@/utils/qr-reader', () => ({
@@ -148,7 +148,7 @@ describe('useTicketVerification — handleImageUpload', () => {
 
   it('ファイルバリデーション失敗時は setCameraError が呼ばれる', async () => {
     const { validateFile } = await import('@/utils/file-validation');
-    vi.mocked(validateFile).mockReturnValueOnce({
+    vi.mocked(validateFile).mockResolvedValueOnce({
       ok: false,
       code: 'WRONG_TYPE',
       message: 'ファイルが不正です',

--- a/src/components/tools/qr-ticket/useTicketVerification.ts
+++ b/src/components/tools/qr-ticket/useTicketVerification.ts
@@ -88,7 +88,7 @@ export function useTicketVerification({
     if (!file) return;
     e.target.value = '';
 
-    const validation = validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
+    const validation = await validateFile(file, { kind: 'image', maxBytes: 15 * 1024 * 1024 });
     if (!validation.ok) {
       camera.setCameraError(validation.message);
       return;

--- a/src/utils/__tests__/file-validation.test.ts
+++ b/src/utils/__tests__/file-validation.test.ts
@@ -12,12 +12,7 @@ const MAX_BYTES = 2 * MB;
  * @param name ファイル名
  * @param type MIME タイプ
  */
-function makeFile(
-  totalBytes: number,
-  name: string,
-  type: string,
-  magic: number[] = []
-): File {
+function makeFile(totalBytes: number, name: string, type: string, magic: number[] = []): File {
   const data = new Uint8Array(totalBytes);
   // 先頭に magic バイトを配置する
   for (let i = 0; i < magic.length && i < totalBytes; i++) {
@@ -34,9 +29,18 @@ const JPEG_MAGIC = [0xff, 0xd8, 0xff, 0xe0];
 const GIF_MAGIC = [0x47, 0x49, 0x46, 0x38];
 // WebP: "RIFF" (offset 0) + 4 bytes サイズ + "WEBP" (offset 8)
 const WEBP_MAGIC = [
-  0x52, 0x49, 0x46, 0x46, // RIFF
-  0x00, 0x00, 0x00, 0x00, // サイズ（ダミー）
-  0x57, 0x45, 0x42, 0x50, // WEBP
+  0x52,
+  0x49,
+  0x46,
+  0x46, // RIFF
+  0x00,
+  0x00,
+  0x00,
+  0x00, // サイズ（ダミー）
+  0x57,
+  0x45,
+  0x42,
+  0x50, // WEBP
 ];
 // PDF magic（画像ではない非画像バイト列、陽性対照に使用）
 const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46, 0x2d]; // "%PDF-"
@@ -138,10 +142,10 @@ describe('validateFile — SVG OK (陰性対照: SVG はテキスト sniff で�
     // 陰性対照: type が空でも先頭テキストで SVG を識別できる
     const svgContent =
       '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"></svg>';
-    const result = await validateFile(
-      new File([svgContent], 'image.svg', { type: '' }),
-      { maxBytes: MAX_BYTES, kind: 'image' }
-    );
+    const result = await validateFile(new File([svgContent], 'image.svg', { type: '' }), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
     expect(result.ok).toBe(true);
   });
 
@@ -166,10 +170,10 @@ describe('validateFile — image WRONG_TYPE (陽性対照: 非画像バイトは
     // 陽性対照: file.type = image/png でも実バイトが PDF magic なら拒否される。
     // 旧実装（file.type.startsWith("image/") チェックのみ）ではこれが ok=true で通っていた。
     // magic-byte 検証への変更により確実に WRONG_TYPE になることを保証する。
-    const result = await validateFile(
-      makeFile(100, 'photo.png', 'image/png', PDF_MAGIC),
-      { maxBytes: MAX_BYTES, kind: 'image' }
-    );
+    const result = await validateFile(makeFile(100, 'photo.png', 'image/png', PDF_MAGIC), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
   });
@@ -197,10 +201,10 @@ describe('validateFile — image WRONG_TYPE (陽性対照: 非画像バイトは
   it('PNG magic を持ち name=fake.jpg type=image/jpeg なファイルは ok = true（実体が画像なら通る）', async () => {
     // 陽性対照の逆証明: magic が正しければ拡張子・MIME が違っても ok になる。
     // これは magic 検証の正しい挙動（file.type 依存ではない証明）。
-    const result = await validateFile(
-      makeFile(100, 'fake.jpg', 'image/jpeg', PNG_MAGIC),
-      { maxBytes: MAX_BYTES, kind: 'image' }
-    );
+    const result = await validateFile(makeFile(100, 'fake.jpg', 'image/jpeg', PNG_MAGIC), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
     expect(result.ok).toBe(true);
   });
 });

--- a/src/utils/__tests__/file-validation.test.ts
+++ b/src/utils/__tests__/file-validation.test.ts
@@ -44,6 +44,21 @@ const WEBP_MAGIC = [
 ];
 // PDF magic（画像ではない非画像バイト列、陽性対照に使用）
 const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46, 0x2d]; // "%PDF-"
+// RIFF だが offset 8 が "WAVE"（WebP ではない）。offset 8 チェックの退行検知用。
+const RIFF_WAVE = [
+  0x52,
+  0x49,
+  0x46,
+  0x46, // RIFF
+  0x00,
+  0x00,
+  0x00,
+  0x00, // サイズ（ダミー）
+  0x57,
+  0x41,
+  0x56,
+  0x45, // WAVE
+];
 
 // ──────────────────────────────────────────────
 // サイズ境界テスト（magic 不問: EMPTY は size 0、TOO_LARGE は size チェックが先行）
@@ -206,6 +221,30 @@ describe('validateFile — image WRONG_TYPE (陽性対照: 非画像バイトは
       kind: 'image',
     });
     expect(result.ok).toBe(true);
+  });
+
+  it('RIFF だが offset 8 が "WAVE" のファイルは WRONG_TYPE を返す', async () => {
+    // 陽性対照: WebP 判定は "RIFF"(0) + "WEBP"(8) の両方を要求する。
+    // offset 8 チェックが将来削られると RIFF コンテナ（WAV 等）が誤って
+    // 画像として通る退行になるため、それを検知する。
+    const result = await validateFile(makeFile(100, 'audio.webp', 'image/webp', RIFF_WAVE), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
+  });
+
+  it('<?xml> 始まりでも <svg> を含まない XML は WRONG_TYPE を返す', async () => {
+    // 陽性対照: XML 宣言の単純包含だけで通すと RSS / SOAP 等まで image 扱いになる。
+    // SVG 要素の存在を必須にしているため、<svg> なしの XML は拒否される。
+    const rss = '<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>';
+    const result = await validateFile(new File([rss], 'feed.xml', { type: 'application/xml' }), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
   });
 });
 

--- a/src/utils/__tests__/file-validation.test.ts
+++ b/src/utils/__tests__/file-validation.test.ts
@@ -4,13 +4,50 @@ import { validateFile } from '@/utils/file-validation';
 const MB = 1024 * 1024;
 const MAX_BYTES = 2 * MB;
 
-function makeFile(bytes: number, name: string, type: string): File {
-  return new File([new Uint8Array(bytes)], name, { type });
+/**
+ * 指定された先頭バイト列 + ゼロ埋めでファイルを生成するヘルパ。
+ * magic-byte 検証に対応するため先頭バイトを指定できるよう拡張した。
+ * @param magic 先頭に配置するバイト列（省略時は全ゼロ）
+ * @param totalBytes ファイル全体のバイト数
+ * @param name ファイル名
+ * @param type MIME タイプ
+ */
+function makeFile(
+  totalBytes: number,
+  name: string,
+  type: string,
+  magic: number[] = []
+): File {
+  const data = new Uint8Array(totalBytes);
+  // 先頭に magic バイトを配置する
+  for (let i = 0; i < magic.length && i < totalBytes; i++) {
+    data[i] = magic[i];
+  }
+  return new File([data], name, { type });
 }
 
+// PNG magic: 0x89 0x50 0x4E 0x47
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47];
+// JPEG magic: 0xFF 0xD8 0xFF
+const JPEG_MAGIC = [0xff, 0xd8, 0xff, 0xe0];
+// GIF magic: "GIF8"
+const GIF_MAGIC = [0x47, 0x49, 0x46, 0x38];
+// WebP: "RIFF" (offset 0) + 4 bytes サイズ + "WEBP" (offset 8)
+const WEBP_MAGIC = [
+  0x52, 0x49, 0x46, 0x46, // RIFF
+  0x00, 0x00, 0x00, 0x00, // サイズ（ダミー）
+  0x57, 0x45, 0x42, 0x50, // WEBP
+];
+// PDF magic（画像ではない非画像バイト列、陽性対照に使用）
+const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46, 0x2d]; // "%PDF-"
+
+// ──────────────────────────────────────────────
+// サイズ境界テスト（magic 不問: EMPTY は size 0、TOO_LARGE は size チェックが先行）
+// ──────────────────────────────────────────────
+
 describe('validateFile — EMPTY', () => {
-  it('0 バイトのファイルは EMPTY を返す', () => {
-    const result = validateFile(makeFile(0, 'empty.png', 'image/png'), {
+  it('0 バイトのファイルは EMPTY を返す（magic チェック前にサイズで弾く）', async () => {
+    const result = await validateFile(makeFile(0, 'empty.png', 'image/png'), {
       maxBytes: MAX_BYTES,
       kind: 'image',
     });
@@ -20,8 +57,9 @@ describe('validateFile — EMPTY', () => {
 });
 
 describe('validateFile — TOO_LARGE', () => {
-  it('maxBytes + 1 バイトは TOO_LARGE を返す', () => {
-    const result = validateFile(makeFile(MAX_BYTES + 1, 'big.png', 'image/png'), {
+  it('maxBytes + 1 バイトは TOO_LARGE を返す（magic チェック前にサイズで弾く）', async () => {
+    // TOO_LARGE はサイズチェックが先行するため magic は全ゼロでよい
+    const result = await validateFile(makeFile(MAX_BYTES + 1, 'big.png', 'image/png'), {
       maxBytes: MAX_BYTES,
       kind: 'image',
     });
@@ -29,8 +67,9 @@ describe('validateFile — TOO_LARGE', () => {
     if (!result.ok) expect(result.code).toBe('TOO_LARGE');
   });
 
-  it('ちょうど maxBytes のファイルは ok = true（境界値）', () => {
-    const result = validateFile(makeFile(MAX_BYTES, 'exact.png', 'image/png'), {
+  it('ちょうど maxBytes のファイルは ok = true（境界値）', async () => {
+    // PNG magic を先頭に置いて magic 判定を通過させる
+    const result = await validateFile(makeFile(MAX_BYTES, 'exact.png', 'image/png', PNG_MAGIC), {
       maxBytes: MAX_BYTES,
       kind: 'image',
     });
@@ -38,46 +77,149 @@ describe('validateFile — TOO_LARGE', () => {
   });
 });
 
-describe('validateFile — image WRONG_TYPE', () => {
-  it('type = application/pdf は WRONG_TYPE を返す', () => {
-    const result = validateFile(makeFile(100, 'doc.pdf', 'application/pdf'), {
+// ──────────────────────────────────────────────
+// 陰性対照（正当な画像 magic → ok = true）
+// ──────────────────────────────────────────────
+
+describe('validateFile — image OK (陰性対照: 正当な magic を持つ画像は通過する)', () => {
+  it('PNG magic を持つファイルは ok = true', async () => {
+    // 陰性対照: 実際の PNG バイト列で始まるファイルは正しく通過する
+    const result = await validateFile(makeFile(100, 'photo.png', 'image/png', PNG_MAGIC), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('JPEG magic を持つファイルは ok = true', async () => {
+    // 陰性対照: JPEG バイト列で始まるファイルは正しく通過する
+    const result = await validateFile(makeFile(100, 'photo.jpg', 'image/jpeg', JPEG_MAGIC), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('WebP magic を持つファイルは ok = true', async () => {
+    // 陰性対照: WebP は RIFF ヘッダ + offset 8 の "WEBP" で判定する
+    const result = await validateFile(makeFile(100, 'photo.webp', 'image/webp', WEBP_MAGIC), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('GIF magic を持つファイルは ok = true', async () => {
+    // 陰性対照: "GIF8" で始まるファイルは正しく通過する
+    const result = await validateFile(makeFile(100, 'anim.gif', 'image/gif', GIF_MAGIC), {
+      maxBytes: MAX_BYTES,
+      kind: 'image',
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────
+// 陰性対照（SVG テキストとして sniff → ok = true）
+// ──────────────────────────────────────────────
+
+describe('validateFile — SVG OK (陰性対照: SVG はテキスト sniff で通過する)', () => {
+  it('<svg ...> で始まる SVG は ok = true（type = image/svg+xml）', async () => {
+    // 陰性対照: QR Reader が SVG アップロードを公式サポートするため SVG を通す必要がある
+    const svgContent = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"></svg>';
+    const result = await validateFile(
+      new File([svgContent], 'icon.svg', { type: 'image/svg+xml' }),
+      { maxBytes: MAX_BYTES, kind: 'image' }
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('<?xml ...><svg> で始まる SVG は ok = true（type 空でも通過）', async () => {
+    // 陰性対照: type が空でも先頭テキストで SVG を識別できる
+    const svgContent =
+      '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"></svg>';
+    const result = await validateFile(
+      new File([svgContent], 'image.svg', { type: '' }),
+      { maxBytes: MAX_BYTES, kind: 'image' }
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('BOM 付き SVG も ok = true（先頭 BOM を除去して sniff）', async () => {
+    // 陰性対照: BOM (U+FEFF) を除去してから小文字比較するため通過する
+    const bom = '﻿';
+    const svgContent = bom + '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+    const result = await validateFile(
+      new File([svgContent], 'bom.svg', { type: 'image/svg+xml' }),
+      { maxBytes: MAX_BYTES, kind: 'image' }
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────
+// 陽性対照（検知能力の証明: 非画像バイトは reject される）
+// ──────────────────────────────────────────────
+
+describe('validateFile — image WRONG_TYPE (陽性対照: 非画像バイトは reject される)', () => {
+  it('PDF バイト列で始まる photo.png（拡張子偽装）は WRONG_TYPE を返す', async () => {
+    // 陽性対照: file.type = image/png でも実バイトが PDF magic なら拒否される。
+    // 旧実装（file.type.startsWith("image/") チェックのみ）ではこれが ok=true で通っていた。
+    // magic-byte 検証への変更により確実に WRONG_TYPE になることを保証する。
+    const result = await validateFile(
+      makeFile(100, 'photo.png', 'image/png', PDF_MAGIC),
+      { maxBytes: MAX_BYTES, kind: 'image' }
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
+  });
+
+  it('全ゼロバイト（magic なし）で name=photo.png type=image/png は WRONG_TYPE を返す', async () => {
+    // 陽性対照: ゼロ埋めファイルは magic に合致せず SVG テキストでもないため拒否される
+    const result = await validateFile(
+      makeFile(100, 'photo.png', 'image/png'), // magic 引数なし = 全ゼロ
+      { maxBytes: MAX_BYTES, kind: 'image' }
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
+  });
+
+  it('type = application/pdf の全ゼロファイルは WRONG_TYPE を返す', async () => {
+    // 陽性対照: MIME も magic も画像でないファイルは当然拒否
+    const result = await validateFile(makeFile(100, 'doc.pdf', 'application/pdf'), {
       maxBytes: MAX_BYTES,
       kind: 'image',
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
   });
-});
 
-describe('validateFile — image OK', () => {
-  it('type = image/png は ok = true', () => {
-    const result = validateFile(makeFile(100, 'photo.png', 'image/png'), {
-      maxBytes: MAX_BYTES,
-      kind: 'image',
-    });
-    expect(result.ok).toBe(true);
-  });
-
-  it('type = image/webp は ok = true', () => {
-    const result = validateFile(makeFile(100, 'photo.webp', 'image/webp'), {
-      maxBytes: MAX_BYTES,
-      kind: 'image',
-    });
+  it('PNG magic を持ち name=fake.jpg type=image/jpeg なファイルは ok = true（実体が画像なら通る）', async () => {
+    // 陽性対照の逆証明: magic が正しければ拡張子・MIME が違っても ok になる。
+    // これは magic 検証の正しい挙動（file.type 依存ではない証明）。
+    const result = await validateFile(
+      makeFile(100, 'fake.jpg', 'image/jpeg', PNG_MAGIC),
+      { maxBytes: MAX_BYTES, kind: 'image' }
+    );
     expect(result.ok).toBe(true);
   });
 });
+
+// ──────────────────────────────────────────────
+// text kind テスト（挙動不変: MIME/拡張子チェックを維持）
+// ──────────────────────────────────────────────
 
 describe('validateFile — text OK by MIME', () => {
-  it('type = text/plain は ok = true', () => {
-    const result = validateFile(makeFile(100, 'note.txt', 'text/plain'), {
+  it('type = text/plain は ok = true', async () => {
+    const result = await validateFile(makeFile(100, 'note.txt', 'text/plain'), {
       maxBytes: MAX_BYTES,
       kind: 'text',
     });
     expect(result.ok).toBe(true);
   });
 
-  it('type = application/json は ok = true', () => {
-    const result = validateFile(makeFile(100, 'data.json', 'application/json'), {
+  it('type = application/json は ok = true', async () => {
+    const result = await validateFile(makeFile(100, 'data.json', 'application/json'), {
       maxBytes: MAX_BYTES,
       kind: 'text',
     });
@@ -86,8 +228,8 @@ describe('validateFile — text OK by MIME', () => {
 });
 
 describe('validateFile — text OK by extension', () => {
-  it('type が空でも acceptExtensions に一致すれば ok = true', () => {
-    const result = validateFile(makeFile(100, 'data.csv', ''), {
+  it('type が空でも acceptExtensions に一致すれば ok = true', async () => {
+    const result = await validateFile(makeFile(100, 'data.csv', ''), {
       maxBytes: MAX_BYTES,
       kind: 'text',
       acceptExtensions: ['.csv'],
@@ -95,8 +237,8 @@ describe('validateFile — text OK by extension', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('拡張子が大文字（.CSV）でも acceptExtensions に一致すれば ok = true', () => {
-    const result = validateFile(makeFile(100, 'DATA.CSV', ''), {
+  it('拡張子が大文字（.CSV）でも acceptExtensions に一致すれば ok = true', async () => {
+    const result = await validateFile(makeFile(100, 'DATA.CSV', ''), {
       maxBytes: MAX_BYTES,
       kind: 'text',
       acceptExtensions: ['.csv'],
@@ -106,8 +248,8 @@ describe('validateFile — text OK by extension', () => {
 });
 
 describe('validateFile — text WRONG_TYPE', () => {
-  it('type = image/jpeg かつ acceptExtensions = [.csv] は WRONG_TYPE', () => {
-    const result = validateFile(makeFile(100, 'photo.jpg', 'image/jpeg'), {
+  it('type = image/jpeg かつ acceptExtensions = [.csv] は WRONG_TYPE', async () => {
+    const result = await validateFile(makeFile(100, 'photo.jpg', 'image/jpeg'), {
       maxBytes: MAX_BYTES,
       kind: 'text',
       acceptExtensions: ['.csv'],
@@ -116,8 +258,8 @@ describe('validateFile — text WRONG_TYPE', () => {
     if (!result.ok) expect(result.code).toBe('WRONG_TYPE');
   });
 
-  it('type = application/octet-stream かつ name = file.exe は WRONG_TYPE', () => {
-    const result = validateFile(makeFile(100, 'file.exe', 'application/octet-stream'), {
+  it('type = application/octet-stream かつ name = file.exe は WRONG_TYPE', async () => {
+    const result = await validateFile(makeFile(100, 'file.exe', 'application/octet-stream'), {
       maxBytes: MAX_BYTES,
       kind: 'text',
     });

--- a/src/utils/file-validation.ts
+++ b/src/utils/file-validation.ts
@@ -48,14 +48,20 @@ function matchesBinaryImageMagic(bytes: Uint8Array): boolean {
 
 /**
  * SVG はバイナリ magic を持たないため XML テキストとして sniff する。
- * 先頭 1KB を UTF-8 デコードし、BOM・前方空白を除いた小文字テキストに
- * "<?xml" または "<svg" が含まれるかで判定する。
+ * 先頭 1KB を UTF-8 デコードし、前方空白を除いた小文字テキストで判定する。
+ * - `<svg` 直開始
+ * - もしくは XML 宣言 `<?xml` 始まり **かつ** `<svg` が出現する場合
+ * `<?xml` の単純包含だけで通すと RSS / SOAP / plist 等の任意 XML まで
+ * image 扱いになるため、SVG 要素の存在を必須にして誤検知を抑える。
  */
 function matchesSvgText(bytes: Uint8Array): boolean {
-  const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
-  // BOM (U+FEFF) と先頭空白を除去して小文字化
-  const trimmed = text.replace(/^﻿/, '').trimStart().toLowerCase();
-  return trimmed.includes('<?xml') || trimmed.startsWith('<svg');
+  // TextDecoder は既定（ignoreBOM: false）で先頭 BOM を消費・除去するため
+  // 別途 BOM を strip する必要はない。前方空白のみ trim して判定する。
+  const trimmed = new TextDecoder('utf-8', { fatal: false })
+    .decode(bytes)
+    .trimStart()
+    .toLowerCase();
+  return trimmed.startsWith('<svg') || (trimmed.startsWith('<?xml') && trimmed.includes('<svg'));
 }
 
 /**
@@ -82,18 +88,12 @@ export async function validateFile(file: File, opts: ValidateOptions): Promise<V
   }
 
   if (opts.kind === 'image') {
-    // file.type は advisory のため実バイトの magic を検証する
-    const buf = await file.slice(0, 16).arrayBuffer();
-    const header = new Uint8Array(buf);
+    // file.type は advisory のため実バイトの magic を検証する。
+    // 先頭 1KB を 1 回だけ読み、binary magic（先頭数バイト）と
+    // SVG テキスト sniff の両方で共用して I/O を 1 回に抑える。
+    const header = new Uint8Array(await file.slice(0, 1024).arrayBuffer());
 
-    if (matchesBinaryImageMagic(header)) {
-      return { ok: true, file };
-    }
-
-    // SVG: バイナリ magic を持たないため先頭 1KB をテキストとして sniff する
-    const svgBuf = await file.slice(0, 1024).arrayBuffer();
-    const svgHeader = new Uint8Array(svgBuf);
-    if (matchesSvgText(svgHeader)) {
+    if (matchesBinaryImageMagic(header) || matchesSvgText(header)) {
       return { ok: true, file };
     }
 

--- a/src/utils/file-validation.ts
+++ b/src/utils/file-validation.ts
@@ -12,7 +12,63 @@ export type ValidationResult =
   | { ok: true; file: File }
   | { ok: false; code: 'TOO_LARGE' | 'WRONG_TYPE' | 'EMPTY'; message: string };
 
-export function validateFile(file: File, opts: ValidateOptions): ValidationResult {
+// ──────────────────────────────────────────────
+// Magic-byte 判定ヘルパ
+//
+// file.type は OS/browser 由来の advisory 値であり、
+// 拡張子を偽装したファイルでも image/png 等が返る。
+// 実際のバイト列（magic number）を読み取ることで堅牢に判定する。
+// ──────────────────────────────────────────────
+
+/** バイト配列が指定オフセットから期待バイト列で始まるか確認する */
+function startsWith(bytes: Uint8Array, magic: readonly number[], offset = 0): boolean {
+  for (let i = 0; i < magic.length; i++) {
+    if (bytes[offset + i] !== magic[i]) return false;
+  }
+  return true;
+}
+
+/** 先頭 16 バイトのバイナリ magic で画像フォーマットを判定する（SVG は別途テキスト sniff）*/
+function matchesBinaryImageMagic(bytes: Uint8Array): boolean {
+  // PNG: 0x89 0x50 0x4E 0x47
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47])) return true;
+  // JPEG: 0xFF 0xD8 0xFF
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return true;
+  // GIF: "GIF8" (0x47 0x49 0x46 0x38)
+  if (startsWith(bytes, [0x47, 0x49, 0x46, 0x38])) return true;
+  // WebP: "RIFF" (offset 0) + "WEBP" (offset 8)
+  if (
+    startsWith(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+    startsWith(bytes, [0x57, 0x45, 0x42, 0x50], 8)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * SVG はバイナリ magic を持たないため XML テキストとして sniff する。
+ * 先頭 1KB を UTF-8 デコードし、BOM・前方空白を除いた小文字テキストに
+ * "<?xml" または "<svg" が含まれるかで判定する。
+ */
+function matchesSvgText(bytes: Uint8Array): boolean {
+  const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  // BOM (U+FEFF) と先頭空白を除去して小文字化
+  const trimmed = text.replace(/^﻿/, '').trimStart().toLowerCase();
+  return trimmed.includes('<?xml') || trimmed.startsWith('<svg');
+}
+
+/**
+ * ファイルのバリデーションを実施する。
+ *
+ * - EMPTY: 0 バイトのファイル
+ * - TOO_LARGE: maxBytes 超過
+ * - WRONG_TYPE: ファイル種別が期待と異なる
+ *
+ * 画像は先頭バイトの magic number を検証する。SVG は XML テキストとして sniff する。
+ * text kind は MIME タイプ + 拡張子による判定（従来ロジック）を維持する。
+ */
+export async function validateFile(file: File, opts: ValidateOptions): Promise<ValidationResult> {
   if (file.size === 0) {
     return { ok: false, code: 'EMPTY', message: 'ファイルが空です' };
   }
@@ -26,13 +82,26 @@ export function validateFile(file: File, opts: ValidateOptions): ValidationResul
   }
 
   if (opts.kind === 'image') {
-    if (!file.type.startsWith('image/')) {
-      return {
-        ok: false,
-        code: 'WRONG_TYPE',
-        message: '画像ファイルを選択してください（PNG/JPEG/WebP/GIF 等）',
-      };
+    // file.type は advisory のため実バイトの magic を検証する
+    const buf = await file.slice(0, 16).arrayBuffer();
+    const header = new Uint8Array(buf);
+
+    if (matchesBinaryImageMagic(header)) {
+      return { ok: true, file };
     }
+
+    // SVG: バイナリ magic を持たないため先頭 1KB をテキストとして sniff する
+    const svgBuf = await file.slice(0, 1024).arrayBuffer();
+    const svgHeader = new Uint8Array(svgBuf);
+    if (matchesSvgText(svgHeader)) {
+      return { ok: true, file };
+    }
+
+    return {
+      ok: false,
+      code: 'WRONG_TYPE',
+      message: '画像ファイルを選択してください（PNG/JPEG/WebP/GIF 等）',
+    };
   } else {
     const isTextMime =
       file.type.startsWith('text/') ||


### PR DESCRIPTION
## 概要

issue #398（案 B）への対応。`validateFile` の image 判定が `file.type.startsWith('image/')` に依存しており、`file.type` は OS/browser 由来の **advisory 値**で拡張子偽装を検知できなかった。renamed 非画像が validation を通過し canvas `drawImage` まで到達する経路を解消する。

image kind の判定を**先頭バイトの magic number 検証**に置換した。

Closes #398

## 変更内容

### `src/utils/file-validation.ts`
- `validateFile` を **async 化**（`Promise<ValidationResult>`）
- image 判定を magic-byte 検証に置換（`file.type` 非依存）:
  - **PNG** `89 50 4E 47` / **JPEG** `FF D8 FF` / **GIF** `"GIF8"` / **WebP** `"RIFF"`(0)+`"WEBP"`(8) を先頭16バイトで判定
  - **SVG** はバイナリ magic を持たないため、先頭1KBを UTF-8 デコードし BOM/前方空白除去後に `<?xml`/`<svg` を sniff（QR Reader が SVG アップロードを公式サポートしているため）
- text kind は従来ロジック（MIME + 拡張子）を維持

### caller の await 化（挙動変更なし）
- `QrReader.tsx` / `qr-ticket/useTicketVerification.ts` / `EncodingConverter.tsx`

## テスト（test-gates 準拠）

検証器の改修のため**陽性対照を同梱**（陰性/陽性を別 describe に分離）:

- **陰性対照**: PNG/JPEG/WebP/GIF の各 magic、SVG（`<svg>` / `<?xml>` / BOM 付き）→ `ok=true`
- **陽性対照（検知能力の証明）**:
  - PDF バイト列を `photo.png`(`image/png`) に偽装 → `WRONG_TYPE`（**旧実装では `ok=true` で通過していた**）
  - 全ゼロバイトの `photo.png`(`image/png`) → `WRONG_TYPE`
  - PNG magic を持つ `fake.jpg`(`image/jpeg`) → `ok=true`（magic が `file.type` 非依存である逆証明）

## 検証

- `npx vitest run file-validation useTicketVerification` → **33/33 passed**
- `node_modules/.bin/astro check` → **0 errors / 0 warnings**

https://claude.ai/code/session_01HxVDdBmoDGFjgJCKCKGeJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxVDdBmoDGFjgJCKCKGeJ7)_