### PR TITLE
fix(a11y): aria/role 欠落を補完（JanCode/CidrCalculator/RegexMatchTester）

### DIFF
--- a/src/components/tools/CidrCalculator.tsx
+++ b/src/components/tools/CidrCalculator.tsx
@@ -406,9 +406,9 @@ export function CidrCalculatorTool() {
             />
           )}
 
-          {/* 行エラー一覧 */}
+          {/* 行エラー一覧: role="alert" で SR に確実に通知する（親 aria-live の初期コンテンツ問題を回避） */}
           {!overlapResult.limitExceeded && overlapResult.errors.length > 0 && (
-            <div className="mb-4">
+            <div role="alert" className="mb-4">
               <p className="body-emphasis text-error mb-2">解析エラーがある行:</p>
               <ul className="flex flex-col gap-1">
                 {overlapResult.errors.map((err) => (

--- a/src/components/tools/CidrCalculator.tsx
+++ b/src/components/tools/CidrCalculator.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useMemo, useRef } from 'react';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { InputField } from '@/components/ui/InputField';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { CopyButton } from '@/components/ui/CopyButton';
@@ -284,13 +285,18 @@ export function CidrCalculatorTool() {
   const splitRows = useMemo(() => (subnets ? buildSplitRows(subnets) : []), [subnets]);
 
   // 重複検出モードの計算
+  // 入力を debounce してから計算する。行エラー一覧は role="alert"（暗黙 assertive + atomic）の
+  // ため、毎キーストロークで再計算すると入力 1 文字ごとにエラー一覧全体が SR へ割り込み再読み上げ
+  // されてしまう（issue #663 レビュー指摘）。打鍵が止まってから 1 度だけ更新することで冗長な
+  // 再読み上げを抑えつつ、エラー出現時の確実な通知（role="alert"）は維持する。
+  const debouncedOverlapInput = useDebouncedValue(overlapInput, 300);
   const overlapResult = useMemo(() => {
     if (mode !== 'overlap') return null;
-    const lines = overlapInput.split('\n');
+    const lines = debouncedOverlapInput.split('\n');
     // 全行空ならスキップ
     if (lines.every((l) => l.trim() === '')) return null;
     return detectOverlaps(lines);
-  }, [mode, overlapInput]);
+  }, [mode, debouncedOverlapInput]);
 
   const overlapRows = useMemo(
     () => (overlapResult ? buildOverlapRows(overlapResult.pairs) : []),

--- a/src/components/tools/JanCode.tsx
+++ b/src/components/tools/JanCode.tsx
@@ -172,7 +172,7 @@ export function JanCodeTool() {
 
           {/* バーコードプレビュー */}
           <div className="rounded-lg flex flex-col items-center gap-4 p-4 border border-default bg-default">
-            <svg ref={svgRef} aria-label={`JANコード ${result.fullCode} のバーコード`} />
+            <svg ref={svgRef} role="img" aria-label={`JANコード ${result.fullCode} のバーコード`} />
             <DownloadButtonGroup onDownloadSvg={downloadSvg} onDownloadPng={downloadPng} />
           </div>
 

--- a/src/components/tools/RegexMatchTester.tsx
+++ b/src/components/tools/RegexMatchTester.tsx
@@ -41,9 +41,16 @@ function highlight(
       nodes.push(<span key={`t-${i}`}>{input.slice(cursor, m.start)}</span>);
     }
     const colorClass = i % 2 === 0 ? 'match-highlight-a' : 'match-highlight-b';
+    // aria-label: 空マッチは「（空マッチ）」を付けて SR が聞き取れるようにする
+    const ariaLabel =
+      m.value === '' ? `マッチ ${i + 1}（空マッチ）` : `マッチ ${i + 1}: ${m.value}`;
     nodes.push(
       <mark
         key={`m-${i}`}
+        role="button"
+        tabIndex={0}
+        aria-pressed={selected === i}
+        aria-label={ariaLabel}
         className={cx(
           'match-highlight text-default',
           colorClass,
@@ -52,6 +59,13 @@ function highlight(
         )}
         onClick={() => onSelect(i)}
         title={`マッチ ${i + 1}`}
+        onKeyDown={(e) => {
+          // Enter または スペースでクリックと同等の動作（キーボード操作対応）
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect(i);
+          }
+        }}
       >
         {m.value === '' ? '​' : m.value}
       </mark>

--- a/tests/e2e/cidr-calculator.spec.ts
+++ b/tests/e2e/cidr-calculator.spec.ts
@@ -116,6 +116,24 @@ test.describe('CIDR/サブネット計算機（production CSP 適用）', () => 
     });
   });
 
+  // a11y 陽性対照: 解析エラーになる不正 CIDR を入力したとき、行エラー一覧が role="alert" で
+  // 取得できることを検証。role="alert" が外れると getByRole('alert') が取得できず fail する。
+  test('重複検出モード: 不正な CIDR を入力すると role="alert" でエラー一覧が表示される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/cidr-calculator', async (page) => {
+      await page.getByRole('button', { name: '重複検出' }).click();
+
+      // 不正な CIDR（prefix 長が範囲外）を入力して解析エラーを発生させる
+      await page.getByLabel('CIDR 一覧（1 行 1 CIDR）').fill('10.0.0.0/99');
+
+      // role="alert" のエラーコンテナが表示され、エラー文言を含むことを確認
+      const alertEl = page.getByRole('alert');
+      await expect(alertEl).toBeVisible();
+      await expect(alertEl).toContainText('解析エラーがある行');
+    });
+  });
+
   // 陽性対照: 有効 CIDR 上限超過時に警告が表示される（O(n²) 爆発防止ガード）
   // 旧実装（limitExceeded ガードなし）に当てると警告が表示されず fail する設計
   test('重複検出モード: 上限超過（257 件）で件数超過の警告を表示する（CSP 違反なし）', async ({

--- a/tests/e2e/jan-code.spec.ts
+++ b/tests/e2e/jan-code.spec.ts
@@ -65,6 +65,20 @@ test.describe('JANコード生成（production CSP 適用）', () => {
     });
   });
 
+  // a11y 陽性対照: バーコード SVG に role="img" と accessible name が付与されることを検証。
+  // role="img" が外れると getByRole('img', ...) が取得できず fail する。
+  test('JAN-13: バーコード SVG が role="img" を持ち accessible name にバーコードを含む（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/jan-code', async (page) => {
+      await page.getByRole('button', { name: 'サンプルを入力' }).click();
+      await expect(page.getByText('完成コード', { exact: true })).toBeVisible();
+      // role="img" と aria-label="JANコード ... のバーコード" が付与されていることを確認
+      const barcodeSvg = page.getByRole('img', { name: /バーコード/ });
+      await expect(barcodeSvg).toBeVisible();
+    });
+  });
+
   // issue #392: downloadPngFromSvgElement Promise 化の陽性対照 E2E。
   // Image 読み込みを強制 onerror させ、async downloadPng の catch 経路で
   // ErrorMessage が表示されることを観測可能な振る舞いとして assert する

--- a/tests/e2e/regex-visualizer.spec.ts
+++ b/tests/e2e/regex-visualizer.spec.ts
@@ -137,6 +137,33 @@ test.describe('正規表現ビジュアライザ', () => {
     });
   });
 
+  // a11y 陽性対照: マッチハイライト <mark> が role="button" を持ちキーボード操作できることを検証。
+  // role="button" が外れると getByRole('button', { name: /マッチ/ }) が取得できず fail する。
+  // aria-pressed=false → Enter で aria-pressed=true に変わることで onKeyDown の動作も証明する。
+  test('マッチハイライトが role="button" を持ちキーボード（Enter）で選択できる（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/regex-visualizer', async (page) => {
+      // g フラグを有効化して複数マッチを出す
+      await page.getByRole('button', { name: 'g: 全マッチ' }).click();
+      await page.getByLabel('正規表現').fill('\\d+');
+      await page.getByLabel('テスト文字列').fill('a1 b22');
+
+      // マッチ件数の表示が出るまで待つ（マッチ処理完了の確認）
+      await expect(page.getByText(/2 件マッチ/)).toBeVisible();
+
+      // 1 件目のハイライトが role="button" として取得でき、未選択（aria-pressed=false）
+      const firstMatch = page.getByRole('button', { name: /マッチ 1/ }).first();
+      await expect(firstMatch).toBeVisible();
+      await expect(firstMatch).toHaveAttribute('aria-pressed', 'false');
+
+      // Enter キーで選択 → aria-pressed=true に変わること（onKeyDown 経路の陽性対照）
+      await firstMatch.focus();
+      await firstMatch.press('Enter');
+      await expect(firstMatch).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
   // ReDoS ゲートの陽性対照（本番 CSP 下・実 recheck 経路）: 既知の脆弱パターンで
   // マッチ実行が無効化されることを確認する。ゲートが空回りすると入力欄が出てこの assert が落ちる。
   test('vulnerable な正規表現ではマッチ実行が無効化される', async ({ browser }) => {


### PR DESCRIPTION
## 概要

issue #663 で検出した DADS 準拠監査の aria / role 欠落・不整合を補完する。3 件とも独立した a11y 修正。

Closes #663

## 変更内容

### 1. JanCode: バーコード svg に `role="img"` を付与
- `src/components/tools/JanCode.tsx`
- `aria-label` はあったが `role="img"` がなく、`<svg>` のデフォルト role はブラウザ依存。`role="img"` を付与して SR が `aria-label` を確実に accessible name として読めるようにする（ARIA 1.2）。`QrCode.tsx` が生成 SVG に `role="img"` を注入済みなのと実装を揃えた。

### 2. CidrCalculator: 重複検出の行エラー一覧に `role="alert"` を付与
- `src/components/tools/CidrCalculator.tsx`
- 親 `<section aria-live="polite">` は既存だが、section 全体が一度にマウントされると live region の初期コンテンツは SR に確実に通知されない。解析エラーは重要なため、エラーコンテナ `<div>` に `role="alert"`（暗黙 assertive + atomic）を付与して確実に通知する。pairs テーブルや「重複なし」メッセージには付けない。

### 3. RegexMatchTester: クリック可能な `<mark>` をキーボード・SR 操作可能に
- `src/components/tools/RegexMatchTester.tsx`
- 行選択用 `onClick` を持つ `<mark>` が `title` のみでマウス専用だった。`role="button"` / `tabIndex={0}` / `aria-pressed`（選択状態）/ `aria-label`（空マッチは「（空マッチ）」付き）/ `onKeyDown`（Enter・スペースで選択）を付与。
- フォーカスリングは `global.css` の `:where(..., [role='button'], ...):focus-visible` global rule が自動適用するため追加 CSS 不要。`outline-none` は未使用。

## テスト（陽性対照 E2E）

属性・キーボード操作が外れると fail する設計で各 spec に追加:

- `tests/e2e/jan-code.spec.ts`: `getByRole('img', { name: /バーコード/ })` で `role="img"` + accessible name を検証
- `tests/e2e/regex-visualizer.spec.ts`: `getByRole('button', { name: /マッチ 1/ })` で `role="button"` を検証し、Enter キーで `aria-pressed` が `false → true` に変わる（`onKeyDown` 経路）ことを検証
- `tests/e2e/cidr-calculator.spec.ts`: 不正 CIDR（`10.0.0.0/99`）入力後に `getByRole('alert')` でエラー一覧コンテナが取得できることを検証

## 検証結果

| 検証 | 結果 |
|------|------|
| `node_modules/.bin/astro check` | 0 errors / 0 warnings / 0 hints |
| `npm run test`（unit） | 関連テスト pass（失敗はビルド成果物・git 署名サーバ依存のメタテストのみで本変更と無関係） |
| `npm run test:e2e`（対象 3 spec + a11y-live-region） | 32 passed / 0 failed |

## 関連

- #479 / #483（config-converter の live region。本 issue のスコープ外）
- #386（QrCode の SVG title / role 付与の先行例）

https://claude.ai/code/session_01QpTRCLJWorrqTYT5WfdVxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpTRCLJWorrqTYT5WfdVxQ)_