### PR TITLE
docs: CLAUDE.md 監査による Agent Teams 記述の更新とプラグイン宣言の同期

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,8 @@
     }
   },
   "enabledPlugins": {
-    "context7@claude-plugins-official": true
+    "context7@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true
   },
   "hooks": {
     "SessionStart": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,11 @@ Claude Code 固有の補足は `.claude/rules/` 配下に分割し、上記 `@im
 
 ### 前提モデル
 
-`.claude/settings.json` で `model: "opus[1m]"`（Claude Opus 5 / 1M context）を指定している。`.agents/rules/common.md` の出力量・委譲判断の規約はこの世代の既定挙動（応答と生成ドキュメントが長い / subagent 委譲に積極的）を前提に書かれている → [Prompting Claude Opus 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5)
+`.claude/settings.json` で `model: "opus[1m]"` を指定している。`opus` は **現行世代の最新 Opus を指すエイリアス**（`[1m]` は 1M context 版）であり、世代が更新されれば解決先も移動する。
+
+`.agents/rules/common.md` の出力量・委譲判断の規約は、執筆時点の現行世代である Claude Opus 5 の既定挙動（応答と生成ドキュメントが長い / subagent 委譲に積極的）を前提にしている → [Prompting Claude Opus 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5)
+
+**エイリアスの解決先が次世代に移ったら、本節と上記規約の前提を見直すこと**（世代番号を固定した記述は Currency ドリフトの発生源になる）。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,22 @@ Claude Code 固有の補足は `.claude/rules/` 配下に分割し、上記 `@im
 
 （注: 上記は Claude 固有。Codex は `.codex/rules/`、Gemini CLI は `docs/setup/gemini-policy.md` を参照）
 
+### 前提モデル
+
+`.claude/settings.json` で `model: "opus[1m]"`（Claude Opus 5 / 1M context）を指定している。`.agents/rules/common.md` の出力量・委譲判断の規約はこの世代の既定挙動（応答と生成ドキュメントが長い / subagent 委譲に積極的）を前提に書かれている → [Prompting Claude Opus 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5)
+
 ---
 
 ## 推奨プラグイン
 
 このプロジェクトは以下の Claude Code プラグインを前提に運用しています。`.claude/settings.json` の `enabledPlugins` で宣言済み。
 
-| プラグイン                         | 用途                                                              |
-| :--------------------------------- | :---------------------------------------------------------------- |
-| `context7@claude-plugins-official` | ライブラリ公式ドキュメントの最新参照（Upstash Context7 MCP 同梱） |
+| プラグイン                                     | 用途                                                                  |
+| :--------------------------------------------- | :-------------------------------------------------------------------- |
+| `context7@claude-plugins-official`             | ライブラリ公式ドキュメントの最新参照（Upstash Context7 MCP 同梱）     |
+| `claude-md-management@claude-plugins-official` | `CLAUDE.md` の監査・改善（`claude-md-improver` / `revise-claude-md`） |
+
+**リポジトリで共有するプラグインは必ず `enabledPlugins` に宣言する**。`claude plugin install` はユーザーレベル設定に書き込むため、宣言を忘れると **web セッションでは入らない**（`session-install.sh` は `enabledPlugins` を読んで install するため）。個人的に試すだけのプラグインは宣言しない。
 
 **superpowers / frontend-design はプラグインではなく `npx skills add` でリポジトリ内に vendor 済み**（`.agents/skills/` + `skills-lock.json` 管理）。Web セッションでプラグイン install が効かない問題の回避のため移行した。frontend-design は単一スキルで MCP を同梱しないため skill 化できる（context7 は MCP server 同梱のためプラグインのまま）。出典・ライセンスは `.agents/skills/README.md` を参照。
 
@@ -38,11 +45,23 @@ CLI / Desktop は `.claude/settings.json` から自動 install を prompt しま
 
 ## Agent Teams (Claude Code 固有機能)
 
-このプロジェクトでは **Claude Code の Agent Teams 機能**（実験的）を有効化しています。
+このプロジェクトでは **Claude Code の Agent Teams 機能**（実験的）を有効化しています。subagent と違い、teammate 同士が直接メッセージを交換し共有タスクリストを self-claim します。
 
 - `.claude/settings.json` に `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"` と `teammateMode: "tmux"` を設定済み。
-- 複数の Claude エージェントが tmux セッション上で協調して作業できます。
-- **活用する場面**:
-  - 独立した複数タスクを並列に進める場合
-  - レビュー担当・実装担当を分けたい場合
-  - 長大な実装を複数エージェントで分担する場合
+- `teammateMode` の既定値は **v2.1.179 で `"auto"` → `"in-process"` に変更**された。本リポジトリが明示している `"tmux"` は split-pane モードで、**tmux または iTerm2 (`it2` CLI) が必須**。**VS Code 統合ターミナル / Windows Terminal / Ghostty では非対応**なので、それらで使う場合は `"in-process"` を選ぶ。
+- `TeamCreate` / `TeamDelete` ツールは廃止済みで、team 作成・命名の事前ステップは不要（セッション終了時に自動クリーンアップ）。Agent tool の `team_name` 入力は受理されるが無視される。
+
+**使う場面**（並列探索が実際に価値を生むもの）:
+
+- research / review: 複数 teammate が別観点で同時に調査し、互いの結論を突き合わせる
+- 競合仮説のデバッグ: 各 teammate が別仮説を検証して収束させる
+- 独立した新規モジュール追加 / レイヤーを跨ぐ変更（担当ファイルが重複しない場合）
+
+**使わない場面**:
+
+- **逐次的なタスク・同一ファイルを編集する作業・依存関係が多い作業** → 単一セッションか subagent の方が効果的。2 人が同じファイルを編集すると上書きになる
+- 親が数ツールコールで完結できる規模の作業（`.agents/rules/common.md` 6.9 節の委譲判断と同じ基準）
+
+**Agent teams は単一セッションより著しく多くトークンを消費する**（teammate ごとに独立した context window を持つため線形に増える）。初手は 3〜5 teammate、実装並列より research / review から始めるのが公式推奨。
+
+詳細 → [Agent teams](https://code.claude.com/docs/en/agent-teams)


### PR DESCRIPTION
## 目的

`claude-md-improver` skill による `CLAUDE.md` 監査の結果を反映する。**スコア 87/100（Grade B）**で、最大の弱点は Currency（10/15）だった。

対象ファイルは `./CLAUDE.md` 1 件のみ（`.claude.local.md` / `~/.claude/CLAUDE.md` は未使用）。`@import` 先 4 ファイルは全て実在確認済み。

## 修正した 3 点

### 1. Agent Teams セクション（Currency）

[公式ドキュメント](https://code.claude.com/docs/en/agent-teams)と突き合わせ、以下の乖離を修正した。

| 項目 | 修正内容 |
| :--- | :--- |
| `teammateMode` の既定値 | **v2.1.179 で `"auto"` → `"in-process"` に変更**された旨を追記 |
| `"tmux"` の前提 | split-pane モードで tmux / iTerm2 (`it2`) が必須。**VS Code 統合ターミナル / Windows Terminal / Ghostty では非対応**と明記 |
| 廃止された API | `TeamCreate` / `TeamDelete` は廃止済み（事前セットアップ不要）、Agent tool の `team_name` は受理されるが無視される |
| **「使わない場面」の欠落** | 公式は「逐次タスク・同一ファイル編集・依存の多い作業では単一セッションか subagent が効果的」「2 人が同じファイルを編集すると上書きになる」と明記しているが、旧記述は「活用する場面」3 つのみだった |
| トークンコスト | 「単一セッションより著しく多く消費」「初手 3〜5 teammate」「実装並列より research / review から」を追記 |

**なぜ重要か**: 旧記述の「長大な実装を複数エージェントで分担する場合」は公式の file conflict 警告と衝突し、また `.agents/rules/common.md` 6.9 節の委譲判断（往復コストを踏まえて委譲しない条件）とも方向性が矛盾していた。

### 2. プラグイン宣言のドリフト（Currency）

`claude-md-management` を install したが `enabledPlugins` に宣言されていなかった。`claude plugin install` はユーザーレベル設定に書き込むため、宣言漏れだと **`session-install.sh` が読めず web セッションでは install されない**。

- `.claude/settings.json` の `enabledPlugins` に追加
- `CLAUDE.md` の推奨プラグイン表に行追加
- 「リポジトリで共有するプラグインは必ず宣言する / 個人的に試すだけのものは宣言しない」と境界を明記

### 3. 前提モデル節を新設（Actionability）

`settings.json` は `model: "opus[1m]"` を指定しているが `CLAUDE.md` にその前提が書かれておらず、規約の背景が追えなかった。`opus` が**現行世代の最新 Opus を指すエイリアス**であること、規約が執筆時点の現行世代（Claude Opus 5）の既定挙動（応答・生成ドキュメントが長い / subagent 委譲に積極的）を前提にしていること、**エイリアスの解決先が世代更新されたら本節を見直すこと**を出典付きで明示した（世代番号の固定は避けた → レビュー指摘対応）。

## 監査で判明したが修正していないもの

- **Commands 18/20**: 初回 clone 時の `npm ci` が worktree 文脈（common.md 6.2.1）にしか書かれていない。実害が小さいため未対応
- **Non-obvious patterns 15/15**: Tailwind v4 の variant 非対応、`docs/` auto scan 除外、loopback deny、`workflow_dispatch` 403 等が**事故 PR 番号付きで根拠を残しており、この項目は模範的**。変更不要

### 取り下げた注記: `session-install.sh` の `unbound variable`

当初「`npm run test` の stderr に `.claude/scripts/session-install.sh: line 65: plugin: unbound variable` が出る」という別 issue 候補を記載していたが、**再現しないため取り下げた**。

- `bash .claude/scripts/session-install.sh` を 3 回直接実行 → 一度も再現せず
- レビュー側でも develop で再現せず
- `set -u` は 15 行目にあるが、`while IFS= read -r plugin` は入力が空でも `plugin` を束縛するため `set -u` には引っかからない（レビューの指摘どおり）
- 初回観測時の出力は変数名部分が文字化けしており（`plugin?:`）、hook の stderr がテスト出力に混線した見かけ上の症状と判断

`.agents/rules/common.md` 6.4 節は「先送りは必ず issue 化」を求めるが、これは**スコープ判断による先送りではなく再現しない観測**なので、issue 化せず本文から削除する扱いとした。

## 検証

| チェック | 結果 |
| :--- | :--- |
| `settings.json` JSON 妥当性 | ✅ valid |
| `npm run format:check` | ✅ pass（初回 fail → `npm run format` でテーブル整形修正） |
| `npm run test` | ✅ 148 files / 2716 passed, 1 skipped |
| `node_modules/.bin/astro check` | ✅ 0 errors / 0 warnings / 0 hints |
| `npm run test:e2e` | ⏭️ 未実行 |

**E2E 未実行の理由**: diff は `CLAUDE.md` と `.claude/settings.json` のみで、`src/` `tests/` に変更がなく E2E が検証する実行時挙動に影響しない。CI を最終ゲートとする。

## 関連

PR #758（`.agents/rules/common.md` への出力量の規律・委譲判断の追加）と同じ監査の流れだが、**対象ファイルが異なるため独立した PR**にしている。本 PR の「前提モデル」節は #758 で追加する規約を参照するので、**#758 → 本 PR の順でマージするのが自然**（逆順でも壊れない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュー対応（2026-07-28）

| 指摘 | 対応 | commit |
| :--- | :--- | :--- |
| nit: 「前提モデル」節の `Opus 5` ハードコードが Currency ドリフトを再導入する | ✅ 修正。`opus` がエイリアスである旨を明記し、世代番号は「執筆時点の現行世代」として位置づけ、解決先が移ったら見直す旨を追記 | `02e767f` |
| deferral 整備: `unbound variable` は再現しないので issue 化するか注記を落とす | ✅ 対応。3 回直接実行して再現せず、注記を本文から取り下げた（上記「取り下げた注記」参照） | 本文のみ |
| 任意: `teammateMode: "tmux"` 設定値そのものの再考 | ⏭️ 対応不要と判断（レビューの見解と一致）。docs-only の本 PR で caveat を明文化済みのため、設定値の変更は別途 |

### nit 修正の差分

```diff
-`.claude/settings.json` で `model: "opus[1m]"`（Claude Opus 5 / 1M context）を指定している。`.agents/rules/common.md` の…
+`.claude/settings.json` で `model: "opus[1m]"` を指定している。`opus` は **現行世代の最新 Opus を指すエイリアス**
+（`[1m]` は 1M context 版）であり、世代が更新されれば解決先も移動する。
+
+`.agents/rules/common.md` の … 執筆時点の現行世代である Claude Opus 5 の既定挙動（…）を前提にしている → [Prompting Claude Opus 5](…)
+
+**エイリアスの解決先が次世代に移ったら、本節と上記規約の前提を見直すこと**（世代番号を固定した記述は Currency ドリフトの発生源になる）。
```

指摘のとおり、監査 PR 自身が Currency ドリフトの発生源になるのは本末転倒でした。エイリアスの性質を明示したうえで、behavioral リファレンスとしての Opus 5 リンクは残しています。

### 再検証（`02e767f` 時点）

| チェック | 結果 |
| :--- | :--- |
| `npm run format:check` | ✅ pass |
| `npm run test` | ✅ 148 files / 2716 passed, 1 skipped |
| `node_modules/.bin/astro check` | ✅ 0 errors / 0 warnings / 0 hints |
