### PR TITLE
docs: merge_pull_request が web セッションで実行可能と確認済みに更新

### DIFF
--- a/.claude/rules/github-web-session.md
+++ b/.claude/rules/github-web-session.md
@@ -21,6 +21,12 @@ web セッションの GitHub 連携トークンには `actions: write` 権限�
 
 ## 過剰な「できない宣言」も避ける
 
-不可と確定しているのは上記 `actions: write` 依存操作のみ。GitHub MCP の read 系（`pull_request_read` / `actions_list` / `get_job_logs` 等）、PR/issue への comment、PR 作成は連携トークンで実行可。`merge_pull_request` 等その他の write 操作の可否は未確認のため、実際に 403 を踏むまで先回りで「できない」と宣言しない。
+不可と確定しているのは上記 `actions: write` 依存操作のみ。以下は連携トークンで**実行可能**であることを確認済み:
+
+- GitHub MCP の read 系（`pull_request_read` / `actions_list` / `get_job_logs` 等）
+- PR/issue への comment、PR 作成（`create_pull_request`）・本文更新（`update_pull_request`）
+- **`merge_pull_request`（squash マージ含む）** — PR #678 で実証（連携トークンで成功）
+
+上記以外の write 操作で可否が未確認のものは、実際に 403 を踏むまで先回りで「できない」と宣言しない。
 
 過去事例: PR #675 で VRT baseline 再生成のため workflow_dispatch を試行 → 403 → 手動依頼、の無駄なラウンドトリップが発生（issue #676）。


### PR DESCRIPTION
## 概要

issue #676 対応（PR #678, merged）で新設した `.claude/rules/github-web-session.md` には、`merge_pull_request` の可否を「未確認」と記載していた。その PR #678 自体を web セッションの連携トークンで `merge_pull_request`（squash）してマージできたことから、**merge は実行可能**と実証された。この切り分け結果をドキュメントに反映する。

## 変更内容

`.claude/rules/github-web-session.md`「過剰な『できない宣言』も避ける」節を更新:

- 連携トークンで**実行可能**と確認済みの操作を箇条書き化
  - read 系（`pull_request_read` / `actions_list` / `get_job_logs` 等）
  - PR/issue への comment、PR 作成・本文更新
  - **`merge_pull_request`（squash マージ含む）** — PR #678 で実証
- 残る未確認の write 操作についての「先回りで不可宣言しない」方針は維持

## 補足

これにより、不可（`actions: write` 依存の workflow_dispatch 系）と可（read / comment / PR 作成・更新・merge）の切り分けがより明確になり、issue #676 が求めていた「過剰な不可宣言も避ける」精度が上がる。

https://claude.ai/code/session_01TfWSSJK5wgqN33sTpbB2uR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfWSSJK5wgqN33sTpbB2uR)_