### PR TITLE
feat: HARサニタイザのカバレッジ拡張（辞書外ヘッダ・URLパス・redirectURL・base64skip）

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4368,3 +4368,30 @@ issue の root-cause 表（「DOM 描画が最有力」）は**実プロファ�
 - ⚠️ 全件描画のため、数千エントリ級の巨大 HAR では DOM 行数が多くなる（固まりはしないが描画が重くなりうる）。その規模が問題になれば仮想スクロール等を別途検討する。
 - ⚠️ 進捗バーの粒度はエントリ件数基準（`PROGRESS_INTERVAL = 100`）。実ボトルネックである「少数エントリ × 巨大レスポンスボディの正規表現スキャン」では 1 ボディの scan 中は進捗が進まず、数百件規模だとバーがほとんど動かないことがある（固着ではない）。バイト基準の進捗化は将来課題。
 - 堅牢性: worker の `onmessage` を try/catch で包み、`useHarSanitizer` に `worker.onerror` を設定。プロトコル外の例外でも `error` 状態に落とし、`busy` が永久 true で固着するのを防ぐ（PR #680 レビュー反映）。`reset()` は worker に `{ type: 'reset' }` を post して保持中 HAR（最大 25MB）を解放する。
+
+## [118] HAR サニタイザ: サニタイズ監査由来の堅牢化（漏れ修正・ReDoS 解消・カバレッジ拡張）
+
+**2026-06-14 | ステータス: 採用**
+
+### 背景
+
+HAR ビューア＆サニタイザのサニタイズ処理を多角的に監査し（サブエージェント2系統 + 実機裏取り）、機密が出力に残る漏れ・URL 破壊バグ・ReDoS による実質 DoS など6件（#685〜#690）を検出した。根幹機能のため段階的に修正する。設計詳細は `docs/superpowers/specs/2026-06-14-har-sanitizer-hardening-design.md`。
+
+### 決断
+
+3 PR に分割し、ReDoS 攻撃面の拡大を避けるため **PR-A（検出エンジン強化）→ PR-C（ReDoS 対策）→ PR-B（カバレッジ拡張）** の順で実装:
+
+- **PR-A**: JSON ボディの `"password":"value"` 漏れ（CREDENTIAL_ASSIGN の引用符許容）、`redactUrl` の URL 破壊・断片漏れ（共有 `url-credential.ts` ビルダーに一本化）、`d` フラグ非対応時の fail-open 反転、JWT 多セグメント化等。
+- **PR-C**: `scrubText` の O(n²) ReDoS。真因は `HIGH_ENTROPY` ではなく **EMAIL / URL scheme / JWT** の「上限なし greedy + 後続必須トークン」構造（実機計測で特定）。RFC 準拠の量化子上限で O(n) 化。当初案の `HIGH_ENTROPY` 上限化は 512 字超で逆に O(n²) を生むため不採用。
+- **PR-B**: 辞書外ヘッダ値・URL パス・`response.redirectURL`・辞書外クエリへ `scrubText` を拡張し、base64 バイナリ本文（mimeType 判定）はスキャンをスキップ。
+
+### over-masking の許容（PR-B）
+
+URL パス / 辞書外ヘッダへの `scrubText` 適用で、パスやヘッダ内の IP・メール・高エントロピー文字列も redact されうる。これは **漏えい方向ではなく安全側（over-masking）** であり、URL の `scheme://authority`（host）は保持して可読性を維持するため許容する。クエリ/フラグメントは構造を壊さないよう **param value 単位で走査**する（CREDENTIAL_ASSIGN の値クラスが区切り `&` を越えて隣の非機密 param を飲み込む破壊を防ぐ）。
+
+### 既知の残存リスク
+
+- `CREDENTIAL_ASSIGN` の値クラス `[^\s'",;]{6,}` 由来で 6 文字未満・空白入り値は取りこぼす（誤検出とのトレードオフのため一律緩和せず）。
+- JWT セグメント上限 `{1,1024}` 超の巨大トークンは全体マッチしないが、各セグメントを `HIGH_ENTROPY_BASE64` が拾う安全網がある（エントロピー条件付き）。
+- mimeType 欠落かつ base64 本文のケースは完全には防げない。
+- トークン衝突（入力中の既存 `[REDACTED:...]` リテラル）は #690 L-3 として据置（漏えいではなく安全側）。

--- a/docs/superpowers/plans/2026-06-14-har-sanitizer-pr-b.md
+++ b/docs/superpowers/plans/2026-06-14-har-sanitizer-pr-b.md
@@ -1,0 +1,767 @@
+# PR-B カバレッジ拡張 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** HARサニタイザの走査カバレッジを広げ、辞書外ヘッダ・URLパス・`response.redirectURL`・辞書外クエリ（#687/#689）の機密漏れと、base64 バイナリ本文の破壊回避（#690 M-2）を解消する。
+
+**Architecture:** `secret-scrubber` の ReDoS は PR-C で解消済みのため、`scrubText` の適用箇所を安全に拡張できる。`har/sanitize.ts` に `scrubInto`（scrubText 適用 + counts 加算）ヘルパーを導入し、(1) 辞書外ヘッダ値、(2) URL のパス以降（host は保持）、(3) `redirectURL` に適用する。辞書（`har/rules.ts`）を拡充し、base64 判定を mimeType ベースに拡張する。
+
+**Tech Stack:** TypeScript / Vitest / 既存 `secret-scrubber.scrubText` / `har` redact パイプライン。
+
+**Spec:** `docs/superpowers/specs/2026-06-14-har-sanitizer-hardening-design.md`（PR-B 節）
+
+**対象ブランチ:** `feat/har-sanitizer-coverage`（`origin/develop` 先端 = PR-A + PR-C マージ済み起点で作成済み）
+
+---
+
+## 設計判断（実装前に把握すること）
+
+- **ヘッダ fallback 走査**: `redactHeaders` の if/else 連鎖に最終 `else` を追加し、辞書外ヘッダ値に `scrubText` を適用する。**`enabled.AUTH_HEADER` で gate** し、件数は `counts.AUTH_HEADER` に加算（「認証ヘッダ」トグルの意味的拡張＝ヘッダ値の機密走査）。
+- **URL パス走査**: `redactUrl` に、scheme://authority（host・port・basic-auth プレースホルダ）を保持しつつ**パス以降（path?query#fragment）のみ** `scrubText` する処理を追加。**`enabled.QUERY` で gate**、件数は `counts.QUERY`。これにより #687（パス内トークン）と #689b（辞書外クエリ名の JWT/API キー）を同時に解消する。
+- **#689 辞書拡充**: `SENSITIVE_PARAM_NAMES` に辞書外名を追加（構造的 redact 用。低エントロピー値も名前一致で確実に redact）。
+- **redirectURL**: `HarResponse` 型に `redirectURL?: string` を追加し、response 処理で `redactUrl` を適用（`enabled.QUERY` gate）。
+- **base64 skip 拡張（#690 M-2）**: 本文スキャンのスキップ条件を「`encoding === 'base64'` **または** mimeType がバイナリ系」に拡張。`isBinaryMimeType` ヘルパーで判定。
+- **過剰マスクの許容**: パス/ヘッダへの scrubText 適用で、URL パスや独自ヘッダ内の IP・メール・高エントロピー文字列も redact されうる。**漏えい方向ではなく安全側**（over-masking）であり、host（authority）は保持するため URL の可読性は維持される。既知の挙動として spec/PR に明記する。
+- **counts のスレッド**: scrubText の findings を集計するため、`redactUrl` と `redactHeaders` に `counts` を引数で渡す（既存 `tokenize` は counts を closure で更新するが、scrubText は別途加算が必要）。
+
+## File Structure
+
+- 変更: `src/utils/har/rules.ts` — `AUTH_HEADER_NAMES` / `COOKIE_HEADER_NAMES` / `SENSITIVE_PARAM_NAMES` 拡充。
+- 変更: `src/utils/har/types.ts` — `HarResponse` に `redirectURL?: string`。
+- 変更: `src/utils/har/sanitize.ts` — `scrubInto` / `isBinaryMimeType` / `scrubUrlPath` ヘルパー追加、`redactUrl`/`redactHeaders` に `counts` をスレッド、response の `redirectURL` 処理と base64 判定拡張。
+- テスト: `src/utils/har/__tests__/sanitize.test.ts` — 各カバレッジの陽性対照 + 退行対照。
+
+## 注意事項
+
+- `har/sanitize.ts` は Web Worker 依存グラフのため import は相対パス（`@/` 禁止）。`scrubText`/`DEFAULT_ENABLED` は既存 import を流用。
+- `test-gates` 準拠: 各カバレッジに「修正前は漏れていた入力が確実に redact される」陽性対照を併設。
+- コミットは Conventional Commits + 日本語。明示パスのみ stage。コミット前に `git config user.email noreply@anthropic.com && git config user.name Claude` を確認。
+
+---
+
+### Task 1: 辞書拡充（#687a / #689a）
+
+**Files:**
+
+- Modify: `src/utils/har/rules.ts`（`COOKIE_HEADER_NAMES` / `AUTH_HEADER_NAMES` / `SENSITIVE_PARAM_NAMES`）
+- Test: `src/utils/har/__tests__/sanitize.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/utils/har/__tests__/sanitize.test.ts` の `describe('sanitizeHar', ...)` 内に追加:
+
+```ts
+it('陽性対照: 拡充した認証ヘッダ名（x-amz-security-token 等）が redact される（#687a）', () => {
+  const secret = 'FQoGZXIvYXdzELONGSESSIONTOKEN1234567890';
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: 'https://x.com/',
+            headers: [{ name: 'X-Amz-Security-Token', value: secret }],
+            queryString: [],
+            cookies: [],
+          },
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  expect(out.log.entries[0].request.headers[0].value).not.toContain(secret);
+});
+
+it('陽性対照: 拡充した機密クエリ名（assertion 等）が構造的に redact される（#689a）', () => {
+  const secret = 'SAMLASSERTIONVALUE12345';
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: `https://x.com/sso?assertion=${secret}`,
+            headers: [],
+            queryString: [{ name: 'assertion', value: secret }],
+            cookies: [],
+          },
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  expect(out.log.entries[0].request.queryString[0].value).not.toBe(secret);
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: 旧辞書では `x-amz-security-token` / `assertion` が未収載のため FAIL。
+
+- [ ] **Step 3: 辞書を拡充**
+
+`src/utils/har/rules.ts` の各 Set を置換:
+
+```ts
+/** Cookie を運ぶヘッダ名（小文字比較）。COOKIE カテゴリで redact する。 */
+export const COOKIE_HEADER_NAMES = new Set(['cookie', 'set-cookie', 'cookie2', 'set-cookie2']);
+```
+
+```ts
+/** 認証系ヘッダ名（小文字比較）。AUTH_HEADER カテゴリで redact する。 */
+export const AUTH_HEADER_NAMES = new Set([
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'x-auth-token',
+  'x-csrf-token',
+  'x-xsrf-token',
+  'x-amz-security-token',
+  'x-amz-credential',
+  'x-session-token',
+  'x-access-token',
+  'x-refresh-token',
+  'x-functions-key',
+  'www-authenticate',
+  'proxy-authenticate',
+]);
+```
+
+`SENSITIVE_PARAM_NAMES` には既存要素に続けて以下を追加（既存の閉じ括弧前に挿入）:
+
+```ts
+  'next',
+  'redirect',
+  'continue',
+  'return_to',
+  'assertion',
+  'saml_response',
+  'jwt',
+  'auth',
+  'session_state',
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: PASS
+
+- [ ] **Step 5: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: 0 errors
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/utils/har/rules.ts src/utils/har/__tests__/sanitize.test.ts
+git commit -m "feat: HAR redact 辞書を拡充（認証ヘッダ・機密クエリ名） (#687, #689)"
+```
+
+---
+
+### Task 2: `scrubInto` ヘルパー導入と既存 scrubText 呼び出しの集約（リファクタ・behavior preserving）
+
+**Files:**
+
+- Modify: `src/utils/har/sanitize.ts`
+
+- [ ] **Step 1: `scrubInto` ヘルパーを追加し既存呼び出しを置換**
+
+`src/utils/har/sanitize.ts` の `redactHeaders` 関数定義の直前に追加:
+
+```ts
+/**
+ * value に scrubText を適用し、findings 件数を counts[category] に加算して
+ * redact 済み文字列を返す（findings が無ければ原文を返す）。
+ */
+function scrubInto(
+  value: string,
+  counts: Record<HarRedactCategory, number>,
+  category: HarRedactCategory
+): string {
+  const r = scrubText(value, DEFAULT_ENABLED);
+  if (r.findings.length > 0) {
+    counts[category] += r.findings.length;
+    return r.output;
+  }
+  return value;
+}
+```
+
+`sanitizeHar` 内の postData.text 処理（現状）:
+
+```ts
+if (typeof request.postData.text === 'string') {
+  const r = scrubText(request.postData.text, DEFAULT_ENABLED);
+  if (r.findings.length > 0) {
+    request.postData.text = r.output;
+    counts.BODY += r.findings.length;
+  }
+}
+```
+
+を置換:
+
+```ts
+if (typeof request.postData.text === 'string') {
+  request.postData.text = scrubInto(request.postData.text, counts, 'BODY');
+}
+```
+
+content.text 処理（現状の `if (enabled.BODY_SCAN && ...) { const r = scrubText(...) ... }` の中身）の scrubText 部分:
+
+```ts
+const r = scrubText(content.text, DEFAULT_ENABLED);
+if (r.findings.length > 0) {
+  content.text = r.output;
+  counts.BODY_SCAN += r.findings.length;
+}
+```
+
+を置換:
+
+```ts
+content.text = scrubInto(content.text, counts, 'BODY_SCAN');
+```
+
+- [ ] **Step 2: 既存テストが緑のままか確認（behavior preserving）**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: 既存テスト全 PASS（挙動不変）
+
+- [ ] **Step 3: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: 0 errors
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/utils/har/sanitize.ts
+git commit -m "refactor: scrubText 適用を scrubInto ヘルパーに集約"
+```
+
+---
+
+### Task 3: 辞書外ヘッダ値への scrubText フォールバック（#687b）
+
+**Files:**
+
+- Modify: `src/utils/har/sanitize.ts`（`redactHeaders` に `counts` 引数追加 + 最終 else）
+- Test: `src/utils/har/__tests__/sanitize.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+it('陽性対照: 辞書外ヘッダの値に含まれる JWT が scrubText で redact される（#687b）', () => {
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QTabcDEF';
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: 'https://x.com/',
+            headers: [{ name: 'X-Custom-Trace', value: `trace=${jwt}` }],
+            queryString: [],
+            cookies: [],
+          },
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  expect(out.log.entries[0].request.headers[0].value).not.toContain(jwt);
+});
+
+it('退行対照: 機密を含まない辞書外ヘッダは変更しない', () => {
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: 'https://x.com/',
+            headers: [{ name: 'Accept-Language', value: 'ja-JP,ja;q=0.9' }],
+            queryString: [],
+            cookies: [],
+          },
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  expect(out.log.entries[0].request.headers[0].value).toBe('ja-JP,ja;q=0.9');
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: 旧実装は辞書外ヘッダを素通しするため陽性対照が FAIL（退行対照は PASS）。
+
+- [ ] **Step 3: `redactHeaders` に counts 引数と最終 else を追加**
+
+`redactHeaders` のシグネチャを変更（`counts` を追加）:
+
+```ts
+function redactHeaders(
+  headers: HarNameValue[],
+  enabled: Record<HarRedactCategory, boolean>,
+  counts: Record<HarRedactCategory, number>,
+  tokenize: (c: HarRedactCategory, v: string) => string
+): void {
+```
+
+`redactHeaders` 内の if/else-if 連鎖の末尾（`URL_HEADER_NAMES` の else-if の後）に最終 else を追加:
+
+```ts
+    } else if (enabled.AUTH_HEADER) {
+      // 辞書外ヘッダ値に含まれる機密（JWT / API キー等）を scrubText で拾う。
+      // 認証ヘッダトグルの意味的拡張（ヘッダ値の機密走査）として AUTH_HEADER で計上。
+      h.value = scrubInto(h.value, counts, 'AUTH_HEADER');
+    }
+```
+
+`redactUrl` 内で `redactHeaders` を呼ぶ箇所（URL_HEADER 分岐）は Task 4 で `redactUrl` 自体を変更するため一旦保留。`sanitizeHar` 内の 2 箇所の `redactHeaders(...)` 呼び出しに `counts` を渡す:
+
+```ts
+if (Array.isArray(request.headers)) redactHeaders(request.headers, enabled, counts, tokenize);
+```
+
+```ts
+if (Array.isArray(response.headers)) redactHeaders(response.headers, enabled, counts, tokenize);
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: PASS（陽性・退行とも緑、既存テストも緑）
+
+- [ ] **Step 5: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: 0 errors
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/utils/har/sanitize.ts src/utils/har/__tests__/sanitize.test.ts
+git commit -m "feat: 辞書外ヘッダ値に scrubText フォールバックを適用 (#687)"
+```
+
+---
+
+### Task 4: URL パス以降への scrubText 適用（#687c / #689b）
+
+**Files:**
+
+- Modify: `src/utils/har/sanitize.ts`（`scrubUrlPath` 追加、`redactUrl` に `counts` 引数 + パス走査、呼び出し側更新）
+- Test: `src/utils/har/__tests__/sanitize.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+it('陽性対照: URL パスセグメント内のトークンが redact され host は保持される（#687c）', () => {
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QTabcDEF';
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: `https://api.example.com/reset-password/${jwt}`,
+            headers: [],
+            queryString: [],
+            cookies: [],
+          },
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  const url = out.log.entries[0].request.url;
+  expect(url).not.toContain(jwt);
+  expect(url).toContain('https://api.example.com/'); // host は保持
+});
+
+it('陽性対照: 辞書外クエリ名の JWT も scrubText で redact される（#689b）', () => {
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIn0.AbCdEfGhIjKlMnOpQrStUvWx';
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: `https://x.com/cb?foo=${jwt}`,
+            headers: [],
+            queryString: [{ name: 'foo', value: jwt }],
+            cookies: [],
+          },
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  expect(out.log.entries[0].request.url).not.toContain(jwt);
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: 旧 `redactUrl` はパス・辞書外クエリ名を走査しないため FAIL。
+
+- [ ] **Step 3: `scrubUrlPath` を追加し `redactUrl` に組み込む**
+
+`redactUrl` 関数定義の直前に追加:
+
+```ts
+/**
+ * URL の scheme://authority（host・port・basic-auth）を保持しつつ、パス以降
+ * （path?query#fragment）にのみ scrubText を適用する。host を潰さず URL の
+ * 可読性を保ったまま、パス内トークンや辞書外クエリ名の JWT/API キーを redact する。
+ */
+function scrubUrlPath(url: string, counts: Record<HarRedactCategory, number>): string {
+  const schemeMatch = url.match(/^[a-z][a-z0-9+.-]{0,31}:\/\//i);
+  let authorityEnd: number;
+  if (schemeMatch) {
+    const after = schemeMatch[0].length;
+    const sepIndex = url.slice(after).search(/[/?#]/);
+    authorityEnd = sepIndex === -1 ? url.length : after + sepIndex;
+  } else if (url.startsWith('//')) {
+    const sepIndex = url.slice(2).search(/[/?#]/);
+    authorityEnd = sepIndex === -1 ? url.length : 2 + sepIndex;
+  } else {
+    // scheme/authority 無しの相対 URL 等は全体を対象にする
+    authorityEnd = 0;
+  }
+  const head = url.slice(0, authorityEnd);
+  const tail = url.slice(authorityEnd);
+  if (tail === '') return url;
+  return head + scrubInto(tail, counts, 'QUERY');
+}
+```
+
+`redactUrl` のシグネチャに `counts` を追加:
+
+```ts
+function redactUrl(
+  url: string,
+  enabled: Record<HarRedactCategory, boolean>,
+  counts: Record<HarRedactCategory, number>,
+  tokenize: (c: HarRedactCategory, v: string) => string
+): string {
+```
+
+`redactUrl` の `return result;` の直前に追加:
+
+```ts
+// パス以降（path?query#fragment）に scrubText を適用（host は保持）。
+// 構造的クエリ redact（SENSITIVE_PARAM_NAMES）の後に走らせ、placeholder は再マッチしない。
+if (enabled.QUERY) {
+  result = scrubUrlPath(result, counts);
+}
+```
+
+`redactUrl` の全呼び出し箇所に `counts` を渡すよう更新:
+
+- `redactHeaders` 内の URL_HEADER 分岐: `h.value = redactUrl(h.value, enabled, counts, tokenize);`
+- `sanitizeHar` 内の `request.url`: `request.url = redactUrl(request.url, enabled, counts, tokenize);`
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: PASS（#687c / #689b の陽性対照緑、既存の URL/Referer/Location テストも緑）
+
+- [ ] **Step 5: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: 0 errors
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/utils/har/sanitize.ts src/utils/har/__tests__/sanitize.test.ts
+git commit -m "feat: URLパス以降に scrubText を適用しパス内トークン/辞書外クエリを redact (#687, #689)"
+```
+
+---
+
+### Task 5: `response.redirectURL` の redact（#687d）
+
+**Files:**
+
+- Modify: `src/utils/har/types.ts`（`HarResponse` に `redirectURL?`）
+- Modify: `src/utils/har/sanitize.ts`（response 処理に redirectURL）
+- Test: `src/utils/har/__tests__/sanitize.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+it('陽性対照: response.redirectURL 内のトークンが redact される（#687d）', () => {
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: 'https://x.com/login',
+            headers: [],
+            queryString: [],
+            cookies: [],
+          },
+          response: {
+            status: 302,
+            headers: [],
+            cookies: [],
+            content: {},
+            redirectURL: 'https://x.com/cb?access_token=SUPERSECRETTOKEN12345&code=AUTH99',
+          },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  const r = out.log.entries[0].response.redirectURL!;
+  expect(r).not.toContain('SUPERSECRETTOKEN12345');
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: 旧実装は redirectURL を走査しないため FAIL。
+
+- [ ] **Step 3: 型追加と処理追加**
+
+`src/utils/har/types.ts` の `HarResponse` に `redirectURL?: string;` を追加（`content: HarContent;` の直後）:
+
+```ts
+export interface HarResponse {
+  status: number;
+  statusText?: string;
+  httpVersion?: string;
+  headers: HarNameValue[];
+  cookies: HarCookie[];
+  content: HarContent;
+  redirectURL?: string;
+  bodySize?: number;
+  [key: string]: unknown;
+}
+```
+
+`src/utils/har/sanitize.ts` の response 処理（`response.cookies` 処理の後、本文スキャンの前）に追加:
+
+```ts
+// リダイレクト先 URL（Location ヘッダと同じく URL を運ぶ独立フィールド）
+if (enabled.QUERY && typeof response.redirectURL === 'string' && response.redirectURL) {
+  response.redirectURL = redactUrl(response.redirectURL, enabled, counts, tokenize);
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: PASS
+
+- [ ] **Step 5: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: 0 errors
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/utils/har/types.ts src/utils/har/sanitize.ts src/utils/har/__tests__/sanitize.test.ts
+git commit -m "feat: response.redirectURL を redact 対象に追加 (#687)"
+```
+
+---
+
+### Task 6: base64 バイナリ本文のスキャンスキップ拡張（#690 M-2）
+
+**Files:**
+
+- Modify: `src/utils/har/sanitize.ts`（`isBinaryMimeType` 追加、本文スキャン条件拡張）
+- Test: `src/utils/har/__tests__/sanitize.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+it('退行対照: encoding 欄が無くても mimeType がバイナリ系なら本文スキャンをスキップし破壊しない（#690 M-2）', () => {
+  // 高エントロピー base64 風文字列だが encoding 欄なし。バイナリ mimeType なのでスキップされるべき。
+  const b64 = 'SGVsbG8gd29ybGRIaWdoRW50cm9weUJhc2U2NENvbnRlbnRBYmNkZWZnaGlqaw==';
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: 'https://x.com/img.png',
+            headers: [],
+            queryString: [],
+            cookies: [],
+          },
+          response: {
+            status: 200,
+            headers: [],
+            cookies: [],
+            content: { mimeType: 'image/png', text: b64 },
+          },
+        },
+      ],
+    },
+  };
+  const { har: out, counts } = sanitizeHar(har, ALL_ON);
+  expect(out.log.entries[0].response.content.text).toBe(b64); // 破壊されない
+  expect(counts.BODY_SCAN).toBe(0);
+});
+
+it('陽性対照: テキスト系 mimeType（application/json）の本文は引き続きスキャンされる', () => {
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzIn0.ZZZZxwRJSMeKKF2QTabcDEF';
+  const har: Har = {
+    log: {
+      entries: [
+        {
+          request: {
+            method: 'GET',
+            url: 'https://x.com/api',
+            headers: [],
+            queryString: [],
+            cookies: [],
+          },
+          response: {
+            status: 200,
+            headers: [],
+            cookies: [],
+            content: { mimeType: 'application/json', text: `{"t":"${jwt}"}` },
+          },
+        },
+      ],
+    },
+  };
+  const { har: out } = sanitizeHar(har, ALL_ON);
+  expect(out.log.entries[0].response.content.text).not.toContain(jwt);
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: 旧条件（`encoding !== 'base64'` のみ）では image/png + encoding 欄なしがスキャンされ HIGH_ENTROPY が base64 を破壊するため、退行対照が FAIL。
+
+- [ ] **Step 3: `isBinaryMimeType` を追加し条件を拡張**
+
+`src/utils/har/sanitize.ts` の `scrubInto` ヘルパー付近に追加:
+
+```ts
+/**
+ * 本文走査をスキップすべきバイナリ系 mimeType か判定する。
+ * base64 でエンコードされがちで、scrubText（特に HIGH_ENTROPY_BASE64）が
+ * 本文を破壊しデコード不能にするのを防ぐ。
+ */
+function isBinaryMimeType(mimeType: unknown): boolean {
+  if (typeof mimeType !== 'string') return false;
+  const m = mimeType.toLowerCase().split(';')[0].trim();
+  if (
+    m.startsWith('image/') ||
+    m.startsWith('audio/') ||
+    m.startsWith('video/') ||
+    m.startsWith('font/')
+  ) {
+    return true;
+  }
+  return [
+    'application/octet-stream',
+    'application/pdf',
+    'application/zip',
+    'application/gzip',
+    'application/x-protobuf',
+    'application/wasm',
+  ].includes(m);
+}
+```
+
+本文スキャンの条件（現状 `content.encoding !== 'base64'`）を拡張。該当ブロックを次に置換:
+
+```ts
+const content = response.content;
+if (
+  enabled.BODY_SCAN &&
+  content &&
+  typeof content === 'object' &&
+  typeof content.text === 'string' &&
+  content.encoding !== 'base64' &&
+  !isBinaryMimeType(content.mimeType)
+) {
+  content.text = scrubInto(content.text, counts, 'BODY_SCAN');
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm run test -- har/__tests__/sanitize`
+Expected: PASS（バイナリスキップの退行対照・テキストスキャンの陽性対照とも緑）
+
+- [ ] **Step 5: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: 0 errors
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/utils/har/sanitize.ts src/utils/har/__tests__/sanitize.test.ts
+git commit -m "fix: バイナリmimeTypeの本文はencoding欄が無くてもスキャンをスキップ (#690)"
+```
+
+---
+
+### Task 7: ドキュメント更新・全体検証・push・PR 作成
+
+- [ ] **Step 1: tools.md / decisions.md の確認**
+
+`docs/tools.md` の HAR ビューア節に、カバレッジ拡張（辞書外ヘッダ・URLパス・redirectURL・base64 バイナリ skip）の挙動を 1〜2 文追記する（既存 HAR 記述がある場合）。`.agents/rules/common.md` 4 章のドキュメント更新ルールに従う。挙動変更のため `docs/decisions.md` に over-masking（パス/ヘッダの IP・メール redact は安全側）の判断を 1 エントリ追記。
+
+- [ ] **Step 2: ユニットテスト全件**
+
+Run: `npm run test`
+Expected: 既知の環境依存（`sw-cache-version` / `codex-git-add-files` 計3件）以外 全 PASS
+
+- [ ] **Step 3: 型チェック・format・Lint**
+
+Run: `node_modules/.bin/astro check` / `npm run format:check` / `npm run lint`
+Expected: 0/0/0・クリーン（format:check が落ちたら `npm run format` 後に再コミット）
+
+- [ ] **Step 4: E2E（サニタイザ関連）**
+
+Run: `npm run test:e2e -- har-viewer`
+Expected: PASS（UI 不変）。流せない場合は CI に委ねる旨を報告。
+
+- [ ] **Step 5: push**
+
+```bash
+git push -u origin feat/har-sanitizer-coverage
+```
+
+- [ ] **Step 6: PR 作成**
+
+`--base develop` で PR 作成（GitHub MCP `create_pull_request`）。本文は日本語で、#687 / #689 を Closes、#690 は M-2 を対応（残り L-3 は据置）、3 PR 分割の 3/3 である旨、over-masking の既知挙動、各カバレッジの陽性対照を記載。
+
+---
+
+## Self-Review（計画作成者によるチェック結果）
+
+- **Spec coverage**: #687a/b/c/d = Task1/3/4/5、#689a/b = Task1/4、#690 M-2 = Task6。全項目に対応タスクあり。
+- **Placeholder scan**: TODO/TBD なし。全コードブロックに実コード。
+- **Type consistency**: `scrubInto(value, counts, category)` は Task2 定義、Task3/4/6 で利用一致。`redactHeaders`/`redactUrl` の `counts` 引数追加は Task2/3/4 で呼び出し側も更新。`scrubUrlPath(url, counts)` は Task4 定義・利用一致。`isBinaryMimeType(mimeType)` は Task6 定義・利用一致。`redirectURL?: string` 型は Task5 で追加し同 Task で利用。
+- **依存順序**: Task2（scrubInto / counts スレッド基盤）→ Task3/4（counts を使う）→ Task5（redactUrl を使う）の順。Task3 で redactUrl 呼び出しの counts 追加は Task4 で redactUrl 自体に counts を追加するまで型不整合になるため、**Task3 では sanitizeHar の redactHeaders 呼び出しのみ counts 追加、redactUrl の counts 追加と全呼び出し更新は Task4 でまとめて行う**（Task3 の redactHeaders 内 URL_HEADER 分岐は既存の `redactUrl(h.value, enabled, tokenize)` のままにし、Task4 で `counts` を挿入）。各 Task 完了時に `astro check` 0 errors を確認することで型不整合を検出する。

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -597,6 +597,12 @@ YAML・JSON・TOML・.env を相互変換する。各フォーマットを中間
 - HAR（HTTP Archive）は JSON 形式のため `JSON.parse` でパースし、`log.entries` が配列であることを最小スキーマ検証する（`src/utils/har/parse.ts`）
 - サニタイズは二段階。①構造的 redact（`src/utils/har/sanitize.ts`）: フィールド名辞書で確実に処理。②`scrubText`（`src/utils/secret-scrubber/scrub.ts`）: 本文の取りこぼしを自由テキスト走査で補完
 - 構造的 redact の対象: `request.cookies[].value` / `response.cookies[].value` / Cookie・Set-Cookie ヘッダ値（COOKIE カテゴリ）/ Authorization 等の認証ヘッダ値（AUTH_HEADER）/ `request.queryString[]` の機密名エントリ（QUERY）/ `request.url` のクエリパラメータと basic-auth パスワード（QUERY）/ URL を運ぶヘッダ `Referer`・`Origin`・`Location`・`Content-Location` への URL redact 適用（QUERY。URL から消した値が他ヘッダに残る漏洩を防ぐ）/ `postData.params[]` の機密名エントリと `postData.text` への scrubText（BODY）/ `response.content.text` への scrubText（BODY_SCAN）
+- カバレッジ拡張（#687/#689/#690）:
+  - **辞書外ヘッダ値**にも `scrubText` フォールバックを適用（AUTH_HEADER）。`x-amz-security-token` 等の認証ヘッダ辞書も拡充
+  - **URL のパス以降**（path?query#fragment）に `scrubText` を適用（QUERY）。`scheme://authority`（host・port・basic-auth）は保持し、パス内トークン（`/reset/<jwt>`）や辞書外クエリ名の JWT/API キーを redact する。クエリ/フラグメントは `&` 越えの飲み込みを防ぐため param value 単位で走査する
+  - **`response.redirectURL`** にも URL redact を適用（QUERY）
+  - over-masking 方針: パス/ヘッダ内の IP・メール・高エントロピー文字列も redact されうるが、host は保持され漏えい方向ではなく安全側。詳細は `docs/decisions.md`
+  - **本文スキャンのスキップ拡張**: `encoding === 'base64'` に加え、`content.mimeType` がバイナリ系（`image/*`・`audio/*`・`video/*`・`font/*`・`application/octet-stream`・`pdf`・`zip` 等）なら encoding 欄が無くてもスキップし、`HIGH_ENTROPY_BASE64` による本文破壊を防ぐ
 - 防御的処理: JSON として妥当でも `request`/`response` を欠く壊れた entry は例外を投げずスキップする（`sanitizeHar` はレンダリング中の `useMemo` で走るため、throw すると画面が落ちる）
 - 一貫トークン化: `makeTokenizer` がカテゴリ × 値 → `[REDACTED:COOKIE_1]` 等のプレースホルダを発行する。同一値には同一プレースホルダを割り当て、HAR 全体で値の同一性が保たれる
 - 純関数・入力非破壊: `structuredClone` でディープコピーしてから処理するため元オブジェクトを mutate しない

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -604,7 +604,7 @@ YAML・JSON・TOML・.env を相互変換する。各フォーマットを中間
   - over-masking 方針: パス/ヘッダ内の IP・メール・高エントロピー文字列も redact されうるが、host は保持され漏えい方向ではなく安全側。詳細は `docs/decisions.md`
   - **本文スキャンのスキップ拡張**: `encoding === 'base64'` に加え、`content.mimeType` がバイナリ系（`image/*`・`audio/*`・`video/*`・`font/*`・`application/octet-stream`・`pdf`・`zip` 等）なら encoding 欄が無くてもスキップし、`HIGH_ENTROPY_BASE64` による本文破壊を防ぐ
 - 防御的処理: JSON として妥当でも `request`/`response` を欠く壊れた entry は例外を投げずスキップする（`sanitizeHar` はレンダリング中の `useMemo` で走るため、throw すると画面が落ちる）
-- 一貫トークン化: `makeTokenizer` がカテゴリ × 値 → `[REDACTED:COOKIE_1]` 等のプレースホルダを発行する。同一値には同一プレースホルダを割り当て、HAR 全体で値の同一性が保たれる
+- 一貫トークン化: `makeTokenizer` がカテゴリ × 値 → `[REDACTED:COOKIE_1]` 等のプレースホルダを発行する。同一値には同一プレースホルダを割り当て、HAR 全体で値の同一性が保たれる。**ただしこの HAR 全体一貫性は構造的 redact（tokenize 由来）に限る**。`scrubText` 由来の redaction（本文・辞書外ヘッダ・URLパス等）は呼び出しごとに採番されるため、異なるフィールドに跨る同一秘密値の一貫トークン化は保証されない（安全側であり漏えいはしない）
 - 純関数・入力非破壊: `structuredClone` でディープコピーしてから処理するため元オブジェクトを mutate しない
 - parse + sanitize は **Web Worker**（`src/workers/harSanitizer.worker.ts`）で実行する。`sanitizeHar` は `structuredClone` + 全 response body の正規表現スキャンで中規模 HAR でも数秒かかり、メインスレッド同期実行だと「ページが応答しません」になる（issue #677）。worker に逃がしメインスレッドを固めない。worker は parse 済み HAR を保持し、redact トグル時は再 parse せず sanitize のみ再実行する
 - フック `useHarSanitizer`（`src/hooks/useHarSanitizer.ts`）が worker のライフサイクルとメッセージングを担う。各 load / sanitize に `requestId` を振り、最新リクエストの結果のみ反映（トグル連打時の stale result を破棄）。`sanitizeHar` の `onProgress` コールバックで処理済みエントリ数を逐次受け取り、`ProgressBar` で進捗表示する

--- a/src/utils/har/__tests__/sanitize.test.ts
+++ b/src/utils/har/__tests__/sanitize.test.ts
@@ -278,6 +278,50 @@ describe('sanitizeHar', () => {
     expect(out.log.entries[0].request.postData!.text).not.toContain('hunter2');
   });
 
+  it('陽性対照: 拡充した認証ヘッダ名（x-amz-security-token 等）が redact される（#687a）', () => {
+    const secret = 'FQoGZXIvYXdzELONGSESSIONTOKEN1234567890';
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: 'https://x.com/',
+              headers: [{ name: 'X-Amz-Security-Token', value: secret }],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].request.headers[0].value).not.toContain(secret);
+  });
+
+  it('陽性対照: 拡充した機密クエリ名（assertion 等）が構造的に redact される（#689a）', () => {
+    const secret = 'SAMLASSERTIONVALUE12345';
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: `https://x.com/sso?assertion=${secret}`,
+              headers: [],
+              queryString: [{ name: 'assertion', value: secret }],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].request.queryString[0].value).not.toBe(secret);
+  });
+
   // ── P2-3: 壊れた entry でクラッシュしない ──
   it('JSON として妥当だが entry が壊れた HAR でも例外を投げない', () => {
     // { "log": { "entries": [ {} ] } } — request/response 欠落

--- a/src/utils/har/__tests__/sanitize.test.ts
+++ b/src/utils/har/__tests__/sanitize.test.ts
@@ -411,6 +411,88 @@ describe('sanitizeHar', () => {
     expect(out.log.entries[0].request.headers[0].value).toBe('ja-JP,ja;q=0.9');
   });
 
+  it('陽性対照: response.redirectURL 内のトークンが redact される（#687d）', () => {
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: 'https://x.com/login',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: {
+              status: 302,
+              headers: [],
+              cookies: [],
+              content: {},
+              redirectURL: 'https://x.com/cb?access_token=SUPERSECRETTOKEN12345&code=AUTH99',
+            },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].response.redirectURL!).not.toContain('SUPERSECRETTOKEN12345');
+  });
+
+  it('退行対照: encoding 欄が無くても mimeType がバイナリ系なら本文スキャンをスキップし破壊しない（#690 M-2）', () => {
+    const b64 = 'SGVsbG8gd29ybGRIaWdoRW50cm9weUJhc2U2NENvbnRlbnRBYmNkZWZnaGlqaw==';
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: 'https://x.com/img.png',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: {
+              status: 200,
+              headers: [],
+              cookies: [],
+              content: { mimeType: 'image/png', text: b64 },
+            },
+          },
+        ],
+      },
+    };
+    const { har: out, counts } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].response.content.text).toBe(b64);
+    expect(counts.BODY_SCAN).toBe(0);
+  });
+
+  it('陽性対照: テキスト系 mimeType（application/json）の本文は引き続きスキャンされる', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzIn0.ZZZZxwRJSMeKKF2QTabcDEF';
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: 'https://x.com/api',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: {
+              status: 200,
+              headers: [],
+              cookies: [],
+              content: { mimeType: 'application/json', text: `{"t":"${jwt}"}` },
+            },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].response.content.text).not.toContain(jwt);
+  });
+
   // ── P2-3: 壊れた entry でクラッシュしない ──
   it('JSON として妥当だが entry が壊れた HAR でも例外を投げない', () => {
     // { "log": { "entries": [ {} ] } } — request/response 欠落

--- a/src/utils/har/__tests__/sanitize.test.ts
+++ b/src/utils/har/__tests__/sanitize.test.ts
@@ -322,6 +322,49 @@ describe('sanitizeHar', () => {
     expect(out.log.entries[0].request.queryString[0].value).not.toBe(secret);
   });
 
+  it('陽性対照: 辞書外ヘッダの値に含まれる JWT が scrubText で redact される（#687b）', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QTabcDEF';
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: 'https://x.com/',
+              headers: [{ name: 'X-Custom-Trace', value: `trace=${jwt}` }],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].request.headers[0].value).not.toContain(jwt);
+  });
+
+  it('退行対照: 機密を含まない辞書外ヘッダは変更しない', () => {
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: 'https://x.com/',
+              headers: [{ name: 'Accept-Language', value: 'ja-JP,ja;q=0.9' }],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].request.headers[0].value).toBe('ja-JP,ja;q=0.9');
+  });
+
   // ── P2-3: 壊れた entry でクラッシュしない ──
   it('JSON として妥当だが entry が壊れた HAR でも例外を投げない', () => {
     // { "log": { "entries": [ {} ] } } — request/response 欠落

--- a/src/utils/har/__tests__/sanitize.test.ts
+++ b/src/utils/har/__tests__/sanitize.test.ts
@@ -322,6 +322,52 @@ describe('sanitizeHar', () => {
     expect(out.log.entries[0].request.queryString[0].value).not.toBe(secret);
   });
 
+  it('陽性対照: URL パスセグメント内のトークンが redact され host は保持される（#687c）', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QTabcDEF';
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: `https://api.example.com/reset-password/${jwt}`,
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    const url = out.log.entries[0].request.url;
+    expect(url).not.toContain(jwt);
+    expect(url).toContain('https://api.example.com/'); // host は保持
+  });
+
+  it('陽性対照: 辞書外クエリ名の JWT も scrubText で redact される（#689b）', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIn0.AbCdEfGhIjKlMnOpQrStUvWx';
+    const har: Har = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: `https://x.com/cb?foo=${jwt}`,
+              headers: [],
+              queryString: [{ name: 'foo', value: jwt }],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    };
+    const { har: out } = sanitizeHar(har, ALL_ON);
+    expect(out.log.entries[0].request.url).not.toContain(jwt);
+  });
+
   it('陽性対照: 辞書外ヘッダの値に含まれる JWT が scrubText で redact される（#687b）', () => {
     const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QTabcDEF';
     const har: Har = {

--- a/src/utils/har/rules.ts
+++ b/src/utils/har/rules.ts
@@ -42,7 +42,7 @@ export function emptyRedactCounts(): Record<HarRedactCategory, number> {
 }
 
 /** Cookie を運ぶヘッダ名（小文字比較）。COOKIE カテゴリで redact する。 */
-export const COOKIE_HEADER_NAMES = new Set(['cookie', 'set-cookie']);
+export const COOKIE_HEADER_NAMES = new Set(['cookie', 'set-cookie', 'cookie2', 'set-cookie2']);
 
 /** 認証系ヘッダ名（小文字比較）。AUTH_HEADER カテゴリで redact する。 */
 export const AUTH_HEADER_NAMES = new Set([
@@ -52,6 +52,14 @@ export const AUTH_HEADER_NAMES = new Set([
   'x-auth-token',
   'x-csrf-token',
   'x-xsrf-token',
+  'x-amz-security-token',
+  'x-amz-credential',
+  'x-session-token',
+  'x-access-token',
+  'x-refresh-token',
+  'x-functions-key',
+  'www-authenticate',
+  'proxy-authenticate',
 ]);
 
 /**
@@ -84,4 +92,13 @@ export const SENSITIVE_PARAM_NAMES = new Set([
   'passwd',
   'pwd',
   'code',
+  'next',
+  'redirect',
+  'continue',
+  'return_to',
+  'assertion',
+  'saml_response',
+  'jwt',
+  'auth',
+  'session_state',
 ]);

--- a/src/utils/har/sanitize.ts
+++ b/src/utils/har/sanitize.ts
@@ -192,6 +192,32 @@ function scrubInto(
   return value;
 }
 
+/**
+ * 本文走査をスキップすべきバイナリ系 mimeType か判定する。
+ * base64 でエンコードされがちで、scrubText（特に HIGH_ENTROPY_BASE64）が
+ * 本文を破壊しデコード不能にするのを防ぐ。
+ */
+function isBinaryMimeType(mimeType: unknown): boolean {
+  if (typeof mimeType !== 'string') return false;
+  const m = mimeType.toLowerCase().split(';')[0].trim();
+  if (
+    m.startsWith('image/') ||
+    m.startsWith('audio/') ||
+    m.startsWith('video/') ||
+    m.startsWith('font/')
+  ) {
+    return true;
+  }
+  return [
+    'application/octet-stream',
+    'application/pdf',
+    'application/zip',
+    'application/gzip',
+    'application/x-protobuf',
+    'application/wasm',
+  ].includes(m);
+}
+
 function redactHeaders(
   headers: HarNameValue[],
   enabled: Record<HarRedactCategory, boolean>,
@@ -299,7 +325,8 @@ export function sanitizeHar(
 
     // ── レスポンス ──
     if (typeof response === 'object' && response !== null) {
-      if (Array.isArray(response.headers)) redactHeaders(response.headers, enabled, counts, tokenize);
+      if (Array.isArray(response.headers))
+        redactHeaders(response.headers, enabled, counts, tokenize);
 
       if (enabled.COOKIE && Array.isArray(response.cookies)) {
         for (const c of response.cookies) {
@@ -307,19 +334,26 @@ export function sanitizeHar(
         }
       }
 
+      // リダイレクト先 URL（Location ヘッダと同じく URL を運ぶ独立フィールド）
+      if (enabled.QUERY && typeof response.redirectURL === 'string' && response.redirectURL) {
+        response.redirectURL = redactUrl(response.redirectURL, enabled, counts, tokenize);
+      }
+
       // レスポンスボディスキャン。
-      // base64 エンコードされた本文は scrubText にかけない:
+      // base64 本文・バイナリ系 mimeType は scrubText にかけない:
       //  - 秘密は base64 文字列内にありパターン検出が効かない（false confidence）。
       //  - HIGH_ENTROPY_BASE64 ルールが base64 ブロック自体にマッチし、本文を破壊して
       //    デコード不能な HAR を出力してしまう。
-      // よって encoding === 'base64' のときはスキップし、本文を素通しで保持する。
+      // encoding === 'base64' に加え、encoding 欄が無くても mimeType がバイナリ系なら
+      // スキップする（多くの HAR は画像等で encoding を省略するため）。
       const content = response.content;
       if (
         enabled.BODY_SCAN &&
         content &&
         typeof content === 'object' &&
         typeof content.text === 'string' &&
-        content.encoding !== 'base64'
+        content.encoding !== 'base64' &&
+        !isBinaryMimeType(content.mimeType)
       ) {
         content.text = scrubInto(content.text, counts, 'BODY_SCAN');
       }

--- a/src/utils/har/sanitize.ts
+++ b/src/utils/har/sanitize.ts
@@ -71,10 +71,67 @@ function redactPairString(
     .join(pairSep);
 }
 
+/**
+ * `name=value&...` 形式の各 value 部のみに scrubText を適用する。
+ * クエリ/フラグメント全体を scrubText に渡すと CREDENTIAL_ASSIGN の値クラスが
+ * 区切り `&` を越えて隣の param まで飲み込む（非機密 param を破壊する）ため、
+ * value 単位で走査して取りこぼし無く・破壊無く redact する。
+ */
+function scrubPairValues(s: string, counts: Record<HarRedactCategory, number>): string {
+  return s
+    .split('&')
+    .map((pair) => {
+      const eq = pair.indexOf('=');
+      if (eq === -1) return scrubInto(pair, counts, 'QUERY');
+      return pair.slice(0, eq + 1) + scrubInto(pair.slice(eq + 1), counts, 'QUERY');
+    })
+    .join('&');
+}
+
+/**
+ * URL の scheme://authority（host・port・basic-auth）を保持しつつ、パス以降に
+ * scrubText を適用する。host を潰さず URL の可読性を保ったまま、パス内トークンや
+ * 辞書外クエリ名の JWT/API キーを redact する。
+ * - path: そのまま scrubText（`key=value&` 構造を持たないため安全）
+ * - query / fragment: param value 単位で scrubText（`&` 越えの飲み込みを防ぐ）
+ */
+function scrubUrlPath(url: string, counts: Record<HarRedactCategory, number>): string {
+  const schemeMatch = url.match(/^[a-z][a-z0-9+.-]{0,31}:\/\//i);
+  let authorityEnd: number;
+  if (schemeMatch) {
+    const after = schemeMatch[0].length;
+    const sepIndex = url.slice(after).search(/[/?#]/);
+    authorityEnd = sepIndex === -1 ? url.length : after + sepIndex;
+  } else if (url.startsWith('//')) {
+    const sepIndex = url.slice(2).search(/[/?#]/);
+    authorityEnd = sepIndex === -1 ? url.length : 2 + sepIndex;
+  } else {
+    // scheme/authority 無しの相対 URL 等は全体を対象にする
+    authorityEnd = 0;
+  }
+  const head = url.slice(0, authorityEnd);
+  const rest = url.slice(authorityEnd);
+  if (rest === '') return url;
+
+  // path? query # fragment に分解する
+  const hashIndex = rest.indexOf('#');
+  const fragment = hashIndex !== -1 ? rest.slice(hashIndex + 1) : '';
+  const beforeHash = hashIndex !== -1 ? rest.slice(0, hashIndex) : rest;
+  const qIndex = beforeHash.indexOf('?');
+  const path = qIndex !== -1 ? beforeHash.slice(0, qIndex) : beforeHash;
+  const query = qIndex !== -1 ? beforeHash.slice(qIndex + 1) : '';
+
+  let result = head + scrubInto(path, counts, 'QUERY');
+  if (qIndex !== -1) result += '?' + scrubPairValues(query, counts);
+  if (hashIndex !== -1) result += '#' + scrubPairValues(fragment, counts);
+  return result;
+}
+
 /** request.url の basic-auth と機密クエリパラメータを redact する。 */
 function redactUrl(
   url: string,
   enabled: Record<HarRedactCategory, boolean>,
+  counts: Record<HarRedactCategory, number>,
   tokenize: (c: HarRedactCategory, v: string) => string
 ): string {
   let result = url;
@@ -108,6 +165,13 @@ function redactUrl(
       result = base + newQuery + hash;
     }
   }
+
+  // パス以降（path?query#fragment）に scrubText を適用（host は保持）。
+  // 構造的クエリ redact（SENSITIVE_PARAM_NAMES）の後に走らせ、placeholder は再マッチしない。
+  if (enabled.QUERY) {
+    result = scrubUrlPath(result, counts);
+  }
+
   return result;
 }
 
@@ -149,7 +213,7 @@ function redactHeaders(
     } else if (enabled.QUERY && URL_HEADER_NAMES.has(lower)) {
       // Referer / Origin / Location 等は URL を運ぶため URL と同じ redact を適用する。
       // （URL のクエリだけ redact しても同じ秘密値がこれらのヘッダに残るのを防ぐ）
-      h.value = redactUrl(h.value, enabled, tokenize);
+      h.value = redactUrl(h.value, enabled, counts, tokenize);
     } else if (enabled.AUTH_HEADER) {
       // 辞書外ヘッダ値に含まれる機密（JWT / API キー等）を scrubText で拾う。
       // 認証ヘッダトグルの意味的拡張（ヘッダ値の機密走査）として AUTH_HEADER で計上。
@@ -211,7 +275,7 @@ export function sanitizeHar(
 
       // URL
       if (typeof request.url === 'string') {
-        request.url = redactUrl(request.url, enabled, tokenize);
+        request.url = redactUrl(request.url, enabled, counts, tokenize);
       }
 
       // POST ボディ

--- a/src/utils/har/sanitize.ts
+++ b/src/utils/har/sanitize.ts
@@ -131,6 +131,7 @@ function scrubInto(
 function redactHeaders(
   headers: HarNameValue[],
   enabled: Record<HarRedactCategory, boolean>,
+  counts: Record<HarRedactCategory, number>,
   tokenize: (c: HarRedactCategory, v: string) => string
 ): void {
   for (const h of headers) {
@@ -149,6 +150,10 @@ function redactHeaders(
       // Referer / Origin / Location 等は URL を運ぶため URL と同じ redact を適用する。
       // （URL のクエリだけ redact しても同じ秘密値がこれらのヘッダに残るのを防ぐ）
       h.value = redactUrl(h.value, enabled, tokenize);
+    } else if (enabled.AUTH_HEADER) {
+      // 辞書外ヘッダ値に含まれる機密（JWT / API キー等）を scrubText で拾う。
+      // 認証ヘッダトグルの意味的拡張（ヘッダ値の機密走査）として AUTH_HEADER で計上。
+      h.value = scrubInto(h.value, counts, 'AUTH_HEADER');
     }
   }
 }
@@ -182,7 +187,7 @@ export function sanitizeHar(
     // ── リクエスト ──
     if (typeof request === 'object' && request !== null) {
       // ヘッダ
-      if (Array.isArray(request.headers)) redactHeaders(request.headers, enabled, tokenize);
+      if (Array.isArray(request.headers)) redactHeaders(request.headers, enabled, counts, tokenize);
 
       // Cookie 配列
       if (enabled.COOKIE && Array.isArray(request.cookies)) {
@@ -230,7 +235,7 @@ export function sanitizeHar(
 
     // ── レスポンス ──
     if (typeof response === 'object' && response !== null) {
-      if (Array.isArray(response.headers)) redactHeaders(response.headers, enabled, tokenize);
+      if (Array.isArray(response.headers)) redactHeaders(response.headers, enabled, counts, tokenize);
 
       if (enabled.COOKIE && Array.isArray(response.cookies)) {
         for (const c of response.cookies) {

--- a/src/utils/har/sanitize.ts
+++ b/src/utils/har/sanitize.ts
@@ -111,6 +111,23 @@ function redactUrl(
   return result;
 }
 
+/**
+ * value に scrubText を適用し、findings 件数を counts[category] に加算して
+ * redact 済み文字列を返す（findings が無ければ原文を返す）。
+ */
+function scrubInto(
+  value: string,
+  counts: Record<HarRedactCategory, number>,
+  category: HarRedactCategory
+): string {
+  const r = scrubText(value, DEFAULT_ENABLED);
+  if (r.findings.length > 0) {
+    counts[category] += r.findings.length;
+    return r.output;
+  }
+  return value;
+}
+
 function redactHeaders(
   headers: HarNameValue[],
   enabled: Record<HarRedactCategory, boolean>,
@@ -206,11 +223,7 @@ export function sanitizeHar(
           }
         }
         if (typeof request.postData.text === 'string') {
-          const r = scrubText(request.postData.text, DEFAULT_ENABLED);
-          if (r.findings.length > 0) {
-            request.postData.text = r.output;
-            counts.BODY += r.findings.length;
-          }
+          request.postData.text = scrubInto(request.postData.text, counts, 'BODY');
         }
       }
     }
@@ -239,11 +252,7 @@ export function sanitizeHar(
         typeof content.text === 'string' &&
         content.encoding !== 'base64'
       ) {
-        const r = scrubText(content.text, DEFAULT_ENABLED);
-        if (r.findings.length > 0) {
-          content.text = r.output;
-          counts.BODY_SCAN += r.findings.length;
-        }
+        content.text = scrubInto(content.text, counts, 'BODY_SCAN');
       }
     }
 

--- a/src/utils/har/types.ts
+++ b/src/utils/har/types.ts
@@ -51,6 +51,7 @@ export interface HarResponse {
   headers: HarNameValue[];
   cookies: HarCookie[];
   content: HarContent;
+  redirectURL?: string;
   bodySize?: number;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## 概要

HARサニタイザのサニタイズ監査（#685〜#690）対応の **3 PR 分割の 3/3（最終）**。`scrubText` の走査カバレッジを広げ、辞書外ヘッダ・URLパス・`response.redirectURL`・辞書外クエリの機密漏れと、base64 バイナリ本文の破壊を解消します。ReDoS 対策（PR-C, #692）が develop に入った後に着手しているため、適用箇所の拡大も安全です。

設計: `docs/superpowers/specs/2026-06-14-har-sanitizer-hardening-design.md`（PR-B 節）
計画: `docs/superpowers/plans/2026-06-14-har-sanitizer-pr-b.md`

## 対応 issue

| issue | 内容 | 対応 |
|-------|------|------|
| #687 | 辞書外ヘッダ・URLパス・`response.redirectURL` に scrubText 未適用 | ✅ Closes |
| #689 | 機密クエリ名辞書の取りこぼし | ✅ Closes |
| #690 | 検出ルール取りこぼし等 | M-2（base64バイナリskip）を対応。L-3（トークン衝突）は据置 |

## 変更内容

- **#687a / #689a 辞書拡充**: `AUTH_HEADER_NAMES`（`x-amz-security-token` / `x-session-token` / `www-authenticate` 等）、`COOKIE_HEADER_NAMES`（`cookie2` / `set-cookie2`）、`SENSITIVE_PARAM_NAMES`（`next` / `redirect` / `assertion` / `jwt` 等）。
- **#687b 辞書外ヘッダ走査**: `redactHeaders` に最終 else を追加し、辞書外ヘッダ値へ `scrubText` フォールバック（AUTH_HEADER）。
- **#687c / #689b URLパス走査**: `redactUrl` に `scheme://authority`（host・port・basic-auth）を**保持**しつつパス以降へ `scrubText` を適用（QUERY）。パス内トークン（`/reset/<jwt>`）・辞書外クエリ名の JWT/API キーを redact。
- **#687d redirectURL**: `HarResponse` に `redirectURL?` を追加し redact 適用。
- **#690 M-2 base64 skip 拡張**: `encoding === 'base64'` に加え、mimeType がバイナリ系（`image/*` 等）なら encoding 欄が無くてもスキャンをスキップし `HIGH_ENTROPY` による本文破壊を防ぐ。
- リファクタ: `scrubInto` ヘルパーに集約、`counts` を `redactUrl`/`redactHeaders` にスレッド。

### 設計上のポイント（破壊回避）

URL のクエリ/フラグメントは **param value 単位で `scrubText`** します。クエリ文字列全体を `scrubText` に渡すと `CREDENTIAL_ASSIGN` の値クラス（`&` を含む）が `token=...&page=2` を丸ごと飲み込み、**非機密 param `page=2` を破壊**するためです（実装中にこの退行を検出 → `scrubPairValues` で value 単位走査に修正）。

### over-masking の許容

パス/ヘッダへの `scrubText` で、内部の IP・メール・高エントロピー文字列も redact されうります。**漏えい方向ではなく安全側**で、host（authority）は保持され URL の可読性は維持されます（`docs/decisions.md [118]` に記録）。

## テスト（test-gates 準拠）

各カバレッジに「修正前は漏れていた入力が確実に redact される」陽性対照と、非機密を壊さない退行対照を併設。

- har sanitize **29 PASS**（拡充ヘッダ / 辞書外ヘッダJWT / URLパストークン / 辞書外クエリJWT / redirectURL / base64バイナリskip / 非機密保持 等）。`astro check` 0/0/0、lint・format クリーン。

> ローカルでは build 未実行の `sw-cache-version`・署名サーバ依存の `codex-git-add-files` 計3件が環境要因で失敗しますが本PR無関係（PR-A/PR-C で CI 通過実証済み）。

## 補足

実装は計画に沿って進めましたが、URLパス走査（#687c）でクエリ破壊の退行を検出し `scrubPairValues`（value 単位走査）に設計修正しました。3 PR（#691 / #692 / 本PR）でサニタイズ監査の6件すべてに対応完了します（#690 L-3 のみ安全側のため据置）。

https://claude.ai/code/session_01YUStCFkmCj7k6piyxJFp8E

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUStCFkmCj7k6piyxJFp8E)_