### PR TITLE
feat: SAMLデコーダのレビュー残余改善（issue #745 の小改善 8 項目）

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -367,12 +367,16 @@ JWT を `.` で 3 分割し、Header・Payload を base64url デコードして 
 
 #### 仕組み・アルゴリズム
 
-- 入力形式を `decode.ts` の `decodeSamlInput` で自動判定する。URL 全体なら `SAMLResponse` / `SAMLRequest` クエリパラメータを抽出（`URLSearchParams` は `+` を空白に変換し base64 を破壊するため、生クエリ文字列から自前パースし percent エンコードのまま `+` を保持する）→ 生 XML 判定 → URL デコード → base64 デコード → UTF-8 として XML と解釈できれば HTTP-POST binding、できなければ `fflate` の `decompressSync`（raw deflate/zlib/gzip 自動判定）で展開し HTTP-Redirect binding と判定する。適用した変換ステップは UI に表示する
+- 入力形式を `decode.ts` の `decodeSamlInput` で自動判定する。URL 全体なら `SAMLResponse` / `SAMLRequest` クエリパラメータを抽出（`URLSearchParams` は `+` を空白に変換し base64 を破壊するため、生クエリ文字列から自前パースし percent エンコードのまま `+` を保持する。クエリキー名が percent エンコードされている場合も比較前に `decodeURIComponent` を試みる）→ 生 XML 判定 → URL デコード → base64 デコード（`-`/`_` を含む base64url 表記は標準 base64 へ変換しパディングを補完してから decode）→ UTF-8 として XML と解釈できれば HTTP-POST binding、できなければ `fflate` の `Decompress`（ストリーミング API。raw deflate/zlib/gzip 自動判定）で展開し HTTP-Redirect binding と判定する。展開後サイズが 32MB を超えた場合は zip bomb 対策としてエラーにする（圧縮データを 64KB 単位のチャンクに分けて渡すことで、上限超過を検知した時点で残りの展開処理を打ち切る）。適用した変換ステップは UI に表示する
 - `parse.ts` が `DOMParser` で XML をパースし、`getElementsByTagNameNS` 等の名前空間 URI ベースの解決で prefix（`saml:` / `samlp:` 等）非依存に構造化する。Response は Issuer/Status/Destination と Assertion ごとの NameID・属性・Conditions・AuthnStatement・SubjectConfirmationData、AuthnRequest は Issuer/Destination/AssertionConsumerServiceURL/ProtocolBinding/NameIDPolicy/RequestedAuthnContext を抽出する。`ds:Signature` の有無・`EncryptedAssertion` の件数も検出する（存在表示のみ、検証・復号はしない）
+  - 二段階ステータス（外側 StatusCode の子にネストした内側 StatusCode）の内側コードも `statusSubCode` として抽出し、UI では Status 行の直後に表示する
+  - `AudienceRestriction` は要素ごとに `string[]`（AND される制約）として保持し、各制約内の `Audience` は OR 列挙として扱う
 - `checks.ts` の `runResponseChecks` が Response の定番チェック（Status / 有効期間 / Audience・Recipient / NameID）を現在時刻基準で実行する。`NotOnOrAfter` は SAML 仕様どおりその時刻自体を含まない排他境界（`now >= notOnOrAfter` で期限切れ）として判定する
-  - タイムゾーン指定（`Z` / `±hh:mm`）のない `NotBefore` / `NotOnOrAfter` はこの端末のローカル時刻として解釈されるため実行環境依存になる旨を警告として注記しつつ、判定自体は継続する
+  - Status が失敗の場合、内側 StatusCode があれば `外側 / 内側`（例: `Responder / RequestDenied`）の形式で併記する
+  - タイムゾーン指定（`Z` / `±hh(:mm)`）のない `NotBefore` / `NotOnOrAfter` はこの端末のローカル時刻として解釈されるため実行環境依存になる旨を警告として注記しつつ、判定自体は継続する。日付のみ形式（`YYYY-MM-DD`）は ES 仕様上 UTC (00:00Z) 解釈が確定するため、ローカル時刻の注記ではなく専用の注記を表示する
   - `Date` でパース不能な日時は「有効期間内」と誤って表示しないよう warning 扱いにする
-- `format.ts` が表示用に生 XML を整形する
+  - SP entityID 入力時の Audience 照合は、複数の `AudienceRestriction` がある場合、空でないすべての制約に entityID が含まれる場合のみ一致とする（AND 判定）
+- `format.ts` が表示用に生 XML を簡易整形する（要素・属性・テキストのみを再構成するため、タグ間に混在するテキスト（mixed content）は表示されない場合がある旨を UI に注記）
 
 #### 準拠仕様・RFC
 
@@ -383,6 +387,7 @@ JWT を `.` で 3 分割し、Header・Payload を base64url デコードして 
 - XMLDSig 署名検証・EncryptedAssertion の復号・LogoutRequest/LogoutResponse 等の他メッセージ型は非対応（署名・暗号化は存在の有無のみ表示。第2版候補）
 - ブラウザの `DOMParser` は外部エンティティを解決しないため XXE は発生しない
 - 全処理はブラウザ内で完結し、入力（Assertion に含まれる氏名・メール等の PII を含む）は外部に送信しない
+- deflate 展開後のサイズが 32MB を超える入力はエラーにする（zip bomb 対策）
 
 ## 変換・解析
 

--- a/src/components/tools/SamlDecoder.tsx
+++ b/src/components/tools/SamlDecoder.tsx
@@ -59,6 +59,15 @@ function buildSampleInput(): string {
   return btoa(bin);
 }
 
+/** 複数 AudienceRestriction は AND 判定のため、2 件以上ならグループが分かる表記にする */
+function formatAudienceRestrictions(restrictions: string[][] | undefined): string | undefined {
+  if (!restrictions) return undefined;
+  const nonEmpty = restrictions.filter((g) => g.length > 0);
+  if (nonEmpty.length === 0) return undefined;
+  if (nonEmpty.length === 1) return nonEmpty[0].join(', ');
+  return nonEmpty.map((g) => `[${g.join(', ')}]`).join(' AND ');
+}
+
 function SummaryRow({ label, value }: { label: string; value?: string }) {
   if (!value) return null;
   return (
@@ -156,7 +165,7 @@ function AssertionSection({
         <SummaryRow label="NotOnOrAfter" value={assertion.conditions?.notOnOrAfter} />
         <SummaryRow
           label="Audience"
-          value={assertion.conditions?.audiences.join(', ') || undefined}
+          value={formatAudienceRestrictions(assertion.conditions?.audienceRestrictions)}
         />
         {assertion.subjectConfirmations.map((sc, i) => (
           <SummaryRow
@@ -280,6 +289,7 @@ export function SamlDecoderTool() {
               <dl className="space-y-1">
                 <SummaryRow label="Issuer (IdP)" value={response.issuer} />
                 <SummaryRow label="Status" value={response.statusCode} />
+                <SummaryRow label="Status (内側)" value={response.statusSubCode} />
                 <SummaryRow label="StatusMessage" value={response.statusMessage} />
                 <SummaryRow label="Destination" value={response.destination} />
                 <SummaryRow label="InResponseTo" value={response.inResponseTo} />
@@ -334,13 +344,17 @@ export function SamlDecoderTool() {
           {/* 生 XML */}
           <details className="rounded-lg bg-subtle">
             <summary className="cursor-pointer p-4 body-emphasis text-default">
-              整形済み XML
+              整形済み XML（簡易整形）
             </summary>
             <div className="px-4 pb-4 space-y-2">
               <div className="flex justify-end">
                 <CopyButton text={prettyXml} label="コピー" />
               </div>
               <pre className="overflow-x-auto font-mono caption text-default">{prettyXml}</pre>
+              <p className="hint-xs text-muted">
+                簡易整形のため、タグ間に混在するテキスト（mixed
+                content）は表示されない場合があります。
+              </p>
             </div>
           </details>
 

--- a/src/utils/__tests__/saml-checks.test.ts
+++ b/src/utils/__tests__/saml-checks.test.ts
@@ -6,6 +6,7 @@ import {
   SAMPLE_RESPONSE_XML,
   FAILED_STATUS_RESPONSE_XML,
   ENCRYPTED_ASSERTION_RESPONSE_XML,
+  NESTED_STATUS_RESPONSE_XML,
 } from './saml-fixtures';
 
 function parseResponse(xml: string): SamlResponseData {
@@ -103,6 +104,13 @@ describe('runResponseChecks: 陽性対照（fail 側の検知能力を実証）'
     expect(item.detail).toContain('不一致');
   });
 
+  it('ネストした StatusCode は外側/内側コードを併記する', () => {
+    const item = byId(runResponseChecks(parseResponse(NESTED_STATUS_RESPONSE_XML)), 'status');
+    expect(item.status).toBe('error');
+    expect(item.detail).toContain('Responder / RequestDenied');
+    expect(item.detail).toContain('Authentication failed');
+  });
+
   it('EncryptedAssertion のみの Response は warning になる', () => {
     const item = byId(
       runResponseChecks(parseResponse(ENCRYPTED_ASSERTION_RESPONSE_XML)),
@@ -162,5 +170,83 @@ describe('runResponseChecks: レビュー指摘の回帰', () => {
     );
     expect(item.status).toBe('error');
     expect(item.detail).toContain('ローカル時刻');
+  });
+});
+
+describe('runResponseChecks: タイムゾーン判定の精度（陽性対照）', () => {
+  // 時のみオフセット（±hh、分なし）に置換。ES 仕様上 TZ 指定ありと解釈される。
+  // "T" 区切りだと `Date` 自体が bare hour offset を解釈できないため、Date が解釈可能な
+  // スペース区切り形式で検証する（`hasTimezone` は raw 文字列末尾の正規表現マッチのみで、
+  // 区切り文字には依存しないため、判定ロジックの検証としては妥当）
+  const HOUR_OFFSET_TZ_RESPONSE_XML = SAMPLE_RESPONSE_XML.replace(
+    'NotBefore="2026-07-16T23:55:00Z" NotOnOrAfter="2026-07-17T00:05:00Z"',
+    'NotBefore="2026-07-16 23:55:00+09" NotOnOrAfter="2026-07-17 00:05:00+09"'
+  );
+  // 上記は UTC 換算で 2026-07-16T14:55:00Z 〜 2026-07-16T15:05:00Z の窓になる
+  const HOUR_OFFSET_IN_WINDOW = new Date('2026-07-16T15:00:00Z');
+
+  it('時のみオフセット（+09）は TZ ありと判定され注記が付かない（旧実装では TZ なし扱いになり fail する）', () => {
+    const item = byId(
+      runResponseChecks(parseResponse(HOUR_OFFSET_TZ_RESPONSE_XML), {
+        now: HOUR_OFFSET_IN_WINDOW,
+      }),
+      'validity-0'
+    );
+    expect(item.status).toBe('success');
+    expect(item.detail).not.toContain('※');
+  });
+
+  // 日付のみ形式（YYYY-MM-DD）に置換。ES 仕様上 UTC (00:00Z) 解釈が確定する
+  const DATE_ONLY_RESPONSE_XML = SAMPLE_RESPONSE_XML.replace(
+    'NotBefore="2026-07-16T23:55:00Z" NotOnOrAfter="2026-07-17T00:05:00Z"',
+    'NotBefore="2026-07-16" NotOnOrAfter="2026-07-17"'
+  );
+  const DATE_ONLY_IN_WINDOW = new Date('2026-07-16T12:00:00Z');
+
+  it('日付のみ形式は UTC (00:00Z) 解釈の専用注記になり、ローカル時刻注記にはならない（陽性対照）', () => {
+    const item = byId(
+      runResponseChecks(parseResponse(DATE_ONLY_RESPONSE_XML), { now: DATE_ONLY_IN_WINDOW }),
+      'validity-0'
+    );
+    expect(item.detail).toContain('UTC (00:00Z)');
+    expect(item.detail).not.toContain('ローカル時刻');
+  });
+});
+
+describe('runResponseChecks: 複数 AudienceRestriction の AND 判定（陽性対照）', () => {
+  // 2 restriction、両方に SP entityID を含む
+  const TWO_RESTRICTIONS_BOTH_MATCH_XML = SAMPLE_RESPONSE_XML.replace(
+    '<saml:AudienceRestriction><saml:Audience>https://sp.example.com/metadata</saml:Audience></saml:AudienceRestriction>',
+    '<saml:AudienceRestriction><saml:Audience>https://sp.example.com/metadata</saml:Audience></saml:AudienceRestriction>' +
+      '<saml:AudienceRestriction><saml:Audience>https://sp.example.com/metadata</saml:Audience><saml:Audience>https://partner.example.com/metadata</saml:Audience></saml:AudienceRestriction>'
+  );
+
+  // 2 restriction、SP entityID は片方の restriction にしか含まれない
+  const TWO_RESTRICTIONS_ONE_MISMATCH_XML = SAMPLE_RESPONSE_XML.replace(
+    '<saml:AudienceRestriction><saml:Audience>https://sp.example.com/metadata</saml:Audience></saml:AudienceRestriction>',
+    '<saml:AudienceRestriction><saml:Audience>https://sp.example.com/metadata</saml:Audience></saml:AudienceRestriction>' +
+      '<saml:AudienceRestriction><saml:Audience>https://other.example.com/metadata</saml:Audience></saml:AudienceRestriction>'
+  );
+
+  it('すべての AudienceRestriction に entityID が含まれる場合は一致する', () => {
+    const item = byId(
+      runResponseChecks(parseResponse(TWO_RESTRICTIONS_BOTH_MATCH_XML), {
+        now: IN_WINDOW,
+        spEntityId: 'https://sp.example.com/metadata',
+      }),
+      'audience'
+    );
+    expect(item.status).toBe('success');
+  });
+
+  it('片方の AudienceRestriction にしか entityID が含まれない場合は不一致になる（旧 flatten 実装では誤って一致してしまい fail する）', () => {
+    const item = byId(
+      runResponseChecks(parseResponse(TWO_RESTRICTIONS_ONE_MISMATCH_XML), {
+        now: IN_WINDOW,
+        spEntityId: 'https://sp.example.com/metadata',
+      }),
+      'audience'
+    );
+    expect(item.status).toBe('error');
   });
 });

--- a/src/utils/__tests__/saml-checks.test.ts
+++ b/src/utils/__tests__/saml-checks.test.ts
@@ -213,6 +213,43 @@ describe('runResponseChecks: タイムゾーン判定の精度（陽性対照）
   });
 });
 
+describe('runResponseChecks: 年月のみ形式・混在注記（レビュー指摘の回帰、陽性対照）', () => {
+  // 年月のみ形式（YYYY-MM）に置換。末尾の "-07" が旧実装の hasTimezone 正規表現
+  // （時刻部の有無を問わず末尾 ±hh にマッチ）に誤マッチし、TZ ありと誤判定されていた
+  const YEAR_MONTH_RESPONSE_XML = SAMPLE_RESPONSE_XML.replace(
+    'NotBefore="2026-07-16T23:55:00Z" NotOnOrAfter="2026-07-17T00:05:00Z"',
+    'NotBefore="2026-07" NotOnOrAfter="2026-08"'
+  );
+  const YEAR_MONTH_IN_WINDOW = new Date('2026-07-16T12:00:00Z');
+
+  it('年月のみ形式（YYYY-MM）は UTC (00:00Z) 解釈の専用注記になる（旧実装では TZ あり誤判定で注記なしになり fail する）', () => {
+    const item = byId(
+      runResponseChecks(parseResponse(YEAR_MONTH_RESPONSE_XML), { now: YEAR_MONTH_IN_WINDOW }),
+      'validity-0'
+    );
+    expect(item.detail).toContain('UTC (00:00Z)');
+    expect(item.detail).not.toContain('ローカル時刻');
+  });
+
+  // NotBefore は日付のみ（dateOnly）、NotOnOrAfter はタイムゾーン指定なし日時（missingTimezone）
+  // という混在ケース。now は NotOnOrAfter と同じ「タイムゾーン指定なし」形式で組み立てることで、
+  // 実行環境の TZ に依存せず NotOnOrAfter との窓内関係を保つ（NO_TZ 系テストと同じ手法）
+  const MIXED_RESPONSE_XML = SAMPLE_RESPONSE_XML.replace(
+    'NotBefore="2026-07-16T23:55:00Z" NotOnOrAfter="2026-07-17T00:05:00Z"',
+    'NotBefore="2026-07-16" NotOnOrAfter="2026-07-17T00:05:00"'
+  );
+  const MIXED_IN_WINDOW = new Date('2026-07-17T00:02:00');
+
+  it('dateOnly と missingTimezone が混在する場合、UTC 注記とローカル時刻注記が両方付く（旧実装では排他分岐で UTC 注記のみになり fail する）', () => {
+    const item = byId(
+      runResponseChecks(parseResponse(MIXED_RESPONSE_XML), { now: MIXED_IN_WINDOW }),
+      'validity-0'
+    );
+    expect(item.detail).toContain('UTC (00:00Z)');
+    expect(item.detail).toContain('ローカル時刻');
+  });
+});
+
 describe('runResponseChecks: 複数 AudienceRestriction の AND 判定（陽性対照）', () => {
   // 2 restriction、両方に SP entityID を含む
   const TWO_RESTRICTIONS_BOTH_MATCH_XML = SAMPLE_RESPONSE_XML.replace(

--- a/src/utils/__tests__/saml-decode.test.ts
+++ b/src/utils/__tests__/saml-decode.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { deflateSync } from 'fflate';
+import { deflateSync, zlibSync } from 'fflate';
 import { decodeSamlInput } from '@/utils/saml';
 import { SAMPLE_RESPONSE_XML, AUTHN_REQUEST_XML, toBase64 } from './saml-fixtures';
 
@@ -113,5 +113,43 @@ describe('decodeSamlInput: レビュー指摘の回帰', () => {
     // 仕様: 実装を単純に保つため「SAMLResponse=」「SAMLRequest=」で始まる場合のみ救済する。
     // RelayState= 等が先頭に来る断片は対象外とし、通常の base64 判定にフォールスルーする。
     expect(() => decodeSamlInput('RelayState=abc&SAMLResponse=xyz')).toThrow();
+  });
+
+  it('percent エンコードされたクエリキー名（SAML%52esponse）も SAMLResponse として抽出する', () => {
+    const url = `https://sp.example.com/acs?SAML%52esponse=${encodeURIComponent(toBase64(SAMPLE_RESPONSE_XML))}`;
+    const r = decodeSamlInput(url);
+    expect(r.binding).toBe('post');
+    expect(r.xml).toContain('<samlp:Response');
+  });
+});
+
+describe('decodeSamlInput: base64url 入力の受容', () => {
+  it('base64url（- _ を含みパディングなし）を標準 base64 として解釈しデコードする', () => {
+    const std = toBase64(SAMPLE_RESPONSE_XML);
+    // フィクスチャの base64 表現が "+" を含むことを前提にしたテスト（含まれていないと
+    // "-" への変換が検知能力を証明できない）
+    expect(std).toContain('+');
+    const urlSafe = std.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const r = decodeSamlInput(urlSafe);
+    expect(r.binding).toBe('post');
+    expect(r.xml).toContain('<samlp:Response');
+    expect(r.steps).toContain('base64url を標準 base64 へ変換');
+  });
+
+  it('通常の base64（- _ を含まない）では変換ステップを追加しない', () => {
+    const r = decodeSamlInput(toBase64(SAMPLE_RESPONSE_XML));
+    expect(r.steps).not.toContain('base64url を標準 base64 へ変換');
+  });
+});
+
+describe('decodeSamlInput: deflate 展開サイズ上限（陽性対照）', () => {
+  it('展開後 32MB を超える入力はサイズ上限エラーになる', () => {
+    // ゼロ埋めは極めて高圧縮率になるため、数十 KB の入力で 40MB 超の展開結果を作れる
+    const huge = new Uint8Array(40 * 1024 * 1024);
+    const compressed = zlibSync(huge);
+    let bin = '';
+    for (const b of compressed) bin += String.fromCharCode(b);
+    const b64 = btoa(bin);
+    expect(() => decodeSamlInput(b64)).toThrow(/上限（32MB）/);
   });
 });

--- a/src/utils/__tests__/saml-decode.test.ts
+++ b/src/utils/__tests__/saml-decode.test.ts
@@ -143,10 +143,13 @@ describe('decodeSamlInput: base64url 入力の受容', () => {
 });
 
 describe('decodeSamlInput: deflate 展開サイズ上限（陽性対照）', () => {
-  it('展開後 32MB を超える入力はサイズ上限エラーになる', () => {
-    // ゼロ埋めは極めて高圧縮率になるため、数十 KB の入力で 40MB 超の展開結果を作れる
-    const huge = new Uint8Array(40 * 1024 * 1024);
-    const compressed = zlibSync(huge);
+  // 34MB のゼロ埋め圧縮 + 32MB 展開は遅い CI ランナーで vitest デフォルト 5s を超えることが
+  // あるため（PR #749 の CI で実測）、明示タイムアウトを設定する
+  it('展開後 32MB を超える入力はサイズ上限エラーになる', { timeout: 30_000 }, () => {
+    // ゼロ埋めは極めて高圧縮率になるため、数十 KB の入力で上限超の展開結果を作れる。
+    // level 1 で圧縮時間を最小化しつつ、上限 32MB を確実に超える 34MB を展開させる
+    const huge = new Uint8Array(34 * 1024 * 1024);
+    const compressed = zlibSync(huge, { level: 1 });
     let bin = '';
     for (const b of compressed) bin += String.fromCharCode(b);
     const b64 = btoa(bin);

--- a/src/utils/__tests__/saml-fixtures.ts
+++ b/src/utils/__tests__/saml-fixtures.ts
@@ -44,6 +44,51 @@ export const ENCRYPTED_ASSERTION_RESPONSE_XML = `<?xml version="1.0" encoding="U
   <saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"/></saml:EncryptedAssertion>
 </samlp:Response>`;
 
+export const NESTED_STATUS_RESPONSE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_resp5" Version="2.0" IssueInstant="2026-07-17T00:00:00Z">
+  <saml:Issuer>https://idp.example.com/metadata</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">
+      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:RequestDenied"/>
+    </samlp:StatusCode>
+    <samlp:StatusMessage>Authentication failed</samlp:StatusMessage>
+  </samlp:Status>
+</samlp:Response>`;
+
+/** prefix なし（default xmlns）の Response。prefix 非依存パースの回帰確認用 */
+export const DEFAULT_NS_RESPONSE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Response xmlns="urn:oasis:names:tc:SAML:2.0:protocol" ID="_resp6" Version="2.0" IssueInstant="2026-07-17T00:00:00Z" Destination="https://sp.example.com/acs">
+  <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">https://idp.example.com/metadata</Issuer>
+  <Status><StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></Status>
+  <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_a6" Version="2.0" IssueInstant="2026-07-17T00:00:00Z">
+    <Issuer>https://idp.example.com/metadata</Issuer>
+    <Subject>
+      <NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">taro.yamada@example.com</NameID>
+    </Subject>
+  </Assertion>
+</Response>`;
+
+/** Assertion 2 件の Response。有効期間ラベルの連番付与の回帰確認用 */
+export const TWO_ASSERTIONS_RESPONSE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_resp7" Version="2.0" IssueInstant="2026-07-17T00:00:00Z">
+  <saml:Issuer>https://idp.example.com/metadata</saml:Issuer>
+  <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+  <saml:Assertion ID="_a7-1" Version="2.0" IssueInstant="2026-07-17T00:00:00Z">
+    <saml:Issuer>https://idp.example.com/metadata</saml:Issuer>
+    <saml:Subject><saml:NameID>user1@example.com</saml:NameID></saml:Subject>
+    <saml:Conditions NotBefore="2026-07-16T23:55:00Z" NotOnOrAfter="2026-07-17T00:05:00Z">
+      <saml:AudienceRestriction><saml:Audience>https://sp.example.com/metadata</saml:Audience></saml:AudienceRestriction>
+    </saml:Conditions>
+  </saml:Assertion>
+  <saml:Assertion ID="_a7-2" Version="2.0" IssueInstant="2026-07-17T00:00:00Z">
+    <saml:Issuer>https://idp.example.com/metadata</saml:Issuer>
+    <saml:Subject><saml:NameID>user2@example.com</saml:NameID></saml:Subject>
+    <saml:Conditions NotBefore="2026-07-16T23:55:00Z" NotOnOrAfter="2026-07-17T00:05:00Z">
+      <saml:AudienceRestriction><saml:Audience>https://sp.example.com/metadata</saml:Audience></saml:AudienceRestriction>
+    </saml:Conditions>
+  </saml:Assertion>
+</samlp:Response>`;
+
 export const AUTHN_REQUEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_req1" Version="2.0" IssueInstant="2026-07-17T00:00:00Z" Destination="https://idp.example.com/sso" AssertionConsumerServiceURL="https://sp.example.com/acs" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
   <saml:Issuer>https://sp.example.com/metadata</saml:Issuer>

--- a/src/utils/__tests__/saml-parse.test.ts
+++ b/src/utils/__tests__/saml-parse.test.ts
@@ -6,6 +6,9 @@ import {
   FAILED_STATUS_RESPONSE_XML,
   ENCRYPTED_ASSERTION_RESPONSE_XML,
   AUTHN_REQUEST_XML,
+  NESTED_STATUS_RESPONSE_XML,
+  DEFAULT_NS_RESPONSE_XML,
+  TWO_ASSERTIONS_RESPONSE_XML,
 } from './saml-fixtures';
 
 describe('parseSamlXml: Response', () => {
@@ -30,7 +33,7 @@ describe('parseSamlXml: Response', () => {
     expect(a.nameIdFormat).toBe('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress');
     expect(a.conditions?.notBefore).toBe('2026-07-16T23:55:00Z');
     expect(a.conditions?.notOnOrAfter).toBe('2026-07-17T00:05:00Z');
-    expect(a.conditions?.audiences).toEqual(['https://sp.example.com/metadata']);
+    expect(a.conditions?.audienceRestrictions).toEqual([['https://sp.example.com/metadata']]);
     expect(a.authnStatements[0].sessionIndex).toBe('_s1');
     expect(a.authnStatements[0].authnContextClassRef).toContain('PasswordProtectedTransport');
     expect(a.subjectConfirmations[0].recipient).toBe('https://sp.example.com/acs');
@@ -63,6 +66,30 @@ describe('parseSamlXml: Response', () => {
     if (m.type !== 'response') throw new Error('response expected');
     expect(m.encryptedAssertionCount).toBe(1);
     expect(m.assertions).toHaveLength(0);
+  });
+
+  it('ネストした StatusCode の内側コードを statusSubCode として抽出する', () => {
+    const m = parseSamlXml(NESTED_STATUS_RESPONSE_XML);
+    if (m.type !== 'response') throw new Error('response expected');
+    expect(m.statusCode).toBe('urn:oasis:names:tc:SAML:2.0:status:Responder');
+    expect(m.statusSubCode).toBe('urn:oasis:names:tc:SAML:2.0:status:RequestDenied');
+  });
+
+  it('prefix なし（default xmlns）の Response も正常にパースする（回帰）', () => {
+    const m = parseSamlXml(DEFAULT_NS_RESPONSE_XML);
+    if (m.type !== 'response') throw new Error('response expected');
+    expect(m.issuer).toBe('https://idp.example.com/metadata');
+    expect(m.statusCode).toBe('urn:oasis:names:tc:SAML:2.0:status:Success');
+    expect(m.assertions).toHaveLength(1);
+    expect(m.assertions[0].nameId).toBe('taro.yamada@example.com');
+  });
+
+  it('Assertion 2 件をどちらも抽出する（回帰）', () => {
+    const m = parseSamlXml(TWO_ASSERTIONS_RESPONSE_XML);
+    if (m.type !== 'response') throw new Error('response expected');
+    expect(m.assertions).toHaveLength(2);
+    expect(m.assertions[0].nameId).toBe('user1@example.com');
+    expect(m.assertions[1].nameId).toBe('user2@example.com');
   });
 });
 

--- a/src/utils/saml/checks.ts
+++ b/src/utils/saml/checks.ts
@@ -19,13 +19,15 @@ export function runResponseChecks(res: SamlResponseData, opts: CheckOptions = {}
     items.push({ id: 'status', label: 'Status', status: 'success', detail: 'Success' });
   } else {
     const code = res.statusCode?.split(':').pop() ?? '不明';
+    const subCode = res.statusSubCode?.split(':').pop();
+    const codeLabel = subCode ? `${code} / ${subCode}` : code;
     items.push({
       id: 'status',
       label: 'Status',
       status: 'error',
       detail: res.statusMessage
-        ? `${code}（StatusMessage: ${res.statusMessage}）`
-        : `${code}（Success ではありません）`,
+        ? `${codeLabel}（StatusMessage: ${res.statusMessage}）`
+        : `${codeLabel}（Success ではありません）`,
     });
   }
 
@@ -72,15 +74,23 @@ export function runResponseChecks(res: SamlResponseData, opts: CheckOptions = {}
       return;
     }
 
-    // timezone designator（Z または ±hh:mm / ±hhmm）が無い場合、端末のローカル時刻として
+    // timezone designator（Z または ±hh / ±hh:mm / ±hhmm）が無い場合、端末のローカル時刻として
     // 解釈されるため判定が実行環境依存になる。判定自体は続行しつつ注記を付ける
-    const hasTimezone = (s: string) => /(?:Z|[+-]\d{2}:?\d{2})$/.test(s);
+    const hasTimezone = (s: string) => /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(s);
+    // 日付のみ形式（YYYY-MM-DD）は ES 仕様上 UTC (00:00Z) 解釈が確定しているため、
+    // ローカル時刻注記の対象からは除外し、専用の注記を出す
+    const isDateOnly = (s: string) => /^\d{4}-\d{2}-\d{2}$/.test(s);
+    const dateOnly =
+      (!!c.notBefore && isDateOnly(c.notBefore)) ||
+      (!!c.notOnOrAfter && isDateOnly(c.notOnOrAfter));
     const missingTimezone =
-      (!!c.notBefore && !hasTimezone(c.notBefore)) ||
-      (!!c.notOnOrAfter && !hasTimezone(c.notOnOrAfter));
-    const tzNote = missingTimezone
-      ? '\n※ タイムゾーン指定がないため、この端末のローカル時刻として解釈しています'
-      : '';
+      (!!c.notBefore && !isDateOnly(c.notBefore) && !hasTimezone(c.notBefore)) ||
+      (!!c.notOnOrAfter && !isDateOnly(c.notOnOrAfter) && !hasTimezone(c.notOnOrAfter));
+    const tzNote = dateOnly
+      ? '\n※ 日付のみのため、UTC (00:00Z) として解釈しています'
+      : missingTimezone
+        ? '\n※ タイムゾーン指定がないため、この端末のローカル時刻として解釈しています'
+        : '';
 
     if (notBefore && now < notBefore) {
       items.push({
@@ -107,7 +117,11 @@ export function runResponseChecks(res: SamlResponseData, opts: CheckOptions = {}
   });
 
   // 4. Audience（SP entityID 入力時のみ照合、未入力は表示のみ）
-  const audiences = [...new Set(res.assertions.flatMap((a) => a.conditions?.audiences ?? []))];
+  // restrictionGroups: AudienceRestriction ごとの Audience 列挙（外側 = AND、内側 = OR）
+  const restrictionGroups = res.assertions.flatMap((a) => a.conditions?.audienceRestrictions ?? []);
+  const audiences = [...new Set(restrictionGroups.flat())];
+  // 空の restriction（Audience 要素なし）は AND 判定の対象外とする
+  const nonEmptyRestrictions = restrictionGroups.filter((g) => g.length > 0);
   const sp = opts.spEntityId?.trim();
   if (audiences.length === 0) {
     items.push({
@@ -118,7 +132,7 @@ export function runResponseChecks(res: SamlResponseData, opts: CheckOptions = {}
     });
   } else if (!sp) {
     items.push({ id: 'audience', label: 'Audience', status: 'info', detail: audiences.join(', ') });
-  } else if (audiences.includes(sp)) {
+  } else if (nonEmptyRestrictions.every((g) => g.includes(sp))) {
     items.push({
       id: 'audience',
       label: 'Audience',

--- a/src/utils/saml/checks.ts
+++ b/src/utils/saml/checks.ts
@@ -75,22 +75,27 @@ export function runResponseChecks(res: SamlResponseData, opts: CheckOptions = {}
     }
 
     // timezone designator（Z または ±hh / ±hh:mm / ±hhmm）が無い場合、端末のローカル時刻として
-    // 解釈されるため判定が実行環境依存になる。判定自体は続行しつつ注記を付ける
-    const hasTimezone = (s: string) => /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(s);
-    // 日付のみ形式（YYYY-MM-DD）は ES 仕様上 UTC (00:00Z) 解釈が確定しているため、
-    // ローカル時刻注記の対象からは除外し、専用の注記を出す
-    const isDateOnly = (s: string) => /^\d{4}-\d{2}-\d{2}$/.test(s);
+    // 解釈されるため判定が実行環境依存になる。判定自体は続行しつつ注記を付ける。
+    // 時刻部（T または スペース区切りの hh:mm）の存在を前提とすることで、年月のみ形式
+    // （例: "2026-07"）の末尾ハイフンをタイムゾーンオフセットと誤認しないようにする
+    const hasTimezone = (s: string) =>
+      /[T ]\d{2}:\d{2}/.test(s) && /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(s);
+    // 日付のみ形式（YYYY / YYYY-MM / YYYY-MM-DD）は ES 仕様上いずれも UTC (00:00Z) 解釈が
+    // 確定しているため、ローカル時刻注記の対象からは除外し、専用の注記を出す
+    const isDateOnly = (s: string) => /^\d{4}(?:-\d{2}(?:-\d{2})?)?$/.test(s);
     const dateOnly =
       (!!c.notBefore && isDateOnly(c.notBefore)) ||
       (!!c.notOnOrAfter && isDateOnly(c.notOnOrAfter));
     const missingTimezone =
       (!!c.notBefore && !isDateOnly(c.notBefore) && !hasTimezone(c.notBefore)) ||
       (!!c.notOnOrAfter && !isDateOnly(c.notOnOrAfter) && !hasTimezone(c.notOnOrAfter));
-    const tzNote = dateOnly
-      ? '\n※ 日付のみのため、UTC (00:00Z) として解釈しています'
-      : missingTimezone
-        ? '\n※ タイムゾーン指定がないため、この端末のローカル時刻として解釈しています'
-        : '';
+    // dateOnly と missingTimezone は排他ではなく、Assertion 内の NotBefore / NotOnOrAfter が
+    // それぞれ異なる形式（例: 日付のみ + タイムゾーンなし日時）を持つ場合は両方該当しうるため、
+    // 該当する注記をすべて連結する
+    let tzNote = '';
+    if (dateOnly) tzNote += '\n※ 日付のみのため、UTC (00:00Z) として解釈しています';
+    if (missingTimezone)
+      tzNote += '\n※ タイムゾーン指定がないため、この端末のローカル時刻として解釈しています';
 
     if (notBefore && now < notBefore) {
       items.push({

--- a/src/utils/saml/decode.ts
+++ b/src/utils/saml/decode.ts
@@ -1,13 +1,53 @@
-import { decompressSync } from 'fflate';
+import { Decompress } from 'fflate';
 import type { DecodedInput } from './types';
 
 const utf8 = new TextDecoder('utf-8', { fatal: true });
+
+/** 展開後サイズの上限（deflate 展開の zip bomb 対策） */
+const MAX_INFLATED_SIZE = 32 * 1024 * 1024;
+/** 圧縮データを与える単位（ストリーミング展開で上限超過を早期検知するため小さく刻む） */
+const INFLATE_CHUNK_SIZE = 64 * 1024;
+
+/** 展開後サイズ上限超過を表す専用エラー（deflate 自体の失敗と区別するため） */
+class InflateLimitError extends Error {}
 
 function base64ToBytes(b64: string): Uint8Array {
   const bin = atob(b64);
   const bytes = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
   return bytes;
+}
+
+/**
+ * fflate のストリーミング Decompress で raw deflate / zlib / gzip を自動判定しつつ展開する。
+ * decompressSync は展開後データを一括生成するため上限チェックが手遅れになる。
+ * 圧縮データを小さいチャンクに分けて渡すことで、上限超過を検知した時点で残りの展開を打ち切れる。
+ */
+function inflateWithLimit(bytes: Uint8Array): Uint8Array {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const inflator = new Decompress((chunk) => {
+    total += chunk.length;
+    if (total > MAX_INFLATED_SIZE) {
+      throw new InflateLimitError('deflate 展開後のサイズが上限（32MB）を超えました');
+    }
+    chunks.push(chunk);
+  });
+
+  let offset = 0;
+  do {
+    const end = Math.min(offset + INFLATE_CHUNK_SIZE, bytes.length);
+    inflator.push(bytes.subarray(offset, end), end === bytes.length);
+    offset = end;
+  } while (offset < bytes.length);
+
+  const result = new Uint8Array(total);
+  let pos = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, pos);
+    pos += chunk.length;
+  }
+  return result;
 }
 
 /**
@@ -21,7 +61,15 @@ function extractSamlParam(rawQuery: string): string | undefined {
   for (const pair of rawQuery.split('&')) {
     const eq = pair.indexOf('=');
     if (eq < 0) continue;
-    const key = pair.slice(0, eq);
+    const rawKey = pair.slice(0, eq);
+    // キー名が percent エンコードされている場合（例: SAML%52esponse）に備え、
+    // 比較前に一度デコードを試みる（失敗時は生キーのまま比較を続行）
+    let key = rawKey;
+    try {
+      key = decodeURIComponent(rawKey);
+    } catch {
+      /* 不正な %-シーケンスの場合は生キーのまま比較する */
+    }
     if (key === 'SAMLResponse' || (key === 'SAMLRequest' && param === undefined)) {
       param = pair.slice(eq + 1);
       if (key === 'SAMLResponse') break;
@@ -82,10 +130,16 @@ export function decodeSamlInput(raw: string): DecodedInput {
     return { xml: text, steps: [...steps, '生 XML と判定'], binding: 'xml' };
   }
 
-  // 4. base64
+  // 4. base64（base64url 表記の場合は標準 base64 へ変換してから decode する）
+  let normalized = text.replace(/\s+/g, '');
+  if (/[-_]/.test(normalized)) {
+    normalized = normalized.replace(/-/g, '+').replace(/_/g, '/');
+    normalized += '='.repeat((4 - (normalized.length % 4)) % 4);
+    steps.push('base64url を標準 base64 へ変換');
+  }
   let bytes: Uint8Array;
   try {
-    bytes = base64ToBytes(text.replace(/\s+/g, ''));
+    bytes = base64ToBytes(normalized);
   } catch {
     throw new Error(
       'base64 として解釈できません（SAMLResponse / SAMLRequest の値か確認してください）'
@@ -103,10 +157,17 @@ export function decodeSamlInput(raw: string): DecodedInput {
     /* UTF-8 でない → deflate 圧縮の可能性 */
   }
 
-  // 6. deflate 展開 → HTTP-Redirect binding（decompressSync は raw deflate / zlib / gzip を自動判定）
+  // 6. deflate 展開 → HTTP-Redirect binding（raw deflate / zlib / gzip を自動判定）
+  let expanded: Uint8Array;
+  try {
+    expanded = inflateWithLimit(bytes);
+  } catch (e) {
+    if (e instanceof InflateLimitError) throw e;
+    throw new Error('デコード結果が XML ではありません（deflate 展開にも失敗しました）');
+  }
   let inflated: string;
   try {
-    inflated = utf8.decode(decompressSync(bytes));
+    inflated = utf8.decode(expanded);
   } catch {
     throw new Error('デコード結果が XML ではありません（deflate 展開にも失敗しました）');
   }

--- a/src/utils/saml/decode.ts
+++ b/src/utils/saml/decode.ts
@@ -5,8 +5,14 @@ const utf8 = new TextDecoder('utf-8', { fatal: true });
 
 /** 展開後サイズの上限（deflate 展開の zip bomb 対策） */
 const MAX_INFLATED_SIZE = 32 * 1024 * 1024;
-/** 圧縮データを与える単位（ストリーミング展開で上限超過を早期検知するため小さく刻む） */
-const INFLATE_CHUNK_SIZE = 64 * 1024;
+/**
+ * 圧縮データを与える単位（ストリーミング展開で上限超過を早期検知するため小さく刻む）。
+ * fflate の Decompress は 1 回の push から生成された展開結果を単一チャンクで ondata に渡すため、
+ * 上限チェックはチャンク割当後にしか走らない。圧縮チャンクを小さくすることで、
+ * 1 push あたりの最悪展開量（8KB × deflate 最大圧縮率 ~1032:1 ≒ ~8MB）を抑える。
+ * 正常系の SAML メッセージは数 KB 程度のため、この縮小による性能影響はない。
+ */
+const INFLATE_CHUNK_SIZE = 8 * 1024;
 
 /** 展開後サイズ上限超過を表す専用エラー（deflate 自体の失敗と区別するため） */
 class InflateLimitError extends Error {}
@@ -22,6 +28,10 @@ function base64ToBytes(b64: string): Uint8Array {
  * fflate のストリーミング Decompress で raw deflate / zlib / gzip を自動判定しつつ展開する。
  * decompressSync は展開後データを一括生成するため上限チェックが手遅れになる。
  * 圧縮データを小さいチャンクに分けて渡すことで、上限超過を検知した時点で残りの展開を打ち切れる。
+ *
+ * 実効ピークメモリの目安: 上限チェックは push 単位でしか走らないため、実効ピークは
+ * MAX_INFLATED_SIZE（32MB）+ 1 push あたりの最悪展開量（INFLATE_CHUNK_SIZE 分、~8MB）
+ * 程度になりうる。
  */
 function inflateWithLimit(bytes: Uint8Array): Uint8Array {
   const chunks: Uint8Array[] = [];

--- a/src/utils/saml/parse.ts
+++ b/src/utils/saml/parse.ts
@@ -52,10 +52,16 @@ export function parseSamlXml(xml: string): SamlMessage {
 
 function parseResponse(root: Element): SamlResponseData {
   const status = childNS(root, NS_P, 'Status');
+  const outerStatusCode = status ? childNS(status, NS_P, 'StatusCode') : undefined;
+  // 二段階ステータス（外側 StatusCode の子にもう1つ StatusCode）の内側コード
+  const innerStatusCode = outerStatusCode
+    ? childNS(outerStatusCode, NS_P, 'StatusCode')
+    : undefined;
   return {
     type: 'response',
     issuer: textOf(childNS(root, NS_A, 'Issuer')),
-    statusCode: status ? attrOf(childNS(status, NS_P, 'StatusCode'), 'Value') : undefined,
+    statusCode: attrOf(outerStatusCode, 'Value'),
+    statusSubCode: attrOf(innerStatusCode, 'Value'),
     statusMessage: status ? textOf(childNS(status, NS_P, 'StatusMessage')) : undefined,
     destination: attrOf(root, 'Destination'),
     inResponseTo: attrOf(root, 'InResponseTo'),
@@ -83,7 +89,7 @@ function parseAssertion(el: Element): SamlAssertion {
       ? {
           notBefore: attrOf(conditions, 'NotBefore'),
           notOnOrAfter: attrOf(conditions, 'NotOnOrAfter'),
-          audiences: childrenNS(conditions, NS_A, 'AudienceRestriction').flatMap((ar) =>
+          audienceRestrictions: childrenNS(conditions, NS_A, 'AudienceRestriction').map((ar) =>
             childrenNS(ar, NS_A, 'Audience').flatMap((a) => textOf(a) ?? [])
           ),
         }

--- a/src/utils/saml/types.ts
+++ b/src/utils/saml/types.ts
@@ -17,7 +17,8 @@ export interface SamlAttribute {
 export interface SamlConditions {
   notBefore?: string;
   notOnOrAfter?: string;
-  audiences: string[];
+  /** AudienceRestriction ごとの Audience 列挙（外側 = AND、内側 = restriction 内の OR） */
+  audienceRestrictions: string[][];
 }
 
 export interface SamlSubjectConfirmation {
@@ -50,6 +51,8 @@ export interface SamlResponseData {
   type: 'response';
   issuer?: string;
   statusCode?: string;
+  /** 外側 StatusCode の直下にネストした内側 StatusCode の Value */
+  statusSubCode?: string;
   statusMessage?: string;
   destination?: string;
   inResponseTo?: string;

--- a/tests/e2e/saml-decoder.spec.ts
+++ b/tests/e2e/saml-decoder.spec.ts
@@ -28,6 +28,14 @@ const AUTHN_REQUEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
   <saml:Issuer>https://sp.example.com/metadata</saml:Issuer>
 </samlp:AuthnRequest>`;
 
+/** UTF-8 → base64url（パディングなし、`-`/`_` 表記） */
+function toBase64Url(xml: string): string {
+  const bytes = new TextEncoder().encode(xml);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
 test.describe('SAMLデコーダ', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/tools/saml-decoder');
@@ -77,6 +85,16 @@ test.describe('SAMLデコーダ', () => {
       .fill(responseXml({ notOnOrAfterOffsetMs: 300_000 }));
     await page.getByLabel(/SP entityID/).fill('https://other.example.com/metadata');
     await expect(page.getByText('SP entityID と不一致です', { exact: false })).toBeVisible();
+  });
+
+  test('base64url（- _ を含みパディングなし）でエンコードした Response も正常にデコードされる', async ({
+    page,
+  }) => {
+    await page
+      .getByLabel(/SAMLResponse \/ SAMLRequest を貼り付け/)
+      .fill(toBase64Url(responseXml({ notOnOrAfterOffsetMs: 300_000 })));
+    await expect(page.getByText('Response サマリ')).toBeVisible();
+    await expect(page.getByText('taro@example.com').first()).toBeVisible();
   });
 
   test('AuthnRequest はサマリのみ表示されチェックリストは出ない', async ({ page }) => {


### PR DESCRIPTION
## 概要

SAML デコーダ初版（PR #746）のコード品質レビューで先送りした非 blocking 改善 7 項目 + 追加コメントの deflate 展開上限、計 8 項目を対応する。

Refs #745（第2版の重量級機能: 署名検証・復号・Logout 系・マスク出力は本 PR のスコープ外のため issue は閉じない）

## 変更内容

| # | 項目 | 変更箇所 |
|---|------|----------|
| 1 | base64url 入力（`-`/`_`・パディングなし）の受容。変換適用時は変換ステップに表示 | `decode.ts` |
| 2 | ネストした StatusCode の内側コード表示（サマリに「Status (内側)」行、チェックリストに `Responder / RequestDenied` 併記） | `parse.ts` / `types.ts` / `checks.ts` / `SamlDecoder.tsx` |
| 3 | 複数 AudienceRestriction の AND 意味論（`audiences: string[]` → `audienceRestrictions: string[][]`。SP entityID 照合は全 restriction に含まれる場合のみ一致。UI は `[a] AND [b]` 表記） | 同上 |
| 4 | 整形済み XML が簡易整形である旨の UI 注記（mixed content 非表示の可能性） | `SamlDecoder.tsx` |
| 5 | 回帰テスト追加（default xmlns の prefix なし XML パース / 複数 Assertion の「有効期間 (Assertion N)」ラベル） | テストのみ |
| 6 | hasTimezone 判定の精度（時のみオフセット `+09` を TZ ありと判定・日付のみ形式は「UTC (00:00Z) として解釈」注記に分離） | `checks.ts` |
| 7 | percent エンコードされたクエリキー名（`SAML%52esponse` 等）の照合 | `decode.ts` |
| 8 | deflate 展開の 32MB 上限（zip bomb 対策。`decompressSync` → ストリーミング `Decompress` + 64KB チャンク供給で早期打ち切り） | `decode.ts` |

## テスト

- ユニットテスト追加（全 146 ファイル 2677 passed / 1 skipped で green）
- `astro check` 0 errors / `npm run lint` / `npm run format:check` クリア
- **test-gates 準拠（項目 8 はガード実装）**: 32MB 上限の陽性対照（ゼロ埋め 40MB を zlib 圧縮した入力で上限エラー）を陰性対照と別テストで同梱。旧実装（`decompressSync`）に当てると fail することを stash 退避で実機確認済み（項目 1・7 の陽性対照も同様に旧実装で fail を確認）
- E2E: base64url 入力の正常デコードケースを追加
- UI 目視確認（PC 1280x800）: base64url 変換ステップ表示 / Status (内側) 行 / チェックリストの外側・内側併記 / `[a] AND [b]` 表記と AND 不一致判定 / 簡易整形注記 をブラウザで確認済み

## 検証の残項目（レビュー時に確認をお願いします）

- **E2E スイートのローカル実行不可**: 本セッションの sandbox が loopback への connect を deny するため（listen は可・connect が EPERM）、`npm run test:e2e` を実行できず CI が最終ゲート。`.claude/rules/git-and-fs.md` 記載の 127.0.0.1 回避策でも connect 自体が拒否される（従来記録と異なる新事象）
- **スマホ 390x844 の目視確認未実施**: Chrome 拡張の `resize_window` が効かず（ウィンドウがフルスクリーンの可能性）。変更は既存レスポンシブパターン（`SummaryRow` / hint テキスト）の踏襲でレイアウト変更なし

## 補足（項目 6 の実装上の注意）

「時のみオフセット `+09`」は `T` 区切りの日時文字列では JS の `Date` がそもそもパースできず NaN（→「日時を解釈できません」warning）になるため、正規表現の緩和が効くのはスペース区切り等の非標準形式のみ。いずれも xs:dateTime 違反入力に限る表示上の改善であり、実データへの影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
