### PR TITLE
fix: har-viewer 壊れた entry の描画クラッシュをガード (#681)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-har-viewer-broken-entry-guard.md
+++ b/docs/superpowers/plans/2026-06-14-har-viewer-broken-entry-guard.md
@@ -21,6 +21,7 @@
 - `tests/e2e/har-viewer.spec.ts` — 壊れた entry の E2E ケース追加。
 
 注意（プロジェクト規約）:
+
 - コミットは Conventional Commits 形式 + **日本語**（`.githooks/commit-msg` が検証）。
 - 色は primitive scale 直書き禁止。既存意味クラス（`text-muted` 等）を使う。本変更で新規の色は使わない。
 - 既存 component test は先頭に `// @vitest-environment jsdom` を付ける（global env は node）。
@@ -31,6 +32,7 @@
 ### Task 1: HarEntryList のガード（プレースホルダ行）
 
 **Files:**
+
 - Test: `src/components/tools/__tests__/HarEntryList.test.tsx`（新規）
 - Modify: `src/components/tools/HarEntryList.tsx`
 
@@ -58,12 +60,26 @@ afterEach(() => {
 const entries = [
   {
     time: 12,
-    request: { method: 'GET', url: 'https://example.com/api/ok', headers: [], queryString: [], cookies: [] },
+    request: {
+      method: 'GET',
+      url: 'https://example.com/api/ok',
+      headers: [],
+      queryString: [],
+      cookies: [],
+    },
     response: { status: 200, headers: [], cookies: [], content: { size: 2 } },
   },
   {}, // request/response 欠落
   null, // entry 自体が null
-  { request: { method: 'POST', url: 'https://example.com/api/noresp', headers: [], queryString: [], cookies: [] } }, // response 欠落
+  {
+    request: {
+      method: 'POST',
+      url: 'https://example.com/api/noresp',
+      headers: [],
+      queryString: [],
+      cookies: [],
+    },
+  }, // response 欠落
 ] as unknown as HarEntry[];
 
 describe('HarEntryList 壊れた entry のガード', () => {
@@ -108,41 +124,37 @@ Expected: FAIL（現状 `e.request.method` で `Cannot read properties of undefi
 `src/components/tools/HarEntryList.tsx` の `<tbody>` の map 部分（現 56-75 行）を以下に置換する。`shortUrl` / `formatSize` / `formatTime` ヘルパ・テーブル構造はそのまま:
 
 ```tsx
-        <tbody>
-          {entries.map((e, i) => {
-            const request = e?.request;
-            const response = e?.response;
-            const url = typeof request?.url === 'string' ? request.url : null;
-            return (
-              <tr key={i} className={selectedIndex === i ? 'bg-active' : undefined}>
-                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
-                  {request?.method ?? '—'}
-                </td>
-                <td className="px-3 py-1.5">
-                  {url != null ? (
-                    <button
-                      type="button"
-                      aria-current={selectedIndex === i ? 'true' : undefined}
-                      className="text-left text-primary underline-offset-2 hover:underline"
-                      onClick={() => onSelect(i)}
-                    >
-                      {shortUrl(url)}
-                    </button>
-                  ) : (
-                    <span className="text-muted">（壊れたエントリ）</span>
-                  )}
-                </td>
-                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
-                  {response?.status ?? '—'}
-                </td>
-                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
-                  {formatSize(response?.content?.size ?? response?.bodySize)}
-                </td>
-                <td className="whitespace-nowrap px-3 py-1.5 font-mono">{formatTime(e?.time)}</td>
-              </tr>
-            );
-          })}
-        </tbody>
+<tbody>
+  {entries.map((e, i) => {
+    const request = e?.request;
+    const response = e?.response;
+    const url = typeof request?.url === 'string' ? request.url : null;
+    return (
+      <tr key={i} className={selectedIndex === i ? 'bg-active' : undefined}>
+        <td className="whitespace-nowrap px-3 py-1.5 font-mono">{request?.method ?? '—'}</td>
+        <td className="px-3 py-1.5">
+          {url != null ? (
+            <button
+              type="button"
+              aria-current={selectedIndex === i ? 'true' : undefined}
+              className="text-left text-primary underline-offset-2 hover:underline"
+              onClick={() => onSelect(i)}
+            >
+              {shortUrl(url)}
+            </button>
+          ) : (
+            <span className="text-muted">（壊れたエントリ）</span>
+          )}
+        </td>
+        <td className="whitespace-nowrap px-3 py-1.5 font-mono">{response?.status ?? '—'}</td>
+        <td className="whitespace-nowrap px-3 py-1.5 font-mono">
+          {formatSize(response?.content?.size ?? response?.bodySize)}
+        </td>
+        <td className="whitespace-nowrap px-3 py-1.5 font-mono">{formatTime(e?.time)}</td>
+      </tr>
+    );
+  })}
+</tbody>
 ```
 
 - [ ] **Step 4: テストが通ることを確認**
@@ -167,6 +179,7 @@ git commit -m "fix: har-viewer 一覧で壊れた entry をガードしプレー
 ### Task 2: HarEntryDetail のガード（プレースホルダ表示）
 
 **Files:**
+
 - Test: `src/components/tools/__tests__/HarEntryDetail.test.tsx`（新規）
 - Modify: `src/components/tools/HarEntryDetail.tsx`
 
@@ -191,13 +204,27 @@ afterEach(() => {
 
 const validEntry = {
   time: 5,
-  request: { method: 'GET', url: 'https://example.com/x', headers: [], queryString: [], cookies: [] },
+  request: {
+    method: 'GET',
+    url: 'https://example.com/x',
+    headers: [],
+    queryString: [],
+    cookies: [],
+  },
   response: { status: 200, statusText: 'OK', headers: [], cookies: [], content: {} },
 } as unknown as HarEntry;
 
 describe('HarEntryDetail 壊れた entry のガード', () => {
   it('response 欠落 entry でも throw せずプレースホルダを表示する', () => {
-    const broken = { request: { method: 'GET', url: 'https://example.com/y', headers: [], queryString: [], cookies: [] } } as unknown as HarEntry;
+    const broken = {
+      request: {
+        method: 'GET',
+        url: 'https://example.com/y',
+        headers: [],
+        queryString: [],
+        cookies: [],
+      },
+    } as unknown as HarEntry;
     expect(() => render(<HarEntryDetail entry={broken} />)).not.toThrow();
     expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
   });
@@ -268,6 +295,7 @@ git commit -m "fix: har-viewer 詳細パネルで壊れた entry をガード (#
 ### Task 3: E2E（壊れた entry を含む HAR でクラッシュしない）
 
 **Files:**
+
 - Modify: `tests/e2e/har-viewer.spec.ts`
 
 - [ ] **Step 1: E2E ケースを追加**
@@ -275,43 +303,41 @@ git commit -m "fix: har-viewer 詳細パネルで壊れた entry をガード (#
 `tests/e2e/har-viewer.spec.ts` の `test.describe('HAR ビューア', ...)` ブロック内（最後の test の後）に以下を追加する。`uploadHar` ヘルパは既存:
 
 ```ts
-  test('壊れた entry（request/response 欠落）を含んでもクラッシュせず描画する', async ({
-    page,
-  }) => {
-    await page.goto('/tools/har-viewer');
+test('壊れた entry（request/response 欠落）を含んでもクラッシュせず描画する', async ({ page }) => {
+  await page.goto('/tools/har-viewer');
 
-    // 1 件目は正常、2 件目は request/response を欠く壊れた entry（issue #681 再現データ）
-    const json = JSON.stringify({
-      log: {
-        version: '1.2',
-        creator: { name: 'test', version: '1.0' },
-        entries: [
-          {
-            time: 10,
-            request: {
-              method: 'GET',
-              url: 'https://example.com/api/ok',
-              headers: [],
-              queryString: [],
-              cookies: [],
-            },
-            response: { status: 200, headers: [], cookies: [], content: {} },
+  // 1 件目は正常、2 件目は request/response を欠く壊れた entry（issue #681 再現データ）
+  const json = JSON.stringify({
+    log: {
+      version: '1.2',
+      creator: { name: 'test', version: '1.0' },
+      entries: [
+        {
+          time: 10,
+          request: {
+            method: 'GET',
+            url: 'https://example.com/api/ok',
+            headers: [],
+            queryString: [],
+            cookies: [],
           },
-          {}, // 壊れた entry
-        ],
-      },
-    });
-    await uploadHar(page, json);
-
-    // 正常 entry が描画される（React island がクラッシュしていない陽性対照）
-    await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
-      timeout: 10000,
-    });
-    // 壊れた entry 行はプレースホルダで表示される
-    await expect(page.getByText('（壊れたエントリ）')).toBeVisible();
-    // サマリのリクエスト件数は 2 件（entry は配列に保持される）
-    await expect(page.getByText(/リクエスト:/)).toBeVisible();
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+        {}, // 壊れた entry
+      ],
+    },
   });
+  await uploadHar(page, json);
+
+  // 正常 entry が描画される（React island がクラッシュしていない陽性対照）
+  await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
+    timeout: 10000,
+  });
+  // 壊れた entry 行はプレースホルダで表示される
+  await expect(page.getByText('（壊れたエントリ）')).toBeVisible();
+  // サマリのリクエスト件数は 2 件（entry は配列に保持される）
+  await expect(page.getByText(/リクエスト:/)).toBeVisible();
+});
 ```
 
 - [ ] **Step 2: E2E を実行**

--- a/docs/superpowers/plans/2026-06-14-har-viewer-broken-entry-guard.md
+++ b/docs/superpowers/plans/2026-06-14-har-viewer-broken-entry-guard.md
@@ -1,0 +1,360 @@
+# har-viewer 壊れた entry 描画ガード Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 壊れた entry（`request`/`response` 欠落）を含む HAR を読み込んでも `HarEntryList` / `HarEntryDetail` がクラッシュせず、プレースホルダで透過的に表示する。
+
+**Architecture:** 描画側（list / detail）で entry のフィールドを直接参照せず optional chaining + フォールバックでガードする。entry は配列にそのまま残し行はスキップしない（サマリ件数とインデックスの整合を維持）。壊れた行は非クリックのプレースホルダにし、詳細パネルは欠落時にプレースホルダ文言を出す。
+
+**Tech Stack:** React + TypeScript (Astro island), Vitest + @testing-library/react (jsdom), Playwright (E2E)。
+
+設計の正本: `docs/superpowers/specs/2026-06-14-har-viewer-broken-entry-guard-design.md`
+
+---
+
+## File Structure
+
+- `src/components/tools/HarEntryList.tsx` — 一覧テーブル。各セルをガード。
+- `src/components/tools/HarEntryDetail.tsx` — 詳細パネル。request/response 欠落時にプレースホルダ。
+- `src/components/tools/__tests__/HarEntryList.test.tsx` — 新規 component test。
+- `src/components/tools/__tests__/HarEntryDetail.test.tsx` — 新規 component test。
+- `tests/e2e/har-viewer.spec.ts` — 壊れた entry の E2E ケース追加。
+
+注意（プロジェクト規約）:
+- コミットは Conventional Commits 形式 + **日本語**（`.githooks/commit-msg` が検証）。
+- 色は primitive scale 直書き禁止。既存意味クラス（`text-muted` 等）を使う。本変更で新規の色は使わない。
+- 既存 component test は先頭に `// @vitest-environment jsdom` を付ける（global env は node）。
+- import は `@/` エイリアス可（component / test は worker 依存グラフ外なので問題ない）。
+
+---
+
+### Task 1: HarEntryList のガード（プレースホルダ行）
+
+**Files:**
+- Test: `src/components/tools/__tests__/HarEntryList.test.tsx`（新規）
+- Modify: `src/components/tools/HarEntryList.tsx`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/components/tools/__tests__/HarEntryList.test.tsx` を新規作成:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+import { HarEntryList } from '@/components/tools/HarEntryList';
+import type { HarEntry } from '@/utils/har';
+
+beforeEach(() => {
+  document.adoptedStyleSheets = [];
+});
+afterEach(() => {
+  cleanup();
+  document.adoptedStyleSheets = [];
+});
+
+// 正常 1 件 + 壊れた entry 3 種（{}, null, response 欠落）を混在させる。
+// 型は実データ（手編集 HAR）を模すため unknown 経由でキャストする。
+const entries = [
+  {
+    time: 12,
+    request: { method: 'GET', url: 'https://example.com/api/ok', headers: [], queryString: [], cookies: [] },
+    response: { status: 200, headers: [], cookies: [], content: { size: 2 } },
+  },
+  {}, // request/response 欠落
+  null, // entry 自体が null
+  { request: { method: 'POST', url: 'https://example.com/api/noresp', headers: [], queryString: [], cookies: [] } }, // response 欠落
+] as unknown as HarEntry[];
+
+describe('HarEntryList 壊れた entry のガード', () => {
+  it('壊れた entry を含んでも throw せず描画できる', () => {
+    expect(() =>
+      render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />)
+    ).not.toThrow();
+  });
+
+  it('正常 entry の method と URL を描画する', () => {
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />);
+    expect(screen.getByText('GET')).toBeTruthy();
+    // shortUrl は host + pathname
+    expect(screen.getByRole('button', { name: 'example.com/api/ok' })).toBeTruthy();
+  });
+
+  it('壊れた entry 行はプレースホルダを表示し URL ボタンを描画しない', () => {
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />);
+    // 「壊れたエントリ」プレースホルダが request 欠落行に出る（{} と null の 2 行）
+    expect(screen.getAllByText('（壊れたエントリ）').length).toBeGreaterThanOrEqual(2);
+    // request はあるが response 欠落の行は URL ボタンを描画する（クリック可能）
+    expect(screen.getByRole('button', { name: 'example.com/api/noresp' })).toBeTruthy();
+  });
+
+  it('壊れた entry の URL セルは選択 button を持たない', () => {
+    const onSelect = vi.fn();
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={onSelect} />);
+    // URL ボタンは正常 entry(ok) と response欠落(noresp) の 2 つだけ（{}/null は非ボタン）
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `npm run test -- HarEntryList`
+Expected: FAIL（現状 `e.request.method` で `Cannot read properties of undefined`、または「壊れたエントリ」が見つからず throw）。
+
+- [ ] **Step 3: HarEntryList を実装**
+
+`src/components/tools/HarEntryList.tsx` の `<tbody>` の map 部分（現 56-75 行）を以下に置換する。`shortUrl` / `formatSize` / `formatTime` ヘルパ・テーブル構造はそのまま:
+
+```tsx
+        <tbody>
+          {entries.map((e, i) => {
+            const request = e?.request;
+            const response = e?.response;
+            const url = typeof request?.url === 'string' ? request.url : null;
+            return (
+              <tr key={i} className={selectedIndex === i ? 'bg-active' : undefined}>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
+                  {request?.method ?? '—'}
+                </td>
+                <td className="px-3 py-1.5">
+                  {url != null ? (
+                    <button
+                      type="button"
+                      aria-current={selectedIndex === i ? 'true' : undefined}
+                      className="text-left text-primary underline-offset-2 hover:underline"
+                      onClick={() => onSelect(i)}
+                    >
+                      {shortUrl(url)}
+                    </button>
+                  ) : (
+                    <span className="text-muted">（壊れたエントリ）</span>
+                  )}
+                </td>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
+                  {response?.status ?? '—'}
+                </td>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
+                  {formatSize(response?.content?.size ?? response?.bodySize)}
+                </td>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">{formatTime(e?.time)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `npm run test -- HarEntryList`
+Expected: PASS（4 ケース）。
+
+- [ ] **Step 5: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: エラーなし（`e?.request` 等のガードで undefined 参照が解消）。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/components/tools/HarEntryList.tsx src/components/tools/__tests__/HarEntryList.test.tsx
+git commit -m "fix: har-viewer 一覧で壊れた entry をガードしプレースホルダ表示 (#681)"
+```
+
+---
+
+### Task 2: HarEntryDetail のガード（プレースホルダ表示）
+
+**Files:**
+- Test: `src/components/tools/__tests__/HarEntryDetail.test.tsx`（新規）
+- Modify: `src/components/tools/HarEntryDetail.tsx`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/components/tools/__tests__/HarEntryDetail.test.tsx` を新規作成:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+import { HarEntryDetail } from '@/components/tools/HarEntryDetail';
+import type { HarEntry } from '@/utils/har';
+
+beforeEach(() => {
+  document.adoptedStyleSheets = [];
+});
+afterEach(() => {
+  cleanup();
+  document.adoptedStyleSheets = [];
+});
+
+const validEntry = {
+  time: 5,
+  request: { method: 'GET', url: 'https://example.com/x', headers: [], queryString: [], cookies: [] },
+  response: { status: 200, statusText: 'OK', headers: [], cookies: [], content: {} },
+} as unknown as HarEntry;
+
+describe('HarEntryDetail 壊れた entry のガード', () => {
+  it('response 欠落 entry でも throw せずプレースホルダを表示する', () => {
+    const broken = { request: { method: 'GET', url: 'https://example.com/y', headers: [], queryString: [], cookies: [] } } as unknown as HarEntry;
+    expect(() => render(<HarEntryDetail entry={broken} />)).not.toThrow();
+    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+  });
+
+  it('空 entry でも throw せずプレースホルダを表示する', () => {
+    const empty = {} as unknown as HarEntry;
+    expect(() => render(<HarEntryDetail entry={empty} />)).not.toThrow();
+    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+  });
+
+  it('正常 entry では method/url/status を表示する', () => {
+    render(<HarEntryDetail entry={validEntry} />);
+    expect(screen.getByText(/GET https:\/\/example.com\/x/)).toBeTruthy();
+    expect(screen.getByText(/200/)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `npm run test -- HarEntryDetail`
+Expected: FAIL（`const { request, response } = entry` 後 `response.status` で throw、またはプレースホルダ文言が無い）。
+
+- [ ] **Step 3: HarEntryDetail を実装**
+
+`src/components/tools/HarEntryDetail.tsx` の `export function HarEntryDetail` 冒頭（現 26-28 行 `const { request, response } = entry;` 周辺）にガードを追加する。`NameValueTable` ヘルパはそのまま:
+
+```tsx
+export function HarEntryDetail({ entry }: Props) {
+  const request = entry?.request;
+  const response = entry?.response;
+
+  // 手編集・切り詰めた HAR では request/response を欠く entry がありうる。
+  // 直接参照すると TypeError でクラッシュするためプレースホルダでガードする（issue #681）。
+  if (!request || typeof request !== 'object' || !response || typeof response !== 'object') {
+    return (
+      <div className="rounded border border-default p-4 text-muted">
+        このエントリは request / response を欠くため詳細を表示できません。
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded border border-default p-4">
+```
+
+（以降の JSX 本体は変更なし。`const { request, response } = entry;` の行は削除し、上記 2 行の宣言に置き換える。）
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `npm run test -- HarEntryDetail`
+Expected: PASS（3 ケース）。
+
+- [ ] **Step 5: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: エラーなし。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/components/tools/HarEntryDetail.tsx src/components/tools/__tests__/HarEntryDetail.test.tsx
+git commit -m "fix: har-viewer 詳細パネルで壊れた entry をガード (#681)"
+```
+
+---
+
+### Task 3: E2E（壊れた entry を含む HAR でクラッシュしない）
+
+**Files:**
+- Modify: `tests/e2e/har-viewer.spec.ts`
+
+- [ ] **Step 1: E2E ケースを追加**
+
+`tests/e2e/har-viewer.spec.ts` の `test.describe('HAR ビューア', ...)` ブロック内（最後の test の後）に以下を追加する。`uploadHar` ヘルパは既存:
+
+```ts
+  test('壊れた entry（request/response 欠落）を含んでもクラッシュせず描画する', async ({
+    page,
+  }) => {
+    await page.goto('/tools/har-viewer');
+
+    // 1 件目は正常、2 件目は request/response を欠く壊れた entry（issue #681 再現データ）
+    const json = JSON.stringify({
+      log: {
+        version: '1.2',
+        creator: { name: 'test', version: '1.0' },
+        entries: [
+          {
+            time: 10,
+            request: {
+              method: 'GET',
+              url: 'https://example.com/api/ok',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+          {}, // 壊れた entry
+        ],
+      },
+    });
+    await uploadHar(page, json);
+
+    // 正常 entry が描画される（React island がクラッシュしていない陽性対照）
+    await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
+      timeout: 10000,
+    });
+    // 壊れた entry 行はプレースホルダで表示される
+    await expect(page.getByText('（壊れたエントリ）')).toBeVisible();
+    // サマリのリクエスト件数は 2 件（entry は配列に保持される）
+    await expect(page.getByText(/リクエスト:/)).toBeVisible();
+  });
+```
+
+- [ ] **Step 2: E2E を実行**
+
+Run: `npm run test:e2e -- har-viewer`
+Expected: PASS（既存ケース + 新規ケース）。preview ビルドが要る場合は `npm run test:e2e` が内部で preview を起動する。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add tests/e2e/har-viewer.spec.ts
+git commit -m "test: har-viewer 壊れた entry のクラッシュ防止 E2E を追加 (#681)"
+```
+
+---
+
+### Task 4: 最終検証
+
+- [ ] **Step 1: ユニットテスト全体**
+
+Run: `npm run test`
+Expected: 全 PASS（新規 component test 含む）。
+
+- [ ] **Step 2: 型チェック全体**
+
+Run: `node_modules/.bin/astro check`
+Expected: エラーなし。
+
+- [ ] **Step 3: Lint / format チェック**
+
+Run: `npm run lint && npm run format:check`
+Expected: エラーなし（format で差分が出たら `npm run format` で整形して該当ファイルを再コミット）。
+
+- [ ] **Step 4: E2E 全体（har-viewer）**
+
+Run: `npm run test:e2e -- har-viewer`
+Expected: 全 PASS。
+
+---
+
+## Self-Review メモ
+
+- **Spec coverage**: 設計の 1（list ガード）→ Task 1、2（detail ガード）→ Task 2、テスト（unit/E2E 陽性対照）→ Task 1/2/3。漏れなし。
+- **陽性対照**: ガードを外すと render が throw して fail する（Task 1/2 のテスト）。検知能力ゼロで green の状態を排除（`test-gates` 方針）。
+- **インデックス整合**: 行をスキップせず絶対 index を維持するため `HarViewer` の `result.har.log.entries[selectedIndex]` 逆引きは不変。
+- **VRT**: ツール追加・slug 変更なし、`PAGES` 配列は変更不要（har-viewer は既に登録済み）。描画ガードによる通常時の見た目は不変（壊れた entry が無い HAR では既存と同一 DOM）。

--- a/docs/superpowers/specs/2026-06-14-har-viewer-broken-entry-guard-design.md
+++ b/docs/superpowers/specs/2026-06-14-har-viewer-broken-entry-guard-design.md
@@ -57,6 +57,7 @@
 ### ユニット（component test, jsdom）
 
 `src/components/tools/__tests__/HarEntryList.test.tsx` を新規追加:
+
 - 壊れた entry（`{}` / `null` / `{ request: {...}, response 欠落 }`）を含む `entries` で `render` しても throw しない。
 - 正常 entry の `method` / URL が描画される。
 - 壊れた entry 行のプレースホルダ（`—` / 「壊れたエントリ」）が描画される。
@@ -64,12 +65,14 @@
 - **陰性対照との区別**: ガードを外すと（直接参照に戻すと）render が throw して fail することで、検知能力があることを担保する。
 
 `src/components/tools/__tests__/HarEntryDetail.test.tsx` を新規追加:
+
 - `request` / `response` 欠落 entry で `render` しても throw せず、プレースホルダ文言を表示する。
 - 正常 entry では従来どおり method/url/status を表示する。
 
 ### E2E
 
 `tests/e2e/har-viewer.spec.ts` にケース追加:
+
 - 2 件目に `request`/`response` を欠く entry を持つ HAR をアップロード → 画面がクラッシュせず、1 件目の正常 entry が描画され、壊れた行のプレースホルダが見える（陽性対照: 壊れた入力で throw せず描画完了）。
 
 ## 影響ファイル

--- a/docs/superpowers/specs/2026-06-14-har-viewer-broken-entry-guard-design.md
+++ b/docs/superpowers/specs/2026-06-14-har-viewer-broken-entry-guard-design.md
@@ -1,0 +1,83 @@
+# har-viewer: 壊れた entry の描画ガード 設計 (issue #681)
+
+## 背景・問題
+
+`HarEntryList` は各 entry を `e.request.method` / `e.request.url` / `e.response.status` で**直接参照**している。一方 `parseHar` は `log.entries` が配列であることのみを検証し、各 entry の形状は検証しない。`sanitizeHar` は壊れた entry（`{}` や `null`、`request`/`response` 欠落）を**防御的にスキップしつつ配列に残す**（`sanitize.test.ts` の「壊れた entry でも例外を投げない」が length 3 保持を確認）。
+
+このため、`request` / `response` を欠く entry を含む HAR を読み込むと、sanitize は通っても**一覧描画時に `TypeError`（`undefined` の `.method` 参照等）で落ち**、React island がクラッシュして画面が空になりうる。`HarEntryDetail` も `const { request, response } = entry` 後に `request.method` / `response.status` を参照するため同様にクラッシュしうる。
+
+**原因**: `sanitize` 側は防御的だが `list` / `detail` 側が無防備、という非対称。既存挙動（PR #675 由来、PR #680 のレビューで指摘・スコープ外分離）。
+
+## 目的
+
+壊れた entry を含む HAR を読み込んでも描画がクラッシュせず、ユーザに「壊れた entry が存在する」ことを透過的に示す。
+
+## スコープ外
+
+- `parseHar` / `sanitizeHar` のスキーマ検証強化（sanitize 側は既に防御的で、本 issue は描画側の非対称を解消するもの）。
+- 壊れた entry の自動修復・除去（出力 HAR は入力同様 entry を保持する）。
+- ページング・仮想化等のパフォーマンス改善。
+
+## 設計
+
+### 1. `HarEntryList` のガード（プレースホルダ行で表示）
+
+各 entry のフィールドを直接参照せず、optional chaining + フォールバックで描画する。entry は配列にそのまま残し、**行は欠落させない**（サマリの `entryCount` と表示行数を一致させ、インデックスのズレも防ぐ）。
+
+- `method`: `entry?.request?.method ?? '—'`
+- `URL` 列: `entry?.request?.url` が string のときのみクリック可能な `<button>`（`onSelect(i)`）を描画する。欠落時は非クリックの `<span className="text-muted">（壊れたエントリ）</span>` を描画し、選択不可にする。
+- `status`: `entry?.response?.status ?? '—'`
+- `size`: `formatSize(entry?.response?.content?.size ?? entry?.response?.bodySize)`（`formatSize` は `undefined` を `'-'` に変換済み）
+- `time`: `formatTime(entry?.time)`（既存挙動を維持）
+
+インデックス `i` は**配列の絶対位置のまま**維持する（`HarViewer` が `result.har.log.entries[selectedIndex]` で逆引きするため）。行のスキップ・フィルタはしない。
+
+### 2. `HarEntryDetail` のガード（プレースホルダ表示）
+
+`entry?.request` / `entry?.response` のどちらかが非オブジェクト（`null` / `undefined`）の場合、クラッシュせずプレースホルダを表示する:
+
+```
+このエントリは request / response を欠くため詳細を表示できません。
+```
+
+`HarViewer` の自動選択（読み込み時に先頭 index=0 を選択）が壊れた entry に当たるケースでも安全になる。request/response が揃っている通常 entry は従来どおり詳細を描画する。`NameValueTable` は既に `if (!rows || rows.length === 0) return null` でガード済みのため、`headers` 等の配列欠落は追加対応不要。
+
+### 3. 共通判定
+
+「entry が描画可能か」の判定は `entry?.request` / `entry?.response` が**非 null のオブジェクトか**で行う。list / detail それぞれにローカルに optional chaining で実装し、新規ユーティリティは増やさない（2 箇所のみで小さく、過度な抽象化を避ける）。
+
+## エラーハンドリング
+
+描画はクラッシュしない（throw しない）。壊れた entry は視覚的にプレースホルダで明示し、ユーザが「データ欠落がある」と認識できる。出力 HAR（コピー / ダウンロード）は入力同様 entry を保持する（情報を失わない）。
+
+## テスト（陽性対照を含む）
+
+本 issue は「描画クラッシュ防止」というリグレッション防止が主目的のため、`test-gates` skill の方針に従い**壊れた entry を含む入力で throw せず描画完了することを assert する陽性対照**を必須とする。
+
+### ユニット（component test, jsdom）
+
+`src/components/tools/__tests__/HarEntryList.test.tsx` を新規追加:
+- 壊れた entry（`{}` / `null` / `{ request: {...}, response 欠落 }`）を含む `entries` で `render` しても throw しない。
+- 正常 entry の `method` / URL が描画される。
+- 壊れた entry 行のプレースホルダ（`—` / 「壊れたエントリ」）が描画される。
+- 壊れた entry 行の URL はクリック可能な button を描画しない（選択不可）。
+- **陰性対照との区別**: ガードを外すと（直接参照に戻すと）render が throw して fail することで、検知能力があることを担保する。
+
+`src/components/tools/__tests__/HarEntryDetail.test.tsx` を新規追加:
+- `request` / `response` 欠落 entry で `render` しても throw せず、プレースホルダ文言を表示する。
+- 正常 entry では従来どおり method/url/status を表示する。
+
+### E2E
+
+`tests/e2e/har-viewer.spec.ts` にケース追加:
+- 2 件目に `request`/`response` を欠く entry を持つ HAR をアップロード → 画面がクラッシュせず、1 件目の正常 entry が描画され、壊れた行のプレースホルダが見える（陽性対照: 壊れた入力で throw せず描画完了）。
+
+## 影響ファイル
+
+- `src/components/tools/HarEntryList.tsx`（ガード追加）
+- `src/components/tools/HarEntryDetail.tsx`（ガード追加）
+- `src/components/tools/__tests__/HarEntryList.test.tsx`（新規）
+- `src/components/tools/__tests__/HarEntryDetail.test.tsx`（新規）
+- `tests/e2e/har-viewer.spec.ts`（ケース追加）
+
+ツール追加・slug 変更・ライブラリ追加はないため `README.md` / `SPEC.md` の更新は不要。`docs/decisions.md` は描画ガードという小さな防御実装のため記録対象外（設計上の重要決断ではない）。

--- a/src/components/tools/HarEntryDetail.tsx
+++ b/src/components/tools/HarEntryDetail.tsx
@@ -24,7 +24,19 @@ function NameValueTable({ rows, label }: { rows: HarNameValue[]; label: string }
 }
 
 export function HarEntryDetail({ entry }: Props) {
-  const { request, response } = entry;
+  const request = entry?.request;
+  const response = entry?.response;
+
+  // 手編集・切り詰めた HAR では request/response を欠く entry がありうる。
+  // 直接参照すると TypeError でクラッシュするためプレースホルダでガードする（issue #681）。
+  if (!request || typeof request !== 'object' || !response || typeof response !== 'object') {
+    return (
+      <div className="rounded border border-default p-4 text-muted">
+        このエントリは request / response を欠くため詳細を表示できません。
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4 rounded border border-default p-4">
       <div>

--- a/src/components/tools/HarEntryList.tsx
+++ b/src/components/tools/HarEntryList.tsx
@@ -53,26 +53,39 @@ export function HarEntryList({ entries, selectedIndex, onSelect }: Props) {
           </tr>
         </thead>
         <tbody>
-          {entries.map((e, i) => (
-            <tr key={i} className={selectedIndex === i ? 'bg-active' : undefined}>
-              <td className="whitespace-nowrap px-3 py-1.5 font-mono">{e.request.method}</td>
-              <td className="px-3 py-1.5">
-                <button
-                  type="button"
-                  aria-current={selectedIndex === i ? 'true' : undefined}
-                  className="text-left text-primary underline-offset-2 hover:underline"
-                  onClick={() => onSelect(i)}
-                >
-                  {shortUrl(e.request.url)}
-                </button>
-              </td>
-              <td className="whitespace-nowrap px-3 py-1.5 font-mono">{e.response.status}</td>
-              <td className="whitespace-nowrap px-3 py-1.5 font-mono">
-                {formatSize(e.response.content?.size ?? e.response.bodySize)}
-              </td>
-              <td className="whitespace-nowrap px-3 py-1.5 font-mono">{formatTime(e.time)}</td>
-            </tr>
-          ))}
+          {entries.map((e, i) => {
+            const request = e?.request;
+            const response = e?.response;
+            const url = typeof request?.url === 'string' ? request.url : null;
+            return (
+              <tr key={i} className={selectedIndex === i ? 'bg-active' : undefined}>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
+                  {request?.method ?? '—'}
+                </td>
+                <td className="px-3 py-1.5">
+                  {url != null ? (
+                    <button
+                      type="button"
+                      aria-current={selectedIndex === i ? 'true' : undefined}
+                      className="text-left text-primary underline-offset-2 hover:underline"
+                      onClick={() => onSelect(i)}
+                    >
+                      {shortUrl(url)}
+                    </button>
+                  ) : (
+                    <span className="text-muted">（壊れたエントリ）</span>
+                  )}
+                </td>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
+                  {response?.status ?? '—'}
+                </td>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">
+                  {formatSize(response?.content?.size ?? response?.bodySize)}
+                </td>
+                <td className="whitespace-nowrap px-3 py-1.5 font-mono">{formatTime(e?.time)}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/components/tools/__tests__/HarEntryDetail.test.tsx
+++ b/src/components/tools/__tests__/HarEntryDetail.test.tsx
@@ -14,13 +14,27 @@ afterEach(() => {
 
 const validEntry = {
   time: 5,
-  request: { method: 'GET', url: 'https://example.com/x', headers: [], queryString: [], cookies: [] },
+  request: {
+    method: 'GET',
+    url: 'https://example.com/x',
+    headers: [],
+    queryString: [],
+    cookies: [],
+  },
   response: { status: 200, statusText: 'OK', headers: [], cookies: [], content: {} },
 } as unknown as HarEntry;
 
 describe('HarEntryDetail 壊れた entry のガード', () => {
   it('response 欠落 entry でも throw せずプレースホルダを表示する', () => {
-    const broken = { request: { method: 'GET', url: 'https://example.com/y', headers: [], queryString: [], cookies: [] } } as unknown as HarEntry;
+    const broken = {
+      request: {
+        method: 'GET',
+        url: 'https://example.com/y',
+        headers: [],
+        queryString: [],
+        cookies: [],
+      },
+    } as unknown as HarEntry;
     expect(() => render(<HarEntryDetail entry={broken} />)).not.toThrow();
     expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
   });

--- a/src/components/tools/__tests__/HarEntryDetail.test.tsx
+++ b/src/components/tools/__tests__/HarEntryDetail.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+import { HarEntryDetail } from '@/components/tools/HarEntryDetail';
+import type { HarEntry } from '@/utils/har';
+
+beforeEach(() => {
+  document.adoptedStyleSheets = [];
+});
+afterEach(() => {
+  cleanup();
+  document.adoptedStyleSheets = [];
+});
+
+const validEntry = {
+  time: 5,
+  request: { method: 'GET', url: 'https://example.com/x', headers: [], queryString: [], cookies: [] },
+  response: { status: 200, statusText: 'OK', headers: [], cookies: [], content: {} },
+} as unknown as HarEntry;
+
+describe('HarEntryDetail 壊れた entry のガード', () => {
+  it('response 欠落 entry でも throw せずプレースホルダを表示する', () => {
+    const broken = { request: { method: 'GET', url: 'https://example.com/y', headers: [], queryString: [], cookies: [] } } as unknown as HarEntry;
+    expect(() => render(<HarEntryDetail entry={broken} />)).not.toThrow();
+    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+  });
+
+  it('空 entry でも throw せずプレースホルダを表示する', () => {
+    const empty = {} as unknown as HarEntry;
+    expect(() => render(<HarEntryDetail entry={empty} />)).not.toThrow();
+    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+  });
+
+  it('正常 entry では method/url/status を表示する', () => {
+    render(<HarEntryDetail entry={validEntry} />);
+    expect(screen.getByText(/GET https:\/\/example.com\/x/)).toBeTruthy();
+    expect(screen.getByText(/200/)).toBeTruthy();
+  });
+});

--- a/src/components/tools/__tests__/HarEntryList.test.tsx
+++ b/src/components/tools/__tests__/HarEntryList.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+import { HarEntryList } from '@/components/tools/HarEntryList';
+import type { HarEntry } from '@/utils/har';
+
+beforeEach(() => {
+  document.adoptedStyleSheets = [];
+});
+afterEach(() => {
+  cleanup();
+  document.adoptedStyleSheets = [];
+});
+
+// 正常 1 件 + 壊れた entry 3 種（{}, null, response 欠落）を混在させる。
+// 型は実データ（手編集 HAR）を模すため unknown 経由でキャストする。
+const entries = [
+  {
+    time: 12,
+    request: { method: 'GET', url: 'https://example.com/api/ok', headers: [], queryString: [], cookies: [] },
+    response: { status: 200, headers: [], cookies: [], content: { size: 2 } },
+  },
+  {}, // request/response 欠落
+  null, // entry 自体が null
+  { request: { method: 'POST', url: 'https://example.com/api/noresp', headers: [], queryString: [], cookies: [] } }, // response 欠落
+] as unknown as HarEntry[];
+
+describe('HarEntryList 壊れた entry のガード', () => {
+  it('壊れた entry を含んでも throw せず描画できる', () => {
+    expect(() =>
+      render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />)
+    ).not.toThrow();
+  });
+
+  it('正常 entry の method と URL を描画する', () => {
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />);
+    expect(screen.getByText('GET')).toBeTruthy();
+    // shortUrl は host + pathname
+    expect(screen.getByRole('button', { name: 'example.com/api/ok' })).toBeTruthy();
+  });
+
+  it('壊れた entry 行はプレースホルダを表示し URL ボタンを描画しない', () => {
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />);
+    // 「壊れたエントリ」プレースホルダが request 欠落行に出る（{} と null の 2 行）
+    expect(screen.getAllByText('（壊れたエントリ）').length).toBeGreaterThanOrEqual(2);
+    // request はあるが response 欠落の行は URL ボタンを描画する（クリック可能）
+    expect(screen.getByRole('button', { name: 'example.com/api/noresp' })).toBeTruthy();
+  });
+
+  it('壊れた entry の URL セルは選択 button を持たない', () => {
+    const onSelect = vi.fn();
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={onSelect} />);
+    // URL ボタンは正常 entry(ok) と response欠落(noresp) の 2 つだけ（{}/null は非ボタン）
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+  });
+});

--- a/src/components/tools/__tests__/HarEntryList.test.tsx
+++ b/src/components/tools/__tests__/HarEntryList.test.tsx
@@ -17,12 +17,26 @@ afterEach(() => {
 const entries = [
   {
     time: 12,
-    request: { method: 'GET', url: 'https://example.com/api/ok', headers: [], queryString: [], cookies: [] },
+    request: {
+      method: 'GET',
+      url: 'https://example.com/api/ok',
+      headers: [],
+      queryString: [],
+      cookies: [],
+    },
     response: { status: 200, headers: [], cookies: [], content: { size: 2 } },
   },
   {}, // request/response 欠落
   null, // entry 自体が null
-  { request: { method: 'POST', url: 'https://example.com/api/noresp', headers: [], queryString: [], cookies: [] } }, // response 欠落
+  {
+    request: {
+      method: 'POST',
+      url: 'https://example.com/api/noresp',
+      headers: [],
+      queryString: [],
+      cookies: [],
+    },
+  }, // response 欠落
 ] as unknown as HarEntry[];
 
 describe('HarEntryList 壊れた entry のガード', () => {

--- a/tests/e2e/har-viewer.spec.ts
+++ b/tests/e2e/har-viewer.spec.ts
@@ -181,4 +181,42 @@ test.describe('HAR ビューア', () => {
     await page.getByRole('button', { name: /Cookie/ }).click();
     await expect(page.getByText(/redact:\s*5\s*件/)).toBeVisible({ timeout: 10000 });
   });
+
+  test('壊れた entry（request/response 欠落）を含んでもクラッシュせず描画する', async ({
+    page,
+  }) => {
+    await page.goto('/tools/har-viewer');
+
+    // 1 件目は正常、2 件目は request/response を欠く壊れた entry（issue #681 再現データ）
+    const json = JSON.stringify({
+      log: {
+        version: '1.2',
+        creator: { name: 'test', version: '1.0' },
+        entries: [
+          {
+            time: 10,
+            request: {
+              method: 'GET',
+              url: 'https://example.com/api/ok',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+          {}, // 壊れた entry
+        ],
+      },
+    });
+    await uploadHar(page, json);
+
+    // 正常 entry が描画される（React island がクラッシュしていない陽性対照）
+    await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
+      timeout: 10000,
+    });
+    // 壊れた entry 行はプレースホルダで表示される
+    await expect(page.getByText('（壊れたエントリ）')).toBeVisible();
+    // サマリのリクエスト件数は 2 件（entry は配列に保持される）
+    await expect(page.getByText(/リクエスト:/)).toBeVisible();
+  });
 });


### PR DESCRIPTION
## 概要

`request` / `response` を欠く壊れた entry を含む HAR を読み込むと、`sanitize` は通っても**一覧描画時に `TypeError`（`undefined` の `.method` 参照等）で React island がクラッシュ**し画面が空になる問題（issue #681）を修正します。

原因は `sanitizeHar` が壊れた entry を防御的にスキップしつつ配列に残す一方で、`HarEntryList` / `HarEntryDetail` が `e.request.method` / `e.response.status` を**直接参照**していた非対称でした。

## 対応

- **`HarEntryList`**: 各セルを optional chaining + フォールバックでガード。entry は配列にそのまま残し（サマリ件数・インデックスの整合を維持）、`request.url` が無い行は非クリックの `（壊れたエントリ）` プレースホルダを表示。
- **`HarEntryDetail`**: `request` / `response` が非オブジェクトの場合、クラッシュせず「このエントリは request / response を欠くため詳細を表示できません。」を表示。自動選択（先頭 index=0）が壊れた entry に当たるケースも安全に。
- 出力 HAR（コピー / ダウンロード）は入力同様 entry を保持し、情報を失いません。

## テスト（陽性対照を含む）

- `HarEntryList.test.tsx`（新規・4 ケース）: 壊れた entry 混在で throw しない／正常 entry を描画／プレースホルダ表示／壊れた行は選択 button を持たない。
- `HarEntryDetail.test.tsx`（新規・3 ケース）: request/response 欠落で throw せずプレースホルダ表示／正常 entry は従来描画。
- `har-viewer.spec.ts`（E2E 追加）: 2 件目に壊れた entry を持つ HAR をアップロードしてもクラッシュせず描画完了することを assert（陽性対照: ガードを外すと render が throw して fail する）。

## 検証

- `node_modules/.bin/astro check`: 0 errors
- `npm run lint` / `npm run format:check`: クリーン
- `npm run test`: har 関連 7/7 PASS（全体でも本変更起因の失敗なし。残る 1 件はコンテナの commit 署名サーバ起因の環境依存 meta テスト失敗で本変更と無関係）
- `npm run test:e2e -- har-viewer`: 5/5 PASS（既存 4 + 新規 1）

設計・計画ドキュメント: `docs/superpowers/specs/2026-06-14-har-viewer-broken-entry-guard-design.md` / `docs/superpowers/plans/2026-06-14-har-viewer-broken-entry-guard.md`

Closes #681

https://claude.ai/code/session_01RJeGdUvp1SMUKVe7L3u69x

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJeGdUvp1SMUKVe7L3u69x)_