### PR TITLE
docs: PR #749 振り返りの規約反映（loopback deny 時の E2E 判断・hydration 待機必須化・重量陽性対照の timeout）

### DIFF
--- a/.agents/rules/ui-conventions.md
+++ b/.agents/rules/ui-conventions.md
@@ -138,3 +138,11 @@ UI 変更時は **PC (1280x800)** と **スマホ (390x844)** 両方でスクリ
 
 - `getByRole` / `getByText` / `getByLabel` を使う。`locator('[role="X"]')` のような属性セレクタは禁止（アクセシビリティ・国際化に弱く、リファクタリング耐性も低い）。
 - DOM 直接操作（`page.evaluate`）より `expect` のオートリトライを優先（React の再レンダータイミングで不安定になるため）。
+
+### 3.4 React island へ入力する E2E spec は hydration 待機が必須
+
+React island（`client:load` でマウントされるツール本体）に `fill` / `click` 等で入力する spec は、**`beforeEach` で `await waitForReactHydration(page);`（`tests/e2e/helpers.ts`）を必ず呼ぶ**。
+
+- hydration 完了前の `fill` は DOM の value だけを書き換え、React の `onChange` が発火しないため state が空のまま進む（例: URI 貼り付け分解で一部フィールドだけ空になる）
+- この race は **CI では顕在化しない**（`workers: 1` の直列実行で hydration が間に合う）が、ローカルの並列実行で flaky になる。「CI green だからテストは正しい」とは判断できない
+- 過去事例: issue #750（`dsn-builder.spec.ts` / `dummy-personal-data.spec.ts` が未呼び出しでローカル 8〜10 件 fail）

--- a/.claude/rules/git-and-fs.md
+++ b/.claude/rules/git-and-fs.md
@@ -24,5 +24,6 @@
 - ブラウザ未インストール環境では `PLAYWRIGHT_BROWSERS_PATH="$PWD/tmp/claude/ms-playwright"`（リポジトリ内の sandbox 書込可能経路）を指定して `npx playwright install chromium chromium-headless-shell` する。デフォルトの `~/Library/Caches` は書込 deny。キャッシュは未追跡のまま残してよい（次セッションで再利用可）。
 - `node` スクリプトから `chromium.launch()` を直接呼ぶと `mach_port_rendezvous ... Permission denied (1100)` で起動できない。**test runner（`npm run test:e2e` / `npx playwright test`）経由なら起動できる**。スクリーンショット撮影等の単発ブラウザ操作も、一時 spec + 専用 config（起動済みサーバを `baseURL` 参照、`webServer` なし）を作って runner 経由で実行する（一時 spec はコミットしない）。
 - 環境によっては `webServer` 自動起動が `listen EPERM ::1:4321`（IPv6 bind 拒否）で失敗することがある。その場合は `astro preview --host 127.0.0.1` を別途起動して `baseURL` で参照する。
+- さらに環境によっては loopback への **connect 自体が全面 deny** される（`astro preview` の起動・listen は成功するのに、node fetch / curl / バックグラウンドタスクからの `127.0.0.1` 接続がすべて EPERM / exit 000）。この状態では上記 workaround を含め **in-session E2E は実行不能**。接続 probe（`curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<port>/` 等）が 2〜3 回失敗した時点で workaround 探索を打ち切り、「CI を E2E の最終ゲートにする」判断へ切り替えて PR 本文にローカル E2E 未実行の旨と理由を明示する。UI の目視確認は claude-in-chrome（ユーザーの実 Chrome、sandbox 外）で代替できる。
 
-（経緯: PR #746 のセッションで親・サブエージェント計 3 者が同じ制約に別々に遭遇したため記録）
+（経緯: PR #746 のセッションで親・サブエージェント計 3 者が同じ制約に別々に遭遇したため記録。loopback connect 全面 deny は PR #749 のセッションで確認し、workaround 試行のラウンドトリップが無駄になったため追記）

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -253,3 +253,26 @@ PR #450 で `databarlimitedcomposite` (GS1 DataBar Limited Composite) が以下 
 
 - PR #450（本件、`height` + `injectCompositeText` の 2 段修正）
 - `src/components/tools/Gs1Databar.tsx:113-117` （`bwip-js v4.9.0` の挙動依存をコメントで明示）
+
+---
+
+## [2026-07-19] 重量フィクスチャの陽性対照テストは CI ランナーで vitest デフォルト 5s を超過する
+
+### 現象
+
+PR #749 の deflate 展開上限（zip bomb 対策）の陽性対照テスト（ゼロ埋め 40MB を `zlibSync` 圧縮 → 展開で上限超過を検証）が、ローカルでは pass するのに CI runner で vitest デフォルトタイムアウト 5000ms を超過して fail した。
+
+### 対処（PR #749 の 4186b81 で実施した組み合わせ）
+
+1. **フィクスチャを上限超過の最小限に縮小**: 40MB → 34MB（上限 32MB を確実に超える最小級）
+2. **圧縮レベルを最小化**: `zlibSync(huge, { level: 1 })`（生成時間を短縮、圧縮率は検証に無関係）
+3. **明示タイムアウトを設定**: `it('...', { timeout: 30_000 }, () => ...)`（CI 実測に基づく余裕値）
+
+### 教訓
+
+- test-gates 系の陽性対照で MB 級データの生成・変換を伴う場合、ローカル pass だけで CI の時間予算を判断しない。**明示 timeout + フィクスチャ最小化**を最初から入れる
+- 検証したい境界（上限 32MB）に対しフィクスチャは「確実に超える最小」を選ぶ。余裕を盛るほど CI 時間を浪費する
+
+### 関連
+
+- PR #749（`src/utils/__tests__/saml-decode.test.ts` の deflate 上限テスト）


### PR DESCRIPTION
## 概要

PR #749（SAMLデコーダのレビュー残余改善）の振り返り（`/retro`）で承認された 3 件をドキュメントに反映する。

## 変更内容

### 1. `.claude/rules/git-and-fs.md` — loopback connect 全面 deny 時の E2E 判断

既存記述は「preview を別途起動して `baseURL` 参照すれば回避可」までだったが、PR #749 のセッションでは **loopback への connect 自体が全面 deny**（listen は成功、node fetch / curl / バックグラウンドタスクからの接続がすべて EPERM）され、workaround 探索のラウンドトリップが無駄になった。接続 probe が 2〜3 回失敗した時点で打ち切り、CI を E2E の最終ゲートにする判断へ切り替える基準を追記。

### 2. `.agents/rules/ui-conventions.md` — React island へ入力する E2E spec の hydration 待機必須化（新設 3.4 節）

`waitForReactHydration` を呼ばない spec は hydration race で flaky になる（CI は `workers: 1` で潜伏し、ローカル並列実行で顕在化）ことを規約化。新規 spec での再生産を防ぐ。既存 2 spec（dsn-builder / dummy-personal-data）の改修は issue #750 で別管理。

### 3. `docs/agent-lessons.md` — 重量フィクスチャの陽性対照テストの CI タイムアウト知見

zip bomb 陽性対照（34MB 展開）がローカル pass / CI fail（vitest デフォルト 5s 超過）となった経緯と対処（フィクスチャ最小化 + 低圧縮レベル + 明示 timeout）を記録。

## 検証

- `npx vitest run tests/meta`: 200 passed / 1 skipped
- `npx prettier --write` 適用済み

## 関連

- 振り返り対象: #749
- Refs #750（hydration flaky の既存 spec 改修）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
