### PR TITLE
fix: har-viewer の null 先頭 entry 自動選択時に詳細プレースホルダを表示 (#684)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-har-viewer-null-entry-placeholder.md
+++ b/docs/superpowers/plans/2026-06-14-har-viewer-null-entry-placeholder.md
@@ -1,0 +1,183 @@
+# har-viewer null entry 詳細パネル一貫化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 先頭 entry が `null` で自動選択された際、詳細パネルが `{}` ケースと同じプレースホルダを表示するよう一貫化する（issue #684）。
+
+**Architecture:** `HarEntryDetail` は既に `entry?.request` の optional chaining で null/undefined entry をガードしプレースホルダへ落ちる。よって `HarEntryDetail.Props.entry` の型を `HarEntry | null | undefined` に拡張し、`HarViewer` の描画ゲートを `selectedEntry &&`（truthy 判定）から `result && selectedIndex != null &&`（選択存在判定）に変更するだけで非対称が解消する。
+
+**Tech Stack:** React + TypeScript, Astro, Vitest (jsdom), Playwright (E2E)。
+
+参照 spec: `docs/superpowers/specs/2026-06-14-har-viewer-null-entry-placeholder-design.md`
+
+---
+
+### Task 1: ユニットテスト追加（型拡張の陽性対照）と HarEntryDetail 型拡張
+
+**Files:**
+- Test: `src/components/tools/__tests__/HarEntryDetail.test.tsx`
+- Modify: `src/components/tools/HarEntryDetail.tsx:3-5`（Props 型）
+
+- [ ] **Step 1: 失敗するユニットテストを書く**
+
+`src/components/tools/__tests__/HarEntryDetail.test.tsx` の `describe('HarEntryDetail 壊れた entry のガード', ...)` ブロック内、「空 entry でも throw せず…」の `it` の直後に以下を追加する:
+
+```tsx
+  it('null entry でも throw せずプレースホルダを表示する', () => {
+    expect(() =>
+      render(<HarEntryDetail entry={null as unknown as HarEntry} />)
+    ).not.toThrow();
+    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+  });
+```
+
+- [ ] **Step 2: テストを実行して fail（または型エラー）を確認**
+
+Run: `npm run test -- HarEntryDetail`
+Expected: 既存ロジックは null を吸収するため実行は pass するが、`entry={null}` は現状の `Props.entry: HarEntry` 型では本来不正。次の Step で型を正す（テストの `as unknown as HarEntry` キャストは型拡張後に外す）。
+
+- [ ] **Step 3: HarEntryDetail の Props 型を拡張**
+
+`src/components/tools/HarEntryDetail.tsx` の Props を以下に変更する（内部ロジックは変更しない。既存の `if (!request || typeof request !== 'object' || !response || typeof response !== 'object')` ガードが null/undefined を吸収する）:
+
+```tsx
+interface Props {
+  entry: HarEntry | null | undefined;
+}
+```
+
+- [ ] **Step 4: テストのキャストを外す**
+
+Step 1 で追加したテストの `entry={null as unknown as HarEntry}` を `entry={null}` に簡素化する:
+
+```tsx
+  it('null entry でも throw せずプレースホルダを表示する', () => {
+    expect(() => render(<HarEntryDetail entry={null} />)).not.toThrow();
+    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+  });
+```
+
+- [ ] **Step 5: テストと型チェックを実行して pass を確認**
+
+Run: `npm run test -- HarEntryDetail && node_modules/.bin/astro check`
+Expected: ユニット全 pass、型エラー 0。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/components/tools/HarEntryDetail.tsx src/components/tools/__tests__/HarEntryDetail.test.tsx
+git commit -m "fix: HarEntryDetail が null entry でもプレースホルダを表示できるよう型拡張 (#684)"
+```
+
+---
+
+### Task 2: HarViewer の描画ゲートを selectedIndex 基準に変更
+
+**Files:**
+- Modify: `src/components/tools/HarViewer.tsx:161`
+
+- [ ] **Step 1: 描画ゲートを変更**
+
+`src/components/tools/HarViewer.tsx` の詳細パネル描画箇所（コメント `{/* 詳細パネル */}` の直下）を以下に変更する:
+
+```tsx
+          {/* 詳細パネル */}
+          {/* selectedIndex があれば（entry が null/壊れていても）プレースホルダを描画し、
+              {} ケースとの UX 非対称を解消する（issue #684） */}
+          {selectedIndex != null && <HarEntryDetail entry={selectedEntry} />}
+```
+
+`selectedEntry` の導出（`HarViewer.tsx:80-81`）はそのまま残す。`result && selectedIndex != null` の `result` は `selectedEntry` 導出内で既に評価されるが、このゲートは `result &&` ブロック（`HarViewer.tsx:129`）の内側にあるため `result` 判定は冗長。`selectedIndex != null` のみで足りる。
+
+- [ ] **Step 2: 型チェックを実行**
+
+Run: `node_modules/.bin/astro check`
+Expected: 型エラー 0。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/components/tools/HarViewer.tsx
+git commit -m "fix: har-viewer の null 先頭 entry でも詳細プレースホルダを表示 (#684)"
+```
+
+---
+
+### Task 3: E2E テスト追加（描画ゲート変更の陽性対照）
+
+**Files:**
+- Modify: `tests/e2e/har-viewer.spec.ts`（既存 `test.describe('HAR ビューア', ...)` ブロック末尾に追加）
+
+- [ ] **Step 1: E2E テストを追加**
+
+`tests/e2e/har-viewer.spec.ts` の `test.describe('HAR ビューア', ...)` 内、最後の `test(...)` の直後（describe の閉じ括弧 `});` の直前）に以下を追加する:
+
+```ts
+  test('先頭 entry が null でも自動選択で詳細プレースホルダが表示される', async ({ page }) => {
+    await page.goto('/tools/har-viewer');
+
+    // 先頭 entry が null（index=0 が自動選択される）+ 2 件目は正常
+    const json = JSON.stringify({
+      log: {
+        version: '1.2',
+        creator: { name: 'test', version: '1.0' },
+        entries: [
+          null,
+          {
+            time: 10,
+            request: {
+              method: 'GET',
+              url: 'https://example.com/api/ok',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    });
+    await uploadHar(page, json);
+
+    // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
+    await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
+      timeout: 10000,
+    });
+    // 先頭 null entry が自動選択され、詳細パネルにプレースホルダが出る。
+    // 修正前は selectedEntry が falsy で詳細パネル自体が描画されず、この assert は fail する（陽性ガード）。
+    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+  });
+```
+
+- [ ] **Step 2: E2E を実行して pass を確認**
+
+Run: `npm run test:e2e -- har-viewer`
+Expected: 追加テストを含め har-viewer の E2E が全 pass。
+
+> 注: parse/sanitize 層が `null` entry を配列に保持し HarEntryList が「（壊れたエントリ）」行を描画することは issue #681 の既存テスト（`{}` ケース）と `HarEntryList` の `e?.request` ガードで担保済み。万一 worker の parse が先頭 null を別扱いし自動選択 index が 0 にならない場合は、`useHarSanitizer` / `parse` の挙動を確認し、テストデータを `null` ではなく `{}` 後続 + 先頭 null の構成に合わせて調整する（ただし HarEntryList は `entries.map` で null をそのまま保持するため通常は不要）。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add tests/e2e/har-viewer.spec.ts
+git commit -m "test: har-viewer の null 先頭 entry 詳細プレースホルダ表示の E2E を追加 (#684)"
+```
+
+---
+
+### 完了時の検証義務（全 Task 後）
+
+push 前に以下を実行し、全て green を確認する（`.agents/rules/common.md` 3 章）:
+
+```bash
+npm run test
+node_modules/.bin/astro check
+npm run test:e2e -- har-viewer
+```
+
+### スコープ外（変更しない）
+
+- HAR パース・サニタイズロジック（`src/utils/har/`, `src/hooks/useHarSanitizer.ts`）。
+- プレースホルダ文言の改訂。
+- 自動選択ロジック（先頭 entry 選択）の挙動。
+- ドキュメント（README/SPEC/decisions）— ツール追加・slug 変更・挙動の外部仕様変更ではないため更新不要。

--- a/docs/superpowers/plans/2026-06-14-har-viewer-null-entry-placeholder.md
+++ b/docs/superpowers/plans/2026-06-14-har-viewer-null-entry-placeholder.md
@@ -15,6 +15,7 @@
 ### Task 1: ユニットテスト追加（型拡張の陽性対照）と HarEntryDetail 型拡張
 
 **Files:**
+
 - Test: `src/components/tools/__tests__/HarEntryDetail.test.tsx`
 - Modify: `src/components/tools/HarEntryDetail.tsx:3-5`（Props 型）
 
@@ -23,12 +24,10 @@
 `src/components/tools/__tests__/HarEntryDetail.test.tsx` の `describe('HarEntryDetail 壊れた entry のガード', ...)` ブロック内、「空 entry でも throw せず…」の `it` の直後に以下を追加する:
 
 ```tsx
-  it('null entry でも throw せずプレースホルダを表示する', () => {
-    expect(() =>
-      render(<HarEntryDetail entry={null as unknown as HarEntry} />)
-    ).not.toThrow();
-    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
-  });
+it('null entry でも throw せずプレースホルダを表示する', () => {
+  expect(() => render(<HarEntryDetail entry={null as unknown as HarEntry} />)).not.toThrow();
+  expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+});
 ```
 
 - [ ] **Step 2: テストを実行して fail（または型エラー）を確認**
@@ -51,10 +50,10 @@ interface Props {
 Step 1 で追加したテストの `entry={null as unknown as HarEntry}` を `entry={null}` に簡素化する:
 
 ```tsx
-  it('null entry でも throw せずプレースホルダを表示する', () => {
-    expect(() => render(<HarEntryDetail entry={null} />)).not.toThrow();
-    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
-  });
+it('null entry でも throw せずプレースホルダを表示する', () => {
+  expect(() => render(<HarEntryDetail entry={null} />)).not.toThrow();
+  expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+});
 ```
 
 - [ ] **Step 5: テストと型チェックを実行して pass を確認**
@@ -74,6 +73,7 @@ git commit -m "fix: HarEntryDetail が null entry でもプレースホルダを
 ### Task 2: HarViewer の描画ゲートを selectedIndex 基準に変更
 
 **Files:**
+
 - Modify: `src/components/tools/HarViewer.tsx:161`
 
 - [ ] **Step 1: 描画ゲートを変更**
@@ -81,10 +81,16 @@ git commit -m "fix: HarEntryDetail が null entry でもプレースホルダを
 `src/components/tools/HarViewer.tsx` の詳細パネル描画箇所（コメント `{/* 詳細パネル */}` の直下）を以下に変更する:
 
 ```tsx
-          {/* 詳細パネル */}
-          {/* selectedIndex があれば（entry が null/壊れていても）プレースホルダを描画し、
-              {} ケースとの UX 非対称を解消する（issue #684） */}
-          {selectedIndex != null && <HarEntryDetail entry={selectedEntry} />}
+{
+  /* 詳細パネル */
+}
+{
+  /* selectedIndex があれば（entry が null/壊れていても）プレースホルダを描画し、
+              {} ケースとの UX 非対称を解消する（issue #684） */
+}
+{
+  selectedIndex != null && <HarEntryDetail entry={selectedEntry} />;
+}
 ```
 
 `selectedEntry` の導出（`HarViewer.tsx:80-81`）はそのまま残す。`result && selectedIndex != null` の `result` は `selectedEntry` 導出内で既に評価されるが、このゲートは `result &&` ブロック（`HarViewer.tsx:129`）の内側にあるため `result` 判定は冗長。`selectedIndex != null` のみで足りる。
@@ -106,6 +112,7 @@ git commit -m "fix: har-viewer の null 先頭 entry でも詳細プレースホ
 ### Task 3: E2E テスト追加（描画ゲート変更の陽性対照）
 
 **Files:**
+
 - Modify: `tests/e2e/har-viewer.spec.ts`（既存 `test.describe('HAR ビューア', ...)` ブロック末尾に追加）
 
 - [ ] **Step 1: E2E テストを追加**
@@ -113,40 +120,40 @@ git commit -m "fix: har-viewer の null 先頭 entry でも詳細プレースホ
 `tests/e2e/har-viewer.spec.ts` の `test.describe('HAR ビューア', ...)` 内、最後の `test(...)` の直後（describe の閉じ括弧 `});` の直前）に以下を追加する:
 
 ```ts
-  test('先頭 entry が null でも自動選択で詳細プレースホルダが表示される', async ({ page }) => {
-    await page.goto('/tools/har-viewer');
+test('先頭 entry が null でも自動選択で詳細プレースホルダが表示される', async ({ page }) => {
+  await page.goto('/tools/har-viewer');
 
-    // 先頭 entry が null（index=0 が自動選択される）+ 2 件目は正常
-    const json = JSON.stringify({
-      log: {
-        version: '1.2',
-        creator: { name: 'test', version: '1.0' },
-        entries: [
-          null,
-          {
-            time: 10,
-            request: {
-              method: 'GET',
-              url: 'https://example.com/api/ok',
-              headers: [],
-              queryString: [],
-              cookies: [],
-            },
-            response: { status: 200, headers: [], cookies: [], content: {} },
+  // 先頭 entry が null（index=0 が自動選択される）+ 2 件目は正常
+  const json = JSON.stringify({
+    log: {
+      version: '1.2',
+      creator: { name: 'test', version: '1.0' },
+      entries: [
+        null,
+        {
+          time: 10,
+          request: {
+            method: 'GET',
+            url: 'https://example.com/api/ok',
+            headers: [],
+            queryString: [],
+            cookies: [],
           },
-        ],
-      },
-    });
-    await uploadHar(page, json);
-
-    // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
-    await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
-      timeout: 10000,
-    });
-    // 先頭 null entry が自動選択され、詳細パネルにプレースホルダが出る。
-    // 修正前は selectedEntry が falsy で詳細パネル自体が描画されず、この assert は fail する（陽性ガード）。
-    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
   });
+  await uploadHar(page, json);
+
+  // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
+  await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
+    timeout: 10000,
+  });
+  // 先頭 null entry が自動選択され、詳細パネルにプレースホルダが出る。
+  // 修正前は selectedEntry が falsy で詳細パネル自体が描画されず、この assert は fail する（陽性ガード）。
+  await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+});
 ```
 
 - [ ] **Step 2: E2E を実行して pass を確認**

--- a/docs/superpowers/specs/2026-06-14-har-viewer-null-entry-placeholder-design.md
+++ b/docs/superpowers/specs/2026-06-14-har-viewer-null-entry-placeholder-design.md
@@ -7,7 +7,9 @@ PR #683（issue #681 の描画クラッシュガード）のレビューで指�
 `HarViewer` は読み込み時に先頭 entry（index=0）を自動選択する。選択中 entry の詳細は `HarViewer.tsx:161` の以下のゲートで描画される。
 
 ```tsx
-{selectedEntry && <HarEntryDetail entry={selectedEntry} />}
+{
+  selectedEntry && <HarEntryDetail entry={selectedEntry} />;
+}
 ```
 
 `selectedEntry` は `result.har.log.entries[selectedIndex]`。
@@ -38,9 +40,13 @@ PR #683（issue #681 の描画クラッシュガード）のレビューで指�
 
    ```tsx
    // before
-   {selectedEntry && <HarEntryDetail entry={selectedEntry} />}
+   {
+     selectedEntry && <HarEntryDetail entry={selectedEntry} />;
+   }
    // after
-   {result && selectedIndex != null && <HarEntryDetail entry={selectedEntry} />}
+   {
+     result && selectedIndex != null && <HarEntryDetail entry={selectedEntry} />;
+   }
    ```
 
    - これにより、`selectedIndex` が設定されている（= 何らかの entry が選択されている）限り、entry が null でも `HarEntryDetail` が描画されプレースホルダが出る。

--- a/docs/superpowers/specs/2026-06-14-har-viewer-null-entry-placeholder-design.md
+++ b/docs/superpowers/specs/2026-06-14-har-viewer-null-entry-placeholder-design.md
@@ -1,0 +1,78 @@
+# har-viewer: null 先頭 entry 自動選択時の詳細パネル一貫化（issue #684）
+
+## 背景・課題
+
+PR #683（issue #681 の描画クラッシュガード）のレビューで指摘された軽微な UX 非対称。
+
+`HarViewer` は読み込み時に先頭 entry（index=0）を自動選択する。選択中 entry の詳細は `HarViewer.tsx:161` の以下のゲートで描画される。
+
+```tsx
+{selectedEntry && <HarEntryDetail entry={selectedEntry} />}
+```
+
+`selectedEntry` は `result.har.log.entries[selectedIndex]`。
+
+- 先頭 entry が `{}`（オブジェクトだが request/response 欠落）の場合 → `selectedEntry` は truthy なので `HarEntryDetail` が描画され、「このエントリは request / response を欠くため詳細を表示できません。」のプレースホルダが出る。
+- 先頭 entry が `null` の場合 → `selectedEntry` が falsy になり **詳細パネル自体が描画されない**。
+
+どちらもクラッシュはせず PR #683 の目的（描画クラッシュ防止）は満たしているが、ユーザ視点では「壊れた entry が選択されているのに何も出ない」状態になり得る非対称が残る。`HarEntryList` は null 行を「（壊れたエントリ）」として可視化しているため、詳細パネルだけ「何も出ない」のは一覧との整合も崩れている。
+
+優先度: 低（クラッシュなし・視覚的な抜けのみ）。
+
+## 目的
+
+「選択中だが描画不能（entry が null / 壊れている）」の場合に、`{}` ケースと同等のプレースホルダを一貫して表示する。
+
+## 設計（描画ゲートを `selectedIndex` 基準に変更）
+
+`HarEntryDetail` は既に `entry?.request` の optional chaining でガード済みで、`entry={null}` を渡しても安全にプレースホルダへ落ちる（issue #681 対応の既存ロジック）。そのため、描画ゲートを `selectedEntry` の truthy 判定から `selectedIndex` の存在判定へ切り替えるだけで非対称が解消する。
+
+### 変更点
+
+1. **`src/components/tools/HarEntryDetail.tsx`**
+   - `Props.entry` の型を `HarEntry` から `HarEntry | null | undefined` に拡張する。
+   - 内部の null ガード（`if (!request || ... || !response || ...)`）は既に optional chaining で `entry` が null/undefined のケースを吸収しているため、ロジック変更は不要。
+
+2. **`src/components/tools/HarViewer.tsx`（161 行目付近）**
+   - 描画ゲートを変更する。
+
+   ```tsx
+   // before
+   {selectedEntry && <HarEntryDetail entry={selectedEntry} />}
+   // after
+   {result && selectedIndex != null && <HarEntryDetail entry={selectedEntry} />}
+   ```
+
+   - これにより、`selectedIndex` が設定されている（= 何らかの entry が選択されている）限り、entry が null でも `HarEntryDetail` が描画されプレースホルダが出る。
+   - entryCount が 0 で `selectedIndex` が null のとき（読み込み済みだが entry 無し）は従来どおり詳細パネルを描画しない。
+
+### 不採用案
+
+- **HarViewer 側で独自プレースホルダを別途描画**: プレースホルダ文言が 2 箇所に分散し DRY 違反。却下。
+- **自動選択ロジックで null entry をスキップ**: issue の意図（壊れた entry が選択されている状態を可視化する一貫性）と逆方向。`HarEntryList` が null 行を「（壊れたエントリ）」として見せる設計とも不整合。却下。
+
+## テスト
+
+検知機構（描画ゲート）の修正にあたり、修正がなければ fail する陽性対照を必ず添える。
+
+1. **ユニットテスト（`src/components/tools/__tests__/HarEntryDetail.test.tsx`）**
+   - `entry={null}` を渡したケースで throw せずプレースホルダ「詳細を表示できません」を表示することを追加検証する（型拡張の陽性対照）。
+
+2. **E2E テスト（`tests/e2e/har-viewer.spec.ts`）**
+   - 先頭 entry が `null` の HAR を読み込み、自動選択された詳細パネルにプレースホルダ「詳細を表示できません」が表示されることを検証する。
+   - **陽性対照性**: この修正前は詳細パネル自体が描画されないため、このアサーションは fail する。修正後に pass することで、ゲート変更が実際に効いていることを担保する。
+
+## 検証義務
+
+push 前に以下を実行する（`.agents/rules/common.md` 3 章）。
+
+- `npm run test`（ユニット）
+- `node_modules/.bin/astro check`（型）
+- `npm run test:e2e`（E2E）
+
+## スコープ外
+
+- HAR パース・サニタイズロジックの変更。
+- プレースホルダ文言の改訂（既存文言を流用）。
+- 自動選択ロジック（先頭 entry 選択）の挙動変更。
+- VRT baseline 更新（新規ツール追加ではなく既存ツールの軽微な分岐追加のため、デザイントークン由来の変更はなし。pixel diff が出た場合は owner 目視判断に委ねる）。

--- a/src/components/tools/HarEntryDetail.tsx
+++ b/src/components/tools/HarEntryDetail.tsx
@@ -1,7 +1,7 @@
 import type { HarEntry, HarNameValue } from '@/utils/har';
 
 interface Props {
-  entry: HarEntry;
+  entry: HarEntry | null | undefined;
 }
 
 function NameValueTable({ rows, label }: { rows: HarNameValue[]; label: string }) {

--- a/src/components/tools/HarViewer.tsx
+++ b/src/components/tools/HarViewer.tsx
@@ -158,7 +158,9 @@ export function HarViewer() {
           />
 
           {/* 詳細パネル */}
-          {selectedEntry && <HarEntryDetail entry={selectedEntry} />}
+          {/* selectedIndex があれば（entry が null/壊れていても）プレースホルダを描画し、
+              {} ケースとの UX 非対称を解消する（issue #684） */}
+          {selectedIndex != null && <HarEntryDetail entry={selectedEntry} />}
 
           {/* 出力ボタン群（JSON.stringify はコピー/DL 押下時のみ遅延生成） */}
           <div className="flex flex-wrap justify-end gap-2">

--- a/src/components/tools/__tests__/HarEntryDetail.test.tsx
+++ b/src/components/tools/__tests__/HarEntryDetail.test.tsx
@@ -45,6 +45,11 @@ describe('HarEntryDetail 壊れた entry のガード', () => {
     expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
   });
 
+  it('null entry でも throw せずプレースホルダを表示する', () => {
+    expect(() => render(<HarEntryDetail entry={null} />)).not.toThrow();
+    expect(screen.getByText(/詳細を表示できません/)).toBeTruthy();
+  });
+
   it('正常 entry では method/url/status を表示する', () => {
     render(<HarEntryDetail entry={validEntry} />);
     expect(screen.getByText(/GET https:\/\/example.com\/x/)).toBeTruthy();

--- a/tests/e2e/har-viewer.spec.ts
+++ b/tests/e2e/har-viewer.spec.ts
@@ -219,4 +219,39 @@ test.describe('HAR ビューア', () => {
     // サマリのリクエスト件数は 2 件（entry は配列に保持される）
     await expect(page.getByText(/リクエスト:/)).toBeVisible();
   });
+
+  test('先頭 entry が null でも自動選択で詳細プレースホルダが表示される', async ({ page }) => {
+    await page.goto('/tools/har-viewer');
+
+    // 先頭 entry が null（index=0 が自動選択される）+ 2 件目は正常
+    const json = JSON.stringify({
+      log: {
+        version: '1.2',
+        creator: { name: 'test', version: '1.0' },
+        entries: [
+          null,
+          {
+            time: 10,
+            request: {
+              method: 'GET',
+              url: 'https://example.com/api/ok',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    });
+    await uploadHar(page, json);
+
+    // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
+    await expect(page.getByRole('button', { name: /\/api\/ok$/ })).toBeVisible({
+      timeout: 10000,
+    });
+    // 先頭 null entry が自動選択され、詳細パネルにプレースホルダが出る。
+    // 修正前は selectedEntry が falsy で詳細パネル自体が描画されず、この assert は fail する（陽性ガード）。
+    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+  });
 });


### PR DESCRIPTION
## 概要

issue #684 の対応。`HarViewer` で先頭 entry が `null` で自動選択された際、詳細パネルが何も描画されない UX 非対称を解消する。

PR #683（issue #681 の描画クラッシュガード）レビューで指摘された軽微な follow-up。

## 背景

`HarViewer` は読み込み時に先頭 entry（index=0）を自動選択する。詳細パネルの描画ゲートが `selectedEntry &&`（truthy 判定）だったため:

- 先頭 entry が `{}`（request/response 欠落）→ `selectedEntry` truthy → プレースホルダ「request / response を欠くため詳細を表示できません。」を表示
- 先頭 entry が `null` → `selectedEntry` falsy → **詳細パネル自体が描画されない**

`HarEntryList` は null 行を「（壊れたエントリ）」として可視化しているため、詳細パネルだけ「何も出ない」のは一覧との整合も崩れていた。

## 変更内容

- `HarEntryDetail`: `Props.entry` の型を `HarEntry | null | undefined` に拡張。内部の null ガード（issue #681 で追加した optional chaining）が既に null/undefined を吸収するためロジック変更は不要。
- `HarViewer`: 詳細パネルの描画ゲートを `selectedEntry &&` から `selectedIndex != null &&` に変更。これにより entry が null でも `HarEntryDetail` が描画され、`{}` ケースと同じプレースホルダが一貫して表示される。

## テスト

検知機構（描画ゲート）の修正にあたり、修正前に当てると fail する陽性対照を併設:

- ユニット（`HarEntryDetail.test.tsx`）: `entry={null}` で throw せずプレースホルダを表示することを検証。
- E2E（`har-viewer.spec.ts`）: 先頭 entry が `null` の HAR を読み込み、自動選択された詳細パネルにプレースホルダが出ることを検証。修正前は詳細パネル自体が描画されず fail する。

## 検証結果

- `node_modules/.bin/astro check`: 0 errors / 0 warnings / 0 hints
- `npm run test`: har-viewer 関連は全 pass（`tests/meta/codex-git-add-files.test.ts` の 1 件は環境の commit 署名サーバー 400 起因のフレークで本変更と無関係）
- `npm run test:e2e -- har-viewer`: 6 passed

## 設計・計画ドキュメント

- 設計: `docs/superpowers/specs/2026-06-14-har-viewer-null-entry-placeholder-design.md`
- 実装計画: `docs/superpowers/plans/2026-06-14-har-viewer-null-entry-placeholder.md`

Closes #684

https://claude.ai/code/session_013cXv18UzJ8PhEAjRgg4Gxk

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXv18UzJ8PhEAjRgg4Gxk)_