### PR TITLE
fix: JSONツリー表示の全展開/全折りたたみを結果ヘッダ内へ移動

### DIFF
--- a/docs/superpowers/specs/2026-06-20-json-tree-expand-buttons-placement-design.md
+++ b/docs/superpowers/specs/2026-06-20-json-tree-expand-buttons-placement-design.md
@@ -1,0 +1,76 @@
+# JSON 整形・ビューア: ツリー展開ボタンの再配置 設計
+
+- 日付: 2026-06-20
+- 対象: `src/components/tools/JsonFormatter.tsx` / `src/components/tools/JsonTreeResult.tsx`
+- 種別: UI 改善（バグ修正寄り）
+
+## 背景・課題
+
+JSON 整形・ビューアのツリー表示時、`全展開` / `全折りたたみ` ボタンが画面上部のオプション行（インデント・モード・表示切替トグルと同じ行）に置かれている。実際の操作対象である結果ツリーは画面下部にあり、ボタンとツリーが視覚的に離れているため操作しづらい。
+
+現状は「入力欄と結果欄の単一行ヘッダ（`min-h-8`）の上端を揃える（がたつき防止）」目的で、ツリー操作をヘッダではなく上部オプション行に逃がしていた（`JsonFormatter.tsx:197-199` のコメント）。本設計はこの制約を満たしたまま、ボタンを結果の隣へ移す。
+
+## ゴール
+
+- `全展開` / `全折りたたみ` を結果パネルのヘッダ内、`結果` ラベルの右隣（左寄せ）に配置する。
+- PC・スマホ両方でデザイン崩れ（はみ出し・上端ずれ）を起こさない。
+- 文言は現状維持（`全展開` / `全折りたたみ`）。
+
+## 非ゴール（スコープ外）
+
+- ボタンの文言・アイコンの刷新。
+- ツリーの展開/折りたたみロジックそのものの変更。
+- text / mask / type 表示の結果ヘッダ（`OutputField`）の変更。
+
+## 設計
+
+### 状態とハンドラの所有
+
+`treeOpen` / `treeKey` 状態と `expandAll` / `collapseAll` ハンドラは引き続き `JsonFormatter` が保持する（ツリー再マウントキーを所有しているため）。`JsonTreeResult` へは props として渡す。
+
+### `JsonTreeResult` の props 追加
+
+```ts
+/** 全展開ハンドラ。ツリーが描画されているときヘッダに「全展開」ボタンを出す。 */
+onExpandAll?: () => void;
+/** 全折りたたみハンドラ。同上で「全折りたたみ」ボタンを出す。 */
+onCollapseAll?: () => void;
+```
+
+### ヘッダのレイアウト
+
+`JsonTreeResult` のヘッダ（現 `JsonTreeResult.tsx:55-63`）を次の構造にする:
+
+```
+[結果  全展開 全折りたたみ] .......... [ダウンロード コピー]
+```
+
+- 左: `<div className="flex items-center gap-3">` で `結果` ラベルとボタン群をまとめる。
+- ボタン群は `tree`（非 null）かつ `onExpandAll` / `onCollapseAll` がある時のみ描画。`tooLarge` 時・無効 JSON 時は出さない（現状の `view==='tree' && hasResult && !treeTooLarge` と等価。`tree` が非 null なら描画対象が存在する）。
+- 右: 現状どおり `rightSlot` + `CopyButton`。
+- 外側コンテナは `flex items-center justify-between mb-3 min-h-8 gap-2` を踏襲しつつ、スマホ安全網として `flex-wrap gap-y-2` を付与。
+- ボタンの class は現状踏襲: `caption text-link-plain btn-link-plain`。
+
+### デザイン崩れの検証根拠
+
+- **PC (md+)**: 結果パネルは入力/結果行（`flex md:flex-row`）の約半幅。左右4要素は十分収まり折り返さない。`min-h-8` 単一行を保ち、入力欄ヘッダとの上端揃え（既存コメントの懸念）を維持する。
+- **スマホ (390px)**: 入力/結果行は `flex-col` で縦積みになるため、入力↔結果の上端揃え制約自体が消える。ヘッダが万一折り返しても破綻しないよう `flex-wrap gap-y-2` を安全網として付与。
+- **VRT**: ページ既定は text 表示で、両ボタンは text 表示では元々非表示。よって既定スクショは不変の見込み（実装時に Playwright で確認）。
+
+### `JsonFormatter` 側の変更
+
+- 上部オプション行のボタンブロック（`JsonFormatter.tsx:255-272`）を削除。
+- `JsonTreeResult` 呼び出しに `onExpandAll={expandAll}` / `onCollapseAll={collapseAll}` を追加。
+- `JsonFormatter.tsx:197-199` のコメントを新配置に合わせて修正（「ヘッダではなく上部オプション行に置く」→「ツリー操作は結果ヘッダ内に置く」）。
+
+## ドキュメント・テストへの影響
+
+- `docs/tools.md` / `docs/decisions.md` に配置を明記した記述があれば整合を確認・更新する。
+- E2E（`tests/e2e/json-formatter.spec.ts` / `json-formatter-tree-virtual.spec.ts`）は `getByRole('button', { name: '全展開' })` 等で参照しており、DOM 位置変更では壊れない見込み。実装後 `npm run test` / `node_modules/.bin/astro check` / `npm run test:e2e` で確認する。
+
+## 検証計画（push 前必須）
+
+1. `node_modules/.bin/astro check`（型）
+2. `npm run test`（ユニット）
+3. `npm run test:e2e`（E2E）
+4. Playwright で PC (1280x800) / スマホ (390x844) のツリー表示スクショを撮り、はみ出し・上端ずれ・タップ領域を目視確認。

--- a/docs/superpowers/specs/2026-06-20-json-tree-expand-buttons-placement-design.md
+++ b/docs/superpowers/specs/2026-06-20-json-tree-expand-buttons-placement-design.md
@@ -45,17 +45,23 @@ onCollapseAll?: () => void;
 [結果  全展開 全折りたたみ] .......... [ダウンロード コピー]
 ```
 
-- 左: `<div className="flex items-center gap-3">` で `結果` ラベルとボタン群をまとめる。
-- ボタン群は `tree`（非 null）かつ `onExpandAll` / `onCollapseAll` がある時のみ描画。`tooLarge` 時・無効 JSON 時は出さない（現状の `view==='tree' && hasResult && !treeTooLarge` と等価。`tree` が非 null なら描画対象が存在する）。
-- 右: 現状どおり `rightSlot` + `CopyButton`。
-- 外側コンテナは `flex items-center justify-between mb-3 min-h-8 gap-2` を踏襲しつつ、スマホ安全網として `flex-wrap gap-y-2` を付与。
-- ボタンの class は現状踏襲: `caption text-link-plain btn-link-plain`。
+- 左: `結果` ラベル（`shrink-0`）のみ。
+- 右: `全展開` / `全折りたたみ`（リンクボタン）→ `rightSlot`（ダウンロード）→ `CopyButton` を 1 つの `<div className="flex items-center gap-2">` に**横一列**でまとめる。
+- 展開/折りたたみは `tree`（非 null）かつ `onExpandAll` / `onCollapseAll` がある時のみ描画。`tooLarge` 時・無効 JSON 時は出さない（現状の `view==='tree' && hasResult && !treeTooLarge` と等価。`tree` が非 null なら描画対象が存在する）。
+- 外側コンテナは `flex items-center justify-between mb-3 min-h-8 gap-2`。**折り返しは禁止**（`flex-wrap` を付けない）。ヘッダを単一行 `min-h-8` に固定し、入力欄ヘッダとの上端揃えを保つ（ユーザー要望: 入力と結果の高さを揃える）。
+- ボタンの class は現状踏襲: `caption text-link-plain btn-link-plain whitespace-nowrap`。
+
+### 横幅対策（実測に基づく）
+
+結果カラムのヘッダ実効幅は、コンテンツ最大幅キャップとサイドバー表示の影響で desktop（1280〜1920）で約 404px に収束する（1024〜1280 はサイドバー表示でむしろ狭くなる）。右側 4 要素（全展開 + 全折りたたみ + ダウンロード + コピー）はそのままだと約 373px 必要で、ラベル + gap を足すと約 418px となり ~404px を超え、`結果` ラベルが 2 行に折り返してしまう。
+
+対策として **ツリー結果のコピーボタンを `compact`（アイコンのみ）** にし、右側グループ幅を約 327px に削減する。これにより 1280〜1920 で十分な余裕（約 32px）を持って単一行に収まり、960/1100/1024/390 でもヘッダ高さ 32px（単一行）を維持することを Playwright で実測確認した。`全展開` / `全折りたたみ` / `ダウンロード` のテキストラベルは保持する。
 
 ### デザイン崩れの検証根拠
 
-- **PC (md+)**: 結果パネルは入力/結果行（`flex md:flex-row`）の約半幅。左右4要素は十分収まり折り返さない。`min-h-8` 単一行を保ち、入力欄ヘッダとの上端揃え（既存コメントの懸念）を維持する。
-- **スマホ (390px)**: 入力/結果行は `flex-col` で縦積みになるため、入力↔結果の上端揃え制約自体が消える。ヘッダが万一折り返しても破綻しないよう `flex-wrap gap-y-2` を安全網として付与。
-- **VRT**: ページ既定は text 表示で、両ボタンは text 表示では元々非表示。よって既定スクショは不変の見込み（実装時に Playwright で確認）。
+- **PC（サイドバー有無を跨ぐ各幅）**: ヘッダは単一行 `min-h-8`（実測 32px）を維持し、入力欄ヘッダと上端が揃う。
+- **スマホ (390px)**: 入力/結果行は `flex-col` で縦積みになり上端揃え制約は消える。ヘッダは 390px でも単一行に収まる（実測）。
+- **VRT**: ページ既定は text 表示で、両ボタンは text 表示では元々非表示。よって既定スクショは不変（PR #725 の CI で VRT 66 件 pass を確認済み）。
 
 ### `JsonFormatter` 側の変更
 

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -168,7 +168,6 @@ export function JsonFormatter() {
 
   const effectiveOutput =
     view === 'type' ? typeOutput : view === 'mask' ? maskOutput : displayOutput;
-  const hasResult = effectiveOutput !== '';
 
   const handleClear = () => {
     reset();
@@ -196,7 +195,7 @@ export function JsonFormatter() {
 
   // 入力欄（InputField）と結果欄（OutputField / ツリー）はどちらも min-h-8 + mb-3 の
   // 単一行ヘッダを持たせ、入力前後で上端がずれない（がたつかない）ようにする。
-  // 表示切替・全展開/全折りたたみはヘッダではなく上部のオプション行に置く。
+  // 表示切替は上部オプション行に置く。ツリーの全展開/全折りたたみは結果ヘッダ内（結果ラベル右隣）に置く。
   const downloadButton = (
     <DownloadButton
       onClick={handleDownload}
@@ -208,7 +207,7 @@ export function JsonFormatter() {
 
   return (
     <div className="space-y-6">
-      {/* オプション行（上端配置。表示切替・ツリー操作もここに集約してヘッダ高さを固定する） */}
+      {/* オプション行（上端配置。表示切替をここに置きヘッダ高さを固定する） */}
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
         <div className="flex items-center gap-2">
           <span className="caption text-muted">インデント</span>
@@ -252,24 +251,6 @@ export function JsonFormatter() {
             layout="wrap"
           />
         </div>
-        {view === 'tree' && hasResult && !treeTooLarge && (
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className="caption text-link-plain btn-link-plain"
-              onClick={expandAll}
-            >
-              全展開
-            </button>
-            <button
-              type="button"
-              className="caption text-link-plain btn-link-plain"
-              onClick={collapseAll}
-            >
-              全折りたたみ
-            </button>
-          </div>
-        )}
       </div>
 
       {/* クエリ欄（JMESPath） */}
@@ -351,6 +332,8 @@ export function JsonFormatter() {
               rightSlot={downloadButton}
               tooLarge={treeTooLarge}
               onForceRender={() => setTreeForced(true)}
+              onExpandAll={expandAll}
+              onCollapseAll={collapseAll}
             />
           )}
         </div>

--- a/src/components/tools/JsonTreeResult.tsx
+++ b/src/components/tools/JsonTreeResult.tsx
@@ -28,6 +28,10 @@ interface Props {
   tooLarge?: boolean;
   /** 「ツリーを表示」押下時（ガードを解除して構築させる）。 */
   onForceRender?: () => void;
+  /** 全展開ハンドラ。ツリー描画時にヘッダへ「全展開」ボタンを出す。 */
+  onExpandAll?: () => void;
+  /** 全折りたたみハンドラ。同上で「全折りたたみ」ボタンを出す。 */
+  onCollapseAll?: () => void;
 }
 
 /**
@@ -42,6 +46,8 @@ export function JsonTreeResult({
   rightSlot,
   tooLarge,
   onForceRender,
+  onExpandAll,
+  onCollapseAll,
 }: Props) {
   const hasResult = output !== '';
   const boxRef = useRef<HTMLDivElement>(null);
@@ -52,8 +58,28 @@ export function JsonTreeResult({
   );
   return (
     <div className="w-full">
-      <div className="flex items-center justify-between mb-3 min-h-8 gap-2">
-        <span className="body-emphasis text-default">結果</span>
+      <div className="flex flex-wrap items-center justify-between mb-3 min-h-8 gap-2 gap-y-2">
+        <div className="flex items-center gap-3">
+          <span className="body-emphasis text-default">結果</span>
+          {tree && onExpandAll && onCollapseAll && (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="caption text-link-plain btn-link-plain"
+                onClick={onExpandAll}
+              >
+                全展開
+              </button>
+              <button
+                type="button"
+                className="caption text-link-plain btn-link-plain"
+                onClick={onCollapseAll}
+              >
+                全折りたたみ
+              </button>
+            </div>
+          )}
+        </div>
         {hasResult && (
           <div className="flex items-center gap-2">
             {rightSlot}

--- a/src/components/tools/JsonTreeResult.tsx
+++ b/src/components/tools/JsonTreeResult.tsx
@@ -58,32 +58,33 @@ export function JsonTreeResult({
   );
   return (
     <div className="w-full">
-      <div className="flex flex-wrap items-center justify-between mb-3 min-h-8 gap-2 gap-y-2">
-        <div className="flex items-center gap-3">
-          <span className="body-emphasis text-default">結果</span>
-          {tree && onExpandAll && onCollapseAll && (
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                className="caption text-link-plain btn-link-plain"
-                onClick={onExpandAll}
-              >
-                全展開
-              </button>
-              <button
-                type="button"
-                className="caption text-link-plain btn-link-plain"
-                onClick={onCollapseAll}
-              >
-                全折りたたみ
-              </button>
-            </div>
-          )}
-        </div>
+      {/* ヘッダは折り返さず単一行（min-h-8）に固定し、入力欄ヘッダと上端を揃える。
+          全展開/全折りたたみ・ダウンロード・コピーは結果ラベル右側に一列で並べる。
+          コピーは横幅を抑えるためツリー結果ではアイコンのみ（compact）にする。 */}
+      <div className="flex items-center justify-between mb-3 min-h-8 gap-2">
+        <span className="body-emphasis text-default shrink-0">結果</span>
         {hasResult && (
           <div className="flex items-center gap-2">
+            {tree && onExpandAll && onCollapseAll && (
+              <>
+                <button
+                  type="button"
+                  className="caption text-link-plain btn-link-plain whitespace-nowrap"
+                  onClick={onExpandAll}
+                >
+                  全展開
+                </button>
+                <button
+                  type="button"
+                  className="caption text-link-plain btn-link-plain whitespace-nowrap"
+                  onClick={onCollapseAll}
+                >
+                  全折りたたみ
+                </button>
+              </>
+            )}
             {rightSlot}
-            <CopyButton text={output} ariaLabel="整形結果をコピー" />
+            <CopyButton text={output} ariaLabel="整形結果をコピー" compact />
           </div>
         )}
       </div>


### PR DESCRIPTION
## 概要

JSON 整形・ビューアのツリー表示時、`全展開` / `全折りたたみ` ボタンが画面上部のオプション行（インデント・モード・表示切替トグルと同じ行）に置かれており、操作対象のツリー（画面下部）から離れていて使いづらかった。ボタンを結果パネルのヘッダ内、`結果` ラベルの右側へ移動した。

## 変更内容

- `JsonTreeResult` に `onExpandAll` / `onCollapseAll` props を追加し、`結果` ラベルの右側に `全展開` / `全折りたたみ` / `ダウンロード` / `コピー` を**横一列**で配置（ツリー描画時のみ展開/折りたたみを表示）。
- `JsonFormatter` 上部オプション行からボタンブロックを削除し、ハンドラを props として `JsonTreeResult` へ渡す。
- 配置意図を説明するコメントを新配置に合わせて修正。

## デザイン（高さ揃え）

- ヘッダは**折り返さない単一行 `min-h-8`** に固定し、入力欄ヘッダと上端を揃える（= 入力と結果の textarea 上端が揃う）。
- 結果カラムのヘッダ実効幅は desktop で約 404px に収束する（コンテンツ最大幅キャップ＋サイドバー表示の影響で 1024〜1280 はむしろ狭い）。4 要素をそのまま並べると約 418px 必要で `結果` ラベルが 2 行に折り返してしまうため、**ツリー結果のコピーボタンを `compact`（アイコンのみ）** にして横幅を約 327px に抑え、単一行に収めた。`全展開` / `全折りたたみ` / `ダウンロード` のテキストラベルは保持。
- Playwright で 1280 / 1100 / 1024 / 960 / 390px のヘッダ高さが全て 32px（単一行）であることを実測確認。

## 検証

- `node_modules/.bin/astro check`: 0 errors / 0 warnings / 0 hints
- `npm run test`: 2509 件 pass
- E2E: `json-formatter.spec.ts`（21）+ `json-formatter-tree-virtual.spec.ts`（4）= 25 件 pass
- Playwright で PC（各幅）/ スマホのツリー表示を目視・実測確認（はみ出し・重なり・上端ずれなし）
- VRT: 既定 text 表示では両ボタン非表示のため基準画像不変（66 件 pass 済み）

設計書: `docs/superpowers/specs/2026-06-20-json-tree-expand-buttons-placement-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)