### PR TITLE
feat(a11y): RegexMatchTester のマッチハイライトを roving tabindex 化 (#666)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-regex-match-roving-tabindex.md
+++ b/docs/superpowers/plans/2026-06-13-regex-match-roving-tabindex.md
@@ -1,0 +1,422 @@
+# RegexMatchTester roving tabindex 化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `RegexMatchTester` のマッチハイライト群を roving tabindex 化し、キーボードの tab stop を N 個から 1 個に削減する（issue #666）。
+
+**Architecture:** 純関数 `highlight()` を `MatchHighlights` サブコンポーネントへ抽出し、`rovingIndex` state と `<mark>` の ref を内包させる。常に 1 個の `<mark>` だけ `tabIndex={0}`、残りは `-1`。矢印 / Home / End で focus を移動（選択は変えない）、Enter / Space で既存の `onSelect` を呼ぶ。
+
+**Tech Stack:** React 19 (function component / hooks), TypeScript, Vitest + @testing-library/react (jsdom), Playwright (E2E, production CSP)。
+
+---
+
+## File Structure
+
+- Modify: `src/components/tools/RegexMatchTester.tsx`
+  - 純関数 `highlight()` を削除し、`MatchHighlights` コンポーネントへ置換。
+  - 呼び出し側（`matches.length > 0 ?` 分岐）を `<MatchHighlights .../>` に変更。
+  - import に `useRef` と型 `KeyboardEvent` を追加。
+- Modify (test): `src/components/tools/__tests__/RegexMatchTester.test.tsx`
+  - roving tabindex のユニットテストを追加（既存テストは維持）。
+- Modify (E2E): `tests/e2e/regex-visualizer.spec.ts`
+  - roving tabindex の E2E（陽性対照）を追加。既存の role="button" テストは維持。
+
+CSS（`src/styles/global.css` の `.match-highlight*`）は変更しない。
+
+---
+
+### Task 1: roving tabindex のユニットテストを追加（失敗する状態にする）
+
+**Files:**
+- Test: `src/components/tools/__tests__/RegexMatchTester.test.tsx`
+
+ロービングの陽性対照テストを追加する。jest-dom の matcher（`toHaveFocus` 等）には依存せず、
+`getAttribute('tabindex')` と `document.activeElement` で素の DOM を検証する（既存テストも
+`.toBeTruthy()` 系で jest-dom 非依存のため、それに合わせる）。
+
+- [ ] **Step 1: 失敗するテストを追記する**
+
+`describe('RegexMatchTester', ...)` ブロックの末尾（既存の最後の `it` の後ろ）に以下を追加:
+
+```tsx
+  it('複数マッチで tabIndex=0 はちょうど 1 個（roving 初期状態）', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+    expect(marks).toHaveLength(2);
+    const tabbable = marks.filter((m) => m.getAttribute('tabindex') === '0');
+    expect(tabbable).toHaveLength(1);
+    expect(marks[0].getAttribute('tabindex')).toBe('0');
+    expect(marks[1].getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('ArrowRight で roving が次のマッチへ移動し、末尾で先頭に wrap する', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+
+    marks[0].focus();
+    fireEvent.keyDown(marks[0], { key: 'ArrowRight' });
+    expect(marks[1].getAttribute('tabindex')).toBe('0');
+    expect(marks[0].getAttribute('tabindex')).toBe('-1');
+    expect(document.activeElement).toBe(marks[1]);
+
+    // 末尾で ArrowRight → 先頭へ wrap
+    fireEvent.keyDown(marks[1], { key: 'ArrowRight' });
+    expect(marks[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[0]);
+
+    // 先頭で ArrowLeft → 末尾へ wrap
+    fireEvent.keyDown(marks[0], { key: 'ArrowLeft' });
+    expect(marks[1].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[1]);
+  });
+
+  it('Home / End で先頭・末尾のマッチへ roving 移動する', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+
+    marks[0].focus();
+    fireEvent.keyDown(marks[0], { key: 'End' });
+    expect(marks[1].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[1]);
+
+    fireEvent.keyDown(marks[1], { key: 'Home' });
+    expect(marks[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[0]);
+  });
+
+  it('Enter / Space は focus 移動ではなく選択（aria-pressed 切替）を行う', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+
+    expect(marks[0].getAttribute('aria-pressed')).toBe('false');
+    fireEvent.keyDown(marks[0], { key: 'Enter' });
+    expect(marks[0].getAttribute('aria-pressed')).toBe('true');
+
+    expect(marks[1].getAttribute('aria-pressed')).toBe('false');
+    fireEvent.keyDown(marks[1], { key: ' ' });
+    expect(marks[1].getAttribute('aria-pressed')).toBe('true');
+  });
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm run test -- RegexMatchTester`
+Expected: 新規 4 件のうち少なくとも「tabIndex=0 はちょうど 1 個」「ArrowRight で roving」
+「Home/End」が FAIL（旧実装は全 `<mark>` が `tabIndex=0` 固定で矢印ハンドラも無いため）。
+既存 6 件は PASS のまま。
+
+- [ ] **Step 3: コミット（red 状態）**
+
+```bash
+git add src/components/tools/__tests__/RegexMatchTester.test.tsx
+git commit -m "test: RegexMatchTester roving tabindex の失敗テストを追加 (#666)"
+```
+
+---
+
+### Task 2: `MatchHighlights` を実装してテストを通す
+
+**Files:**
+- Modify: `src/components/tools/RegexMatchTester.tsx`
+
+- [ ] **Step 1: import を更新する**
+
+1 行目を:
+
+```tsx
+import { useEffect, useState } from 'react';
+```
+
+から次へ変更:
+
+```tsx
+import { useEffect, useState, useRef } from 'react';
+```
+
+3 行目を:
+
+```tsx
+import type { ReactNode } from 'react';
+```
+
+から次へ変更:
+
+```tsx
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+```
+
+- [ ] **Step 2: 純関数 `highlight()` を `MatchHighlights` コンポーネントへ置換する**
+
+現状の `highlight` 関数全体（`/** マッチ結果を…交互色 mark で囲む。 */` コメントから
+関数末尾 `}` まで、ファイルの 30〜79 行目相当）を、次の実装で丸ごと置き換える:
+
+```tsx
+interface MatchHighlightsProps {
+  text: string;
+  matches: RegexMatch[];
+  selected: number | null;
+  onSelect: (i: number) => void;
+}
+
+/**
+ * マッチ箇所を交互色 mark でハイライトする。roving tabindex パターンで、ハイライト群全体を
+ * 1 つの tab stop に集約する（issue #666）。常に 1 個の <mark> だけ tabIndex=0、残りは -1。
+ * 矢印 / Home / End で focus を移動（選択は変えない）、Enter / Space で onSelect を呼ぶ。
+ */
+function MatchHighlights({ text, matches, selected, onSelect }: MatchHighlightsProps) {
+  const [rovingIndex, setRovingIndex] = useState(0);
+  const markRefs = useRef<Array<HTMLElement | null>>([]);
+
+  // 新しいマッチ結果（安定参照）が来たら roving を先頭へリセットする
+  useEffect(() => {
+    setRovingIndex(0);
+  }, [matches]);
+
+  const n = matches.length;
+  // 件数縮小時の安全弁: 常に有効な tab stop が 1 個残るようにクランプ
+  const safeRoving = Math.min(rovingIndex, n - 1);
+
+  const focusMatch = (i: number) => {
+    setRovingIndex(i);
+    markRefs.current[i]?.focus();
+  };
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLElement>, i: number) => {
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        focusMatch((i + 1) % n);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        focusMatch((i - 1 + n) % n);
+        break;
+      case 'Home':
+        e.preventDefault();
+        focusMatch(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        focusMatch(n - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        // Enter / スペースは focus 移動ではなく選択（クリックと同等）
+        e.preventDefault();
+        onSelect(i);
+        break;
+    }
+  };
+
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  matches.forEach((m, i) => {
+    if (m.start > cursor) {
+      nodes.push(<span key={`t-${i}`}>{text.slice(cursor, m.start)}</span>);
+    }
+    const colorClass = i % 2 === 0 ? 'match-highlight-a' : 'match-highlight-b';
+    // aria-label: 空マッチは「（空マッチ）」を付けて SR が聞き取れるようにする
+    const ariaLabel =
+      m.value === '' ? `マッチ ${i + 1}（空マッチ）` : `マッチ ${i + 1}: ${m.value}`;
+    nodes.push(
+      <mark
+        key={`m-${i}`}
+        ref={(el) => {
+          markRefs.current[i] = el;
+        }}
+        role="button"
+        // roving tabindex: 常に 1 個だけ 0、残りは -1（tab stop を 1 つに集約）
+        tabIndex={i === safeRoving ? 0 : -1}
+        aria-pressed={selected === i}
+        aria-label={ariaLabel}
+        className={cx(
+          'match-highlight text-default',
+          colorClass,
+          selected === i && 'match-highlight-active',
+          m.value === '' && 'match-highlight-empty'
+        )}
+        onClick={() => {
+          // クリックでも roving item を更新し、次の Tab 復帰先を保持する
+          setRovingIndex(i);
+          onSelect(i);
+        }}
+        title={`マッチ ${i + 1}`}
+        onKeyDown={(e) => handleKeyDown(e, i)}
+      >
+        {m.value === '' ? '​' : m.value}
+      </mark>
+    );
+    cursor = Math.max(cursor, m.end);
+  });
+  if (cursor < text.length) {
+    nodes.push(<span key="t-tail">{text.slice(cursor)}</span>);
+  }
+
+  // role="group" + aria-label で「矢印ナビ可能な 1 グループ」であることを SR に伝える。
+  // span（inline）でラップし、親コンテナの whitespace-pre-wrap / break-all 描画を変えない。
+  return (
+    <span role="group" aria-label="マッチ箇所">
+      {nodes}
+    </span>
+  );
+}
+```
+
+> 注: `mark` に挿入している空マッチ用文字はゼロ幅スペース（U+200B）。元コードからそのまま移植する
+> こと（`{m.value === '' ? '​' : m.value}` の最初の文字列リテラルは見た目空だが U+200B を含む）。
+
+- [ ] **Step 3: 呼び出し側を置換する**
+
+`matches.length > 0 ?` 分岐内の呼び出しを変更する。現状:
+
+```tsx
+                {matches.length > 0 ? (
+                  highlight(shownText, matches, selectedIndex, setSelected)
+                ) : (
+```
+
+を次へ:
+
+```tsx
+                {matches.length > 0 ? (
+                  <MatchHighlights
+                    text={shownText}
+                    matches={matches}
+                    selected={selectedIndex}
+                    onSelect={setSelected}
+                  />
+                ) : (
+```
+
+- [ ] **Step 4: 型チェック**
+
+Run: `npx astro check --filter src/components/tools/RegexMatchTester.tsx`
+（filter が効かない場合は `node_modules/.bin/astro check`）
+Expected: エラー 0。
+
+- [ ] **Step 5: ユニットテストが通ることを確認する**
+
+Run: `npm run test -- RegexMatchTester`
+Expected: 既存 6 件 + 新規 4 件すべて PASS。
+
+- [ ] **Step 6: コミット（green 状態）**
+
+```bash
+git add src/components/tools/RegexMatchTester.tsx
+git commit -m "feat(a11y): RegexMatchTester のマッチハイライトを roving tabindex 化 (#666)"
+```
+
+---
+
+### Task 3: E2E（陽性対照）を追加する
+
+**Files:**
+- Modify: `tests/e2e/regex-visualizer.spec.ts`
+
+- [ ] **Step 1: 既存の role="button" E2E の直後にロービング E2E を追加する**
+
+PR #665 で追加された
+`test('マッチハイライトが role="button" を持ちキーボード（Enter）で選択できる…')`
+ブロックの直後に、次を追加する:
+
+```ts
+  // a11y 陽性対照: roving tabindex で tab stop を 1 つに集約していることを検証。
+  // 旧実装（全マッチ tabindex=0）に当てると「非 roving 要素が tabindex=-1」が偽になり fail する。
+  test('マッチハイライトが roving tabindex で 1 つの tab stop に集約される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/regex-visualizer', async (page) => {
+      await page.getByRole('button', { name: 'g: 全マッチ' }).click();
+      await page.getByLabel('正規表現').fill('\\d+');
+      await page.getByLabel('テスト文字列').fill('a1 b22');
+
+      await expect(page.getByText(/2 件マッチ/)).toBeVisible();
+
+      const m1 = page.getByRole('button', { name: /マッチ 1/ }).first();
+      const m2 = page.getByRole('button', { name: /マッチ 2/ }).first();
+
+      // roving 初期状態: 1 件目だけ tab stop（0）、2 件目は -1（旧実装＝両方 0 と区別）
+      await expect(m1).toHaveAttribute('tabindex', '0');
+      await expect(m2).toHaveAttribute('tabindex', '-1');
+
+      // 1 件目に focus → ArrowRight で 2 件目へ roving（focus と tabindex が移動）
+      await m1.focus();
+      await m1.press('ArrowRight');
+      await expect(m2).toBeFocused();
+      await expect(m2).toHaveAttribute('tabindex', '0');
+      await expect(m1).toHaveAttribute('tabindex', '-1');
+
+      // 末尾で ArrowRight → 先頭へ wrap
+      await m2.press('ArrowRight');
+      await expect(m1).toBeFocused();
+
+      // Enter は focus 移動ではなく選択（aria-pressed=true）
+      await m1.press('Enter');
+      await expect(m1).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+```
+
+- [ ] **Step 2: E2E を実行する**
+
+Run: `npm run test:e2e -- regex-visualizer`
+Expected: 新規テストを含め PASS。
+（実行に preview build が必要。フルランは `npm run test:e2e`。）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add tests/e2e/regex-visualizer.spec.ts
+git commit -m "test(e2e): RegexMatchTester roving tabindex の陽性対照を追加 (#666)"
+```
+
+---
+
+### Task 4: 最終検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: ユニット全件**
+
+Run: `npm run test`
+Expected: 全 PASS（meta テスト含む）。
+
+- [ ] **Step 2: 型チェック全体**
+
+Run: `node_modules/.bin/astro check`
+Expected: エラー 0。
+
+- [ ] **Step 3: フォーマットチェック**
+
+Run: `npm run format:check`
+Expected: 差分なし（あれば `npm run format` 後に再コミット）。
+
+- [ ] **Step 4: E2E 全件（regex 関連最低限 + production CSP スイート）**
+
+Run: `npm run test:e2e -- regex-visualizer`
+Expected: PASS。
+
+- [ ] **Step 5: VRT 確認**
+
+`/tools/regex-visualizer` の VRT に差分が出ないことを確認する（DOM 属性のみの変更で描画不変の想定）。
+差分が出た場合は baseline を安易に更新せず、DOM 構造 diff / computed style diff の 2 段階検証の上で
+親（レビュアー）へ目視判断を仰ぐ（`.agents/rules/common.md` §6.8）。
+
+---
+
+## 完了報告フォーマット（subagent 用）
+
+各タスクについて「実装 / 既存で十分 / スキップ理由」を項目別に明記すること。特に:
+
+- Task 1〜4 の各テスト追加が漏れていないか（依頼 4 タスク vs 実装タスク数の突き合わせ）。
+- `RegexMatchTester.tsx` の import 変更（`useRef` / `KeyboardEvent`）が入っているか。
+- `npm run test` / `astro check` / `npm run test:e2e -- regex-visualizer` の実行結果（PASS/FAIL の実出力）。

--- a/docs/superpowers/plans/2026-06-13-regex-match-roving-tabindex.md
+++ b/docs/superpowers/plans/2026-06-13-regex-match-roving-tabindex.md
@@ -28,6 +28,7 @@ CSS（`src/styles/global.css` の `.match-highlight*`）は変更しない。
 ### Task 1: roving tabindex のユニットテストを追加（失敗する状態にする）
 
 **Files:**
+
 - Test: `src/components/tools/__tests__/RegexMatchTester.test.tsx`
 
 ロービングの陽性対照テストを追加する。jest-dom の matcher（`toHaveFocus` 等）には依存せず、
@@ -39,72 +40,72 @@ CSS（`src/styles/global.css` の `.match-highlight*`）は変更しない。
 `describe('RegexMatchTester', ...)` ブロックの末尾（既存の最後の `it` の後ろ）に以下を追加:
 
 ```tsx
-  it('複数マッチで tabIndex=0 はちょうど 1 個（roving 初期状態）', async () => {
-    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
-    typeTest('a1 b22');
-    await screen.findByText(/2 件マッチ/, undefined, FIND);
+it('複数マッチで tabIndex=0 はちょうど 1 個（roving 初期状態）', async () => {
+  render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+  typeTest('a1 b22');
+  await screen.findByText(/2 件マッチ/, undefined, FIND);
 
-    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
-    expect(marks).toHaveLength(2);
-    const tabbable = marks.filter((m) => m.getAttribute('tabindex') === '0');
-    expect(tabbable).toHaveLength(1);
-    expect(marks[0].getAttribute('tabindex')).toBe('0');
-    expect(marks[1].getAttribute('tabindex')).toBe('-1');
-  });
+  const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+  expect(marks).toHaveLength(2);
+  const tabbable = marks.filter((m) => m.getAttribute('tabindex') === '0');
+  expect(tabbable).toHaveLength(1);
+  expect(marks[0].getAttribute('tabindex')).toBe('0');
+  expect(marks[1].getAttribute('tabindex')).toBe('-1');
+});
 
-  it('ArrowRight で roving が次のマッチへ移動し、末尾で先頭に wrap する', async () => {
-    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
-    typeTest('a1 b22');
-    await screen.findByText(/2 件マッチ/, undefined, FIND);
-    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+it('ArrowRight で roving が次のマッチへ移動し、末尾で先頭に wrap する', async () => {
+  render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+  typeTest('a1 b22');
+  await screen.findByText(/2 件マッチ/, undefined, FIND);
+  const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
 
-    marks[0].focus();
-    fireEvent.keyDown(marks[0], { key: 'ArrowRight' });
-    expect(marks[1].getAttribute('tabindex')).toBe('0');
-    expect(marks[0].getAttribute('tabindex')).toBe('-1');
-    expect(document.activeElement).toBe(marks[1]);
+  marks[0].focus();
+  fireEvent.keyDown(marks[0], { key: 'ArrowRight' });
+  expect(marks[1].getAttribute('tabindex')).toBe('0');
+  expect(marks[0].getAttribute('tabindex')).toBe('-1');
+  expect(document.activeElement).toBe(marks[1]);
 
-    // 末尾で ArrowRight → 先頭へ wrap
-    fireEvent.keyDown(marks[1], { key: 'ArrowRight' });
-    expect(marks[0].getAttribute('tabindex')).toBe('0');
-    expect(document.activeElement).toBe(marks[0]);
+  // 末尾で ArrowRight → 先頭へ wrap
+  fireEvent.keyDown(marks[1], { key: 'ArrowRight' });
+  expect(marks[0].getAttribute('tabindex')).toBe('0');
+  expect(document.activeElement).toBe(marks[0]);
 
-    // 先頭で ArrowLeft → 末尾へ wrap
-    fireEvent.keyDown(marks[0], { key: 'ArrowLeft' });
-    expect(marks[1].getAttribute('tabindex')).toBe('0');
-    expect(document.activeElement).toBe(marks[1]);
-  });
+  // 先頭で ArrowLeft → 末尾へ wrap
+  fireEvent.keyDown(marks[0], { key: 'ArrowLeft' });
+  expect(marks[1].getAttribute('tabindex')).toBe('0');
+  expect(document.activeElement).toBe(marks[1]);
+});
 
-  it('Home / End で先頭・末尾のマッチへ roving 移動する', async () => {
-    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
-    typeTest('a1 b22');
-    await screen.findByText(/2 件マッチ/, undefined, FIND);
-    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+it('Home / End で先頭・末尾のマッチへ roving 移動する', async () => {
+  render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+  typeTest('a1 b22');
+  await screen.findByText(/2 件マッチ/, undefined, FIND);
+  const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
 
-    marks[0].focus();
-    fireEvent.keyDown(marks[0], { key: 'End' });
-    expect(marks[1].getAttribute('tabindex')).toBe('0');
-    expect(document.activeElement).toBe(marks[1]);
+  marks[0].focus();
+  fireEvent.keyDown(marks[0], { key: 'End' });
+  expect(marks[1].getAttribute('tabindex')).toBe('0');
+  expect(document.activeElement).toBe(marks[1]);
 
-    fireEvent.keyDown(marks[1], { key: 'Home' });
-    expect(marks[0].getAttribute('tabindex')).toBe('0');
-    expect(document.activeElement).toBe(marks[0]);
-  });
+  fireEvent.keyDown(marks[1], { key: 'Home' });
+  expect(marks[0].getAttribute('tabindex')).toBe('0');
+  expect(document.activeElement).toBe(marks[0]);
+});
 
-  it('Enter / Space は focus 移動ではなく選択（aria-pressed 切替）を行う', async () => {
-    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
-    typeTest('a1 b22');
-    await screen.findByText(/2 件マッチ/, undefined, FIND);
-    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+it('Enter / Space は focus 移動ではなく選択（aria-pressed 切替）を行う', async () => {
+  render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+  typeTest('a1 b22');
+  await screen.findByText(/2 件マッチ/, undefined, FIND);
+  const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
 
-    expect(marks[0].getAttribute('aria-pressed')).toBe('false');
-    fireEvent.keyDown(marks[0], { key: 'Enter' });
-    expect(marks[0].getAttribute('aria-pressed')).toBe('true');
+  expect(marks[0].getAttribute('aria-pressed')).toBe('false');
+  fireEvent.keyDown(marks[0], { key: 'Enter' });
+  expect(marks[0].getAttribute('aria-pressed')).toBe('true');
 
-    expect(marks[1].getAttribute('aria-pressed')).toBe('false');
-    fireEvent.keyDown(marks[1], { key: ' ' });
-    expect(marks[1].getAttribute('aria-pressed')).toBe('true');
-  });
+  expect(marks[1].getAttribute('aria-pressed')).toBe('false');
+  fireEvent.keyDown(marks[1], { key: ' ' });
+  expect(marks[1].getAttribute('aria-pressed')).toBe('true');
+});
 ```
 
 - [ ] **Step 2: テストが失敗することを確認する**
@@ -126,6 +127,7 @@ git commit -m "test: RegexMatchTester roving tabindex の失敗テストを追�
 ### Task 2: `MatchHighlights` を実装してテストを通す
 
 **Files:**
+
 - Modify: `src/components/tools/RegexMatchTester.tsx`
 
 - [ ] **Step 1: import を更新する**
@@ -320,6 +322,7 @@ git commit -m "feat(a11y): RegexMatchTester のマッチハイライトを rovin
 ### Task 3: E2E（陽性対照）を追加する
 
 **Files:**
+
 - Modify: `tests/e2e/regex-visualizer.spec.ts`
 
 - [ ] **Step 1: 既存の role="button" E2E の直後にロービング E2E を追加する**
@@ -329,41 +332,41 @@ PR #665 で追加された
 ブロックの直後に、次を追加する:
 
 ```ts
-  // a11y 陽性対照: roving tabindex で tab stop を 1 つに集約していることを検証。
-  // 旧実装（全マッチ tabindex=0）に当てると「非 roving 要素が tabindex=-1」が偽になり fail する。
-  test('マッチハイライトが roving tabindex で 1 つの tab stop に集約される（CSP 違反なし）', async ({
-    browser,
-  }) => {
-    await withProductionCsp(browser, '/tools/regex-visualizer', async (page) => {
-      await page.getByRole('button', { name: 'g: 全マッチ' }).click();
-      await page.getByLabel('正規表現').fill('\\d+');
-      await page.getByLabel('テスト文字列').fill('a1 b22');
+// a11y 陽性対照: roving tabindex で tab stop を 1 つに集約していることを検証。
+// 旧実装（全マッチ tabindex=0）に当てると「非 roving 要素が tabindex=-1」が偽になり fail する。
+test('マッチハイライトが roving tabindex で 1 つの tab stop に集約される（CSP 違反なし）', async ({
+  browser,
+}) => {
+  await withProductionCsp(browser, '/tools/regex-visualizer', async (page) => {
+    await page.getByRole('button', { name: 'g: 全マッチ' }).click();
+    await page.getByLabel('正規表現').fill('\\d+');
+    await page.getByLabel('テスト文字列').fill('a1 b22');
 
-      await expect(page.getByText(/2 件マッチ/)).toBeVisible();
+    await expect(page.getByText(/2 件マッチ/)).toBeVisible();
 
-      const m1 = page.getByRole('button', { name: /マッチ 1/ }).first();
-      const m2 = page.getByRole('button', { name: /マッチ 2/ }).first();
+    const m1 = page.getByRole('button', { name: /マッチ 1/ }).first();
+    const m2 = page.getByRole('button', { name: /マッチ 2/ }).first();
 
-      // roving 初期状態: 1 件目だけ tab stop（0）、2 件目は -1（旧実装＝両方 0 と区別）
-      await expect(m1).toHaveAttribute('tabindex', '0');
-      await expect(m2).toHaveAttribute('tabindex', '-1');
+    // roving 初期状態: 1 件目だけ tab stop（0）、2 件目は -1（旧実装＝両方 0 と区別）
+    await expect(m1).toHaveAttribute('tabindex', '0');
+    await expect(m2).toHaveAttribute('tabindex', '-1');
 
-      // 1 件目に focus → ArrowRight で 2 件目へ roving（focus と tabindex が移動）
-      await m1.focus();
-      await m1.press('ArrowRight');
-      await expect(m2).toBeFocused();
-      await expect(m2).toHaveAttribute('tabindex', '0');
-      await expect(m1).toHaveAttribute('tabindex', '-1');
+    // 1 件目に focus → ArrowRight で 2 件目へ roving（focus と tabindex が移動）
+    await m1.focus();
+    await m1.press('ArrowRight');
+    await expect(m2).toBeFocused();
+    await expect(m2).toHaveAttribute('tabindex', '0');
+    await expect(m1).toHaveAttribute('tabindex', '-1');
 
-      // 末尾で ArrowRight → 先頭へ wrap
-      await m2.press('ArrowRight');
-      await expect(m1).toBeFocused();
+    // 末尾で ArrowRight → 先頭へ wrap
+    await m2.press('ArrowRight');
+    await expect(m1).toBeFocused();
 
-      // Enter は focus 移動ではなく選択（aria-pressed=true）
-      await m1.press('Enter');
-      await expect(m1).toHaveAttribute('aria-pressed', 'true');
-    });
+    // Enter は focus 移動ではなく選択（aria-pressed=true）
+    await m1.press('Enter');
+    await expect(m1).toHaveAttribute('aria-pressed', 'true');
   });
+});
 ```
 
 - [ ] **Step 2: E2E を実行する**

--- a/docs/superpowers/specs/2026-06-13-regex-match-roving-tabindex-design.md
+++ b/docs/superpowers/specs/2026-06-13-regex-match-roving-tabindex-design.md
@@ -60,12 +60,12 @@ issue 本文は「コンテナを `tabIndex={0}`」と「個々の `<mark>` の�
 
 各 `<mark>` の `onKeyDown(e, i)` で以下を処理する（いずれも `e.preventDefault()`）:
 
-| キー            | 動作                                                          |
+| キー            | 動作                                                         |
 | :-------------- | :----------------------------------------------------------- |
 | `ArrowRight`    | 次のマッチへ focus 移動（末尾なら先頭へ wrap）               |
 | `ArrowLeft`     | 前のマッチへ focus 移動（先頭なら末尾へ wrap）               |
-| `Home`          | 先頭マッチへ focus 移動                                       |
-| `End`           | 末尾マッチへ focus 移動                                       |
+| `Home`          | 先頭マッチへ focus 移動                                      |
+| `End`           | 末尾マッチへ focus 移動                                      |
 | `Enter` / `' '` | `onSelect(i)`（= `aria-pressed` + `ResultTable` 連動、現行） |
 
 - 矢印 / Home / End は **focus のみ移動**し、選択（`selected`）は変えない（toolbar 型）。

--- a/docs/superpowers/specs/2026-06-13-regex-match-roving-tabindex-design.md
+++ b/docs/superpowers/specs/2026-06-13-regex-match-roving-tabindex-design.md
@@ -1,0 +1,133 @@
+# RegexMatchTester マッチハイライトの roving tabindex 化 設計
+
+- 対象 issue: #666
+- 関連: PR #665（`<mark>` の `role="button"` 化 / issue #663）
+- 優先度: 低（a11y 改善。現状でも操作自体は可能）
+- 作成日: 2026-06-13
+
+## 背景・課題
+
+PR #665 で `RegexMatchTester` のマッチハイライト `<mark>` を `role="button"` + `tabIndex={0}`
+でキーボード操作可能にした。しかし `g` フラグ + 長文では全マッチがそれぞれ独立した tab stop に
+なり、キーボードユーザーはマッチ N 個に対し N 回 Tab を踏む。下部 `ResultTable` でも行選択できる
+ため実害は小さいが、navigation コストが高い。
+
+## ゴール
+
+- マッチハイライト群の tab stop を **N → 1** に削減する（roving tabindex パターン）。
+- 既存の挙動（選択・`aria-pressed`・`ResultTable` 連動・色分け・空マッチ表示）は維持する。
+- キーボードユーザーが矢印キーでマッチ間を移動できるようにする。
+
+## 非ゴール（スコープ外）
+
+- マッチ実行ロジック（`runMatch` / `useDebouncedTransform`）の変更。
+- `ResultTable` 側の挙動変更。
+- CSS（`.match-highlight*`）の見た目変更。
+- `aria-current` の導入（選択状態は既存の `aria-pressed` を継続使用する）。
+
+## 設計
+
+### 1. 構造リファクタ: `MatchHighlights` サブコンポーネント抽出
+
+現状の純関数 `highlight(input, matches, selected, onSelect)` は ref / focus / 内部 state を
+持てないため、roving ロジックを内包する **`MatchHighlights` サブコンポーネント** へ抽出する。
+
+- props: `text: string` / `matches: RegexMatch[]` / `selected: number | null` /
+  `onSelect: (i: number) => void`（現行 `highlight()` と同じ情報量）。
+- 呼び出し側（`RegexMatchTester` 内 `matches.length > 0 ?` 分岐）を
+  `<MatchHighlights text={shownText} matches={matches} selected={selectedIndex} onSelect={setSelected} />`
+  に置換する。
+- テキストセグメントと `<mark>` を交互に並べる描画ロジックは現行 `highlight()` をそのまま移植する。
+
+### 2. roving tabindex（子ローブ方式）
+
+issue 本文は「コンテナを `tabIndex={0}`」と「個々の `<mark>` のうち選択中のみ `tabIndex={0}`」を
+併記しているが、両立すると tab stop が二重になる。標準的でクリーンな **子ローブ方式** を採用する:
+
+- コンテナ自体は tab stop にしない（`tabIndex` を付けない）。
+- マッチ群のうち **常に 1 個だけ `tabIndex={0}`**（roving item）、残りは `tabIndex={-1}`。
+- `MatchHighlights` 内で `rovingIndex` state を保持。`safeRoving = Math.min(rovingIndex, n - 1)`
+  を tabIndex 割当に使う（マッチ件数が縮小したときの安全弁。常に有効な tab stop が 1 個残る）。
+- 各 `<mark>` に ref を持たせる（`markRefs = useRef<Array<HTMLElement | null>>([])`、
+  `ref={(el) => { markRefs.current[i] = el; }}`）。キー操作時に `markRefs.current[idx]?.focus()`。
+- `matches`（`useDebouncedTransform` でメモ化された安定参照）が変わったら
+  `useEffect(() => setRovingIndex(0), [matches])` で先頭へリセットする。
+
+> 補足: `MatchHighlights` は `matches.length > 0` の分岐内でのみマウントされ、`matches` は
+> メモ化済みの安定参照のため、`useEffect([matches])` は新しいマッチ結果が来たときだけ発火する。
+
+### 3. キーバインド（`onKeyDown` 拡張）
+
+各 `<mark>` の `onKeyDown(e, i)` で以下を処理する（いずれも `e.preventDefault()`）:
+
+| キー            | 動作                                                          |
+| :-------------- | :----------------------------------------------------------- |
+| `ArrowRight`    | 次のマッチへ focus 移動（末尾なら先頭へ wrap）               |
+| `ArrowLeft`     | 前のマッチへ focus 移動（先頭なら末尾へ wrap）               |
+| `Home`          | 先頭マッチへ focus 移動                                       |
+| `End`           | 末尾マッチへ focus 移動                                       |
+| `Enter` / `' '` | `onSelect(i)`（= `aria-pressed` + `ResultTable` 連動、現行） |
+
+- 矢印 / Home / End は **focus のみ移動**し、選択（`selected`）は変えない（toolbar 型）。
+  focus 移動時は `setRovingIndex(next)` + `markRefs.current[next]?.focus()`。
+- wrap 計算: `next = (i + 1) % n` / `prev = (i - 1 + n) % n`。
+- `↑` / `↓` は割り当てない（今回スコープ外）。
+
+### 4. クリック時の roving 同期
+
+`onClick` は現行どおり `onSelect(i)` を呼ぶことに加え、`setRovingIndex(i)` でその要素を roving item
+にする（クリック後の Tab 復帰先を、最後に触れたマッチへ保持するため）。
+
+### 5. a11y 補強
+
+ハイライト容器 `<div>`（`rounded-lg border ... whitespace-pre-wrap break-all`）に
+`role="group"` + `aria-label="マッチ箇所"` を付与し、矢印ナビゲーション可能な 1 グループであることを
+SR に伝える。既存の `role="button"` / `aria-pressed` / `aria-label`（空マッチは「（空マッチ）」付き）
+/ `title` はすべて維持する。
+
+### 6. CSS
+
+変更なし。`.match-highlight` / `-a` / `-b` / `-active` / `-empty` はそのまま。
+
+## テスト戦略（陽性対照付き）
+
+> ガード / 回帰防止テストの実装のため、`test-gates` skill を参照し陽性対照の妥当性を担保する。
+
+### Unit (`src/components/tools/__tests__/RegexMatchTester.test.tsx`)
+
+1. **roving 初期状態**: 複数マッチ時、`tabIndex=0` を持つ `<mark>` がちょうど 1 個・他は `-1`。
+   - 陽性対照: 旧実装（全マッチ `tabIndex=0`）に当てると「1 個だけ」が偽になり fail する。
+2. **`ArrowRight` で roving 移動**: focus した 1 件目で `→` → 2 件目が `tabIndex=0` / focus。
+3. **wrap**: 末尾で `→` → 先頭へ。
+4. **`Home` / `End`**: それぞれ先頭 / 末尾へ roving 移動。
+5. **`Enter` / `Space` で選択維持**: `aria-pressed` が `false → true` に切り替わる。
+
+既存ユニットテスト（件数集計 / g ヒント / no-match / vulnerable / unknown / regexValid=false）は
+そのまま維持する。
+
+### E2E (`tests/e2e/regex-visualizer.spec.ts`)
+
+- 既存の `role="button"` + `Enter` 選択テストは維持。
+- 追加（陽性対照）: `g` フラグ + `\d+` + `a1 b22`（2 マッチ）で、
+  - roving 要素は `tabindex="0"`、非 roving 要素は `tabindex="-1"`（旧実装＝全 `0` と区別）。
+  - 1 件目を `focus()` → `→` で 2 件目が `toBeFocused`（roving 移動の証明）。
+  - `Enter` で `aria-pressed="true"`。
+- ロケーターは `getByRole('button', { name: /マッチ N/ })` を使用（属性セレクタ禁止）。
+
+### VRT
+
+DOM 属性（`tabindex` / `role` / `aria-*`）変更のみで描画は不変のため baseline 更新は不要の見込み。
+万一 pixel diff が出た場合は数値根拠で baseline 更新を勧めず、DOM 構造 / computed style の 2 段階
+検証の上でユーザーの目視判断を仰ぐ。
+
+## 検証（push 前必須）
+
+- `npm run test`（ユニット）
+- `node_modules/.bin/astro check`（型）
+- `npm run test:e2e`（E2E）
+
+## ドキュメント更新
+
+- 挙動の細かな a11y 改善であり、ツール追加 / slug 変更 / ライブラリ変更には当たらないため
+  `README.md` / `SPEC.md` の更新は不要。`docs/tools.md` も仕組みの説明に影響しないため対象外。
+- 必要に応じて `docs/decisions.md` への追記は行わない（設計上の重要決断ではなく既存パターン適用）。

--- a/src/components/tools/RegexMatchTester.tsx
+++ b/src/components/tools/RegexMatchTester.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { cx } from '@/utils/cx';
-import type { ReactNode } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
 import { InputField } from '@/components/ui/InputField';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { ResultTable, type TableColumn } from '@/components/ui/ResultTable';
@@ -27,18 +27,68 @@ const UNKNOWN_CAP = 1000; // unknown verdict の force 実行時の入力長上�
 const TEXTAREA_MAX_LENGTH = 10000; // textarea の粗い上限（safe は線形マッチ）
 const EMPTY_MATCH: MatchResult | null = null; // useDebouncedTransform 用の安定参照
 
-/** マッチ結果をハイライト済み React 要素配列へ。マッチ全体を交互色 mark で囲む。 */
-function highlight(
-  input: string,
-  matches: RegexMatch[],
-  selected: number | null,
-  onSelect: (i: number) => void
-): ReactNode[] {
+interface MatchHighlightsProps {
+  text: string;
+  matches: RegexMatch[];
+  selected: number | null;
+  onSelect: (i: number) => void;
+}
+
+/**
+ * マッチ箇所を交互色 mark でハイライトする。roving tabindex パターンで、ハイライト群全体を
+ * 1 つの tab stop に集約する（issue #666）。常に 1 個の <mark> だけ tabIndex=0、残りは -1。
+ * 矢印 / Home / End で focus を移動（選択は変えない）、Enter / Space で onSelect を呼ぶ。
+ */
+function MatchHighlights({ text, matches, selected, onSelect }: MatchHighlightsProps) {
+  const [rovingIndex, setRovingIndex] = useState(0);
+  const markRefs = useRef<Array<HTMLElement | null>>([]);
+
+  // 新しいマッチ結果（安定参照）が来たら roving を先頭へリセットする
+  useEffect(() => {
+    setRovingIndex(0);
+  }, [matches]);
+
+  const n = matches.length;
+  // 件数縮小時の安全弁: 常に有効な tab stop が 1 個残るようにクランプ
+  const safeRoving = Math.min(rovingIndex, n - 1);
+
+  const focusMatch = (i: number) => {
+    setRovingIndex(i);
+    markRefs.current[i]?.focus();
+  };
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLElement>, i: number) => {
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        focusMatch((i + 1) % n);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        focusMatch((i - 1 + n) % n);
+        break;
+      case 'Home':
+        e.preventDefault();
+        focusMatch(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        focusMatch(n - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        // Enter / スペースは focus 移動ではなく選択（クリックと同等）
+        e.preventDefault();
+        onSelect(i);
+        break;
+    }
+  };
+
   const nodes: ReactNode[] = [];
   let cursor = 0;
   matches.forEach((m, i) => {
     if (m.start > cursor) {
-      nodes.push(<span key={`t-${i}`}>{input.slice(cursor, m.start)}</span>);
+      nodes.push(<span key={`t-${i}`}>{text.slice(cursor, m.start)}</span>);
     }
     const colorClass = i % 2 === 0 ? 'match-highlight-a' : 'match-highlight-b';
     // aria-label: 空マッチは「（空マッチ）」を付けて SR が聞き取れるようにする
@@ -47,8 +97,12 @@ function highlight(
     nodes.push(
       <mark
         key={`m-${i}`}
+        ref={(el) => {
+          markRefs.current[i] = el;
+        }}
         role="button"
-        tabIndex={0}
+        // roving tabindex: 常に 1 個だけ 0、残りは -1（tab stop を 1 つに集約）
+        tabIndex={i === safeRoving ? 0 : -1}
         aria-pressed={selected === i}
         aria-label={ariaLabel}
         className={cx(
@@ -57,25 +111,30 @@ function highlight(
           selected === i && 'match-highlight-active',
           m.value === '' && 'match-highlight-empty'
         )}
-        onClick={() => onSelect(i)}
-        title={`マッチ ${i + 1}`}
-        onKeyDown={(e) => {
-          // Enter または スペースでクリックと同等の動作（キーボード操作対応）
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onSelect(i);
-          }
+        onClick={() => {
+          // クリックでも roving item を更新し、次の Tab 復帰先を保持する
+          setRovingIndex(i);
+          onSelect(i);
         }}
+        title={`マッチ ${i + 1}`}
+        onKeyDown={(e) => handleKeyDown(e, i)}
       >
         {m.value === '' ? '​' : m.value}
       </mark>
     );
     cursor = Math.max(cursor, m.end);
   });
-  if (cursor < input.length) {
-    nodes.push(<span key="t-tail">{input.slice(cursor)}</span>);
+  if (cursor < text.length) {
+    nodes.push(<span key="t-tail">{text.slice(cursor)}</span>);
   }
-  return nodes;
+
+  // role="group" + aria-label で「矢印ナビ可能な 1 グループ」であることを SR に伝える。
+  // span（inline）でラップし、親コンテナの whitespace-pre-wrap / break-all 描画を変えない。
+  return (
+    <span role="group" aria-label="マッチ箇所">
+      {nodes}
+    </span>
+  );
 }
 
 export function RegexMatchTester({ pattern, flags, redosStatus, regexValid }: Props) {
@@ -189,7 +248,12 @@ export function RegexMatchTester({ pattern, flags, redosStatus, regexValid }: Pr
               )}
               <div className="rounded-lg border border-default p-3 font-mono caption whitespace-pre-wrap break-all">
                 {matches.length > 0 ? (
-                  highlight(shownText, matches, selectedIndex, setSelected)
+                  <MatchHighlights
+                    text={shownText}
+                    matches={matches}
+                    selected={selectedIndex}
+                    onSelect={setSelected}
+                  />
                 ) : (
                   <span className="text-muted" aria-live="polite">
                     マッチしませんでした。

--- a/src/components/tools/__tests__/RegexMatchTester.test.tsx
+++ b/src/components/tools/__tests__/RegexMatchTester.test.tsx
@@ -55,4 +55,71 @@ describe('RegexMatchTester', () => {
     expect(screen.getByText(/有効な正規表現を入力すると/)).toBeTruthy();
     expect(screen.queryByLabelText('テスト文字列')).toBeNull();
   });
+
+  it('複数マッチで tabIndex=0 はちょうど 1 個（roving 初期状態）', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+    expect(marks).toHaveLength(2);
+    const tabbable = marks.filter((m) => m.getAttribute('tabindex') === '0');
+    expect(tabbable).toHaveLength(1);
+    expect(marks[0].getAttribute('tabindex')).toBe('0');
+    expect(marks[1].getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('ArrowRight で roving が次のマッチへ移動し、末尾で先頭に wrap する', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+
+    marks[0].focus();
+    fireEvent.keyDown(marks[0], { key: 'ArrowRight' });
+    expect(marks[1].getAttribute('tabindex')).toBe('0');
+    expect(marks[0].getAttribute('tabindex')).toBe('-1');
+    expect(document.activeElement).toBe(marks[1]);
+
+    // 末尾で ArrowRight → 先頭へ wrap
+    fireEvent.keyDown(marks[1], { key: 'ArrowRight' });
+    expect(marks[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[0]);
+
+    // 先頭で ArrowLeft → 末尾へ wrap
+    fireEvent.keyDown(marks[0], { key: 'ArrowLeft' });
+    expect(marks[1].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[1]);
+  });
+
+  it('Home / End で先頭・末尾のマッチへ roving 移動する', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+
+    marks[0].focus();
+    fireEvent.keyDown(marks[0], { key: 'End' });
+    expect(marks[1].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[1]);
+
+    fireEvent.keyDown(marks[1], { key: 'Home' });
+    expect(marks[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(marks[0]);
+  });
+
+  it('Enter / Space は focus 移動ではなく選択（aria-pressed 切替）を行う', async () => {
+    render(<RegexMatchTester pattern={String.raw`\d+`} flags="g" redosStatus="safe" regexValid />);
+    typeTest('a1 b22');
+    await screen.findByText(/2 件マッチ/, undefined, FIND);
+    const marks = screen.getAllByRole('button', { name: /マッチ \d/ });
+
+    expect(marks[0].getAttribute('aria-pressed')).toBe('false');
+    fireEvent.keyDown(marks[0], { key: 'Enter' });
+    expect(marks[0].getAttribute('aria-pressed')).toBe('true');
+
+    expect(marks[1].getAttribute('aria-pressed')).toBe('false');
+    fireEvent.keyDown(marks[1], { key: ' ' });
+    expect(marks[1].getAttribute('aria-pressed')).toBe('true');
+  });
 });

--- a/tests/e2e/regex-visualizer.spec.ts
+++ b/tests/e2e/regex-visualizer.spec.ts
@@ -164,6 +164,42 @@ test.describe('正規表現ビジュアライザ', () => {
     });
   });
 
+  // a11y 陽性対照: roving tabindex で tab stop を 1 つに集約していることを検証。
+  // 旧実装（全マッチ tabindex=0）に当てると「非 roving 要素が tabindex=-1」が偽になり fail する。
+  test('マッチハイライトが roving tabindex で 1 つの tab stop に集約される（CSP 違反なし）', async ({
+    browser,
+  }) => {
+    await withProductionCsp(browser, '/tools/regex-visualizer', async (page) => {
+      await page.getByRole('button', { name: 'g: 全マッチ' }).click();
+      await page.getByLabel('正規表現').fill('\\d+');
+      await page.getByLabel('テスト文字列').fill('a1 b22');
+
+      await expect(page.getByText(/2 件マッチ/)).toBeVisible();
+
+      const m1 = page.getByRole('button', { name: /マッチ 1/ }).first();
+      const m2 = page.getByRole('button', { name: /マッチ 2/ }).first();
+
+      // roving 初期状態: 1 件目だけ tab stop（0）、2 件目は -1（旧実装＝両方 0 と区別）
+      await expect(m1).toHaveAttribute('tabindex', '0');
+      await expect(m2).toHaveAttribute('tabindex', '-1');
+
+      // 1 件目に focus → ArrowRight で 2 件目へ roving（focus と tabindex が移動）
+      await m1.focus();
+      await m1.press('ArrowRight');
+      await expect(m2).toBeFocused();
+      await expect(m2).toHaveAttribute('tabindex', '0');
+      await expect(m1).toHaveAttribute('tabindex', '-1');
+
+      // 末尾で ArrowRight → 先頭へ wrap
+      await m2.press('ArrowRight');
+      await expect(m1).toBeFocused();
+
+      // Enter は focus 移動ではなく選択（aria-pressed=true）
+      await m1.press('Enter');
+      await expect(m1).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
   // ReDoS ゲートの陽性対照（本番 CSP 下・実 recheck 経路）: 既知の脆弱パターンで
   // マッチ実行が無効化されることを確認する。ゲートが空回りすると入力欄が出てこの assert が落ちる。
   test('vulnerable な正規表現ではマッチ実行が無効化される', async ({ browser }) => {


### PR DESCRIPTION
## 概要

issue #666 の対応。`RegexMatchTester` のマッチハイライト `<mark>` 群を **roving tabindex パターン**へ変更し、キーボードの tab stop を **N 個 → 1 個**に削減した。

PR #665（issue #663）で `<mark>` を `role="button"` + `tabIndex={0}` 化したが、`g` フラグ + 長文では全マッチがそれぞれ独立した tab stop になり、キーボードユーザーがマッチ N 個に対し N 回 Tab を踏む navigation コストがあった。

## 変更内容

- 純関数 `highlight()` を `MatchHighlights` サブコンポーネントへ抽出（roving ロジックを 1 ユニットに隔離）。
- **roving tabindex（子ローブ方式）**: コンテナ自体は tab stop にせず、マッチ群のうち常に 1 個だけ `tabIndex={0}`、残りは `-1`。`safeRoving = Math.min(rovingIndex, n - 1)` で件数縮小時も有効な tab stop を 1 個保つ。
- **キーバインド**（`onKeyDown`）:
  - `←` / `→`: 前後のマッチへ focus 移動（端で wrap-around）
  - `Home` / `End`: 先頭 / 末尾のマッチへ focus 移動
  - `Enter` / `Space`: 選択（既存の `aria-pressed` + `ResultTable` 連動。focus 移動はしない toolbar 型）
- クリック時も roving item を更新し、次の Tab 復帰先を保持。
- a11y 補強: ハイライト群を `role="group"` + `aria-label="マッチ箇所"` の inline span でラップ（描画は不変）。
- 既存の `role="button"` / `aria-pressed` / `aria-label`（空マッチ対応）/ 色分け / 空マッチ表示はすべて維持。CSS 変更なし。

## テスト（陽性対照付き）

- **Unit** (`RegexMatchTester.test.tsx`): roving 初期状態（`tabIndex=0` がちょうど 1 個）/ `←`・`→` の wrap / `Home`・`End` / `Enter`・`Space` の選択維持 を追加。旧実装（全 `tabIndex=0`）に当てると fail する回帰ガード。
- **E2E** (`regex-visualizer.spec.ts`): production CSP 下で「非 roving 要素が `tabindex=-1`・roving は `0`」「`→` で focus がロービング」「`Enter` で `aria-pressed=true`」を検証（旧実装と区別する陽性対照）。

## 検証結果

- `npm run test -- RegexMatchTester`: 10 passed（既存 6 + 新規 4）
- `node_modules/.bin/astro check`: 0 errors / 0 warnings
- `npm run format:check`: clean
- `npm run test:e2e -- regex-visualizer`: 15 passed（既存 14 + 新規 1）

## 設計・計画ドキュメント

- 設計: `docs/superpowers/specs/2026-06-13-regex-match-roving-tabindex-design.md`
- 計画: `docs/superpowers/plans/2026-06-13-regex-match-roving-tabindex.md`

Closes #666

https://claude.ai/code/session_01Rdom5FQDzGFgpHsPnY2vrq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdom5FQDzGFgpHsPnY2vrq)_