### PR TITLE
fix: har-viewer 壊れた entry 行をクリック可能にして再選択を許可 (#701)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-har-viewer-broken-row-reselect.md
+++ b/docs/superpowers/plans/2026-06-14-har-viewer-broken-row-reselect.md
@@ -23,6 +23,7 @@
 ### Task 1: ユニットテストを新挙動に更新（失敗させる）
 
 **Files:**
+
 - Test: `src/components/tools/__tests__/HarEntryList.test.tsx`
 
 既存ファイルの内容を以下に置き換える。変更点は (a) 「button を持たない」assert を新挙動（壊れ行も button）に更新、(b) 壊れ行クリックで `onSelect` がその index で呼ばれる陽性対照を追加。
@@ -124,6 +125,7 @@ Expected: FAIL（壊れ行がまだ `<span>` なので button 数が 2 になり
 ### Task 2: HarEntryList の壊れた行を button 化
 
 **Files:**
+
 - Modify: `src/components/tools/HarEntryList.tsx`（`url == null` 分岐の `<span>` を `<button>` に）
 
 - [ ] **Step 1: 壊れた行の span を button に置き換える**
@@ -152,6 +154,7 @@ Expected: FAIL（壊れ行がまだ `<span>` なので button 数が 2 になり
 ```
 
 注意:
+
 - `type="button"` 必須（lint の button type 漏れ検出に該当）。
 - `text-muted` を維持し URL リンク（`text-primary`）と視覚的に区別する。`underline`/`hover:underline` は Tailwind コア utility なので variant が効く（`@layer components` 手書き class ではない）。
 - a11y 属性 `aria-current` は正常行の URL button と同じパターン。
@@ -183,6 +186,7 @@ git commit -m "fix: har-viewer 壊れた entry 行をクリック可能にして
 ### Task 3: 再現シナリオの回帰 E2E を追加
 
 **Files:**
+
 - Modify: `tests/e2e/har-viewer.spec.ts`（`test.describe('HAR ビューア', ...)` 内の末尾に追加）
 
 - [ ] **Step 1: E2E テストを追加**
@@ -190,52 +194,52 @@ git commit -m "fix: har-viewer 壊れた entry 行をクリック可能にして
 `tests/e2e/har-viewer.spec.ts` の最後の `test('先頭 entry が null でも...')` ブロックの直後（`});` で describe が閉じる直前）に以下を挿入:
 
 ```ts
-  test('正常 entry 選択後も壊れた行を再クリックして詳細プレースホルダを再表示できる', async ({
-    page,
-  }) => {
-    await page.goto('/tools/har-viewer');
+test('正常 entry 選択後も壊れた行を再クリックして詳細プレースホルダを再表示できる', async ({
+  page,
+}) => {
+  await page.goto('/tools/har-viewer');
 
-    // 先頭が壊れた entry（{}）+ 2 件目は正常（issue #701 再現データ）
-    const json = JSON.stringify({
-      log: {
-        version: '1.2',
-        creator: { name: 'test', version: '1.0' },
-        entries: [
-          {}, // 壊れた entry（先頭。auto-select で index=0 が選ばれる）
-          {
-            time: 10,
-            request: {
-              method: 'GET',
-              url: 'https://example.com/api/ok',
-              headers: [],
-              queryString: [],
-              cookies: [],
-            },
-            response: { status: 200, headers: [], cookies: [], content: {} },
+  // 先頭が壊れた entry（{}）+ 2 件目は正常（issue #701 再現データ）
+  const json = JSON.stringify({
+    log: {
+      version: '1.2',
+      creator: { name: 'test', version: '1.0' },
+      entries: [
+        {}, // 壊れた entry（先頭。auto-select で index=0 が選ばれる）
+        {
+          time: 10,
+          request: {
+            method: 'GET',
+            url: 'https://example.com/api/ok',
+            headers: [],
+            queryString: [],
+            cookies: [],
           },
-        ],
-      },
-    });
-    await uploadHar(page, json);
-
-    // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
-    const okButton = page.getByRole('button', { name: /\/api\/ok$/ });
-    await expect(okButton).toBeVisible({ timeout: 10000 });
-
-    // 前提: 先頭の壊れ entry が auto-select され詳細プレースホルダが出る
-    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
-
-    // 正常 entry をクリックして選択を移す → 詳細に正常 entry の URL が出る
-    await okButton.click();
-    await expect(page.getByText('https://example.com/api/ok')).toBeVisible();
-    // プレースホルダは消える
-    await expect(page.getByText(/詳細を表示できません/)).toHaveCount(0);
-
-    // 壊れた行（「（壊れたエントリ）」button）を再クリック → 詳細プレースホルダが再表示される。
-    // 修正前は壊れ行が button でなくクリックできないため、ここで fail する（陽性ガード）。
-    await page.getByRole('button', { name: '（壊れたエントリ）' }).click();
-    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+          response: { status: 200, headers: [], cookies: [], content: {} },
+        },
+      ],
+    },
   });
+  await uploadHar(page, json);
+
+  // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
+  const okButton = page.getByRole('button', { name: /\/api\/ok$/ });
+  await expect(okButton).toBeVisible({ timeout: 10000 });
+
+  // 前提: 先頭の壊れ entry が auto-select され詳細プレースホルダが出る
+  await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+
+  // 正常 entry をクリックして選択を移す → 詳細に正常 entry の URL が出る
+  await okButton.click();
+  await expect(page.getByText('https://example.com/api/ok')).toBeVisible();
+  // プレースホルダは消える
+  await expect(page.getByText(/詳細を表示できません/)).toHaveCount(0);
+
+  // 壊れた行（「（壊れたエントリ）」button）を再クリック → 詳細プレースホルダが再表示される。
+  // 修正前は壊れ行が button でなくクリックできないため、ここで fail する（陽性ガード）。
+  await page.getByRole('button', { name: '（壊れたエントリ）' }).click();
+  await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+});
 ```
 
 - [ ] **Step 2: E2E を実行して PASS を確認**
@@ -255,6 +259,7 @@ git commit -m "test: har-viewer 壊れた行の再選択 E2E を追加 (#701)"
 ### Task 4: ドキュメント確認・更新
 
 **Files:**
+
 - Check: `docs/tools.md`（har-viewer の挙動記述）
 
 - [ ] **Step 1: docs/tools.md の har-viewer 記述を確認**

--- a/docs/superpowers/plans/2026-06-14-har-viewer-broken-row-reselect.md
+++ b/docs/superpowers/plans/2026-06-14-har-viewer-broken-row-reselect.md
@@ -1,0 +1,280 @@
+# har-viewer 壊れた行の再選択対応 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `HarEntryList` の壊れた entry 行（URL 欠落）をクリック可能にし、auto-select 後に再選択できない非対称（issue #701）を解消する。
+
+**Architecture:** 非クリッカブルな `<span>（壊れたエントリ）</span>` を `onSelect(i)` を呼ぶ `<button>` に置き換える。クリックすると `HarEntryDetail` の既存プレースホルダが描画され、auto-select の挙動と一貫する。styling は URL リンク（`text-primary`）と区別するため `text-muted` を維持。
+
+**Tech Stack:** React (TSX) / Astro / Vitest (jsdom) / Playwright / Tailwind v4
+
+---
+
+## File Structure
+
+- `src/components/tools/HarEntryList.tsx` — 壊れた行を button 化（本体、1 箇所の JSX 分岐のみ変更）
+- `src/components/tools/__tests__/HarEntryList.test.tsx` — 既存 assert 更新 + 陽性対照追加
+- `tests/e2e/har-viewer.spec.ts` — 再現シナリオの回帰 E2E 追加
+
+ドキュメント影響: ツール追加・挙動変更ではあるが UI 内部の微修正でツール一覧・SPEC に影響なし。`docs/tools.md` の har-viewer 記述に「壊れた行も選択可能」と補足する必要があるか確認（後述 Task 4）。
+
+---
+
+### Task 1: ユニットテストを新挙動に更新（失敗させる）
+
+**Files:**
+- Test: `src/components/tools/__tests__/HarEntryList.test.tsx`
+
+既存ファイルの内容を以下に置き換える。変更点は (a) 「button を持たない」assert を新挙動（壊れ行も button）に更新、(b) 壊れ行クリックで `onSelect` がその index で呼ばれる陽性対照を追加。
+
+- [ ] **Step 1: テストを新挙動に書き換える**
+
+`src/components/tools/__tests__/HarEntryList.test.tsx` を以下で全置換:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+import { HarEntryList } from '@/components/tools/HarEntryList';
+import type { HarEntry } from '@/utils/har';
+
+beforeEach(() => {
+  document.adoptedStyleSheets = [];
+});
+afterEach(() => {
+  cleanup();
+  document.adoptedStyleSheets = [];
+});
+
+// 正常 1 件 + 壊れた entry 3 種（{}, null, response 欠落）を混在させる。
+// 型は実データ（手編集 HAR）を模すため unknown 経由でキャストする。
+const entries = [
+  {
+    time: 12,
+    request: {
+      method: 'GET',
+      url: 'https://example.com/api/ok',
+      headers: [],
+      queryString: [],
+      cookies: [],
+    },
+    response: { status: 200, headers: [], cookies: [], content: { size: 2 } },
+  },
+  {}, // request/response 欠落
+  null, // entry 自体が null
+  {
+    request: {
+      method: 'POST',
+      url: 'https://example.com/api/noresp',
+      headers: [],
+      queryString: [],
+      cookies: [],
+    },
+  }, // response 欠落
+] as unknown as HarEntry[];
+
+describe('HarEntryList 壊れた entry のガード', () => {
+  it('壊れた entry を含んでも throw せず描画できる', () => {
+    expect(() =>
+      render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />)
+    ).not.toThrow();
+  });
+
+  it('正常 entry の method と URL を描画する', () => {
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />);
+    expect(screen.getByText('GET')).toBeTruthy();
+    // shortUrl は host + pathname
+    expect(screen.getByRole('button', { name: 'example.com/api/ok' })).toBeTruthy();
+  });
+
+  it('壊れた entry 行はプレースホルダ文言の button を描画する', () => {
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />);
+    // 「（壊れたエントリ）」プレースホルダが request 欠落行に出る（{} と null の 2 行）
+    expect(screen.getAllByText('（壊れたエントリ）').length).toBeGreaterThanOrEqual(2);
+    // url を持つ行（ok / noresp）と壊れ行（{} / null）すべてが button（計 4 つ）
+    expect(screen.getAllByRole('button')).toHaveLength(4);
+    // 壊れ行「（壊れたエントリ）」も accessible name を持つ button として取得できる
+    expect(screen.getAllByRole('button', { name: '（壊れたエントリ）' })).toHaveLength(2);
+  });
+
+  it('壊れた entry 行クリックでその index の onSelect が呼ばれる（再選択可能）', () => {
+    const onSelect = vi.fn();
+    render(<HarEntryList entries={entries} selectedIndex={null} onSelect={onSelect} />);
+    // 壊れ行は {} (index 1) と null (index 2)。先頭の壊れ行をクリック。
+    const brokenButtons = screen.getAllByRole('button', { name: '（壊れたエントリ）' });
+    brokenButtons[0].click();
+    expect(onSelect).toHaveBeenCalledWith(1);
+    brokenButtons[1].click();
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm run test -- HarEntryList`
+Expected: FAIL（壊れ行がまだ `<span>` なので button 数が 2 になり `toHaveLength(4)` / `（壊れたエントリ）` button 取得 / onSelect 呼び出しが失敗）
+
+- [ ] **Step 3: コミット（red 状態のテストはまだコミットしない）**
+
+このステップではコミットしない。Task 2 の実装と合わせてコミットする。
+
+---
+
+### Task 2: HarEntryList の壊れた行を button 化
+
+**Files:**
+- Modify: `src/components/tools/HarEntryList.tsx`（`url == null` 分岐の `<span>` を `<button>` に）
+
+- [ ] **Step 1: 壊れた行の span を button に置き換える**
+
+`src/components/tools/HarEntryList.tsx` の以下の箇所:
+
+```tsx
+                  ) : (
+                    <span className="text-muted">（壊れたエントリ）</span>
+                  )}
+```
+
+を次に置き換える:
+
+```tsx
+                  ) : (
+                    <button
+                      type="button"
+                      aria-current={selectedIndex === i ? 'true' : undefined}
+                      className="text-left text-muted underline-offset-2 hover:underline"
+                      onClick={() => onSelect(i)}
+                    >
+                      （壊れたエントリ）
+                    </button>
+                  )}
+```
+
+注意:
+- `type="button"` 必須（lint の button type 漏れ検出に該当）。
+- `text-muted` を維持し URL リンク（`text-primary`）と視覚的に区別する。`underline`/`hover:underline` は Tailwind コア utility なので variant が効く（`@layer components` 手書き class ではない）。
+- a11y 属性 `aria-current` は正常行の URL button と同じパターン。
+
+- [ ] **Step 2: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: エラーなし（0 errors）
+
+- [ ] **Step 3: lint（button type 漏れ検出）**
+
+Run: `npm run lint`
+Expected: エラーなし
+
+- [ ] **Step 4: ユニットテストを実行して PASS を確認**
+
+Run: `npm run test -- HarEntryList`
+Expected: PASS（全 4 テスト green）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/components/tools/HarEntryList.tsx src/components/tools/__tests__/HarEntryList.test.tsx
+git commit -m "fix: har-viewer 壊れた entry 行をクリック可能にして再選択を許可 (#701)"
+```
+
+---
+
+### Task 3: 再現シナリオの回帰 E2E を追加
+
+**Files:**
+- Modify: `tests/e2e/har-viewer.spec.ts`（`test.describe('HAR ビューア', ...)` 内の末尾に追加）
+
+- [ ] **Step 1: E2E テストを追加**
+
+`tests/e2e/har-viewer.spec.ts` の最後の `test('先頭 entry が null でも...')` ブロックの直後（`});` で describe が閉じる直前）に以下を挿入:
+
+```ts
+  test('正常 entry 選択後も壊れた行を再クリックして詳細プレースホルダを再表示できる', async ({
+    page,
+  }) => {
+    await page.goto('/tools/har-viewer');
+
+    // 先頭が壊れた entry（{}）+ 2 件目は正常（issue #701 再現データ）
+    const json = JSON.stringify({
+      log: {
+        version: '1.2',
+        creator: { name: 'test', version: '1.0' },
+        entries: [
+          {}, // 壊れた entry（先頭。auto-select で index=0 が選ばれる）
+          {
+            time: 10,
+            request: {
+              method: 'GET',
+              url: 'https://example.com/api/ok',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    });
+    await uploadHar(page, json);
+
+    // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
+    const okButton = page.getByRole('button', { name: /\/api\/ok$/ });
+    await expect(okButton).toBeVisible({ timeout: 10000 });
+
+    // 前提: 先頭の壊れ entry が auto-select され詳細プレースホルダが出る
+    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+
+    // 正常 entry をクリックして選択を移す → 詳細に正常 entry の URL が出る
+    await okButton.click();
+    await expect(page.getByText('https://example.com/api/ok')).toBeVisible();
+    // プレースホルダは消える
+    await expect(page.getByText(/詳細を表示できません/)).toHaveCount(0);
+
+    // 壊れた行（「（壊れたエントリ）」button）を再クリック → 詳細プレースホルダが再表示される。
+    // 修正前は壊れ行が button でなくクリックできないため、ここで fail する（陽性ガード）。
+    await page.getByRole('button', { name: '（壊れたエントリ）' }).click();
+    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+  });
+```
+
+- [ ] **Step 2: E2E を実行して PASS を確認**
+
+Run: `npm run test:e2e -- har-viewer`
+Expected: PASS（追加テスト含め har-viewer の全 E2E green）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add tests/e2e/har-viewer.spec.ts
+git commit -m "test: har-viewer 壊れた行の再選択 E2E を追加 (#701)"
+```
+
+---
+
+### Task 4: ドキュメント確認・更新
+
+**Files:**
+- Check: `docs/tools.md`（har-viewer の挙動記述）
+
+- [ ] **Step 1: docs/tools.md の har-viewer 記述を確認**
+
+Run: `grep -n "har-viewer\|HAR" docs/tools.md`
+har-viewer の「壊れた entry」「クリック」に関する記述があれば、「壊れた行も選択可能（プレースホルダ表示）」と整合するよう 1 行追記。記述がなければ変更不要（本変更は UI 内部の微修正でツール仕様の本質は不変）。
+
+- [ ] **Step 2: 変更があればコミット**
+
+```bash
+git add docs/tools.md
+git commit -m "docs: har-viewer 壊れた行の選択挙動を追記 (#701)"
+```
+
+変更なしの場合はこの Task をスキップ。
+
+---
+
+## Self-Review
+
+- **Spec coverage:** spec の「HarEntryList.tsx 変更」→ Task 2、「ユニットテスト更新 + 陽性対照」→ Task 1、「E2E 追加」→ Task 3、「ドキュメント」→ Task 4。全要件にタスク対応あり。
+- **Placeholder scan:** 全 code step に実コードを記載。TBD/TODO なし。
+- **Type consistency:** `onSelect(index: number)` は既存 `Props` シグネチャと一致。`selectedIndex` / `aria-current` も既存正常行と同名同型。テストの `getByRole('button', { name: '（壊れたエントリ）' })` は Task 2 で付与する button テキストと一致。

--- a/docs/superpowers/specs/2026-06-14-har-viewer-broken-row-reselect-design.md
+++ b/docs/superpowers/specs/2026-06-14-har-viewer-broken-row-reselect-design.md
@@ -1,0 +1,106 @@
+# har-viewer: 壊れた entry 行の再選択対応（issue #701）
+
+## 背景・課題
+
+`HarEntryList` は URL を持たない（request/response を欠く）壊れた entry 行を、非クリッカブルな
+`<span>（壊れたエントリ）</span>` で描画している（`src/components/tools/HarEntryList.tsx`）。
+
+- 読み込み時に先頭 entry が壊れている場合、auto-select で詳細パネルにプレースホルダが出る
+  （issue #684 / PR #700 で対応済み）。
+- しかし一度別の正常 entry をクリックして選択を移すと、**壊れた行はクリックできないため
+  二度と選択し直せない**という非対称が残る。
+
+issue #701 はこの非対称の解消方針を決めてから着手する follow-up。優先度は低（クラッシュなし）。
+
+## 方針（owner 承認済み）
+
+**壊れた行もクリック可能にして再選択できるようにする**（issue の対応案）。クリックすると
+`HarEntryDetail` の既存プレースホルダ「request / response を欠くため詳細を表示できません。」が
+出るため、auto-select の挙動と完全に一貫する。
+
+検討した代替案:
+
+- **auto-select が壊れ行を回避**: 読み込み時に最初の正常 entry を選ぶ案。プレースホルダを auto でも
+  出さない方向だが、PR #700 が陽性 E2E で固定した「先頭 null でもプレースホルダ表示」の意図と衝突し、
+  既存テストの書き換えが必要になるため不採用。
+- **wontfix クローズ**: 既存仕様の範囲だが、再選択不能は明確な UX バグであり owner が対応を選択。
+
+## 設計
+
+### 変更対象
+
+- `src/components/tools/HarEntryList.tsx`（本体）
+- `src/components/tools/__tests__/HarEntryList.test.tsx`（既存 assert 更新 + 陽性対照追加）
+- `tests/e2e/har-viewer.spec.ts`（再現シナリオの回帰 E2E 追加）
+
+### HarEntryList.tsx の変更
+
+`url == null` の分岐で描画している `<span>` を、`onSelect(i)` を呼ぶ `<button>` に置き換える。
+
+```tsx
+// before
+<span className="text-muted">（壊れたエントリ）</span>
+
+// after
+<button
+  type="button"
+  aria-current={selectedIndex === i ? 'true' : undefined}
+  className="text-left text-muted underline-offset-2 hover:underline"
+  onClick={() => onSelect(i)}
+>
+  （壊れたエントリ）
+</button>
+```
+
+- **affordance**: 正常行の URL ボタン（`text-primary` + `hover:underline`）と区別するため
+  `text-muted` を維持。クリック可能性は `hover:underline` で示す（`underline` は Tailwind コア
+  utility なので `hover:` variant が効く。`@layer components` 手書き class ではないため
+  variant 非対応問題には該当しない）。
+- **選択状態**: `aria-current` を正常行と同様に付与。行ハイライト（`bg-active`）は既存の `<tr>`
+  側ロジックでそのまま効く。
+- **対象**: `{}`・`null`・`url 欠落 request` のすべての `url == null` 行。これらは auto-select が
+  land する index と一致するため、これで非対称が解消する。
+
+`type="button"` は必須（lint で button type 漏れ検出あり）。
+
+### データフロー
+
+クリック → `onSelect(i)` → `HarViewer.setSelectedIndex(i)` → `selectedEntry` が壊れた entry →
+`HarEntryDetail` が既存プレースホルダを描画。auto-select 経路と同一。
+
+## テスト
+
+### ユニット（HarEntryList.test.tsx）
+
+既存テストが新挙動と矛盾するため更新する:
+
+- 「壊れた entry の URL セルは選択 button を持たない」（現在 `getAllByRole('button')` が
+  `toHaveLength(2)`）→ **新挙動に合わせて更新**。4 件中、url を持つ 2 行（ok / noresp）+
+  壊れた 2 行（{} / null）= 計 4 button になる。
+- **陽性対照を追加**: 壊れた行（「（壊れたエントリ）」button）をクリックすると `onSelect` が
+  その index で呼ばれることを `vi.fn()` で検証。これを欠くと「button にしたが onSelect 未配線」の
+  回帰を検知できない。
+- 「（壊れたエントリ）」テキストが button の accessible name として残ることを確認。
+
+### E2E（har-viewer.spec.ts）
+
+issue の再現シナリオを回帰ガードとして追加:
+
+1. 先頭が壊れた entry（`{}` または `null`）+ 正常 entry を含む HAR を読み込む。
+2. auto-select で詳細プレースホルダが出ることを確認（前提）。
+3. 正常 entry をクリックして選択を移す → 詳細に正常 entry の URL が出る。
+4. 壊れた行（「（壊れたエントリ）」button）を再クリック → 詳細プレースホルダが再表示される。
+
+修正前は手順 4 の button が存在せずクリックできないため、この E2E は fail する（陽性ガード）。
+
+## スコープ外
+
+- `HarEntryDetail` のプレースホルダ文言。
+- `HarViewer` の auto-select ロジック。
+- 他コンポーネント・VRT baseline（DOM 構造は button 化のみで視覚差は hover 時のみ。
+  既存ページの静止 screenshot には影響しない想定。CI VRT で確認）。
+
+## 検証
+
+push 前に必須: `npm run test`（ユニット）/ `node_modules/.bin/astro check`（型）/
+`npm run test:e2e`（E2E）。`npm run lint`（button type 漏れ検出）も実行。

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -607,7 +607,7 @@ YAML・JSON・TOML・.env を相互変換する。各フォーマットを中間
   - **`data:` URL は scrubText を適用しない**（#695）。`data:image/png;base64,...` のようなペイロードに `HIGH_ENTROPY_BASE64` が誤マッチして base64 を `[REDACTED]` に置換しデコード不能にする破壊を防ぐ
   - over-masking 方針: パス/ヘッダ内の IP・メール・高エントロピー文字列も redact されうるが、host は保持され漏えい方向ではなく安全側。詳細は `docs/decisions.md`
   - **本文スキャンのスキップ拡張**: `encoding === 'base64'` に加え、`content.mimeType` がバイナリ系（`image/*`・`audio/*`・`video/*`・`font/*`・`application/octet-stream`・`pdf`・`zip` 等）なら encoding 欄が無くてもスキップし、`HIGH_ENTROPY_BASE64` による本文破壊を防ぐ
-- 防御的処理: JSON として妥当でも `request`/`response` を欠く壊れた entry は例外を投げずスキップする（`sanitizeHar` はレンダリング中の `useMemo` で走るため、throw すると画面が落ちる）
+- 防御的処理: JSON として妥当でも `request`/`response` を欠く壊れた entry は例外を投げずスキップする（`sanitizeHar` はレンダリング中の `useMemo` で走るため、throw すると画面が落ちる）。一覧（`HarEntryList`）では壊れた行を「（壊れたエントリ）」プレースホルダのクリック可能 button として描画し、クリックすると詳細パネルにプレースホルダを表示する（正常 entry 選択後に壊れた行を再クリックしても詳細が切り替わる、issue #701）
 - 一貫トークン化: `makeTokenizer` がカテゴリ × 値 → `[REDACTED:COOKIE_1]` 等のプレースホルダを発行する。同一値には同一プレースホルダを割り当て、HAR 全体で値の同一性が保たれる。**ただしこの HAR 全体一貫性は構造的 redact（tokenize 由来）に限る**。`scrubText` 由来の redaction（本文・辞書外ヘッダ・URLパス等）は呼び出しごとに採番されるため、異なるフィールドに跨る同一秘密値の一貫トークン化は保証されない（安全側であり漏えいはしない）
 - 純関数・入力非破壊: `structuredClone` でディープコピーしてから処理するため元オブジェクトを mutate しない
 - parse + sanitize は **Web Worker**（`src/workers/harSanitizer.worker.ts`）で実行する。`sanitizeHar` は `structuredClone` + 全 response body の正規表現スキャンで中規模 HAR でも数秒かかり、メインスレッド同期実行だと「ページが応答しません」になる（issue #677）。worker に逃がしメインスレッドを固めない。worker は parse 済み HAR を保持し、redact トグル時は再 parse せず sanitize のみ再実行する

--- a/src/components/tools/HarEntryList.tsx
+++ b/src/components/tools/HarEntryList.tsx
@@ -73,7 +73,14 @@ export function HarEntryList({ entries, selectedIndex, onSelect }: Props) {
                       {shortUrl(url)}
                     </button>
                   ) : (
-                    <span className="text-muted">（壊れたエントリ）</span>
+                    <button
+                      type="button"
+                      aria-current={selectedIndex === i ? 'true' : undefined}
+                      className="text-left text-muted underline-offset-2 hover:underline"
+                      onClick={() => onSelect(i)}
+                    >
+                      （壊れたエントリ）
+                    </button>
                   )}
                 </td>
                 <td className="whitespace-nowrap px-3 py-1.5 font-mono">

--- a/src/components/tools/__tests__/HarEntryList.test.tsx
+++ b/src/components/tools/__tests__/HarEntryList.test.tsx
@@ -53,19 +53,24 @@ describe('HarEntryList 壊れた entry のガード', () => {
     expect(screen.getByRole('button', { name: 'example.com/api/ok' })).toBeTruthy();
   });
 
-  it('壊れた entry 行はプレースホルダを表示し URL ボタンを描画しない', () => {
+  it('壊れた entry 行はプレースホルダ文言の button を描画する', () => {
     render(<HarEntryList entries={entries} selectedIndex={null} onSelect={() => {}} />);
-    // 「壊れたエントリ」プレースホルダが request 欠落行に出る（{} と null の 2 行）
+    // 「（壊れたエントリ）」プレースホルダが request 欠落行に出る（{} と null の 2 行）
     expect(screen.getAllByText('（壊れたエントリ）').length).toBeGreaterThanOrEqual(2);
-    // request はあるが response 欠落の行は URL ボタンを描画する（クリック可能）
-    expect(screen.getByRole('button', { name: 'example.com/api/noresp' })).toBeTruthy();
+    // url を持つ行（ok / noresp）と壊れ行（{} / null）すべてが button（計 4 つ）
+    expect(screen.getAllByRole('button')).toHaveLength(4);
+    // 壊れ行「（壊れたエントリ）」も accessible name を持つ button として取得できる
+    expect(screen.getAllByRole('button', { name: '（壊れたエントリ）' })).toHaveLength(2);
   });
 
-  it('壊れた entry の URL セルは選択 button を持たない', () => {
+  it('壊れた entry 行クリックでその index の onSelect が呼ばれる（再選択可能）', () => {
     const onSelect = vi.fn();
     render(<HarEntryList entries={entries} selectedIndex={null} onSelect={onSelect} />);
-    // URL ボタンは正常 entry(ok) と response欠落(noresp) の 2 つだけ（{}/null は非ボタン）
-    const buttons = screen.getAllByRole('button');
-    expect(buttons).toHaveLength(2);
+    // 壊れ行は {} (index 1) と null (index 2)。先頭の壊れ行をクリック。
+    const brokenButtons = screen.getAllByRole('button', { name: '（壊れたエントリ）' });
+    brokenButtons[0].click();
+    expect(onSelect).toHaveBeenCalledWith(1);
+    brokenButtons[1].click();
+    expect(onSelect).toHaveBeenCalledWith(2);
   });
 });

--- a/tests/e2e/har-viewer.spec.ts
+++ b/tests/e2e/har-viewer.spec.ts
@@ -254,4 +254,51 @@ test.describe('HAR ビューア', () => {
     // 修正前は selectedEntry が falsy で詳細パネル自体が描画されず、この assert は fail する（陽性ガード）。
     await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
   });
+
+  test('正常 entry 選択後も壊れた行を再クリックして詳細プレースホルダを再表示できる', async ({
+    page,
+  }) => {
+    await page.goto('/tools/har-viewer');
+
+    // 先頭が壊れた entry（{}）+ 2 件目は正常（issue #701 再現データ）
+    const json = JSON.stringify({
+      log: {
+        version: '1.2',
+        creator: { name: 'test', version: '1.0' },
+        entries: [
+          {}, // 壊れた entry（先頭。auto-select で index=0 が選ばれる）
+          {
+            time: 10,
+            request: {
+              method: 'GET',
+              url: 'https://example.com/api/ok',
+              headers: [],
+              queryString: [],
+              cookies: [],
+            },
+            response: { status: 200, headers: [], cookies: [], content: {} },
+          },
+        ],
+      },
+    });
+    await uploadHar(page, json);
+
+    // 正常 entry が一覧に描画される（React island がクラッシュしていない陽性対照）
+    const okButton = page.getByRole('button', { name: /\/api\/ok$/ });
+    await expect(okButton).toBeVisible({ timeout: 10000 });
+
+    // 前提: 先頭の壊れ entry が auto-select され詳細プレースホルダが出る
+    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+
+    // 正常 entry をクリックして選択を移す → 詳細に正常 entry の URL が出る
+    await okButton.click();
+    await expect(page.getByText('https://example.com/api/ok')).toBeVisible();
+    // プレースホルダは消える
+    await expect(page.getByText(/詳細を表示できません/)).toHaveCount(0);
+
+    // 壊れた行（「（壊れたエントリ）」button）を再クリック → 詳細プレースホルダが再表示される。
+    // 修正前は壊れ行が button でなくクリックできないため、ここで fail する（陽性ガード）。
+    await page.getByRole('button', { name: '（壊れたエントリ）' }).click();
+    await expect(page.getByText(/詳細を表示できません/)).toBeVisible();
+  });
 });


### PR DESCRIPTION
## 概要

issue #701 の対応。`HarEntryList` の壊れた entry 行（URL を持たない = request/response を欠く行）をクリック可能にし、auto-select 後に再選択できない非対称を解消する。

## 背景

- 読み込み時に先頭 entry が壊れている場合、auto-select で詳細パネルにプレースホルダが出る（#684 / PR #700 で対応済み）。
- しかし一度別の正常 entry をクリックして選択を移すと、**壊れた行は非クリッカブルな `<span>` だったため二度と選択し直せない**非対称が残っていた。

## 方針（owner 承認済み）

ブレインストーミングで以下を決定（issue が方針決定を follow-up に委ねていたため）:

- 壊れた行も `onSelect(i)` を呼ぶ `<button>` にして再選択可能にする（issue の対応案）。
- クリックすると `HarEntryDetail` の既存プレースホルダ「request / response を欠くため詳細を表示できません。」が出るため、auto-select の挙動と完全に一貫する。

代替案（auto-select が壊れ行を回避 / wontfix）は、PR #700 の陽性 E2E の意図と衝突する・UX バグを放置する等の理由で不採用。設計・計画の詳細は `docs/superpowers/specs/` と `docs/superpowers/plans/` に記録。

## 変更内容

- **`src/components/tools/HarEntryList.tsx`**: 壊れた行の `<span>（壊れたエントリ）</span>` を `<button onClick={() => onSelect(i)}>` に置換。URL リンク（`text-primary`）と区別するため `text-muted` を維持し、クリック可能性は `hover:underline` で示す。正常行同様に `aria-current` を付与。`type="button"` 明示。
- **`src/components/tools/__tests__/HarEntryList.test.tsx`**: 既存 assert を新挙動に更新（button 数 2 → 4）。**陽性対照**として壊れた行クリックで `onSelect` がその index で呼ばれることを検証するテストを追加。
- **`tests/e2e/har-viewer.spec.ts`**: 再現シナリオの回帰 E2E を追加（auto-select でプレースホルダ → 正常 entry 選択 → 壊れた行を再クリック → プレースホルダ再表示）。修正前は壊れ行が button でなくクリック不能のため fail する陽性ガード。
- **`docs/tools.md`**: har-viewer の防御的処理の記述に壊れた行の選択挙動を追記。

## 検証

- `npm run test -- HarEntryList` → PASS（4 件）
- `node_modules/.bin/astro check` → 0 errors / 0 warnings / 0 hints
- `npm run lint` → エラーなし
- `npm run test:e2e -- har-viewer` → PASS（7 件、新規回帰テスト含む）

## スコープ外

- `HarEntryDetail` のプレースホルダ文言・`HarViewer` の auto-select ロジックは不変。
- VRT baseline: button 化による視覚差は hover 時のみで静止 screenshot に影響しない想定（CI VRT で確認）。

Closes #701

https://claude.ai/code/session_01U7NhUK9foks3oAWVJNxbgG

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7NhUK9foks3oAWVJNxbgG)_