### PR TITLE
docs: push 前必須チェックに format:check を追加（PR #753 振り返り）

### DIFF
--- a/.agents/rules/common.md
+++ b/.agents/rules/common.md
@@ -37,8 +37,8 @@
 
 **E2E テストは実装と同時に書く**: バグ修正・UI 挙動の変更時はコミット前に該当ケースの E2E を追加する。後回し禁止。
 
-**push 前に必須**: `npm run test`（ユニット）／ `node_modules/.bin/astro check`（型）／ `npm run test:e2e`（E2E）。
-post-PR 代行は不要、CI が最終ゲート。
+**push 前に必須**: `npm run format:check`（整形）／ `npm run test`（ユニット）／ `node_modules/.bin/astro check`（型）／ `npm run test:e2e`（E2E）。
+post-PR 代行は不要、CI が最終ゲート。**`format:check` を含める理由**: CI の `test` ジョブは `format:check` を最初に走らせるため、`npm run test` だけでは整形崩れ（特に `Write` / `Edit` で作成した Markdown）を検出できず CI が赤になる（PR #753 実例）。
 
 **ガード / バリデータ / 検知機構には陽性対照を必須**: 検出する・拒否する・違反したら fail させる仕組み（CSP 違反検知 / 入力 validator / lint / セキュリティヘッダ assert / E2E ガード / regex マッチ系）を追加 / 修正する場合は **`Skill` tool で `test-gates` skill を必ず呼ぶ**。陰性対照のみでは「検知能力ゼロで green」と区別不能（PR #233 `applyProductionCsp` 空回り事故）。詳細・チェックリストは skill 本体に集約してこの doc では肥大化させない。
 

--- a/docs/playbooks/e2e-validation.md
+++ b/docs/playbooks/e2e-validation.md
@@ -34,9 +34,12 @@
 | --- | --------------------- | ------------------------------------------------------------------------------------------ |
 | 0   | node_modules 整備     | `npm ci`（新規作成 worktree では必須。fresh worktree なら 5〜10 秒で完了。詳細は下記参照） |
 | 1   | develop ベース確認    | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致              |
-| 2   | ユニットテスト全 pass | `npm run test`                                                                             |
-| 3   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                                |
-| 4   | E2E テスト            | `npm run test:e2e`（env 不備で走らない場合は未完了の旨を明記して親に引き継ぐ）             |
+| 2   | 整形チェック          | `npm run format:check`（CI の `test` ジョブが最初に走らせる。下記補足参照）                |
+| 3   | ユニットテスト全 pass | `npm run test`                                                                             |
+| 4   | 型チェック            | `node_modules/.bin/astro check`（0 errors）                                                |
+| 5   | E2E テスト            | `npm run test:e2e`（env 不備で走らない場合は未完了の旨を明記して親に引き継ぐ）             |
+
+> **`format:check` を push 前必須にする理由**: CI の `test` ジョブは `format:check`（`prettier --check .`）→ lint → 型 → vitest の順で実行するため、`npm run test`（vitest のみ）がローカルで green でも `format:check` 崩れで CI が赤になる。特に **`Write` / `Edit` ツールで新規作成・編集した Markdown（設計 doc・実装計画・docs）** は、サブエージェントが prettier をかけるコードと違い整形漏れが起きやすい（PR #753 で設計 doc / 実装計画の整形崩れにより CI 赤 → 修正 → 再 push のラウンドトリップが発生）。`prettier --check .` は数秒で完了するため push 前に必ず通す。
 
 > **ステップ 0 の補足**: fresh subagent isolation worktree では node_modules が存在しないため、素の `npm ci` のみで十分（過去の `scripts/agent-worktree-setup.sh` は不要と判明し、issue #241 / decisions [062] で廃止）。`.claude/settings.json` の SessionStart hook は session 開始時のみ fire するため、mid-session で `git worktree add` した worktree には適用されない。新規作成 worktree では作成直後に手動で `npm ci` を実行する必須ステップとして扱うこと。
 >

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -59,14 +59,14 @@ git rebase --onto origin/develop $(git merge-base HEAD origin/develop) HEAD
 
 親セッションが直接 push する際は、以下をすべて確認する。
 
-| #   | チェック項目         | コマンド                                                                                                                           |
-| --- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| 0   | node_modules 整備    | `npm ci`（新規作成 worktree では必須。SessionStart hook は session 開始時のみ fire し mid-session 作成 worktree には適用されない） |
-| 1   | develop ベース確認   | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                                      |
+| #   | チェック項目         | コマンド                                                                                                                                                |
+| --- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | node_modules 整備    | `npm ci`（新規作成 worktree では必須。SessionStart hook は session 開始時のみ fire し mid-session 作成 worktree には適用されない）                      |
+| 1   | develop ベース確認   | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                                                           |
 | 2   | 整形チェック         | `npm run format:check`（CI の `test` ジョブが最初に走らせる。`Write` / `Edit` で作成した Markdown の整形漏れを防ぐ。詳細は `e2e-validation.md` 2.1 節） |
-| 3   | スコープ外差分の確認 | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認             |
-| 4   | E2E 直列実行         | `npm run test:e2e`（preview 経由・複数 worktree がある場合は同時実行しない、詳細は `e2e-validation.md` 3 章）                      |
-| 5   | PR ベース            | `gh pr create --base develop`                                                                                                      |
+| 3   | スコープ外差分の確認 | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認                                  |
+| 4   | E2E 直列実行         | `npm run test:e2e`（preview 経由・複数 worktree がある場合は同時実行しない、詳細は `e2e-validation.md` 3 章）                                           |
+| 5   | PR ベース            | `gh pr create --base develop`                                                                                                                           |
 
 ---
 

--- a/docs/playbooks/pr-creation.md
+++ b/docs/playbooks/pr-creation.md
@@ -63,9 +63,10 @@ git rebase --onto origin/develop $(git merge-base HEAD origin/develop) HEAD
 | --- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | 0   | node_modules 整備    | `npm ci`（新規作成 worktree では必須。SessionStart hook は session 開始時のみ fire し mid-session 作成 worktree には適用されない） |
 | 1   | develop ベース確認   | `git rev-parse origin/develop` と `git merge-base HEAD origin/develop` が一致                                                      |
-| 2   | スコープ外差分の確認 | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認             |
-| 3   | E2E 直列実行         | `npm run test:e2e`（preview 経由・複数 worktree がある場合は同時実行しない、詳細は `e2e-validation.md` 3 章）                      |
-| 4   | PR ベース            | `gh pr create --base develop`                                                                                                      |
+| 2   | 整形チェック         | `npm run format:check`（CI の `test` ジョブが最初に走らせる。`Write` / `Edit` で作成した Markdown の整形漏れを防ぐ。詳細は `e2e-validation.md` 2.1 節） |
+| 3   | スコープ外差分の確認 | `git diff origin/develop --name-only` で想定外ファイルがないか確認。aria-\* 削除行（`git diff` の `-` 行）がないか確認             |
+| 4   | E2E 直列実行         | `npm run test:e2e`（preview 経由・複数 worktree がある場合は同時実行しない、詳細は `e2e-validation.md` 3 章）                      |
+| 5   | PR ベース            | `gh pr create --base develop`                                                                                                      |
 
 ---
 


### PR DESCRIPTION
## 概要

PR #753（SAMLデコーダ Logout 対応）の振り返り（retro）で抽出した再発防止策を反映します。

## 背景

PR #753 の作業で、`Write` ツールで新規作成した設計 doc・実装計画（Markdown）の prettier 整形崩れにより CI の `test` ジョブが赤になりました。原因は、CI の `test` ジョブが `format:check`（`prettier --check .`）→ lint → 型 → vitest の順で走るのに対し、ローカルの push 前チェックが `npm run test`（vitest のみ）で `format:check` を含んでいなかったためです。結果として「CI 赤 → 整形修正 → 再 push」のラウンドトリップが 1 回発生しました。

特に **`Write` / `Edit` ツールで作成・編集した Markdown** は、サブエージェントが prettier をかけるコードと違い整形漏れが起きやすい経路です。

## 変更内容

push 前必須チェックリストに `npm run format:check` を追加しました。`prettier --check .` は数秒で完了するため、追加コストは小さく赤ラウンドトリップを防げます。

- **正本** `docs/playbooks/e2e-validation.md` 2.1 節: チェックリストに整形チェック行を追加し、理由（CI の実行順・Markdown で漏れやすい点・PR #753 実例）を補足
- **要約** `.agents/rules/common.md` 3 章: push 前必須リストに `format:check` を追加し理由を一文で明記

## 振り返りで破棄した気づき（記録）

- 実装計画のテストの TZ 依存バグ: 既存 `saml-checks.test.ts` に同じ回避手法が既にあり新規知見でないため破棄
- spec-reviewer サブエージェントのセッション上限失敗 → 親が代替: 一度限りの状況対応で subagent-driven の既定範囲内のため破棄

## 関連

- 振り返り対象: PR #753
- retro skill の Step 5 に基づくドキュメント改善 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
