### PR TITLE
test: verifyTicket が timestamp 0・負値を拒否することを回帰ガード

### DIFF
--- a/docs/superpowers/plans/2026-06-26-verify-ticket-timestamp-guard.md
+++ b/docs/superpowers/plans/2026-06-26-verify-ticket-timestamp-guard.md
@@ -1,0 +1,77 @@
+# verifyTicket timestamp 0・負値 回帰ガード Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `verifyTicket` が timestamp 0・負値の署名済みチケットを `valid: false` で拒否することを回帰テストで固定する。
+
+**Architecture:** 既存実装（`src/utils/qr-ticket.ts:182` の `timestamp <= 0` ガード）の現挙動を回帰テストで固定するのみ。実装変更は行わない。陽性対照は既存の正常系テスト（`valid: true`）が担保。
+
+**Tech Stack:** Vitest, TypeScript, WebCrypto（ECDSA P-256）
+
+---
+
+### Task 1: timestamp 0・負値の回帰テストを追加
+
+**Files:**
+- Modify: `src/utils/__tests__/qr-ticket.test.ts`（`signTicket / verifyTicket` describe の末尾、現状 `297` 行目 `});` の直前に追加）
+
+**前提確認（コードは既に揃っている）:**
+- `qr-ticket.test.ts` 冒頭で `generateKeyPair`, `signTicket`, `verifyTicket`, `ticketToQrString`, `type TicketPayload` が import 済み。
+- describe `'signTicket / verifyTicket'` 内に正常系テスト（`valid: true`、陽性対照）が既存。
+
+- [ ] **Step 1: 失敗するはずのテスト2件を追加**
+
+`src/utils/__tests__/qr-ticket.test.ts` の `describe('signTicket / verifyTicket', ...)` ブロック内、最後の `it(...)`（`'任意フィールド（n, p）付きチケットの署名・検証が正しく動作する'`）の直後・describe 閉じ `});` の直前に以下を挿入する:
+
+```ts
+  it('timestamp が 0 の署名済みチケットは verifyTicket で valid: false になる', async () => {
+    const pair = await generateKeyPair();
+    const zeroTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: 0 };
+    const signed = await signTicket(zeroTs, pair.privateKey);
+    const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
+    expect(result.valid).toBe(false);
+  });
+
+  it('timestamp が負値の署名済みチケットは verifyTicket で valid: false になる', async () => {
+    const pair = await generateKeyPair();
+    const negTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: -3600 };
+    const signed = await signTicket(negTs, pair.privateKey);
+    const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
+    expect(result.valid).toBe(false);
+  });
+```
+
+- [ ] **Step 2: テストを実行して green を確認**
+
+実装は既に `timestamp <= 0` を弾くため、追加直後から PASS する（これは現挙動の固定）。
+
+Run: `npm run test -- src/utils/__tests__/qr-ticket.test.ts`
+Expected: 追加2件を含め全 PASS。
+
+- [ ] **Step 3: 陽性対照の担保を確認（test-gates）**
+
+同 describe 内の `'正常系: 署名したチケットを公開鍵で検証できる'`（`valid: true` を確認）が陽性対照として既存であることを目視確認する。「常に false を返す壊れ方」を検出できる状態であることを担保（新規追加は不要）。
+
+- [ ] **Step 4: 型チェック**
+
+Run: `node_modules/.bin/astro check`
+Expected: エラー 0。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/utils/__tests__/qr-ticket.test.ts
+git commit -m "test: verifyTicket が timestamp 0・負値を拒否することを回帰ガード"
+```
+
+---
+
+## 検証（全体）
+
+- `npm run test -- src/utils/__tests__/qr-ticket.test.ts`（該当ファイル green）
+- `node_modules/.bin/astro check`（型）
+- E2E / VRT: UI 変更なしのため対象外。
+
+## ドキュメント更新
+
+ツール追加・挙動変更ではないため README / SPEC / docs/tools.md の更新は不要。

--- a/docs/superpowers/plans/2026-06-26-verify-ticket-timestamp-guard.md
+++ b/docs/superpowers/plans/2026-06-26-verify-ticket-timestamp-guard.md
@@ -13,9 +13,11 @@
 ### Task 1: timestamp 0・負値の回帰テストを追加
 
 **Files:**
+
 - Modify: `src/utils/__tests__/qr-ticket.test.ts`（`signTicket / verifyTicket` describe の末尾、現状 `297` 行目 `});` の直前に追加）
 
 **前提確認（コードは既に揃っている）:**
+
 - `qr-ticket.test.ts` 冒頭で `generateKeyPair`, `signTicket`, `verifyTicket`, `ticketToQrString`, `type TicketPayload` が import 済み。
 - describe `'signTicket / verifyTicket'` 内に正常系テスト（`valid: true`、陽性対照）が既存。
 
@@ -24,21 +26,21 @@
 `src/utils/__tests__/qr-ticket.test.ts` の `describe('signTicket / verifyTicket', ...)` ブロック内、最後の `it(...)`（`'任意フィールド（n, p）付きチケットの署名・検証が正しく動作する'`）の直後・describe 閉じ `});` の直前に以下を挿入する:
 
 ```ts
-  it('timestamp が 0 の署名済みチケットは verifyTicket で valid: false になる', async () => {
-    const pair = await generateKeyPair();
-    const zeroTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: 0 };
-    const signed = await signTicket(zeroTs, pair.privateKey);
-    const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
-    expect(result.valid).toBe(false);
-  });
+it('timestamp が 0 の署名済みチケットは verifyTicket で valid: false になる', async () => {
+  const pair = await generateKeyPair();
+  const zeroTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: 0 };
+  const signed = await signTicket(zeroTs, pair.privateKey);
+  const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
+  expect(result.valid).toBe(false);
+});
 
-  it('timestamp が負値の署名済みチケットは verifyTicket で valid: false になる', async () => {
-    const pair = await generateKeyPair();
-    const negTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: -3600 };
-    const signed = await signTicket(negTs, pair.privateKey);
-    const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
-    expect(result.valid).toBe(false);
-  });
+it('timestamp が負値の署名済みチケットは verifyTicket で valid: false になる', async () => {
+  const pair = await generateKeyPair();
+  const negTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: -3600 };
+  const signed = await signTicket(negTs, pair.privateKey);
+  const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
+  expect(result.valid).toBe(false);
+});
 ```
 
 - [ ] **Step 2: テストを実行して green を確認**

--- a/docs/superpowers/specs/2026-06-26-verify-ticket-timestamp-guard-design.md
+++ b/docs/superpowers/specs/2026-06-26-verify-ticket-timestamp-guard-design.md
@@ -1,0 +1,45 @@
+# verifyTicket の timestamp 0・負値拒否 回帰ガード（issue #576）
+
+## 目的
+
+`verifyTicket` が「timestamp が 0 もしくは負値の署名済みチケットを `valid: false` で拒否する」ことを回帰テストで固定する。`serializeTicket` 側（timestamp 0・負値を文字列として通す）は #574 / PR #575 で既にピン止め済みであり、その対となる verify 側の回帰ガードが欠けている。両側を固定することで「serialize で通し verify で弾く」という責務分離が回帰ガードとして完結する。
+
+## 背景
+
+- PR #575 レビュー（fumtas1k）の Suggestion 由来。
+- 現状の実装: `src/utils/qr-ticket.ts:182` で `timestamp <= 0` を**署名検証より前に**弾き、`valid: false` / `error: '必須フィールドの欠落または形式が不正です'` を返す。
+- そのため本テスト追加は**実装変更を伴わない純粋なテスト追加**である（実装の現挙動を回帰ガードとして固定するのみ）。
+
+## スコープ
+
+### やること
+
+`src/utils/__tests__/qr-ticket.test.ts` の `signTicket / verifyTicket` describe 内に以下 2 ケースを追加する。
+
+1. `timestamp: 0` の署名済みチケットを `verifyTicket` に通すと `valid: false` になる
+2. `timestamp: -3600`（負値）の署名済みチケットを `verifyTicket` に通すと `valid: false` になる
+
+各ケースは `generateKeyPair` → `signTicket` → `ticketToQrString` → `verifyTicket` の実フローで検証する（issue #576 記載の完成形コードに準拠）。
+
+### やらないこと
+
+- 実装（`src/utils/qr-ticket.ts`）の変更。現挙動を固定するのみ。
+- `serializeTicket` 側のテスト追加（#574 / PR #575 で対応済み）。
+- UI 変更・新ツール追加に類する作業は一切ない（README / SPEC / docs/tools.md / VRT は対象外）。
+
+## test-gates 観点
+
+本テストは「検知機構（validator = `verifyTicket`）の回帰ガード」にあたる。陰性対照（`valid: false` を期待するケース）のみでは「`verifyTicket` が常に false を返す壊れ方」と区別できないため、陽性対照が必須。
+
+- 陽性対照は既存テスト `'正常系: 署名したチケットを公開鍵で検証できる'`（`qr-ticket.test.ts:210`、正常な未来 timestamp で `valid: true` を確認）が担保している。
+- よって陽性対照の新規追加は不要。実装時に `test-gates` skill を参照し、この担保関係を確認すること。
+
+## 検証
+
+- `npm run test`（該当テストファイルが green になること）
+- `node_modules/.bin/astro check`（型チェック）
+- E2E（`npm run test:e2e`）・VRT は UI 変更がないため対象外。
+
+## 関連
+
+- issue #576 / PR #575（#574 対応）/ #574

--- a/src/utils/__tests__/qr-ticket.test.ts
+++ b/src/utils/__tests__/qr-ticket.test.ts
@@ -302,6 +302,9 @@ describe('signTicket / verifyTicket', () => {
     const signed = await signTicket(zeroTs, pair.privateKey);
     const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
     expect(result.valid).toBe(false);
+    // timestamp<=0 ガード経路で弾かれたことを弁別する（expired フォールバックなら expired:true / ticket:payload になり通り道違いを検出できない）
+    expect(result.expired).toBe(false);
+    expect(result.ticket).toBeNull();
   });
 
   it('timestamp が負値の署名済みチケットは verifyTicket で valid: false になる', async () => {
@@ -310,5 +313,8 @@ describe('signTicket / verifyTicket', () => {
     const signed = await signTicket(negTs, pair.privateKey);
     const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
     expect(result.valid).toBe(false);
+    // timestamp<=0 ガード経路で弾かれたことを弁別する（expired フォールバックなら expired:true / ticket:payload になり通り道違いを検出できない）
+    expect(result.expired).toBe(false);
+    expect(result.ticket).toBeNull();
   });
 });

--- a/src/utils/__tests__/qr-ticket.test.ts
+++ b/src/utils/__tests__/qr-ticket.test.ts
@@ -295,4 +295,20 @@ describe('signTicket / verifyTicket', () => {
     expect(result.ticket?.n).toBe('山田 太郎');
     expect(result.ticket?.p).toBe('VIP');
   });
+
+  it('timestamp が 0 の署名済みチケットは verifyTicket で valid: false になる', async () => {
+    const pair = await generateKeyPair();
+    const zeroTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: 0 };
+    const signed = await signTicket(zeroTs, pair.privateKey);
+    const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
+    expect(result.valid).toBe(false);
+  });
+
+  it('timestamp が負値の署名済みチケットは verifyTicket で valid: false になる', async () => {
+    const pair = await generateKeyPair();
+    const negTs: TicketPayload = { e: 'ev', t: 'T-1', timestamp: -3600 };
+    const signed = await signTicket(negTs, pair.privateKey);
+    const result = await verifyTicket(ticketToQrString(signed), pair.publicKey);
+    expect(result.valid).toBe(false);
+  });
 });


### PR DESCRIPTION
## 概要

`verifyTicket` が **timestamp 0・負値の署名済みチケットを `valid: false` で拒否する**ことを回帰テストで固定します。closes #576

`serializeTicket` 側（timestamp 0・負値を文字列として通す）は #574 / PR #575 で既にピン止め済みで、その対となる verify 側の回帰ガードが欠けていました。両側を固定することで「serialize で通し verify で弾く」という責務分離が回帰ガードとして完結します。

## 変更内容

`src/utils/__tests__/qr-ticket.test.ts` の `signTicket / verifyTicket` describe に 2 ケースを追加（issue #576 記載の完成形コードに準拠）:

- `timestamp: 0` の署名済みチケット → `verifyTicket` で `valid: false`
- `timestamp: -3600`（負値）の署名済みチケット → `valid: false`

各ケースは `generateKeyPair` → `signTicket` → `ticketToQrString` → `verifyTicket` の実フローを通し、mock による bypass はありません。

## 実装変更なし

現状の実装（`src/utils/qr-ticket.ts:182` の `timestamp <= 0` を署名検証より前に弾くガード）の挙動を固定するのみで、**`qr-ticket.ts` の変更はありません**。

## test-gates 観点

検知機構（validator = `verifyTicket`）の回帰ガードのため陽性対照が必須ですが、既存テスト `'正常系: 署名したチケットを公開鍵で検証できる'`（正常な未来 timestamp で `valid: true` を確認）が担保しているため新規追加は不要です。「常に false を返す壊れ方」も検出可能な状態です。

## 検証

- `npm run test -- src/utils/__tests__/qr-ticket.test.ts` → 33 tests PASS（追加2件含む）
- `node_modules/.bin/astro check` → 0 errors / 0 warnings / 0 hints
- E2E / VRT: UI 変更がないため対象外

## 設計・計画ドキュメント

- spec: `docs/superpowers/specs/2026-06-26-verify-ticket-timestamp-guard-design.md`
- plan: `docs/superpowers/plans/2026-06-26-verify-ticket-timestamp-guard.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTYmwwq39iknHimgGtStyn)_