### PR TITLE
refactor: トップページヒーローの色 arbitrary value を semantic class へ移行

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,13 +22,9 @@ const jsonLd = {
   jsonLd={jsonLd}
 >
   <!-- ヒーロー -->
-  <section
-    class="text-center px-4 py-8 bg-[var(--color-background)] border-b border-[var(--color-blue-100)]"
-  >
+  <section class="hero-section text-center px-4 py-8">
     <h1 class="mb-2 font-bold hero-heading text-default">DevTools</h1>
-    <p class="text-base leading-[1.7] tracking-[0.02em] text-[var(--color-neutral-600)]">
-      ブラウザで完結する無料の開発者ツール集
-    </p>
+    <p class="hero-lead">ブラウザで完結する無料の開発者ツール集</p>
   </section>
 
   <!-- ツール一覧 -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -814,6 +814,25 @@
     letter-spacing: 0.01em;
   }
 
+  /* トップページ hero セクションの背景 + 下境界線 (index.astro)。
+     arbitrary value (`bg-[var(--color-background)]` / `border-[var(--color-blue-100)]`) を
+     semantic class へ移行 (#289 の inline/arbitrary 撤去方針を継続)。
+     `.footer-bar` 同様に section 固有の bg + border をまとめて bake-in する。値は従来から不変。 */
+  .hero-section {
+    background: var(--color-background);
+    border-bottom: 1px solid var(--color-blue-100);
+  }
+
+  /* hero サブタイトル (index.astro): 本文サイズ + neutral-600。
+     arbitrary value (`text-[var(--color-neutral-600)]` + `leading-[1.7]` + `tracking-[0.02em]`) を
+     typography + color baked-in の semantic class へ移行 (`.text-body` の先例に追従)。値は従来から不変。 */
+  .hero-lead {
+    font-size: 1rem;
+    line-height: 1.7;
+    letter-spacing: 0.02em;
+    color: var(--color-neutral-600);
+  }
+
   /* ページ h1 見出し: about/privacy/404 の静的ページ共通 (1.75rem)。
      .section-heading (h2, 1.125rem) より一段大きい page タイトル用。
      color は .section-heading と同様 class に含めず consumer 側で text-default を併用 (issue #535)。 */


### PR DESCRIPTION
## 概要

完全版 DADS スキル（`dads-design`）を構造・コンポーネント設計の参考にしつつ、本体 `src/` を正典規約（`dads-design-system` スキル + `CLAUDE.md` §7）に沿って **DADS 準拠リファクタ**する取り組みの第一歩です。まず代表的な 1 画面（トップページ `index.astro` ヒーロー）で方針を確立します。

## 背景・方針

DADS 準拠ギャップを調査した結果、本体の真の `CLAUDE.md` §7 違反として残っていたのは **色の arbitrary value 直書き**でした（`tracking-[]` / `leading-[]` 等の typography arbitrary は §7 が許可する範囲なので対象外）。

本 PR はプロジェクトで既に確立済みの **#289（PR 7a/7b）の「Astro の inline/arbitrary `var()` → `@layer components` semantic class」移行パターン**を継続します。

- `bg-[var(--color-background)]` / `border-[var(--color-blue-100)]` → `.hero-section`
- `text-base leading-[1.7] tracking-[0.02em] text-[var(--color-neutral-600)]` → `.hero-lead`

`.footer-bar`（bg+border bake-in）・`.text-body`（typography+color bake-in）の先例に追従しています。

## 変更点

- `src/styles/global.css`: `@layer components` に `.hero-section`（背景 + 下境界線）/ `.hero-lead`（サブタイトルの typography + color）を追加
- `src/pages/index.astro`: ヒーローを semantic class へ書き換え

## 見た目への影響

**なし（純リファクタ）**。トークン値は従来から不変です。

- build 出力で CSS rule 生成を確認（`@layer components` 手書き class は §7.1 に従い build 反映を検証）
  - `.hero-section{background:var(--color-background);border-bottom:1px solid var(--color-blue-100)}`
  - `.hero-lead{letter-spacing:.02em;color:var(--color-neutral-600);font-size:1rem;line-height:1.7}`
- PC(1280x800) / スマホ(390x844) のスクショで見た目不変を目視確認

## 検証

- `npm run format` ✓
- `node_modules/.bin/astro check` ✓（0 errors / 0 warnings / 0 hints）
- `npm run build` ✓
- `npm run test` ✓（138 files / 2509 tests passed）
- VRT（E2E）は CI を最終ゲートとします

## フォーカスリングについて（補足）

DADS 公式はデュアルフォーカスリング（黒 4px + yellow-300）ですが、本体は意図的に青 2px を `:focus-visible` へ一括適用する適応値を採用済みです。a11y 上は適切に機能しているため**本 PR では変更しません**。

## 今後の横展開候補（別 PR・要合意）

- `Section.tsx` の `rounded-xl(12px) → rounded-lg(16px)`：DADS scale 準拠だが**見た目が変わる**ため、`.agents/rules/common.md` §6.8 に従い目視確認を前提とし、VRT baseline 更新を伴う別 PR とします
- ピルバッジの重複実装（`CertDecoder` / `JwtDecoder` / `TotpHotpGenerator`）→ `StatusBadge` / `ChipLabel` の size variant 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqZ4TSkjSuLcz2n21VqDRM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqZ4TSkjSuLcz2n21VqDRM)_