### PR TITLE
docs: web セッションで workflow_dispatch 不可を明文化

### DIFF
--- a/.agents/rules/common.md
+++ b/.agents/rules/common.md
@@ -70,7 +70,7 @@ post-PR 代行は不要、CI が最終ゲート。
 1. `src/components/tools/ToolName.tsx` を作成
 2. `src/pages/tools/tool-slug.astro` を作成（`client:load` で React コンポーネントをマウント）
 3. `src/data/tools.ts` の `toolEntries` 配列にエントリを追加（slug / name / description / category / yomi）。`yomi` は並び替え用の読み仮名（ひらがな）で、表示順はこの `yomi` の五十音順に自動ソートされる（手動で位置を決める必要はない）
-4. `tests/e2e/visual-regression-pages.ts` の `PAGES` 配列に `/tools/<slug>` を追加（VRT 対象に登録）。baseline は CI Linux runner で `Update Visual Regression Baseline` workflow を `workflow_dispatch` trigger して生成（mac との font 描画差を回避するためローカル生成は不可）。**漏れた場合は `tests/meta/vrt-pages-coverage.test.ts` が `npm run test` で fail させる**ため CI で必ず検知される（issue #355 で導入）。⚠️ **web セッションでは連携トークンに `actions: write` が無く、この `workflow_dispatch` をエージェント自身が起動できない**（`403 Resource not accessible by integration`）。エージェントは「自分でトリガーする」と提案せず、**最初から手動トリガー手順を案内する**（手順詳細 → 6.10）。
+4. `tests/e2e/visual-regression-pages.ts` の `PAGES` 配列に `/tools/<slug>` を追加（VRT 対象に登録）。baseline は CI Linux runner で `Update Visual Regression Baseline` workflow を `workflow_dispatch` trigger して生成（mac との font 描画差を回避するためローカル生成は不可）。**漏れた場合は `tests/meta/vrt-pages-coverage.test.ts` が `npm run test` で fail させる**ため CI で必ず検知される（issue #355 で導入）。※ この `workflow_dispatch` をエージェント自身が起動できるかは実行環境のトークン権限に依存する（Claude Code on the web では `actions: write` が無く起動不可・手動トリガー必須 → `.claude/rules/github-web-session.md`。他エージェントは各固有ルール参照）。
 5. 4 章「ドキュメント更新ルール」に従い `README.md` / `SPEC.md` / `docs/decisions.md` を更新
 6. 候補リスト（`docs/tool-candidates.md`）由来のツールの場合、PR マージ時に該当行の「状態」列へ ✅ と PR 番号を記載する
 
@@ -170,27 +170,6 @@ VRT が小さい pixel diff (例: 0.07%) を検出しても「微小だから ba
 - **`package.json` 変更時は `package-lock.json` 同期確認**: subagent が deps を追加・更新した場合、`git diff origin/develop --name-only` に `package.json` が含まれる場合は必ず `package-lock.json` も含まれているか確認する。漏れていれば親で `npm install --package-lock-only --cache "$TMPDIR/npm-cache" --no-audit --no-fund` を実行し別コミットで lock 同期を push する（過去事例: PR #181 で lock 不整合のまま push される寸前で発覚）。
 - **PR 本文の更新は親で実行**: `gh pr edit --body-file` は `permissions.ask` のため subagent から非対話 deny される。subagent は完了報告に「PR 本文更新が必要」と明記し、親 (司令塔) が `gh pr edit` で引き取る（過去事例: PR #189 で subagent から呼べず指摘事項対応が止まった）。
 - **subagent プロンプトに矛盾する設計指示を混ぜない**: subagent は指示を素直に実装するため、矛盾を内包した指示はそのまま矛盾した実装になる。subagent の判断力に期待してプロンプトの曖昧さを残さない。特に React の effect / memo では「memo 化した派生値を依存配列に保つ」と「依存配列を一次入力に展開する」は反対方向の設計判断であり併記しない（片方に寄せる）。どうしても両論併記する場合は「`eslint-disable` は使わない、それで済まない設計なら知らせる」と判断材料を明記する（過去事例: PR #217 で矛盾指示により `react-hooks/exhaustive-deps` を 2 箇所 `eslint-disable` で抑制する実装になりレビューで差し戻し）。
-
-### 6.10 web セッションの GitHub 連携トークンでは `workflow_dispatch` を実行できない
-
-web セッション（claude.ai/code 等のリモート実行環境）の GitHub 連携トークンには `actions: write` 権限が無い。そのため `workflow_dispatch` による workflow 起動は **必ず `403 Resource not accessible by integration` で失敗** する。**権限スコープ（トークン）の問題なのでリトライしても解消しない**。
-
-不可と確定している操作（`actions: write` 依存）:
-
-- `workflow_dispatch` による workflow 起動（GitHub MCP の `actions_run_trigger` の `run_workflow`）
-- `rerun_*` / `cancel_workflow_run` 等の workflow run 再実行・キャンセル系
-
-エージェントは「自分でトリガーします」と提案・実行して 403 を踏むのではなく、**最初から手動トリガー手順を案内する**:
-
-1. GitHub の対象リポジトリ → **Actions** タブを開く
-2. 左メニューから対象 workflow（例: `Update Visual Regression Baseline`）を選択
-3. **Run workflow** → branch に **対象 PR のブランチ**を選んで実行
-
-特に **ツール追加 PR では VRT baseline 再生成（`Update Visual Regression Baseline` の `workflow_dispatch`）が毎回必須** になるため再発頻度が高い（5 章のフロー参照）。
-
-**過剰な「できない宣言」も避ける**: 不可と確定しているのは上記 `actions: write` 依存操作のみ。GitHub MCP の read 系（`pull_request_read` / `actions_list` / `get_job_logs` 等）、PR/issue への comment、PR 作成は連携トークンで実行可。`merge_pull_request` 等その他の write 操作の可否は未確認のため、実際に 403 を踏むまで先回りで「できない」と宣言しない。
-
-過去事例: PR #675 で VRT baseline 再生成のため workflow_dispatch を試行 → 403 → 手動依頼、の無駄なラウンドトリップが発生（issue #676）。
 
 ---
 

--- a/.agents/rules/common.md
+++ b/.agents/rules/common.md
@@ -70,7 +70,7 @@ post-PR 代行は不要、CI が最終ゲート。
 1. `src/components/tools/ToolName.tsx` を作成
 2. `src/pages/tools/tool-slug.astro` を作成（`client:load` で React コンポーネントをマウント）
 3. `src/data/tools.ts` の `toolEntries` 配列にエントリを追加（slug / name / description / category / yomi）。`yomi` は並び替え用の読み仮名（ひらがな）で、表示順はこの `yomi` の五十音順に自動ソートされる（手動で位置を決める必要はない）
-4. `tests/e2e/visual-regression-pages.ts` の `PAGES` 配列に `/tools/<slug>` を追加（VRT 対象に登録）。baseline は CI Linux runner で `Update Visual Regression Baseline` workflow を `workflow_dispatch` trigger して生成（mac との font 描画差を回避するためローカル生成は不可）。**漏れた場合は `tests/meta/vrt-pages-coverage.test.ts` が `npm run test` で fail させる**ため CI で必ず検知される（issue #355 で導入）。
+4. `tests/e2e/visual-regression-pages.ts` の `PAGES` 配列に `/tools/<slug>` を追加（VRT 対象に登録）。baseline は CI Linux runner で `Update Visual Regression Baseline` workflow を `workflow_dispatch` trigger して生成（mac との font 描画差を回避するためローカル生成は不可）。**漏れた場合は `tests/meta/vrt-pages-coverage.test.ts` が `npm run test` で fail させる**ため CI で必ず検知される（issue #355 で導入）。⚠️ **web セッションでは連携トークンに `actions: write` が無く、この `workflow_dispatch` をエージェント自身が起動できない**（`403 Resource not accessible by integration`）。エージェントは「自分でトリガーする」と提案せず、**最初から手動トリガー手順を案内する**（手順詳細 → 6.10）。
 5. 4 章「ドキュメント更新ルール」に従い `README.md` / `SPEC.md` / `docs/decisions.md` を更新
 6. 候補リスト（`docs/tool-candidates.md`）由来のツールの場合、PR マージ時に該当行の「状態」列へ ✅ と PR 番号を記載する
 
@@ -170,6 +170,27 @@ VRT が小さい pixel diff (例: 0.07%) を検出しても「微小だから ba
 - **`package.json` 変更時は `package-lock.json` 同期確認**: subagent が deps を追加・更新した場合、`git diff origin/develop --name-only` に `package.json` が含まれる場合は必ず `package-lock.json` も含まれているか確認する。漏れていれば親で `npm install --package-lock-only --cache "$TMPDIR/npm-cache" --no-audit --no-fund` を実行し別コミットで lock 同期を push する（過去事例: PR #181 で lock 不整合のまま push される寸前で発覚）。
 - **PR 本文の更新は親で実行**: `gh pr edit --body-file` は `permissions.ask` のため subagent から非対話 deny される。subagent は完了報告に「PR 本文更新が必要」と明記し、親 (司令塔) が `gh pr edit` で引き取る（過去事例: PR #189 で subagent から呼べず指摘事項対応が止まった）。
 - **subagent プロンプトに矛盾する設計指示を混ぜない**: subagent は指示を素直に実装するため、矛盾を内包した指示はそのまま矛盾した実装になる。subagent の判断力に期待してプロンプトの曖昧さを残さない。特に React の effect / memo では「memo 化した派生値を依存配列に保つ」と「依存配列を一次入力に展開する」は反対方向の設計判断であり併記しない（片方に寄せる）。どうしても両論併記する場合は「`eslint-disable` は使わない、それで済まない設計なら知らせる」と判断材料を明記する（過去事例: PR #217 で矛盾指示により `react-hooks/exhaustive-deps` を 2 箇所 `eslint-disable` で抑制する実装になりレビューで差し戻し）。
+
+### 6.10 web セッションの GitHub 連携トークンでは `workflow_dispatch` を実行できない
+
+web セッション（claude.ai/code 等のリモート実行環境）の GitHub 連携トークンには `actions: write` 権限が無い。そのため `workflow_dispatch` による workflow 起動は **必ず `403 Resource not accessible by integration` で失敗** する。**権限スコープ（トークン）の問題なのでリトライしても解消しない**。
+
+不可と確定している操作（`actions: write` 依存）:
+
+- `workflow_dispatch` による workflow 起動（GitHub MCP の `actions_run_trigger` の `run_workflow`）
+- `rerun_*` / `cancel_workflow_run` 等の workflow run 再実行・キャンセル系
+
+エージェントは「自分でトリガーします」と提案・実行して 403 を踏むのではなく、**最初から手動トリガー手順を案内する**:
+
+1. GitHub の対象リポジトリ → **Actions** タブを開く
+2. 左メニューから対象 workflow（例: `Update Visual Regression Baseline`）を選択
+3. **Run workflow** → branch に **対象 PR のブランチ**を選んで実行
+
+特に **ツール追加 PR では VRT baseline 再生成（`Update Visual Regression Baseline` の `workflow_dispatch`）が毎回必須** になるため再発頻度が高い（5 章のフロー参照）。
+
+**過剰な「できない宣言」も避ける**: 不可と確定しているのは上記 `actions: write` 依存操作のみ。GitHub MCP の read 系（`pull_request_read` / `actions_list` / `get_job_logs` 等）、PR/issue への comment、PR 作成は連携トークンで実行可。`merge_pull_request` 等その他の write 操作の可否は未確認のため、実際に 403 を踏むまで先回りで「できない」と宣言しない。
+
+過去事例: PR #675 で VRT baseline 再生成のため workflow_dispatch を試行 → 403 → 手動依頼、の無駄なラウンドトリップが発生（issue #676）。
 
 ---
 

--- a/.claude/rules/github-web-session.md
+++ b/.claude/rules/github-web-session.md
@@ -1,0 +1,26 @@
+# Claude Code (web): GitHub 連携トークンの制約
+
+`.agents/rules/common.md` の補足。**Claude Code on the web（claude.ai/code 等のリモート実行環境）固有**の GitHub 連携トークン制約を定める。Codex / Gemini CLI 等は別の実行環境・別トークンを使うため本ルールの対象外（各エージェント固有ルールを参照）。
+
+## `workflow_dispatch` はエージェント自身が起動できない
+
+web セッションの GitHub 連携トークンには `actions: write` 権限が無い。そのため `workflow_dispatch` による workflow 起動は **必ず `403 Resource not accessible by integration` で失敗** する。**権限スコープ（トークン）の問題なのでリトライしても解消しない**。
+
+不可と確定している操作（`actions: write` 依存）:
+
+- `workflow_dispatch` による workflow 起動（GitHub MCP の `actions_run_trigger` の `run_workflow`）
+- `rerun_*` / `cancel_workflow_run` 等の workflow run 再実行・キャンセル系
+
+エージェントは「自分でトリガーします」と提案・実行して 403 を踏むのではなく、**最初から手動トリガー手順を案内する**:
+
+1. GitHub の対象リポジトリ → **Actions** タブを開く
+2. 左メニューから対象 workflow（例: `Update Visual Regression Baseline`）を選択
+3. **Run workflow** → branch に **対象 PR のブランチ**を選んで実行
+
+特に **ツール追加 PR では VRT baseline 再生成（`Update Visual Regression Baseline` の `workflow_dispatch`）が毎回必須** になるため再発頻度が高い（`.agents/rules/common.md` 5 章のツール追加フロー参照）。
+
+## 過剰な「できない宣言」も避ける
+
+不可と確定しているのは上記 `actions: write` 依存操作のみ。GitHub MCP の read 系（`pull_request_read` / `actions_list` / `get_job_logs` 等）、PR/issue への comment、PR 作成は連携トークンで実行可。`merge_pull_request` 等その他の write 操作の可否は未確認のため、実際に 403 を踏むまで先回りで「できない」と宣言しない。
+
+過去事例: PR #675 で VRT baseline 再生成のため workflow_dispatch を試行 → 403 → 手動依頼、の無駄なラウンドトリップが発生（issue #676）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 @.agents/rules/common.md
 @.agents/rules/ui-conventions.md
 @.claude/rules/git-and-fs.md
+@.claude/rules/github-web-session.md
 
 ---
 
@@ -13,6 +14,7 @@
 Claude Code 固有の補足は `.claude/rules/` 配下に分割し、上記 `@import` で読み込んでいます。
 
 - `.claude/rules/git-and-fs.md`: 一時ファイル / sandbox 制約 / git 操作
+- `.claude/rules/github-web-session.md`: web セッションの GitHub 連携トークン制約（`workflow_dispatch` 不可等）
 
 （注: 上記は Claude 固有。Codex は `.codex/rules/`、Gemini CLI は `docs/setup/gemini-policy.md` を参照）
 


### PR DESCRIPTION
## 概要

issue #676（web セッションで実行不可な `workflow_dispatch` をエージェントが毎回「自分でやる」と提案して失敗する問題）に対応。連携トークンに `actions: write` が無く `workflow_dispatch`（VRT baseline 再生成等）が `403 Resource not accessible by integration` で必ず失敗するのに、エージェントが「自分でトリガーします」→失敗→手動依頼、という無駄なラウンドトリップが毎回発生していた（PR #675 で発生）。エージェントが最初から手動手順を案内するよう規約を明文化する。

## 変更内容

この制約は **Claude Code on the web 固有**（Codex/Gemini CLI は別実行環境・別トークンで可否未確認）であるため、全エージェント共通規約ではなく Claude 固有規約に配置した。

- **`.claude/rules/github-web-session.md` を新規追加** — web セッションの GitHub 連携トークン制約を集約
  - 不可と確定している操作（`workflow_dispatch` / `rerun_*` / `cancel_workflow_run` 等の `actions: write` 依存）と、リトライでは解消しないことを明記
  - エージェントは「自分でトリガーする」と提案せず、**最初から手動トリガー手順**（Actions → Run workflow → PR ブランチ選択）を案内
  - **過剰な「できない宣言」も避ける**: read 系 / comment / PR 作成は可、`merge_pull_request` 等は未確認のため先回りで「できない」と言わない
  - 過去事例（PR #675 / issue #676）を記載
- **`CLAUDE.md`** — 上記ファイルを `@import` に追加し、Claude 固有ルール一覧に追記
- **`.agents/rules/common.md` 5 章（ツール追加フロー）step 4** — VRT baseline の `workflow_dispatch` 起動可否は実行環境のトークン権限に依存する旨を**中立的に**記し、Claude 固有ルールへ誘導（共通規約には実行環境固有の断定を書かない）

## issue チェックリスト対応

- [x] `workflow_dispatch` が `403` で実行できないことを記載
- [x] エージェントが即座に手動 workflow_dispatch 手順を案内するルールを明文化
- [x] ツール追加フロー（共通規約 5 章）から VRT baseline 再生成の手動トリガー必須に誘導
- [x] 不可操作の切り分け（`actions: write` 依存のみ不可、read/comment/PR 作成は可、merge は未確認）を記載し過剰な不可宣言を予防

## 配置に関する補足

当初は共通規約 `.agents/rules/common.md` 6.10 に置いたが、レビューで「他エージェントには当てはまらない Claude Code web 固有の制約」と指摘を受け、`.claude/rules/`（Claude 固有の運用ルール置き場）へ移設した。教訓自体は再発頻度が高く `docs/agent-lessons.md` バッファを経由せず直接規約化している。

Closes #676

https://claude.ai/code/session_01TfWSSJK5wgqN33sTpbB2uR