### PR TITLE
fix: HarLog.entries を null 要素対応の型に正す (#702)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-har-entries-null-type.md
+++ b/docs/superpowers/plans/2026-06-14-har-entries-null-type.md
@@ -24,6 +24,7 @@
 ### Task 1: 中核型と境界 prop 型を null 要素対応に変更
 
 **Files:**
+
 - Modify: `src/utils/har/types.ts:69`
 - Modify: `src/components/tools/HarEntryList.tsx:4`
 
@@ -61,6 +62,7 @@ Expected: `src/utils/har/__tests__/sanitize.test.ts` と `src/utils/har/__tests_
 ### Task 2: テストの非 null アクセスに `!` を付与
 
 **Files:**
+
 - Modify: `src/utils/har/__tests__/sanitize.test.ts`
 - Modify: `src/utils/har/__tests__/parse.test.ts`
 
@@ -87,6 +89,7 @@ expect(har.log.entries[0]!.request.postData!.text)...
 ```
 
 注意:
+
 - `entries[0]` 直後にのみ `!` を挿入する。`.request` / `.response` 以降の既存 `!`（`postData!` / `redirectURL!` 等）は維持する。
 - `entries[0]` を経由しないアクセス（例: `out.log.entries.length` のような配列メソッド）は変更しない。
 - これは挙動不変の機械的変更。fixture は必ず該当インデックスの entry を持つため `!` は安全。

--- a/docs/superpowers/plans/2026-06-14-har-entries-null-type.md
+++ b/docs/superpowers/plans/2026-06-14-har-entries-null-type.md
@@ -1,0 +1,122 @@
+# har-viewer entries 型 null 対応 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `HarLog.entries` を `(HarEntry | null)[]` に正し、runtime の null ガードと型を一致させる（issue #702）。
+
+**Architecture:** 中核型（`HarLog.entries`）と境界 prop 型（`HarEntryList.Props.entries`）を null 要素対応に変更。コンポーネント内部・worker・parse は既に防御済みでロジック変更なし。型変更で発生するテストの非 null アクセスエラーを `!`（non-null assertion）で機械的に吸収する。
+
+**Tech Stack:** TypeScript, Astro, React, Vitest。型チェックは `node_modules/.bin/astro check`、テストは `npm run test`。
+
+---
+
+## File Structure
+
+- Modify: `src/utils/har/types.ts` — `HarLog.entries` の型
+- Modify: `src/components/tools/HarEntryList.tsx` — `Props.entries` の型
+- Modify: `src/utils/har/__tests__/sanitize.test.ts` — 非 null アクセスに `!` 付与
+- Modify: `src/utils/har/__tests__/parse.test.ts` — 非 null アクセスに `!` 付与
+
+`HarViewer.tsx` / `harSanitizer.worker.ts` / `parse.ts` / `HarEntryDetail.tsx` は変更不要（spec の「消費側の追従」参照）。
+
+---
+
+### Task 1: 中核型と境界 prop 型を null 要素対応に変更
+
+**Files:**
+- Modify: `src/utils/har/types.ts:69`
+- Modify: `src/components/tools/HarEntryList.tsx:4`
+
+- [ ] **Step 1: `HarLog.entries` の型を変更**
+
+`src/utils/har/types.ts` の `HarLog` インターフェース内の該当行:
+
+```ts
+// 変更前
+  entries: HarEntry[];
+// 変更後
+  entries: (HarEntry | null)[];
+```
+
+- [ ] **Step 2: `HarEntryList.Props.entries` の型を変更**
+
+`src/components/tools/HarEntryList.tsx` の `Props` インターフェース内の該当行:
+
+```ts
+// 変更前
+  entries: HarEntry[];
+// 変更後
+  entries: (HarEntry | null)[];
+```
+
+内部ロジック（`entries.map((e, i) => { const request = e?.request; ... })`）は既に optional chaining で防御済みのため変更しない。
+
+- [ ] **Step 3: 型チェックを実行し、テスト側のエラーのみが残ることを確認**
+
+Run: `node_modules/.bin/astro check`
+Expected: `src/utils/har/__tests__/sanitize.test.ts` と `src/utils/har/__tests__/parse.test.ts` で「Object is possibly 'null'」系のエラーが出る（src 本体・HarViewer・worker ではエラーが出ない）。本体側でエラーが出た場合は spec の想定外なので停止して報告する。
+
+---
+
+### Task 2: テストの非 null アクセスに `!` を付与
+
+**Files:**
+- Modify: `src/utils/har/__tests__/sanitize.test.ts`
+- Modify: `src/utils/har/__tests__/parse.test.ts`
+
+- [ ] **Step 1: `astro check` の出力からエラー箇所を列挙**
+
+Run: `node_modules/.bin/astro check 2>&1 | grep -E "sanitize.test|parse.test"`
+
+各エラー行の `…entries[N].xxx` を `…entries[N]!.xxx` に修正する（`N` はそのテストが構築した fixture のインデックス）。
+
+例:
+
+```ts
+// 変更前
+const auth = har.log.entries[0].request.headers.find((h) => h.name === 'Authorization');
+// 変更後
+const auth = har.log.entries[0]!.request.headers.find((h) => h.name === 'Authorization');
+```
+
+```ts
+// 変更前
+expect(har.log.entries[0].request.postData!.text)...
+// 変更後（既存の postData! はそのまま、entries[0] にのみ ! を追加）
+expect(har.log.entries[0]!.request.postData!.text)...
+```
+
+注意:
+- `entries[0]` 直後にのみ `!` を挿入する。`.request` / `.response` 以降の既存 `!`（`postData!` / `redirectURL!` 等）は維持する。
+- `entries[0]` を経由しないアクセス（例: `out.log.entries.length` のような配列メソッド）は変更しない。
+- これは挙動不変の機械的変更。fixture は必ず該当インデックスの entry を持つため `!` は安全。
+
+- [ ] **Step 2: 型チェックを再実行しエラーがゼロになることを確認**
+
+Run: `node_modules/.bin/astro check`
+Expected: エラー 0 件。
+
+- [ ] **Step 3: ユニットテストを実行し全 green を確認**
+
+Run: `npm run test`
+Expected: 全テスト PASS（挙動不変）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/utils/har/types.ts src/components/tools/HarEntryList.tsx src/utils/har/__tests__/sanitize.test.ts src/utils/har/__tests__/parse.test.ts
+git commit -m "fix: HarLog.entries を null 要素対応の型に正す (#702)"
+```
+
+---
+
+## 検証（最終）
+
+- `node_modules/.bin/astro check`: 型エラーゼロ。
+- `npm run test`: 全 green。
+- UI 変更なしのため `npm run test:e2e` / VRT・目視確認は対象外（型のみの変更）。
+
+## 注意
+
+- ドキュメント（`README.md` / `SPEC.md`）更新は不要（ツール追加・挙動変更ではない）。
+- spec: `docs/superpowers/specs/2026-06-14-har-entries-null-type-design.md`

--- a/docs/superpowers/specs/2026-06-14-har-entries-null-type-design.md
+++ b/docs/superpowers/specs/2026-06-14-har-entries-null-type-design.md
@@ -1,0 +1,79 @@
+# har-viewer: HarLog.entries の型を null 要素対応に正す（issue #702）
+
+## 背景
+
+HAR の `entries` 配列は手編集・切り詰めにより `null` 要素を含みうる。runtime は既に防御済み:
+
+- `sanitize.ts:286` の sanitize ループは `if (typeof entry !== 'object' || entry === null) continue;` で null をガード。
+- `HarEntryList` は `e?.request` の optional chaining で null 要素を処理。
+- PR #700 で `HarEntryDetail.Props.entry` を `HarEntry | null | undefined` に正した。
+
+にもかかわらず中核型は `HarLog.entries: HarEntry[]`（非 null 配列）のまま残り、runtime の防御コードと型が食い違っている。issue #702 はこの型不整合の解消を求める。
+
+## 方針
+
+issue が提示した 2 案のうち **案1（中核型を正す）** を採用（owner 判断）。最も正確で、runtime ガードと型が一致する。代償としてテストの非 null アクセスに `!` 付与が必要だが機械的変更で挙動不変。
+
+## 変更内容
+
+### 1. 中核型
+
+`src/utils/har/types.ts`:
+
+```ts
+export interface HarLog {
+  version?: string;
+  entries: (HarEntry | null)[]; // ← HarEntry[] から変更
+  [key: string]: unknown;
+}
+```
+
+### 2. 境界 prop 型
+
+`src/components/tools/HarEntryList.tsx`:
+
+```ts
+interface Props {
+  entries: (HarEntry | null)[]; // ← HarEntry[] から変更
+  selectedIndex: number | null;
+  onSelect: (index: number) => void;
+}
+```
+
+コンポーネント内部は既に `e?.request` / `e?.response` / `e?.time` で防御済みのため**ロジック変更なし**。
+
+### 3. 消費側の追従
+
+- `HarViewer.tsx:81` `result.har.log.entries[selectedIndex]` は `HarEntry | null` になり、`HarEntryDetail`（`HarEntry | null | undefined` 受け）にそのまま渡せる → **変更不要**。
+- `HarViewer.tsx:155` `entries={result.har.log.entries}` は新 Props 型と一致 → **変更不要**。
+- `harSanitizer.worker.ts:34` `parsed.log.entries.length` は配列の length なので影響なし → **変更不要**。
+- `parse.ts` の検証ロジック（配列であることのみ確認）は影響なし → **変更不要**。
+
+### 4. テストの追従（機械的）
+
+`har.log.entries[0].request...` 形式の非 optional アクセスは `entries[0]` が `HarEntry | null` になり型エラーになる。`entries[0]!.request...` のように `!`（non-null assertion）を付与する。
+
+- `src/utils/har/__tests__/sanitize.test.ts`: 約 38 箇所
+- `src/utils/har/__tests__/parse.test.ts`: 1 箇所
+
+これらは「`entries[0]` が存在する fixture を自分で構築している」テスト前提を `!` で明示するもので、挙動は不変。正確な箇所と件数は `astro check` の出力で確定する。
+
+`HarEntryList.test.tsx` / `HarEntryDetail.test.tsx` は `entries: [...]` リテラルを component に渡す形であり、リテラル `HarEntry[]` は `(HarEntry | null)[]` に代入可能なため**影響なし**。
+
+## 検証
+
+- `node_modules/.bin/astro check`: 型エラーゼロ。
+- `npm run test`: 全 green（挙動不変）。
+- UI 変更なしのため VRT・目視確認は対象外。
+
+## スコープ外
+
+- rules / sanitize のロジック変更。
+- `HarEntryDetail` のさらなる型変更（PR #700 で対応済み）。
+- 新規ヘルパー（`firstEntry(har)` 等）の導入。テスト churn を `!` で吸収する方針のため不採用。
+- `README.md` / `SPEC.md` 更新（ツール追加・挙動変更ではなく型の正確性のみ）。
+
+## 補足
+
+- 優先度: 低（runtime は防御済みでバグはない・型の正確性のみ）。
+- 出典: PR #700 レビュー（owner）指摘2 の follow-up。

--- a/src/components/tools/HarEntryList.tsx
+++ b/src/components/tools/HarEntryList.tsx
@@ -1,7 +1,7 @@
 import type { HarEntry } from '@/utils/har';
 
 interface Props {
-  entries: HarEntry[];
+  entries: (HarEntry | null)[];
   selectedIndex: number | null;
   onSelect: (index: number) => void;
 }

--- a/src/utils/har/__tests__/parse.test.ts
+++ b/src/utils/har/__tests__/parse.test.ts
@@ -26,7 +26,7 @@ describe('parseHar', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.har.log.entries).toHaveLength(1);
-      expect(result.har.log.entries[0].request.method).toBe('GET');
+      expect(result.har.log.entries[0]!.request.method).toBe('GET');
     }
   });
 

--- a/src/utils/har/__tests__/sanitize.test.ts
+++ b/src/utils/har/__tests__/sanitize.test.ts
@@ -60,7 +60,7 @@ const ALL_OFF = {
 describe('sanitizeHar', () => {
   it('陽性対照: Cookie 値が redact される', () => {
     const { har } = sanitizeHar(makeHar(), ALL_ON);
-    const e = har.log.entries[0];
+    const e = har.log.entries[0]!;
     expect(e.request.cookies[0].value).not.toBe('deadbeefcookie');
     expect(e.request.cookies[0].value).toMatch(/REDACTED/);
     const cookieHeader = e.request.headers.find((h) => h.name === 'Cookie');
@@ -71,13 +71,13 @@ describe('sanitizeHar', () => {
 
   it('陽性対照: 認証ヘッダ値が redact される', () => {
     const { har } = sanitizeHar(makeHar(), ALL_ON);
-    const auth = har.log.entries[0].request.headers.find((h) => h.name === 'Authorization');
+    const auth = har.log.entries[0]!.request.headers.find((h) => h.name === 'Authorization');
     expect(auth?.value).not.toContain('abc.def.ghi');
   });
 
   it('陽性対照: 機密クエリ値が redact され URL からも消える', () => {
     const { har } = sanitizeHar(makeHar(), ALL_ON);
-    const e = har.log.entries[0];
+    const e = har.log.entries[0]!;
     const tokenQ = e.request.queryString.find((q) => q.name === 'token');
     expect(tokenQ?.value).not.toBe('SECRETTOKEN123');
     expect(e.request.url).not.toContain('SECRETTOKEN123');
@@ -88,14 +88,14 @@ describe('sanitizeHar', () => {
 
   it('陽性対照: POST ボディの機密 param と本文が redact される', () => {
     const { har } = sanitizeHar(makeHar(), ALL_ON);
-    const pd = har.log.entries[0].request.postData!;
+    const pd = har.log.entries[0]!.request.postData!;
     expect(pd.params![0].value).not.toBe('myP@ssw0rd');
     expect(pd.text).not.toContain('myP@ssw0rd');
   });
 
   it('陽性対照: BODY_SCAN でレスポンスボディの API キーが redact される', () => {
     const { har } = sanitizeHar(makeHar(), ALL_ON);
-    expect(har.log.entries[0].response.content.text).not.toContain(
+    expect(har.log.entries[0]!.response.content.text).not.toContain(
       'sk-proj-abcdef1234567890abcdef1234567890ab'
     );
   });
@@ -103,7 +103,7 @@ describe('sanitizeHar', () => {
   it('陰性対照: 全カテゴリ OFF なら何も変わらない', () => {
     const original = makeHar();
     const { har, counts } = sanitizeHar(original, ALL_OFF);
-    const e = har.log.entries[0];
+    const e = har.log.entries[0]!;
     expect(e.request.cookies[0].value).toBe('deadbeefcookie');
     expect(e.request.headers.find((h) => h.name === 'Authorization')?.value).toBe(
       'Bearer abc.def.ghi'
@@ -116,13 +116,13 @@ describe('sanitizeHar', () => {
   it('入力非破壊: 元オブジェクトを mutate しない', () => {
     const original = makeHar();
     sanitizeHar(original, ALL_ON);
-    expect(original.log.entries[0].request.cookies[0].value).toBe('deadbeefcookie');
-    expect(original.log.entries[0].request.url).toContain('SECRETTOKEN123');
+    expect(original.log.entries[0]!.request.cookies[0].value).toBe('deadbeefcookie');
+    expect(original.log.entries[0]!.request.url).toContain('SECRETTOKEN123');
   });
 
   it('一貫トークン化: 同一 Cookie 値は同一プレースホルダ', () => {
     const { har } = sanitizeHar(makeHar(), ALL_ON);
-    const e = har.log.entries[0];
+    const e = har.log.entries[0]!;
     const cookieVal = e.request.cookies[0].value;
     const headerVal = e.request.headers.find((h) => h.name === 'Cookie')!.value;
     // Cookie ヘッダ "session=<redacted>" に同じプレースホルダが含まれる
@@ -132,7 +132,7 @@ describe('sanitizeHar', () => {
   it('出力が有効な JSON 構造を保つ', () => {
     const { har } = sanitizeHar(makeHar(), ALL_ON);
     expect(() => JSON.stringify(har)).not.toThrow();
-    expect(har.log.entries[0].response.status).toBe(200);
+    expect(har.log.entries[0]!.response.status).toBe(200);
   });
 
   // ── P1-1: URL を運ぶヘッダ（Referer / Location 等）のトークン漏洩防止 ──
@@ -154,9 +154,9 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    const referer = out.log.entries[0].request.headers.find((h) => h.name === 'Referer');
+    const referer = out.log.entries[0]!.request.headers.find((h) => h.name === 'Referer');
     // URL からもヘッダからも同じ秘密値が消えていること（不整合な残存がない）
-    expect(out.log.entries[0].request.url).not.toContain('SUPERSECRET12345');
+    expect(out.log.entries[0]!.request.url).not.toContain('SUPERSECRET12345');
     expect(referer?.value).not.toContain('SUPERSECRET12345');
   });
 
@@ -183,7 +183,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    const loc = out.log.entries[0].response.headers.find((h) => h.name === 'Location');
+    const loc = out.log.entries[0]!.response.headers.find((h) => h.name === 'Location');
     expect(loc?.value).not.toContain('AUTHCODE9999');
   });
 
@@ -213,7 +213,7 @@ describe('sanitizeHar', () => {
     };
     const { har: out, counts } = sanitizeHar(har, ALL_ON);
     // 本文がそのまま保持され、デコードしても壊れないこと
-    expect(out.log.entries[0].response.content.text).toBe(b64);
+    expect(out.log.entries[0]!.response.content.text).toBe(b64);
     expect(counts.BODY_SCAN).toBe(0);
   });
 
@@ -235,8 +235,8 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.url).not.toContain('secretpw');
-    expect(out.log.entries[0].request.url).toContain('@host.com/path');
+    expect(out.log.entries[0]!.request.url).not.toContain('secretpw');
+    expect(out.log.entries[0]!.request.url).toContain('@host.com/path');
   });
 
   it('退行対照: host:port を含む URL を破壊しない', () => {
@@ -258,7 +258,7 @@ describe('sanitizeHar', () => {
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
     // ポート/パスが壊れず保持される
-    expect(out.log.entries[0].request.url).toBe('https://host:8080/p@th');
+    expect(out.log.entries[0]!.request.url).toBe('https://host:8080/p@th');
   });
 
   it('陽性対照: JSON 形式 POST ボディの password が redact される（#685）', () => {
@@ -283,7 +283,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.postData!.text).not.toContain('hunter2');
+    expect(out.log.entries[0]!.request.postData!.text).not.toContain('hunter2');
   });
 
   it('陽性対照: 拡充した認証ヘッダ名（x-amz-security-token 等）が redact される（#687a）', () => {
@@ -305,7 +305,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.headers[0].value).not.toContain(secret);
+    expect(out.log.entries[0]!.request.headers[0].value).not.toContain(secret);
   });
 
   it('陽性対照: 拡充した機密クエリ名（assertion 等）が構造的に redact される（#689a）', () => {
@@ -327,7 +327,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.queryString[0].value).not.toBe(secret);
+    expect(out.log.entries[0]!.request.queryString[0].value).not.toBe(secret);
   });
 
   it('陽性対照: URL パスセグメント内のトークンが redact され host は保持される（#687c）', () => {
@@ -349,7 +349,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    const url = out.log.entries[0].request.url;
+    const url = out.log.entries[0]!.request.url;
     expect(url).not.toContain(jwt);
     expect(url).toContain('https://api.example.com/'); // host は保持
   });
@@ -373,7 +373,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.url).not.toContain(jwt);
+    expect(out.log.entries[0]!.request.url).not.toContain(jwt);
   });
 
   it('陽性対照: 辞書外ヘッダの値に含まれる JWT が scrubText で redact される（#687b）', () => {
@@ -395,7 +395,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.headers[0].value).not.toContain(jwt);
+    expect(out.log.entries[0]!.request.headers[0].value).not.toContain(jwt);
   });
 
   it('退行対照: 機密を含まない辞書外ヘッダは変更しない', () => {
@@ -416,7 +416,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.headers[0].value).toBe('ja-JP,ja;q=0.9');
+    expect(out.log.entries[0]!.request.headers[0].value).toBe('ja-JP,ja;q=0.9');
   });
 
   it('陽性対照: response.redirectURL 内のトークンが redact される（#687d）', () => {
@@ -443,7 +443,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].response.redirectURL!).not.toContain('SUPERSECRETTOKEN12345');
+    expect(out.log.entries[0]!.response.redirectURL!).not.toContain('SUPERSECRETTOKEN12345');
   });
 
   it('退行対照: encoding 欄が無くても mimeType がバイナリ系なら本文スキャンをスキップし破壊しない（#690 M-2）', () => {
@@ -470,7 +470,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out, counts } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].response.content.text).toBe(b64);
+    expect(out.log.entries[0]!.response.content.text).toBe(b64);
     expect(counts.BODY_SCAN).toBe(0);
   });
 
@@ -498,7 +498,7 @@ describe('sanitizeHar', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].response.content.text).not.toContain(jwt);
+    expect(out.log.entries[0]!.response.content.text).not.toContain(jwt);
   });
 
   // ── P2-3: 壊れた entry でクラッシュしない ──
@@ -540,7 +540,7 @@ describe('#695: data: URL を破壊しない', () => {
     };
     const { har: out, counts } = sanitizeHar(har, ALL_ON);
     // ガードが機能すれば URL は原文のまま
-    expect(out.log.entries[0].request.url).toBe(dataUrl);
+    expect(out.log.entries[0]!.request.url).toBe(dataUrl);
     // PATH_SCAN カウントは 0（base64 を誤検出しない）
     expect(counts.PATH_SCAN).toBe(0);
   });
@@ -570,7 +570,7 @@ describe('#695: data: URL を破壊しない', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].response.redirectURL).toBe(dataUrl);
+    expect(out.log.entries[0]!.response.redirectURL).toBe(dataUrl);
   });
 
   it('退行対照: 通常の https:// URL のパストークン redact は従来どおり動作する', () => {
@@ -593,8 +593,8 @@ describe('#695: data: URL を破壊しない', () => {
       },
     };
     const { har: out } = sanitizeHar(har, ALL_ON);
-    expect(out.log.entries[0].request.url).not.toContain(jwt);
-    expect(out.log.entries[0].request.url).toContain('https://api.example.com/');
+    expect(out.log.entries[0]!.request.url).not.toContain(jwt);
+    expect(out.log.entries[0]!.request.url).toContain('https://api.example.com/');
   });
 });
 
@@ -649,8 +649,8 @@ describe('#694: HEADER_SCAN / PATH_SCAN 独立制御', () => {
     };
     const enabled = { ...ALL_OFF, AUTH_HEADER: true };
     const { har: out, counts } = sanitizeHar(har, enabled);
-    const authHeader = out.log.entries[0].request.headers.find((h) => h.name === 'Authorization');
-    const customHeader = out.log.entries[0].request.headers.find(
+    const authHeader = out.log.entries[0]!.request.headers.find((h) => h.name === 'Authorization');
+    const customHeader = out.log.entries[0]!.request.headers.find(
       (h) => h.name === 'X-Custom-Trace'
     );
     // Authorization（辞書一致）は redact される
@@ -685,8 +685,8 @@ describe('#694: HEADER_SCAN / PATH_SCAN 独立制御', () => {
     };
     const enabled = { ...ALL_OFF, HEADER_SCAN: true };
     const { har: out, counts } = sanitizeHar(har, enabled);
-    const authHeader = out.log.entries[0].request.headers.find((h) => h.name === 'Authorization');
-    const customHeader = out.log.entries[0].request.headers.find(
+    const authHeader = out.log.entries[0]!.request.headers.find((h) => h.name === 'Authorization');
+    const customHeader = out.log.entries[0]!.request.headers.find(
       (h) => h.name === 'X-Custom-Trace'
     );
     // Authorization は AUTH_HEADER OFF なので（辞書一致でも）redact されない
@@ -721,7 +721,7 @@ describe('#694: HEADER_SCAN / PATH_SCAN 独立制御', () => {
     };
     const enabled = { ...ALL_OFF, QUERY: true };
     const { har: out, counts } = sanitizeHar(har, enabled);
-    const url = out.log.entries[0].request.url;
+    const url = out.log.entries[0]!.request.url;
     // 辞書一致クエリ（token）は QUERY で redact される
     expect(url).not.toContain('SECRET123');
     expect(counts.QUERY).toBeGreaterThan(0);
@@ -755,12 +755,12 @@ describe('#694: HEADER_SCAN / PATH_SCAN 独立制御', () => {
     };
     const enabled = { ...ALL_OFF, PATH_SCAN: true };
     const { har: out, counts } = sanitizeHar(har, enabled);
-    const url = out.log.entries[0].request.url;
+    const url = out.log.entries[0]!.request.url;
     // URL パスの JWT は PATH_SCAN で redact される
     expect(url).not.toContain(jwt);
     expect(counts.PATH_SCAN).toBeGreaterThan(0);
     // queryString 配列は QUERY OFF なので辞書一致 token も残る
-    expect(out.log.entries[0].request.queryString.find((q) => q.name === 'token')?.value).toBe(
+    expect(out.log.entries[0]!.request.queryString.find((q) => q.name === 'token')?.value).toBe(
       secret
     );
     expect(counts.QUERY).toBe(0);

--- a/src/utils/har/types.ts
+++ b/src/utils/har/types.ts
@@ -66,7 +66,7 @@ export interface HarEntry {
 
 export interface HarLog {
   version?: string;
-  entries: HarEntry[];
+  entries: (HarEntry | null)[];
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## 概要

issue #702 の対応。HAR の `entries` 配列は手編集・切り詰めにより `null` 要素を含みうり、runtime は既に防御済み（`sanitize.ts` の null ガード / `HarEntryList` の `e?.request` / PR #700 の `HarEntryDetail`）だが、中核型 `HarLog.entries` は `HarEntry[]`（非 null 配列）のままで型と runtime が食い違っていた。

issue が提示した 2 案のうち **案1（中核型を正す）** を採用（owner 判断）し、型を `(HarEntry | null)[]` に正した。

## 変更内容

| 種別 | ファイル | 変更 |
|---|---|---|
| 中核型 | `src/utils/har/types.ts` | `HarLog.entries: HarEntry[]` → `(HarEntry \| null)[]` |
| 境界 prop | `src/components/tools/HarEntryList.tsx` | `Props.entries` を同上に。内部は既に `e?.request` で防御済みのためロジック変更なし |
| テスト | `src/utils/har/__tests__/sanitize.test.ts`（36） / `parse.test.ts`（1） | `entries[N]` 直後に `!` を付与（計37箇所）。`!` 挿入のみの機械的変更で**挙動不変** |

`HarViewer.tsx` / `harSanitizer.worker.ts` / `parse.ts` / `HarEntryDetail.tsx` は変更不要（消費側は新型と整合）。

## 検証

- `node_modules/.bin/astro check`: **0 エラー / 0 警告**（422 ファイル）。本体側への型エラー波及なし。
- HAR 関連テスト: **51 件 pass**。
- テスト差分は `entries[N]` への `!` 挿入のみ（`]!`→`]` で削除行と完全一致）であることを検証済み＝挙動不変。
- UI・runtime 挙動の変更はないため E2E / VRT・目視確認は対象外（型の正確性のみ）。
- ガード / 検知機構の追加ではないため test-gates（陽性対照）対象外。

## スコープ外

- rules / sanitize のロジック変更、新規ヘルパー（`firstEntry` 等）導入、`HarEntryDetail` の追加変更、`README.md` / `SPEC.md` 更新（ツール追加・挙動変更ではないため）。

## 設計・計画ドキュメント

- spec: `docs/superpowers/specs/2026-06-14-har-entries-null-type-design.md`
- plan: `docs/superpowers/plans/2026-06-14-har-entries-null-type.md`

出典: PR #700 レビュー（owner）指摘2 の follow-up。

https://claude.ai/code/session_01NHVVosShtitbCfUZnKrYX2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHVVosShtitbCfUZnKrYX2)_