### PR TITLE
fix: クリップボードインスペクタのクリア競合と空 type 表示を修正

### DIFF
--- a/src/components/tools/ClipboardInspector.tsx
+++ b/src/components/tools/ClipboardInspector.tsx
@@ -260,17 +260,20 @@ export function ClipboardInspectorTool() {
             </p>
           )}
 
-          {snapshot.strings.map((flavor, i) => (
+          {snapshot.strings.map((flavor, i) => {
+            // 空 type のフォールバックは表示タイトルと SR 向け aria-label で揃える
+            const typeLabel = flavor.type || '(type 不明)';
+            return (
             <Section
               key={`${flavor.type}-${i}`}
-              title={<code className="font-mono">{flavor.type || '(type 不明)'}</code>}
+              title={<code className="font-mono">{typeLabel}</code>}
               headerSlot={
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="caption text-muted leading-none">
                     {[...flavor.content].length.toLocaleString('ja-JP')} 文字 /{' '}
                     {flavor.byteSize.toLocaleString('ja-JP')} バイト
                   </span>
-                  <CopyButton text={flavor.content} ariaLabel={`${flavor.type} の内容をコピー`} />
+                  <CopyButton text={flavor.content} ariaLabel={`${typeLabel} の内容をコピー`} />
                 </div>
               }
             >
@@ -284,7 +287,8 @@ export function ClipboardInspectorTool() {
                 <FlavorPre content={flavor.content} />
               )}
             </Section>
-          ))}
+            );
+          })}
 
           {snapshot.files.map((entry, i) => (
             <FileFlavorCard key={`${entry.name}-${i}`} entry={entry} />

--- a/src/components/tools/ClipboardInspector.tsx
+++ b/src/components/tools/ClipboardInspector.tsx
@@ -264,29 +264,29 @@ export function ClipboardInspectorTool() {
             // 空 type のフォールバックは表示タイトルと SR 向け aria-label で揃える
             const typeLabel = flavor.type || '(type 不明)';
             return (
-            <Section
-              key={`${flavor.type}-${i}`}
-              title={<code className="font-mono">{typeLabel}</code>}
-              headerSlot={
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="caption text-muted leading-none">
-                    {[...flavor.content].length.toLocaleString('ja-JP')} 文字 /{' '}
-                    {flavor.byteSize.toLocaleString('ja-JP')} バイト
-                  </span>
-                  <CopyButton text={flavor.content} ariaLabel={`${typeLabel} の内容をコピー`} />
-                </div>
-              }
-            >
-              {flavor.type === 'text/html' ? (
-                <HtmlFlavorBody
-                  html={flavor.content}
-                  view={htmlViews[i] ?? 'source'}
-                  onViewChange={(v) => setHtmlViews((prev) => ({ ...prev, [i]: v }))}
-                />
-              ) : (
-                <FlavorPre content={flavor.content} />
-              )}
-            </Section>
+              <Section
+                key={`${flavor.type}-${i}`}
+                title={<code className="font-mono">{typeLabel}</code>}
+                headerSlot={
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="caption text-muted leading-none">
+                      {[...flavor.content].length.toLocaleString('ja-JP')} 文字 /{' '}
+                      {flavor.byteSize.toLocaleString('ja-JP')} バイト
+                    </span>
+                    <CopyButton text={flavor.content} ariaLabel={`${typeLabel} の内容をコピー`} />
+                  </div>
+                }
+              >
+                {flavor.type === 'text/html' ? (
+                  <HtmlFlavorBody
+                    html={flavor.content}
+                    view={htmlViews[i] ?? 'source'}
+                    onViewChange={(v) => setHtmlViews((prev) => ({ ...prev, [i]: v }))}
+                  />
+                ) : (
+                  <FlavorPre content={flavor.content} />
+                )}
+              </Section>
             );
           })}
 

--- a/src/components/tools/ClipboardInspector.tsx
+++ b/src/components/tools/ClipboardInspector.tsx
@@ -244,6 +244,9 @@ export function ClipboardInspectorTool() {
             </div>
             <ClearButton
               onClick={() => {
+                // in-flight キャプチャの resolve を破棄する（クリア後に古い getAsString が
+                // 解決して snapshot を復活させるのを防ぐ）。capture の seq ガードと一貫させる
+                captureSeqRef.current++;
                 setSnapshot(null);
                 setAnnouncement('クリアしました');
               }}
@@ -260,7 +263,7 @@ export function ClipboardInspectorTool() {
           {snapshot.strings.map((flavor, i) => (
             <Section
               key={`${flavor.type}-${i}`}
-              title={<code className="font-mono">{flavor.type}</code>}
+              title={<code className="font-mono">{flavor.type || '(type 不明)'}</code>}
               headerSlot={
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="caption text-muted leading-none">

--- a/src/components/tools/__tests__/ClipboardInspector.test.tsx
+++ b/src/components/tools/__tests__/ClipboardInspector.test.tsx
@@ -179,13 +179,15 @@ describe('ClipboardInspector — paste 捕捉', () => {
     expect(screen.queryByText('text/plain')).toBeNull();
   });
 
-  it('type が空のフレーバーは "(type 不明)" と表示する', async () => {
+  it('type が空のフレーバーは表示タイトルとコピーボタンの aria-label を "(type 不明)" に揃える', async () => {
     render(<ClipboardInspectorTool />);
     fireEvent.paste(document, {
       clipboardData: mockClipboardData({ '': '型なしデータ' }),
     });
     await waitFor(() => expect(screen.getByText('型なしデータ')).toBeTruthy());
     expect(screen.getByText('(type 不明)')).toBeTruthy();
+    // SR 向け名前も空 type を露出させず（" の内容をコピー" にならず）フォールバックで揃える
+    expect(screen.getByRole('button', { name: '(type 不明) の内容をコピー' })).toBeTruthy();
   });
 
   it('連続 paste で先行キャプチャの遅延 resolve が後発の結果を上書きしない', async () => {

--- a/src/components/tools/__tests__/ClipboardInspector.test.tsx
+++ b/src/components/tools/__tests__/ClipboardInspector.test.tsx
@@ -157,6 +157,37 @@ describe('ClipboardInspector — paste 捕捉', () => {
     expect(live!.textContent).toBe('クリアしました');
   });
 
+  it('クリア後に in-flight キャプチャが遅延 resolve しても結果を復活させない（陽性対照: clear の seq 無効化）', async () => {
+    // Clear ハンドラが captureSeqRef を進めない実装だと、遅延 resolve が seq 一致のまま
+    // snapshot を復活させ fail する設計（陽性対照）
+    render(<ClipboardInspectorTool />);
+    // 1 回目: 即時 resolve → snapshot 表示（クリアボタンが出る）
+    fireEvent.paste(document, {
+      clipboardData: mockClipboardData({ 'text/plain': '最初のデータ' }),
+    });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'クリア' })).toBeTruthy());
+    // 2 回目: resolve を 50ms 遅延（in-flight キャプチャ）
+    fireEvent.paste(document, {
+      clipboardData: mockClipboardData({ 'text/plain': '遅延データ' }, 50),
+    });
+    // 2 回目の resolve 前にクリア
+    fireEvent.click(screen.getByRole('button', { name: 'クリア' }));
+    expect(screen.queryByText('最初のデータ')).toBeNull();
+    // 遅延 resolve を待っても結果が復活しないこと
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(screen.queryByText('遅延データ')).toBeNull();
+    expect(screen.queryByText('text/plain')).toBeNull();
+  });
+
+  it('type が空のフレーバーは "(type 不明)" と表示する', async () => {
+    render(<ClipboardInspectorTool />);
+    fireEvent.paste(document, {
+      clipboardData: mockClipboardData({ '': '型なしデータ' }),
+    });
+    await waitFor(() => expect(screen.getByText('型なしデータ')).toBeTruthy());
+    expect(screen.getByText('(type 不明)')).toBeTruthy();
+  });
+
   it('連続 paste で先行キャプチャの遅延 resolve が後発の結果を上書きしない', async () => {
     render(<ClipboardInspectorTool />);
     // 1 回目: getAsString の resolve を 50ms 遅延（大きい HTML の貼り付けを模擬）


### PR DESCRIPTION
## 背景

クリップボードインスペクタ（コンポーネント・サニタイザ・スナップショット処理）のロジック・セキュリティレビューを実施した。

**セキュリティは堅牢**で重大な脆弱性は無し（HTML プレビューは許可リストサニタイザ + `sandbox=""` iframe の二重防御、リモート画像 src 除去によるトラッキング防止、深いネストでの DoS 回避など）。一方でロジック面の軽微な不具合を 2 点検出したため修正する。

## 修正内容

### 1. クリア時の in-flight キャプチャ競合（低リスク）

`ClearButton` のハンドラが `captureSeqRef` を進めていなかったため、キャプチャの `getAsString` が解決する前にクリアすると、遅延 resolve が seq 一致のまま `setSnapshot` を実行し、**クリアした内容が復活し得る**状態だった。クリア時にも `captureSeqRef` を進め、`capture` 側の seq ガードと一貫させる。

### 2. 空 `type` フレーバーの表示不揃い（軽微）

ファイルフレーバーは `entry.type || '(type 不明)'` でフォールバックしていたが、string フレーバーは `type` が空文字の場合に空表示になっていた。表示を統一する。

## テスト

両修正の**陽性対照テスト**を追加（旧実装に当てると fail する設計、test-gates 鉄則 1）。fix を stash して旧実装で 2 件が fail することを実機確認済み。

- ユニット: `ClipboardInspector.test.tsx` 12 件 pass
- 型チェック: `astro check` 0 errors
- E2E: `clipboard-inspector.spec.ts` 8 件 pass（CSP 違反検知の陽性対照含む）

https://claude.ai/code/session_013zYuRzcG47xXTT4boxja1v

---
_Generated by [Claude Code](https://claude.ai/code/session_013zYuRzcG47xXTT4boxja1v)_