### PR TITLE
chore: 無効な Write 権限ルールを除去し defaultMode を auto に変更

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,7 +91,7 @@
     }
   },
   "permissions": {
-    "defaultMode": "default",
+    "defaultMode": "auto",
     "allow": [
       "Read(./**)",
       "Read(~/.claude/**)",
@@ -106,12 +106,6 @@
       "Edit(/tmp/claude/**)",
       "Edit(/tmp/claude-[0-9a-f]*/**)",
       "Edit(/var/folders/*/*/T/**)",
-      "Write(./**)",
-      "Write(/private/tmp/claude/**)",
-      "Write(/private/tmp/claude-[0-9a-f]*/**)",
-      "Write(/tmp/claude/**)",
-      "Write(/tmp/claude-[0-9a-f]*/**)",
-      "Write(/var/folders/*/*/T/**)",
       "WebFetch(domain:ai.google.dev)",
       "WebFetch(domain:code.claude.com)",
       "WebFetch(domain:docs.anthropic.com)",
@@ -187,9 +181,7 @@
     ],
     "ask": [
       "Edit(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
-      "Write(**/.claude/{*.json,*.sh,hooks/**,agents/**,skills/**,commands/**,plugins/**})",
       "Edit(./.gemini/**)",
-      "Write(./.gemini/**)",
       "Bash(git push*)",
       "Bash(git reset --hard*)",
       "Bash(git commit --amend*)",


### PR DESCRIPTION
## 概要

`.claude/settings.json` の権限ルールに含まれていた **無効な `Write(...)` ルールを除去**し、併せて **`permissions.defaultMode` を `default` → `auto`** に変更する。

## 背景

ハーネスからの警告どおり、ファイルの権限チェックは **`Edit(path)` ルールでのみ照合され、`Write(path)` ルールは無視される**（`Edit` ルールが Write ツールを含む全ファイル編集ツールをカバーするため）。`allow` / `ask` に書かれていた `Write(...)` は、いずれも直上にある同一パスの `Edit(...)` と重複しており、実効権限に寄与していなかった。

特に `ask` の `Write(**/.claude/...)` / `Write(./.gemini/**)` は「本来は確認プロンプトを出したい対象」だが、対応する `Edit(...)` 側で保護されているため、削除しても保護は維持される。

## 変更内容

- `permissions.allow` から重複 `Write(...)` 6 行を削除
  - `Write(./**)` / `Write(/private/tmp/claude/**)` / `Write(/private/tmp/claude-[0-9a-f]*/**)` / `Write(/tmp/claude/**)` / `Write(/tmp/claude-[0-9a-f]*/**)` / `Write(/var/folders/*/*/T/**)`
- `permissions.ask` から重複 `Write(...)` 2 行を削除
  - `Write(**/.claude/{...})` / `Write(./.gemini/**)`
- `permissions.defaultMode`: `"default"` → `"auto"`

## 安全性

- 削除した `Write(...)` は全て同一パスの `Edit(...)` と重複しており、**実効権限は変わらない**。
- `auto` mode でも `deny` リスト（force push・secret 操作・`rm -rf /` 等）は常にブロックされるため、破壊的操作の歯止めは維持される。
- JSON 妥当性は `node -e "JSON.parse(...)"` で確認済み。

## 影響

`defaultMode` の変更は次回セッション起動時から反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
