### PR TITLE
fix: HARビューアの表カラムが狭幅で折り返す問題を修正

### DIFF
--- a/src/components/tools/HarEntryList.tsx
+++ b/src/components/tools/HarEntryList.tsx
@@ -35,19 +35,19 @@ export function HarEntryList({ entries, selectedIndex, onSelect }: Props) {
         <caption className="sr-only">HTTP リクエスト一覧</caption>
         <thead>
           <tr className="bg-subtle text-left">
-            <th scope="col" className="px-3 py-2 font-medium">
+            <th scope="col" className="whitespace-nowrap px-3 py-2 font-medium">
               メソッド
             </th>
             <th scope="col" className="px-3 py-2 font-medium">
               URL
             </th>
-            <th scope="col" className="px-3 py-2 font-medium">
+            <th scope="col" className="whitespace-nowrap px-3 py-2 font-medium">
               ステータス
             </th>
-            <th scope="col" className="px-3 py-2 font-medium">
+            <th scope="col" className="whitespace-nowrap px-3 py-2 font-medium">
               サイズ
             </th>
-            <th scope="col" className="px-3 py-2 font-medium">
+            <th scope="col" className="whitespace-nowrap px-3 py-2 font-medium">
               時間
             </th>
           </tr>
@@ -55,7 +55,7 @@ export function HarEntryList({ entries, selectedIndex, onSelect }: Props) {
         <tbody>
           {entries.map((e, i) => (
             <tr key={i} className={selectedIndex === i ? 'bg-active' : undefined}>
-              <td className="px-3 py-1.5 font-mono">{e.request.method}</td>
+              <td className="whitespace-nowrap px-3 py-1.5 font-mono">{e.request.method}</td>
               <td className="px-3 py-1.5">
                 <button
                   type="button"
@@ -66,11 +66,11 @@ export function HarEntryList({ entries, selectedIndex, onSelect }: Props) {
                   {shortUrl(e.request.url)}
                 </button>
               </td>
-              <td className="px-3 py-1.5 font-mono">{e.response.status}</td>
-              <td className="px-3 py-1.5 font-mono">
+              <td className="whitespace-nowrap px-3 py-1.5 font-mono">{e.response.status}</td>
+              <td className="whitespace-nowrap px-3 py-1.5 font-mono">
                 {formatSize(e.response.content?.size ?? e.response.bodySize)}
               </td>
-              <td className="px-3 py-1.5 font-mono">{formatTime(e.time)}</td>
+              <td className="whitespace-nowrap px-3 py-1.5 font-mono">{formatTime(e.time)}</td>
             </tr>
           ))}
         </tbody>

--- a/tests/e2e/har-viewer.spec.ts
+++ b/tests/e2e/har-viewer.spec.ts
@@ -132,6 +132,35 @@ test.describe('HAR ビューア', () => {
     await expect(page.getByText('https://example.com/api/item/119')).toBeVisible();
   });
 
+  test('固定文言カラムの見出しが nowrap で1文字ずつ縦折り返ししない（狭幅でも）', async ({
+    page,
+  }) => {
+    // スマホ相当の狭幅にしてカラムが squeeze される状況を再現
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tools/har-viewer');
+
+    const json = buildTestHar(3);
+    await uploadHar(page, json);
+
+    // テーブル描画を待つ
+    await expect(page.getByRole('button', { name: /\/api\/item\/0$/ })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // 固定文言カラムの見出しは折り返さない（whitespace-nowrap）。
+    // これを外すと computed style が 'normal' に戻りこの assert が fail する（陽性ガード）。
+    for (const name of ['メソッド', 'ステータス', 'サイズ', '時間']) {
+      const header = page.getByRole('columnheader', { name });
+      const whiteSpace = await header.evaluate((el) => getComputedStyle(el).whiteSpace);
+      expect(whiteSpace, `${name} カラム見出しは nowrap であるべき`).toBe('nowrap');
+    }
+
+    // URL カラムは可変長を吸収するため折り返し可のまま（nowrap にしない）
+    const urlHeader = page.getByRole('columnheader', { name: 'URL' });
+    const urlWhiteSpace = await urlHeader.evaluate((el) => getComputedStyle(el).whiteSpace);
+    expect(urlWhiteSpace).not.toBe('nowrap');
+  });
+
   test('redact トグルで Web Worker の再 sanitize が走り redact 件数が変化する', async ({
     page,
   }) => {


### PR DESCRIPTION
## 概要

HAR ビューア＆サニタイザのリクエスト一覧テーブルで、スマホ幅などカラムが狭くなると「メソッド」「ステータス」「サイズ」といった日本語見出しが1文字ずつ縦に折り返してしまう問題を修正しました。

## 変更内容

- `src/components/tools/HarEntryList.tsx` の以下のカラム（見出し `th` と値 `td`）に `whitespace-nowrap` を付与:
  - メソッド / ステータス / サイズ / 時間
- URL カラムは折り返し可のまま残し、余剰幅を吸収させる。
- カラムが収まらない場合は既存の `overflow-x-auto`（テーブルラッパー）で横スクロールする。
- **回帰ガード E2E を追加**（`tests/e2e/har-viewer.spec.ts`）: 狭幅でテーブルを描画し、固定文言カラム見出しの computed `white-space` が `nowrap`、URL カラムは `nowrap` でないことを assert。

## 確認

- `node_modules/.bin/astro check`: 0 errors
- Playwright でスマホ (390x844) / PC (1280x800) のスクリーンショットを取得し、見出しが1行に収まり、スマホでは横スクロールに切り替わることを目視確認。
- `npm run test:e2e -- har-viewer.spec.ts`: 4 件 pass。
- **陽性対照の実機確認**: ソースから `whitespace-nowrap` を外して rebuild すると追加した回帰ガードが fail（`Expected "nowrap", Received "normal"`）することを確認済み。

※ VRT 対象（`/tools/har-viewer`）はファイル未アップロード状態を撮影するためテーブルは描画されず、baseline 再生成は不要。

https://claude.ai/code/session_01YcB3D5t1EM4fvrusTYBJbQ